### PR TITLE
Only compare view numbers if in non-genesis block

### DIFF
--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -38,11 +38,7 @@ impl State {
             return Err(Error::IncorrectParent);
         }
 
-        // New view number must be greater than current
-        if *view_number <= self.view_number {
-            return Err(Error::IncorrectView);
-        }
-
+        // Is this is a genesis block?
         if self.block_height == 0 {
             // Must contain only a genesis transaction
             if block.transactions.len() != 1 {
@@ -52,6 +48,11 @@ impl State {
                 return Err(Error::MissingGenesis);
             }
         } else {
+            // New view number must be greater than current
+            if *view_number <= self.view_number {
+                return Err(Error::IncorrectView);
+            }
+
             // If any txn is Genesis, fail
             if block
                 .transactions


### PR DESCRIPTION
This was causing a bug in the test where appending a genesis block to an empty state led to an `IncorrectView` error.