### PR TITLE
Readme: add note about dual stack networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ for i in `seq $N`; do
     target/release/sequencer --cdn-url tcp://localhost:$PORT &
 done
 ```
+
+Note: if the sequencer shows a `"Connection refused"` error you may need to use
+`127.0.0.1` instead of `localhost` when connecting to the CDN. This is because
+`localhost` may resolve to `::1` if dual stack (ipv4 and ipv6) networking is
+enabled.


### PR DESCRIPTION
I'm not sure how to solve this properly. I'm thinking binding to `::0` in https://github.com/EspressoSystems/espresso-sequencer/blob/readme-add-localhost-note/sequencer/src/bin/cdn-server.rs#L195 wouldn't work if ipv6 is disabled. 

So for now I just added a note to the readme.