### PR TITLE
Start consensus in sequencer main

### DIFF
--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -72,9 +72,13 @@ async fn main() {
     }
     .expect("Failed to initialize query data storage");
 
-    serve(query_data, init_handle, args.port)
+    let (handle, task) = serve(query_data, init_handle, args.port)
         .await
-        .expect("Failed to initialize API")
-        .await
-        .expect("Failed to initialize app");
+        .expect("Failed to initialize API");
+
+    // Start doing consensus.
+    handle.start().await;
+
+    // Block on the API server.
+    task.await.expect("Error in API server");
 }


### PR DESCRIPTION
I noticed in the demo, the L2 adaptor was not getting any blocks to sequence, even empty ones. I think this is why.

Refactors `serve` to return a handle so that `main` can start the consensus. I think having `serve` return the handle to consensus is a sensible API in any case.