### PR TITLE
CI: move linting to own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release-*
-      - ma/ci-testing
     tags:
       # YYYYMMDD
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
@@ -18,41 +17,26 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/espressosystems/devops-rust:stable
+    # The tests that use docker compose currently only work on github's
+    # public runners.
+    runs-on: ubuntu-latest
     steps:
-
-      # From https://docs.docker.com/engine/install/ubuntu/
-      - name: Install docker compose
-        run: |
-          apt update
-          apt install -y lsb-release
-          mkdir -m 0755 -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-          apt update
-          apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-      - name: Try docker
-        run: docker info
 
       - name: Check /proc/cpuinfo
         run: cat /proc/cpuinfo
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - uses: styfle/cancel-workflow-action@0.11.0
         name: Cancel Outdated Builds
         with:
           all_but_latest: true
           access_token: ${{ github.token }}
-
-      - name: Configure git submodule directories
-        run: |
-          git config --global --add safe.directory /__w/espresso-sequencer/espresso-sequencer/zkevm-contracts
-          git config --global --add safe.directory /__w/espresso-sequencer/espresso-sequencer/zkevm-node
-          git config --global --add safe.directory /__w/espresso-sequencer/espresso-sequencer/contracts/lib/forge-std
 
       - uses: actions/checkout@v3
         name: Checkout Repository
@@ -65,6 +49,7 @@ jobs:
           git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf git://github.com
           git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
 
+
       - name: Login to Github Container Repo
         uses: docker/login-action@v2
         # if: github.event_name != 'pull_request'
@@ -74,7 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull all docker compose images
-        run: docker compose -f docker-compose.yaml -f docker-compose-anvil.yaml -f permissionless-docker-compose.yaml pull
+        run: docker-compose -f docker-compose.yaml -f docker-compose-anvil.yaml -f permissionless-docker-compose.yaml pull
 
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
@@ -82,11 +67,6 @@ jobs:
       - name: Build
         run: |
           cargo build --release --workspace
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
 
       - name: Test
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release-*
-      - ma/ci-testing
     tags:
       # YYYYMMDD
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"


### PR DESCRIPTION
We still can't run the tests that use docker compose on our own runners or inside docker.

This PR should make the CI run a bit faster however.