### PR TITLE
Add script to update zkevm-node contract bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ In order to avoid constant warnings about checksum mismatches with
 - Update the rust bindings: `cargo run --bin gen-bindings`
 - Compile contracts and update bindings: `just update-contract-bindings`
 - Run a hardhat dev node: `just hardhat node`
+- Update the zkevm-node contract bindings to match zkevm-contracts: `just
+  update-zkevm-node-contract-bindings`
 
 ## Implementation Plan
 

--- a/justfile
+++ b/justfile
@@ -22,7 +22,10 @@ hardhat *args:
     cd zkevm-contracts && nix develop -c bash -c "npx hardhat {{args}}"
 
 update-contract-bindings: (hardhat "compile")
-   cargo run --bin gen-bindings
+    cargo run --bin gen-bindings
+
+update-zkevm-node-contract-bindings:
+    scripts/update-zkevm-node-contract-bindings
 
 npm *args:
    cd zkevm-contracts && nix develop -c bash -c "npm {{args}}"

--- a/scripts/update-zkevm-node-contract-bindings
+++ b/scripts/update-zkevm-node-contract-bindings
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq go-ethereum
+set -euo pipefail
+
+REPO_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
+cd "$REPO_DIR"
+
+# Install npm dependencies
+just npm i
+
+# Compile contracts
+just hardhat compile
+
+# Copy contracts ABI and bytecode from zkevm-contracts to zkevm-node
+function copy_contract() {
+    contract=$(basename $1)
+    destination=$2
+    # The destination files are indented with tabs, we do the same to avoid unnecessary changes.
+    cat zkevm-contracts/artifacts/contracts/$1.sol/$contract.json | jq --tab -r '.bytecode' > zkevm-node/etherman/smartcontracts/bin/$destination.bin
+    cat zkevm-contracts/artifacts/contracts/$1.sol/$contract.json | jq --tab -r '.abi' > zkevm-node/etherman/smartcontracts/abi/$destination.abi
+}
+
+copy_contract PolygonZkEVM polygonzkevm
+copy_contract mocks/VerifierRollupHelperMock mockverifier
+copy_contract PolygonZkEVMBridge polygonzkevmbrige
+copy_contract PolygonZkEVMGlobalExitRoot polygonzkevmglobalexitroot
+
+# Generate the go bindings
+cd zkevm-node/etherman/smartcontracts/
+./script.sh
+
+echo
+echo "Done!"
+echo "Check changes in zkevm-node, and commit if the changes look Ok."


### PR DESCRIPTION
If I 

1. checkout branch `ma/hotshot-interface` of `zkevm-contracts`
2. run the script: `just update-zkevm-node-contract-bindings`
3. run `make build` inside the `zkevm-node` 

I get these errors 

```
make: arch: No such file or directory
GOBIN=/home/lulu/r/EspressoSystems/espresso-sequencer/zkevm-node/dist CGO_ENABLED=0 GOOS=linux GOARCH= go build -ldflags "all=-X 'github.com/0xPolygonHermez/zkevm-node.Version=v0.0.3-RC1-25-gbbcaf6b' -X 'github.com/0xPolygonHermez/zkevm-node.GitRev=bbcaf6b' -X 'github.com/0xPolygonHermez/zkevm-node.GitBranch=HEAD' -X 'github.com/0xPolygonHermez/zkevm-node.BuildDate=Wed, 15 Mar 2023 12:24:52 +0100'" -o /home/lulu/r/EspressoSystems/espresso-sequencer/zkevm-node/dist/zkevm-node /home/lulu/r/EspressoSystems/espresso-sequencer/zkevm-node/cmd
# github.com/0xPolygonHermez/zkevm-node/etherman
etherman/types.go:38:15: undefined: polygonzkevm.PolygonZkEVMBatchData
etherman/types.go:67:15: undefined: polygonzkevm.PolygonZkEVMForcedBatchData
etherman/etherman.go:426:29: undefined: polygonzkevm.PolygonZkEVMBatchData
etherman/etherman.go:432:25: undefined: polygonzkevm.PolygonZkEVMBatchData
etherman/etherman.go:442:26: etherMan.PoE.SequenceBatches undefined (type *polygonzkevm.Polygonzkevm has no field or method SequenceBatches)
etherman/etherman.go:494:3: not enough arguments in call to etherMan.PoE.VerifyBatchesTrustedAggregator
	have (*bind.TransactOpts, number, uint64, uint64, [32]byte, [32]byte, [2]*big.Int, [2][2]*big.Int, [2]*big.Int)
	want (*bind.TransactOpts, uint64, uint64, uint64, [32]byte, [32]byte, [2]*big.Int, [2][2]*big.Int, [2]*big.Int, polygonzkevm.PolygonZkEVMPackedHotShotParams)
etherman/etherman.go:656:31: undefined: polygonzkevm.PolygonZkEVMBatchData
etherman/etherman.go:783:34: undefined: polygonzkevm.PolygonZkEVMForcedBatchData
etherman/simulated.go:66:138: not enough arguments in call to polygonzkevm.DeployPolygonzkevm
	have (*bind.TransactOpts, *backends.SimulatedBackend, common.Address, common.Address, common.Address, common.Address, number, number)
	want (*bind.TransactOpts, bind.ContractBackend, common.Address, common.Address, common.Address, common.Address, common.Address, uint64, uint64)
make: *** [Makefile:25: build] Error 2
```

which I think agrees with the changes we made to the contracts.

I wonder if it would make things somewhat easier for what @LaplaceFox is doing if we didn't delete unused code from the contracts but left it there until we have the new code working and remove the unused code afterwards in a separate step.