### PR TITLE
Allow foundry commands to be run from anywhere in repo

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -48,10 +48,10 @@ jobs:
           git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
 
       - name: Format check
-        run: cd contracts && forge fmt --check
+        run: forge fmt --check
 
       - name: Build contracts
-        run: cd contracts && forge build --deny-warnings
+        run: forge build --deny-warnings
 
       - name: Check if bindings up to date
         run: |
@@ -62,4 +62,4 @@ jobs:
           # exit $(git status --porcelain | wc -l)
 
       - name: Run tests
-        run: cd contracts && forge test -vvv
+        run: forge test -vvv

--- a/README.md
+++ b/README.md
@@ -81,18 +81,15 @@ enabled.
 
 ### Developing contracts
 
-
 A foundry project for the contracts specific to HotShot can be found in the directory `contracts`.
 
 To compile
 ```shell
-cd contracts
 forge build
 ```
 
 To run the tests
 ```shell
-cd contracts
 forge test
 ```
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,6 +1,0 @@
-[profile.default]
-src = 'src'
-out = 'out'
-libs = ['lib']
-
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
               forge-fmt = {
                 enable = true;
                 description = "Enforce forge fmt";
-                entry = "cd contracts && forge fmt --check";
+                entry = "forge fmt";
                 pass_filenames = false;
               };
             };

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+# Note that if we want to move the `./contracts` directory into it's own repo we
+# need to move the foundry.toml and remove the `./contracts` prefix from the
+# directories below.
+src = 'contracts/src'
+out = 'contracts/out'
+test = 'contracts/test'
+libs = ['contracts/lib']
+
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
- Move `foundry.toml` to repo root.
- Fix `forge-fmt` pre-commit hook. The `cd` part fails on nixos and the pre-commit hook should not run in check mode but modify files so that they can be conveniently committed if the hook makes changes. The hook will fail with `Files were modified by this hook.` if the hook modifies files.