### PR TITLE
Avoid aborting builds when cachix login fails

### DIFF
--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -24,6 +24,8 @@ jobs:
         uses: cachix/install-nix-action@v20
 
       - uses: cachix/cachix-action@v12
+        # If PR is from a non-collaborator (e. g. dependabot) the secrets are missing and the login to cachix fails.
+        continue-on-error: true
         with:
           name: espresso-systems-private
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
Currently the `build_static` workflow doesn't work for dependabot PRs because they can't access the secrets. With this PR these builds should continue to run anyway.