### PR TITLE
Fix race condition in sequencer::api::serve.

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -137,9 +137,15 @@ pub async fn serve<I: NodeImplementation<SeqTypes, Leaf = Leaf>>(
 
     // Start up handle
     let (handle, node_index) = init_handle(metrics).await;
-    handle.start().await;
 
+    // Get a clone the handle to use for populating the query data with consensus events.
+    //
+    // We must do this _before_ starting consensus on the handle, otherwise we could miss the first
+    // events emitted by consensus.
     let mut watch_handle = handle.clone();
+
+    // Start consensus.
+    handle.start().await;
 
     let state = Arc::new(RwLock::new(AppState::<I> {
         submit_state: handle.clone(),


### PR DESCRIPTION
When cloning a HotShotHandle, it is always important to take the clone _before_ any events you may want to process have been emitted, because the clone won't inherit buffered events from the original. This is a sharp edge that we really should smooth over soon.

I don't have a good way of confirming if this is the bug that was causing the slow L1 test to fail, since I hadn't been able to reproduce it, but the shoe fits. I'm very glad I added those extra checks to the rollup contract, because this is an actual bug that has gone undetected for months.