### PR TITLE
Remove --report-time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Test
         run: |
           cargo test --release --workspace --all-features --no-run
-          cargo test --release --workspace --all-features --verbose -- -Zunstable-options --report-time --test-threads 1 --nocapture
+          cargo test --release --workspace --all-features --verbose -- --test-threads 1 --nocapture
         timeout-minutes: 30


### PR DESCRIPTION
This (correctly) doesn't work anymore on 1.70.0 (stable).