### PR TITLE
HotShot Block trait requires Display

### DIFF
--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -109,8 +109,6 @@ impl TestableBlock for Block {
     }
 }
 
-// Required for TestableBlock
-#[cfg(any(test, feature = "testing"))]
 impl Display for Block {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:#?}")


### PR DESCRIPTION
I think this doesn't surface because we never compile without testing but it breaks compilation in downstream crates when the sequencer crate is used without testing feature, or used only as peer dependency.

https://github.com/EspressoSystems/hotshot/blob/4754551604f02d8fda93518b857f3c93f5c589f4/types/src/traits/block_contents.rs#L29

https://github.com/EspressoSystems/espresso-sequencer/issues/443