### PR TITLE
Decrease block time for testing.

### DIFF
--- a/example-l2/src/executor.rs
+++ b/example-l2/src/executor.rs
@@ -504,7 +504,7 @@ mod test {
 
         // Once the contracts have been deployed, restart the L1 with a slow block time.
         anvil
-            .restart(AnvilOptions::default().block_time(Duration::from_secs(30)))
+            .restart(AnvilOptions::default().block_time(Duration::from_secs(5)))
             .await;
 
         test_rollup.reset_socket_connnection().await;

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -409,7 +409,7 @@ pub mod testing {
             start_delay: Duration::from_millis(1).as_millis() as u64,
             num_bootstrap: 1usize,
             propose_min_round_time: Duration::from_secs(1),
-            propose_max_round_time: Duration::from_secs(5),
+            propose_max_round_time: Duration::from_secs(1),
             election_config: Some(ElectionConfig {}),
             da_committee_nodes: nodes_pub_keys.clone(), // All nodes are in the DA committee.
         };


### PR DESCRIPTION
There is no reason to have a slow block time during testing, where we have low throughput anyways. This will make the tests run faster and also make it easier to test scenarios where the L1 is significantly slower than HotShot (ie preconfirmations).