### PR TITLE
Refactor sequencer options to make API modules modular

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
  "derive_more",
  "ethers",
  "futures",
+ "hotshot",
  "hotshot-query-service",
  "jf-primitives",
  "portpicker",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,8 @@ services:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
-    # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- api
+    # Run the API server (with options taken from the environment) and the optional submission API
+    command: sequencer -- http -- query -- submit
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -36,7 +36,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER1_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- api
+    command: sequencer -- http -- query
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -49,7 +49,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER2_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- api
+    command: sequencer -- http -- query
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -62,7 +62,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER3_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- api
+    command: sequencer -- http -- query
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -75,7 +75,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER4_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- http -- api
+    command: sequencer -- http -- query
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- api
+    command: sequencer -- http -- api
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -36,7 +36,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER1_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- api
+    command: sequencer -- http -- api
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -49,7 +49,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER2_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- api
+    command: sequencer -- http -- api
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -62,7 +62,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER3_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- api
+    command: sequencer -- http -- api
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT
@@ -75,7 +75,7 @@ services:
     ports:
       - "$ESPRESSO_SEQUENCER4_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
     # Run the API server (with options taken from the environment)
-    command: sequencer -- api
+    command: sequencer -- http -- api
     environment:
       - ESPRESSO_SEQUENCER_CDN_URL
       - ESPRESSO_SEQUENCER_API_PORT

--- a/example-l2/Cargo.toml
+++ b/example-l2/Cargo.toml
@@ -34,6 +34,10 @@ toml = "0.5"
 tracing = "0.1"
 
 [dev-dependencies]
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", features = [
+    "async-std-executor",
+    "channel-async-std",
+] }
 portpicker = "0.1.1"
 sequencer-utils = { path = "../utils" }
 tempfile = "3.4.0"

--- a/example-l2/src/api.rs
+++ b/example-l2/src/api.rs
@@ -107,7 +107,9 @@ mod tests {
     use rand::SeedableRng;
     use rand_chacha::ChaChaRng;
     use sequencer::{
-        api::SequencerNode, testing::wait_for_decide_on_handle, Transaction as SeqTransaction,
+        api::{HttpOptions, QueryOptions, SequencerNode},
+        testing::wait_for_decide_on_handle,
+        Transaction as SeqTransaction,
     };
     use surf_disco::Client;
     use tempfile::TempDir;
@@ -156,14 +158,15 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let storage_path = tmp_dir.path().join("tmp_storage");
         let init_handle = Box::new(move |_| (ready((api_node, 0)).boxed()));
-        let SequencerNode { handle, .. } = sequencer::api::serve(
-            sequencer::api::Options {
-                storage_path,
-                port: sequencer_port,
-                reset_store: true,
-            },
-            init_handle,
-        )
+        let SequencerNode { handle, .. } = sequencer::api::Options::from(HttpOptions {
+            port: sequencer_port,
+        })
+        .submit(Default::default())
+        .query(QueryOptions {
+            storage_path,
+            reset_store: true,
+        })
+        .serve(init_handle)
         .await
         .unwrap();
         for node in &nodes {

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use futures::future::{join_all, FutureExt};
 use hotshot_types::traits::metrics::NoMetrics;
 use sequencer::{
-    api::{serve, SequencerNode},
+    api::{self, SequencerNode},
     hotshot_commitment::run_hotshot_commitment_task,
     init_node, Block, Options,
 };
@@ -33,18 +33,34 @@ async fn main() {
 
     let mut tasks = vec![];
 
-    // Inititialize HotShot. If the user requested the API module, we must initialize the handle in
+    // Inititialize HotShot. If the user requested the HTTP module, we must initialize the handle in
     // a special way, in order to populate the API with consensus metrics. Otherwise, we initialize
     // the handle directly, with no metrics.
-    let (mut handle, api_port) = match modules.api {
-        Some(options) => {
-            let port = options.port;
+    let (mut handle, query_api_port) = match modules.http {
+        Some(opt) => {
+            // Add optional API modules as requested.
+            let mut opt = api::Options::from(opt);
+            if let Some(query) = modules.query {
+                opt = opt.query(query);
+            }
+            if let Some(submit) = modules.submit {
+                opt = opt.submit(submit);
+            }
+
+            // Save the port if we are running a query API. This can be used later when starting the
+            // commitment task; otherwise the user must give us the URL of an external query API.
+            let query_api_port = if opt.query.is_some() {
+                Some(opt.http.port)
+            } else {
+                None
+            };
             let init_handle =
                 Box::new(move |metrics| init_node(cdn_addr, genesis, metrics).boxed());
-            let SequencerNode { handle, .. } = serve(options, init_handle)
+            let SequencerNode { handle, .. } = opt
+                .serve(init_handle)
                 .await
                 .expect("Failed to initialize API");
-            (handle, Some(port))
+            (handle, query_api_port)
         }
         None => (
             init_node(cdn_addr, genesis, Box::new(NoMetrics)).await.0,
@@ -73,7 +89,8 @@ async fn main() {
             options.query_service_url = Some(
                 format!(
                     "http://localhost:{}",
-                    api_port.expect("API port is required when running commitment task")
+                    query_api_port
+                        .expect("Query API port is required when running commitment task")
                 )
                 .parse()
                 .unwrap(),

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -1,5 +1,6 @@
 use crate::{api, hotshot_commitment::CommitmentTaskOptions};
 use clap::{error::ErrorKind, Args, FromArgMatches, Parser};
+use std::collections::HashSet;
 use std::iter::once;
 use url::Url;
 
@@ -75,6 +76,7 @@ impl ModuleArgs {
     fn try_parse(&self) -> Result<Modules, clap::Error> {
         let mut modules = Modules::default();
         let mut curr = self.0.clone();
+        let mut provided = Default::default();
 
         while !curr.is_empty() {
             // The first argument (the program name) is used only for help generation. We include a
@@ -84,9 +86,11 @@ impl ModuleArgs {
                 once("sequencer --").chain(curr.iter().map(|s| s.as_str())),
             )?;
             match module {
-                SequencerModule::Api(m) => curr = m.add("api", &mut modules.api)?,
+                SequencerModule::Http(m) => curr = m.add(&mut modules.http, &mut provided)?,
+                SequencerModule::Query(m) => curr = m.add(&mut modules.query, &mut provided)?,
+                SequencerModule::Submit(m) => curr = m.add(&mut modules.submit, &mut provided)?,
                 SequencerModule::CommitmentTask(m) => {
-                    curr = m.add("commitment-task", &mut modules.commitment_task)?
+                    curr = m.add(&mut modules.commitment_task, &mut provided)?
                 }
             }
         }
@@ -95,8 +99,30 @@ impl ModuleArgs {
     }
 }
 
+trait ModuleInfo: Args + FromArgMatches {
+    const NAME: &'static str;
+    fn requires() -> Vec<&'static str>;
+}
+
+macro_rules! module {
+    ($name:expr, $opt:ty $(,requires: $($req:expr),*)?) => {
+        impl ModuleInfo for $opt {
+            const NAME: &'static str = $name;
+
+            fn requires() -> Vec<&'static str> {
+                vec![$($($req),*)?]
+            }
+        }
+    };
+}
+
+module!("http", api::HttpOptions);
+module!("query", api::QueryOptions, requires: "http");
+module!("submit", api::SubmitOptions, requires: "http");
+module!("commitment-task", CommitmentTaskOptions);
+
 #[derive(Clone, Debug, Args)]
-struct Module<Options: Args + FromArgMatches> {
+struct Module<Options: ModuleInfo> {
     #[clap(flatten)]
     options: Box<Options>,
 
@@ -105,28 +131,57 @@ struct Module<Options: Args + FromArgMatches> {
     modules: Vec<String>,
 }
 
-impl<Options: Args + FromArgMatches> Module<Options> {
+impl<Options: ModuleInfo> Module<Options> {
     /// Add this as an optional module. Return the next optional module args.
-    fn add(self, name: &str, options: &mut Option<Options>) -> Result<Vec<String>, clap::Error> {
+    fn add(
+        self,
+        options: &mut Option<Options>,
+        provided: &mut HashSet<&'static str>,
+    ) -> Result<Vec<String>, clap::Error> {
         if options.is_some() {
             return Err(clap::Error::raw(
                 ErrorKind::TooManyValues,
-                format!("optional module {name} can only be started once"),
+                format!("optional module {} can only be started once", Options::NAME),
             ));
         }
+        for req in Options::requires() {
+            if !provided.contains(&req) {
+                return Err(clap::Error::raw(
+                    ErrorKind::MissingRequiredArgument,
+                    format!("module {} is missing required module {req}", Options::NAME),
+                ));
+            }
+        }
         *options = Some(*self.options);
+        provided.insert(Options::NAME);
         Ok(self.modules)
     }
 }
 
 #[derive(Clone, Debug, Parser)]
 enum SequencerModule {
-    Api(Module<api::Options>),
+    /// Run an HTTP server.
+    ///
+    /// The basic HTTP server comes with healthcheck and version endpoints. Add additional endpoints
+    /// by enabling additional modules:
+    /// * query: add query service endpoints
+    /// * submit: add transaction submission endpoints
+    Http(Module<api::HttpOptions>),
+    /// Run the query service API module.
+    ///
+    /// This modules requires the http module to be started.
+    Query(Module<api::QueryOptions>),
+    /// Run the transaction submission API module.
+    ///
+    /// This modules requires the http module to be started.
+    Submit(Module<api::SubmitOptions>),
     CommitmentTask(Module<CommitmentTaskOptions>),
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct Modules {
-    pub api: Option<api::Options>,
+    pub http: Option<api::HttpOptions>,
+    pub query: Option<api::QueryOptions>,
+    pub submit: Option<api::SubmitOptions>,
     pub commitment_task: Option<CommitmentTaskOptions>,
 }


### PR DESCRIPTION
Previously, we had one optional module for the entire API. If you chose this you would get all the services (query service and submit API), if you omitted it you would get nothing. This makes it impossible to run an HTTP server with just a healthcheck endpoint, for example, or to run just the submit API without the heavyweight query API.

Now, there is one base module (http) which starts a barebones web server with healthcheck and version endpoints. There are additional modules you can add after that one (query and commit) which enable additional functionality.

Closes #491