### PR TITLE
Explicitly set contract address in event filters.

### DIFF
--- a/contracts/rust/src/hotshot_contract.rs
+++ b/contracts/rust/src/hotshot_contract.rs
@@ -48,6 +48,11 @@ mod test {
         let (event, meta) = &hotshot
             .new_blocks_filter()
             .from_block(0)
+            // Ethers does not set the contract address on filters created via contract bindings.
+            // This seems like a bug and I have reported it:
+            // https://github.com/gakonst/ethers-rs/issues/2528. In the mean time we can work around
+            // by setting the address manually.
+            .address(hotshot.address().into())
             .query_with_meta()
             .await
             .unwrap()[0];

--- a/example-l2/src/executor.rs
+++ b/example-l2/src/executor.rs
@@ -63,7 +63,13 @@ pub async fn run_executor(opt: &ExecutorOptions, state: Arc<RwLock<State>>) {
 
     let rollup_contract = ExampleRollup::new(*rollup_address, l1.clone());
     let hotshot_contract = HotShot::new(*hotshot_address, Arc::new(socket_provider));
-    let filter = hotshot_contract.new_blocks_filter().from_block(0);
+    let filter = hotshot_contract
+        .new_blocks_filter()
+        .from_block(0)
+        // Ethers does not set the contract address on filters created via contract bindings. This
+        // seems like a bug and I have reported it: https://github.com/gakonst/ethers-rs/issues/2528.
+        // In the mean time we can work around by setting the address manually.
+        .address(hotshot_contract.address().into());
     let mut commits_stream = filter
         .subscribe()
         .await
@@ -257,7 +263,15 @@ mod test {
         }
 
         pub async fn subscribe(&self) -> SubscriptionStream<'_, Ws, Log> {
-            let state_update_filter = self.contract.state_update_filter().filter;
+            let state_update_filter = self
+                .contract
+                .state_update_filter()
+                .filter
+                // Ethers does not set the contract address on filters created via contract
+                // bindings. This seems like a bug and I have reported it:
+                // https://github.com/gakonst/ethers-rs/issues/2528. In the mean time we can work
+                // around by setting the address manually.
+                .address(self.contract.address());
             self.socket_provider
                 .subscribe_logs(&state_update_filter)
                 .await

--- a/sequencer/src/hotshot_commitment.rs
+++ b/sequencer/src/hotshot_commitment.rs
@@ -279,6 +279,11 @@ mod test {
             .hotshot
             .new_blocks_filter()
             .from_block(l1_initial_block)
+            // Ethers does not set the contract address on filters created via contract bindings.
+            // This seems like a bug and I have reported it:
+            // https://github.com/gakonst/ethers-rs/issues/2528. In the mean time we can work around
+            // by setting the address manually.
+            .address(l1.hotshot.address().into())
             .query_with_meta()
             .await
             .unwrap()


### PR DESCRIPTION
This works around what appears to be a bug or deficiency in Ethers: https://github.com/gakonst/ethers-rs/issues/2528