### PR TITLE
Update dependencies, rust 1.71.2 -> 1.72.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 
+resolver = "2"
+
 members = [
   "contract-bindings",
   "contracts/rust",

--- a/README.md
+++ b/README.md
@@ -35,19 +35,25 @@ Docker images and the [docker-compose-demo.yaml](docker-compose-demo.yaml) file 
 Docker-based demo fetches the images from the `ghcr` repository, where they are updated with every push to `main` on
 GitHub. For testing uncommitted changes, you can also run the binaries by manually building and running the services.
 
-Build all executables with `cargo build --release`. You may then start a sequencer network. First, start an orchestrator. Choose a port `$PORT` to run it on and decide how many sequencer nodes `$N` you
-will use, then run `target/release/orchestrator -p $PORT -n $N`.
+Build all executables with `cargo build --release`. You may then start a sequencer network. First, start an
+orchestrator. Choose a port `$PORT` to run it on and decide how many sequencer nodes `$N` you will use, then run
+`target/release/orchestrator -p $PORT -n $N`.
 
 The sequencer will distribute a HotShot configuration to all the nodes which connect to it, which specifies consensus
 parameters like view timers. There is a default config, but you can override any parameters you want by passing
 additional options to the `orchestrator` executable. Run `target/release/orchestrator --help` to see a list of available
-options. Next, you must launch two `web-server` instances, which are necessary to facilitate consensus. One web server is for data availability, while the other coordinates consensus among sequencer nodes. Pick a `$DA_PORT` and a `$CONSENSUS_PORT` and run:
+options. Next, you must launch two `web-server` instances, which are necessary to facilitate consensus. One web server
+is for data availability, while the other coordinates consensus among sequencer nodes. Pick a `$DA_PORT` and a
+`$CONSENSUS_PORT` and run:
+
 ```bash
 target/release/web-server -p $DA_PORT
 target/release/web-server -p $CONSENSUS_PORT
 ```
 
-Once you have started the orchestrator and the web servers, you must connect `$N` sequencer nodes to them, after which the network will start up automatically. To start one node, run
+Once you have started the orchestrator and the web servers, you must connect `$N` sequencer nodes to them, after which
+the network will start up automatically. To start one node, run
+
 ```bash
 target/release/sequencer \
     --orchestrator-url http://localhost:$PORT \
@@ -55,6 +61,7 @@ target/release/sequencer \
     --consensus-server-url http://localhost:$CONSENSUS_PORT \
     -- http --port 8083 -- query --storage-path storage -- submit
 ```
+
 A useful Bash snippet for running `$N` nodes simultaneously in the background of your shell is:
 
 ```bash
@@ -67,8 +74,8 @@ done
 ```
 
 Note: if the sequencer shows a `"Connection refused"` error you may need to use `127.0.0.1` instead of `localhost` when
-connecting to the web server. This is because `localhost` may resolve to `::1` if dual stack (ipv4 and ipv6) networking is
-enabled.
+connecting to the web server. This is because `localhost` may resolve to `::1` if dual stack (ipv4 and ipv6) networking
+is enabled.
 
 ### Developing contracts
 
@@ -98,6 +105,7 @@ forge doc
 ```
 
 To verify the HotShot contract on sepolia via Etherscan run
+
 ```
 env ETHERSCAN_API_KEY=... scripts/verify-contract HOTSHOT_ADDRESS
 ```

--- a/example-l2/README.md
+++ b/example-l2/README.md
@@ -51,7 +51,7 @@ Make sure nix is installed. See instructions [here](https://github.com/EspressoS
 1. Build all executables: `cargo build --release`
 2. Run the orchestrator: `just dev-orchestrator`
 3. Run the DA web server: `just dev-da-server`
-4. Run the consensus web server: `just dev-consensus-server` 
+4. Run the consensus web server: `just dev-consensus-server`
 5. Run the sequencer: `just dev-sequencer`
 6. Run a test Anvil node: `anvil`
 7. Once the Sequencer HotShot network is running (there is a 10 second delay), run the demo: `just dev-demo`

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1691821122,
-        "narHash": "sha256-X+QjauytB2WbW99woLNjn0FGOlyuW+GUPryl36ZCHs8=",
+        "lastModified": 1694413301,
+        "narHash": "sha256-AZ0snLWWRwH/ttGKdJyDYCreLH2GW9dWPrTaBj8zjsI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f8800cb5a572fcdf25ea6fccf89d5ff25f6ad053",
+        "rev": "6c25d0a1907e4dc9f94c708f36fe60efbb7dcd3c",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1691480592,
-        "narHash": "sha256-csMBjIBnIcpB0wnggBbfKJ3Vj2Il00x8+OE/P9DMQBE=",
+        "lastModified": 1694438370,
+        "narHash": "sha256-BNhfFeI9nVSw7zQBNOX7wyCXIwfOIRYb5FLF4bs/2bQ=",
         "owner": "alekseysidorov",
         "repo": "nixpkgs-cross-overlay",
-        "rev": "9bc654aa5182fb1f87eb8623f60d1581270431bd",
+        "rev": "51b6fd34c4bceafe6dcfac254e57d234606b5559",
         "type": "github"
       },
       "original": {
@@ -235,11 +235,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1691654369,
-        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1690881714,
-        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1691747570,
-        "narHash": "sha256-J3fnIwJtHVQ0tK2JMBv4oAmII+1mCdXdpeCxtIsrL2A=",
+        "lastModified": 1694364351,
+        "narHash": "sha256-oadhSCqopYXxURwIA6/Anpe5IAG11q2LhvTJNP5zE6o=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c5ac3aa3324bd8aebe8622a3fc92eeb3975d317a",
+        "rev": "4f883a76282bc28eb952570afc3d8a1bf6f481d7",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1691752485,
-        "narHash": "sha256-uTUzlpV3chzwFinpswAfc76RA3y+5eoPQBW6BLYp1sI=",
+        "lastModified": 1694328901,
+        "narHash": "sha256-6GjjGVCn0lNlGQifjM8AqRRMzVxf/KNyQqmAl8a9HME=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "1fde334195f0a8ac43d242bc871e6723e963620d",
+        "rev": "326f37ef1f53575fd38e768065b6bcfcebdce462",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691374719,
-        "narHash": "sha256-HCodqnx1Mi2vN4f3hjRPc7+lSQy18vRn8xWW68GeQOg=",
+        "lastModified": 1694225334,
+        "narHash": "sha256-f3uOfcfmG53biFl6zHPHSFrBucLGQp0LpRYQJlozZSA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b520a3889b24aaf909e287d19d406862ced9ffc9",
+        "rev": "1b4fad9dccece45c25b9ebda607427d69a8f1eae",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1691806075,
-        "narHash": "sha256-yuq7cNkFOQse4WwLw0rUiXhG58aI6eyXKfcTw5Act/I=",
+        "lastModified": 1694398298,
+        "narHash": "sha256-Hi904+2V5DJhFdEy9DcARSRrGJOlYSILHUC6CgTtuZU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b87a7db512340dea25e95f444db29e9264ff7a63",
+        "rev": "6c520f2e31f4bebeb29cc4563543de7187013575",
         "type": "github"
       },
       "original": {

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -418,7 +418,10 @@ impl<N: network::Type> AppState<N> {
             .enumerate()
         {
             let Some(block) = block else {
-                tracing::warn!("missing block {}, index may be out of date", prev_block_height + i);
+                tracing::warn!(
+                    "missing block {}, index may be out of date",
+                    prev_block_height + i
+                );
                 continue;
             };
             index_block_by_time(&mut self.blocks_by_time, &block);

--- a/sequencer/src/hotshot_commitment.rs
+++ b/sequencer/src/hotshot_commitment.rs
@@ -73,7 +73,6 @@ pub async fn run_hotshot_commitment_task(opt: &CommitmentTaskOptions) {
     // Connect to the layer one HotShot contract.
     let Some(l1) = connect_l1(opt).await else {
         panic!("unable to connect to L1, hotshot commitment task exiting");
-
     };
     let contract = HotShot::new(opt.hotshot_address, l1.clone());
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -196,7 +196,6 @@ pub mod network {
 /// The Sequencer node is generic over the hotshot CommChannel.
 #[derive(Derivative, Serialize, Deserialize)]
 #[derivative(
-    Clone(bound = ""),
     Copy(bound = ""),
     Debug(bound = ""),
     Default(bound = ""),
@@ -205,6 +204,14 @@ pub mod network {
     Hash(bound = "")
 )]
 pub struct Node<N: network::Type>(PhantomData<fn(&N)>);
+
+// Using derivative to derive Clone triggers the clippy lint
+// https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_clone_impl_on_copy_type
+impl<N: network::Type> Clone for Node<N> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 #[derive(
     Clone, Copy, Debug, Default, Hash, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
@@ -505,6 +512,7 @@ pub mod testing {
                     >>::Networking,
                 ) + 'static,
         > {
+            #[allow(clippy::arc_with_non_send_sync)]
             let network_generator = Arc::new(<MemoryNetwork<
                 Message<SeqTypes, Node<network::Memory>>,
                 <SeqTypes as NodeType>::SignatureKey,
@@ -518,6 +526,7 @@ pub mod testing {
                 da_committee_size,
                 false,
             ));
+            #[allow(clippy::arc_with_non_send_sync)]
             let network_da_generator = Arc::new(<MemoryNetwork<
                 Message<SeqTypes, Node<network::Memory>>,
                 <SeqTypes as NodeType>::SignatureKey,


### PR DESCRIPTION
Ignore one clippy lint and work around another.

Rest of the changes are due to formatters.