### PR TITLE
Move L1 interactions off critical path, to asynchronous task

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,5 +39,4 @@ jobs:
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
       - name: Audit
-        # See https://github.com/libp2p/rust-libp2p/issues/4327 for RUSTSEC-2022-0093
-        run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2023-0053 --ignore RUSTSEC-2023-0063
+        run: cargo audit --ignore RUSTSEC-2023-0063 --ignore RUSTSEC-2023-0065

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,12 +68,14 @@ services:
       - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
       - ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
       - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
       orchestrator:
+        condition: service_healthy
+      demo-l1-network:
         condition: service_healthy
     stop_grace_period: 1s
 
@@ -89,12 +91,14 @@ services:
       - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
       - ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
       - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
       orchestrator:
+        condition: service_healthy
+      demo-l1-network:
         condition: service_healthy
     stop_grace_period: 1s
 
@@ -110,12 +114,14 @@ services:
       - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
       - ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
       - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
       orchestrator:
+        condition: service_healthy
+      demo-l1-network:
         condition: service_healthy
     stop_grace_period: 1s
 
@@ -131,12 +137,14 @@ services:
       - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
       - ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
       - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
       orchestrator:
+        condition: service_healthy
+      demo-l1-network:
         condition: service_healthy
     stop_grace_period: 1s
 
@@ -152,12 +160,14 @@ services:
       - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
       - ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
       - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
       - RUST_LOG
       - RUST_LOG_FORMAT
     depends_on:
       orchestrator:
+        condition: service_healthy
+      demo-l1-network:
         condition: service_healthy
     stop_grace_period: 1s
 

--- a/sequencer/src/bin/commitment-task.rs
+++ b/sequencer/src/bin/commitment-task.rs
@@ -3,10 +3,7 @@ use async_std::task::spawn;
 use clap::Parser;
 use contract_bindings::{create_signer, HotShot};
 use ethers::{prelude::*, providers::Provider};
-use sequencer::{
-    hotshot_commitment::{run_hotshot_commitment_task, CommitmentTaskOptions},
-    init_static,
-};
+use sequencer::hotshot_commitment::{run_hotshot_commitment_task, CommitmentTaskOptions};
 use url::Url;
 
 /// Commitment Task Command
@@ -68,8 +65,6 @@ pub struct Options {
 async fn main() {
     setup_logging();
     setup_backtrace();
-
-    init_static();
 
     let opt = Options::parse();
     let hotshot_address;

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -1,7 +1,9 @@
-use crate::{Error, NMTRoot, NamespaceProofType, Transaction, TransactionNMT, VmId, MAX_NMT_DEPTH};
+use crate::{
+    Error, L1BlockInfo, NMTRoot, NamespaceProofType, Transaction, TransactionNMT, VmId,
+    MAX_NMT_DEPTH,
+};
 use ark_serialize::CanonicalSerialize;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
-use ethers::prelude::{H256, U256};
 use hotshot::traits::Block as HotShotBlock;
 use hotshot_query_service::QueryableBlock;
 use hotshot_types::traits::state::TestableBlock;
@@ -116,33 +118,6 @@ impl Block {
                 root: self.transaction_nmt.commitment().digest(),
             },
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Hash, PartialEq, Eq)]
-pub struct L1BlockInfo {
-    pub number: u64,
-    pub timestamp: U256,
-    pub hash: H256,
-}
-
-impl Committable for L1BlockInfo {
-    fn commit(&self) -> Commitment<Self> {
-        let mut timestamp = [0u8; 32];
-        self.timestamp.to_little_endian(&mut timestamp);
-
-        RawCommitmentBuilder::new(&Self::tag())
-            .u64_field("number", self.number)
-            // `RawCommitmentBuilder` doesn't have a `u256_field` method, so we simulate it:
-            .constant_str("timestamp")
-            .fixed_size_bytes(&timestamp)
-            .constant_str("hash")
-            .fixed_size_bytes(&self.hash.0)
-            .finalize()
-    }
-
-    fn tag() -> String {
-        "L1BLOCK".into()
     }
 }
 

--- a/sequencer/src/l1_client.rs
+++ b/sequencer/src/l1_client.rs
@@ -1,0 +1,312 @@
+//! L1 Client
+//!
+//! [`L1Client`] defines the interface that Espresso Sequencer nodes use to interact with the L1.
+//! Sequencer nodes must read from the L1 to populate Espresso block metadata such as the L1 chain
+//! height, which is used to facilitate bridging between the L1 and any rollups which are running on
+//! the sequencer.
+//!
+//! This client runs asynchronously, updating an in-memory snapshot of the relevant L1 information
+//! each time a new L1 block is published. This design as a few advantages:
+//! * The L1 client is not synchronized with or triggered by HotShot consensus. It can run in pace
+//!   with the L1, which makes it easy to use a subscription instead of polling for new blocks,
+//!   vastly reducing the number of L1 RPC calls we make.
+//! * HotShot block building does not interact directly with the L1; it simply reads the latest
+//!   snapshot from the client's memory. This means that block production is instant and infallible.
+//!   Any failures or delays in interacting with the L1 will just slow the updating of the L1
+//!   snapshot, which will cause the block builder to propose with a slightly old snapshot, but they
+//!   will still be able to propose on time.
+
+use async_std::{
+    sync::{Arc, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard},
+    task::{sleep, spawn},
+};
+use commit::{Commitment, Committable, RawCommitmentBuilder};
+use ethers::prelude::*;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use url::Url;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub struct L1BlockInfo {
+    pub number: u64,
+    pub timestamp: U256,
+    pub hash: H256,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub struct L1Snapshot {
+    /// The relevant snapshot of the L1 includes a reference to the current head of the L1 chain.
+    ///
+    /// Note that the L1 head is subject to changing due to a reorg. However, no reorg will change
+    /// the _number_ of this block in the chain: L1 block numbers will always be sequentially
+    /// increasing. Therefore, the sequencer does not have to worry about reorgs invalidating this
+    /// snapshot.
+    pub head: u64,
+
+    /// The snapshot also includes information about the latest finalized L1 block.
+    ///
+    /// Since this block is finalized (ie cannot be reorged) we can include specific information
+    /// about the particular block, such as its hash and timestamp.
+    ///
+    /// This block may be `None` in the rare case where Espresso has started shortly after the
+    /// genesis of the L1, and the L1 has yet to finalize a block. In all other cases it will be
+    /// `Some`.
+    pub finalized: Option<L1BlockInfo>,
+}
+
+impl Committable for L1BlockInfo {
+    fn commit(&self) -> Commitment<Self> {
+        let mut timestamp = [0u8; 32];
+        self.timestamp.to_little_endian(&mut timestamp);
+
+        RawCommitmentBuilder::new(&Self::tag())
+            .u64_field("number", self.number)
+            // `RawCommitmentBuilder` doesn't have a `u256_field` method, so we simulate it:
+            .constant_str("timestamp")
+            .fixed_size_bytes(&timestamp)
+            .constant_str("hash")
+            .fixed_size_bytes(&self.hash.0)
+            .finalize()
+    }
+
+    fn tag() -> String {
+        "L1BLOCK".into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct L1ClientOptions {
+    url: Url,
+    finalized_block_tag: BlockNumber,
+    retry_delay: Duration,
+}
+
+impl L1ClientOptions {
+    pub fn with_url(url: Url) -> Self {
+        Self {
+            url,
+            finalized_block_tag: BlockNumber::Finalized,
+            retry_delay: Duration::from_secs(1),
+        }
+    }
+
+    pub fn with_latest_block_tag(mut self) -> Self {
+        // For testing with a pre-merge geth node that does not support the finalized block tag we
+        // allow setting the client to use the latest block instead.
+        self.finalized_block_tag = BlockNumber::Latest;
+        self
+    }
+
+    pub async fn start(self) -> Result<L1Client, ProviderError> {
+        let rpc = Provider::connect(self.url).await?;
+
+        // Fetch the initial L1 snapshot now, blocking, so that we will have a reasonable baseline
+        // at least until the background task starts updating the snapshot.
+        let snapshot = L1Snapshot {
+            head: rpc.get_block_number().await?.as_u64(),
+            finalized: get_finalized_block(&rpc, self.finalized_block_tag, self.retry_delay).await,
+        };
+        tracing::info!("L1 client initialized with snapshot {snapshot:?}");
+
+        let client = L1Client {
+            latest_snapshot: Arc::new(RwLock::new(snapshot)),
+        };
+
+        // Spawn a background task to update the in-memory snapshot whenever a new L1 block is
+        // produced.
+        spawn(update_loop(
+            rpc,
+            self.finalized_block_tag,
+            self.retry_delay,
+            client.latest_snapshot.clone(),
+        ));
+
+        Ok(client)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct L1Client {
+    latest_snapshot: Arc<RwLock<L1Snapshot>>,
+}
+
+impl L1Client {
+    pub async fn snapshot(&self) -> L1Snapshot {
+        *self.latest_snapshot.read().await
+    }
+}
+
+async fn update_loop(
+    rpc: Provider<Ws>,
+    finalized_tag: BlockNumber,
+    retry_delay: Duration,
+    snapshot: Arc<RwLock<L1Snapshot>>,
+) {
+    loop {
+        // Subscribe to new blocks. This task cannot fail; retry until we succeed.
+        let mut block_stream = loop {
+            match rpc.subscribe_blocks().await {
+                Ok(stream) => break stream,
+                Err(err) => {
+                    tracing::error!("error subscribing to L1 blocks: {err}");
+                    sleep(retry_delay).await;
+                }
+            }
+        };
+
+        while let Some(head) = block_stream.next().await {
+            let Some(head) = head.number else {
+                // This shouldn't happen, but if it does, it means the block stream has erroneously
+                // given us a pending block. We are only interested in committed blocks, so just
+                // skip this one.
+                tracing::warn!("got block from L1 block stream with no number");
+                continue;
+            };
+            let head = head.as_u64();
+
+            // Take a read lock on the snapshot to check if it needs to be updated.
+            let snapshot = snapshot.upgradable_read().await;
+            if head <= snapshot.head {
+                // We got a notification for a new block which is not newer than the current
+                // snapshotted head. This can happen due to an L1 reorg. We are not allowed to
+                // propose an L1 block number which is older than that of the previous Espresso
+                // block, so we skip this notification.
+                //
+                // This does mean that we may end up proposing with a block number that is newer
+                // than the current L1 head, if the height of the L1 is reduced in a reorg. This is
+                // not the best for UX, as rollups will have to block until the new L1 block is
+                // produced, but the L1 chain will _eventually_ (and usualy quickly) catch up, and
+                // this only happens in very rare cases anyways. In such rare cases we prioritize
+                // maintaining our invariants (increasing L1 block numbers) over UX.
+                tracing::warn!(
+                    "got L1 head {head} which is not newer than previous head {}",
+                    snapshot.head
+                );
+                continue;
+            }
+
+            // A new block has been produced. This happens fairly rarely, so it is now ok to poll to
+            // see if a new block has been finalized.
+            let finalized = get_finalized_block(&rpc, finalized_tag, retry_delay).await;
+
+            // Update the snapshot.
+            let mut snapshot = RwLockUpgradableReadGuard::upgrade(snapshot).await;
+            *snapshot = L1Snapshot { head, finalized };
+
+            // Drop our exclusive lock before logging anything.
+            let snapshot = RwLockWriteGuard::downgrade(snapshot);
+            tracing::info!("updated L1 snapshot to {:?}", *snapshot);
+        }
+
+        tracing::error!("L1 block stream ended unexpectedly, trying to re-establish");
+    }
+}
+
+async fn get_finalized_block<P: JsonRpcClient>(
+    rpc: &Provider<P>,
+    tag: BlockNumber,
+    retry_delay: Duration,
+) -> Option<L1BlockInfo> {
+    // This cannot fail, retry until we succeed.
+    loop {
+        let block = match rpc.get_block(tag).await {
+            Ok(Some(block)) => block,
+            Ok(None) => {
+                // This can happen in rare cases where the L1 chain is very young and has not
+                // finalized a block yet. This is more common in testing and demo environments. In
+                // any case, we proceed with a null L1 block rather than wait for the L1 to finalize
+                // a block, which can take a long time.
+                tracing::warn!("no finalized block yet");
+                return None;
+            }
+            Err(err) => {
+                tracing::error!("failed to get finalized block from L1 provider, retrying ({err})");
+                sleep(retry_delay).await;
+                continue;
+            }
+        };
+
+        // The block number always exists unless the block is pending. The finalized block cannot be
+        // pending, unless there has been a catastrophic reorg of the finalized prefix of the L1
+        // chain, so it is OK to panic if this happens.
+        let number = block.number.expect("finalized block has no number");
+        // Same for the hash.
+        let hash = block.hash.expect("finalized block has no hash");
+
+        break Some(L1BlockInfo {
+            number: number.as_u64(),
+            timestamp: block.timestamp,
+            hash,
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
+    use sequencer_utils::AnvilOptions;
+    use std::time::Instant;
+
+    #[async_std::test]
+    async fn test_l1_block_scanning() {
+        setup_logging();
+        setup_backtrace();
+
+        let test_duration = Duration::from_secs(10);
+        let test_interval = Duration::from_millis(500);
+        let anvil = AnvilOptions::default()
+            .block_time(Duration::from_secs(1))
+            .spawn()
+            .await;
+        let l1_client = L1ClientOptions::with_url(anvil.ws_url())
+            .start()
+            .await
+            .unwrap();
+        let anvil_client = Provider::try_from(anvil.url().to_string()).unwrap();
+
+        let start = Instant::now();
+        while start.elapsed() < test_duration {
+            let snapshot = l1_client.snapshot().await;
+
+            let expected_head = anvil_client.get_block_number().await.unwrap().as_u64();
+            let expected_finalized = anvil_client
+                .get_block(BlockNumber::Finalized)
+                .await
+                .unwrap();
+
+            // The snapshotted head should be within one of the observed head, it may be one block
+            // behind if the head just changed and the snapshot hasn't updated yet.
+            assert!(
+                expected_head == snapshot.head || expected_head == snapshot.head + 1,
+                "snapshotted head {} does not match expected head {}",
+                snapshot.head,
+                expected_head
+            );
+
+            // And same for the finalized block, unless there is no finalized block.
+            if let Some(expected_finalized) = expected_finalized {
+                let expected_finalized_number = expected_finalized.number.unwrap().as_u64();
+                let snapshot_finalized = snapshot.finalized.unwrap();
+                assert!(
+                    expected_finalized_number == snapshot_finalized.number
+                        || expected_finalized_number == snapshot_finalized.number + 1,
+                    "snapshotted finalized {} does not match expected finalized {}",
+                    snapshot_finalized.number,
+                    expected_finalized_number
+                );
+                if expected_finalized_number == snapshot_finalized.number {
+                    assert_eq!(expected_finalized.hash.unwrap(), snapshot_finalized.hash);
+                    assert_eq!(expected_finalized.timestamp, snapshot_finalized.timestamp);
+                    tracing::info!("L1 finalized block fully synchronized");
+                }
+            } else {
+                tracing::info!("no finalized L1 block yet");
+                assert_eq!(snapshot.finalized, None);
+            }
+
+            sleep(test_interval).await;
+        }
+    }
+}

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -4,6 +4,7 @@ mod chain_variables;
 pub mod hotshot_commitment;
 pub mod options;
 use url::Url;
+mod l1_client;
 mod state;
 pub mod transaction;
 mod vm;
@@ -52,12 +53,13 @@ use std::{fmt::Debug, sync::Arc};
 use std::{marker::PhantomData, net::IpAddr};
 use typenum::U2;
 
-pub use block::{Block, Header, L1BlockInfo};
+pub use block::{Block, Header};
 pub use chain_variables::ChainVariables;
 use jf_primitives::merkle_tree::{
     examples::{Sha3Digest, Sha3Node},
     namespaced_merkle_tree::NMT,
 };
+pub use l1_client::L1BlockInfo;
 pub use options::Options;
 pub use state::State;
 pub use transaction::Transaction;
@@ -71,12 +73,11 @@ pub const MAX_NMT_DEPTH: usize = 10;
 pub type TransactionNMT = NMT<Transaction, Sha3Digest, U2, VmId, Sha3Node>;
 pub type NamespaceProofType = <TransactionNMT as NamespacedMerkleTreeScheme>::NamespaceProof;
 
-/// Initialize the static variables for the commitment task
+/// Initialize the static variables for the sequencer
 ///
 /// Calling it early on startup makes it easier to catch errors.
 pub fn init_static() {
-    lazy_static::initialize(&state::L1_PROVIDER);
-    lazy_static::initialize(&state::L1_BLOCK_TAG);
+    lazy_static::initialize(&state::L1_CLIENT);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
Instead of querying the L1 directly to find the latest head and finalized block each time we need to propose, we now have each sequencer node run a background task to update an in-memory snapshot of the L1 state each time there is a new L1 block, and the proposer logic just reads from this snapshot.

This has numerous benefits, including
* Drastically lower Infura usage. Instead of 2 RPC calls per HotShot block (one to fetch the head and one to fetch the finalized block) we have one RPC call per sequencer node per L1 block, plus one subscription stream per sequencer. This is far more optimized for the case where L1 blocks are much slower than HotShot blocks. For example, with a 1s HotShot block time, 12s L1 block time, and 9 HotShot nodes, the total RPC calls are reduced from 2/s to 0.75/s.
* Move L1 interactions off critical path. Before, failures or delays in Infura calls could cause a HotShot node to miss or delay a proposal. We suspect this may have contributed to irregular block production that was ultimately observed in the OP rollup. Now, Infura failures and delays can cause a sequencer node to propose with a slightly old L1 block number, but not to miss a proposal.
* Closer to the desired design. This is more similar to how the L1 interactions _should_ work once each sequencer is running its own L1 light client in the background. All we have to do to make this design production-ready, once the ValidatedState API is ready, is use ValidatedState to replace the process-global L1Client with an L1Client in the ValidatedState.

The only potential downside I see to deploying this right now is that it adds fairly complicated code that has not been thoroughly tested. However, I would argue that the failures in Cortado mean that all the local testing we did on the previous iteration was not sufficient to thoroughly test it either, and that therefore we might as well just deploy this code and stress test it in a realistic setting (Sepolia). That's what testnets are for, after all.

Edit: another potential downside is that this might increase the _per node_ cost of querying the L1, especially for very small stakers who are rarely leader. Previously, you only need to query the L1 at all when you became leader. Now, you need to be querying the L1 constantly, albeit only once every 12 seconds. IMO this is fine, since the previous design was, in my view, cheating a bit, by putting logic onto the consensus critical path that shouldn't have been there. Long term, we could optimize for small stakers by having the background L1 client only start updating when the node is about to become leader. Short term, with only 9 nodes, this is still much cheaper over all in terms of API usage than the previous design.

Local testing: I have run the sequencer unit tests. I have run the local devent with both Polygon and OP rollups deployed on the sequencer demo. End-to-end tests for both pass and the rollups run without crashing for at least 15-30 minutes. The op-e2e unit tests also work with the new sequencer images.