### PR TITLE
Wrap docker binaries with tini

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
       - ESPRESSO_ORCHESTRATOR_MAX_PROPOSE_TIME=1s
       - RUST_LOG
       - RUST_LOG_FORMAT
-    stop_grace_period: 1s
 
   da-server:
     image: ghcr.io/espressosystems/espresso-sequencer/web-server:main
@@ -41,7 +40,6 @@ services:
     depends_on:
       orchestrator:
         condition: service_healthy
-    stop_grace_period: 1s
 
   consensus-server:
     image: ghcr.io/espressosystems/espresso-sequencer/web-server:main
@@ -54,7 +52,6 @@ services:
     depends_on:
       orchestrator:
         condition: service_healthy
-    stop_grace_period: 1s
 
   sequencer0:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -77,7 +74,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   sequencer1:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -100,7 +96,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   sequencer2:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -123,7 +118,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   sequencer3:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -146,7 +140,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   sequencer4:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -169,7 +162,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   commitment-task:
     image: ghcr.io/espressosystems/espresso-sequencer/commitment-task:main
@@ -190,7 +182,6 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-    stop_grace_period: 1s
 
   example-rollup:
     image: ghcr.io/espressosystems/espresso-sequencer/example-rollup:main
@@ -211,4 +202,3 @@ services:
         condition: service_healthy
       commitment-task:
         condition: service_healthy
-    stop_grace_period: 1s

--- a/docker/commitment-task.Dockerfile
+++ b/docker/commitment-task.Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:jammy
 
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y curl libcurl4
+RUN apt-get update && apt-get install -y curl libcurl4 tini
+ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/commitment-task /bin/commitment-task
 RUN chmod +x /bin/commitment-task

--- a/docker/example-rollup.Dockerfile
+++ b/docker/example-rollup.Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:jammy
 
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y --no-install-recommends libcurl4 curl \
+RUN apt-get update && apt-get install -y --no-install-recommends libcurl4 curl tini \
     &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/example-l2 /bin/example-l2
 COPY target/$TARGETARCH/release/cli /bin/cli

--- a/docker/orchestrator.Dockerfile
+++ b/docker/orchestrator.Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it \
+    &&  apt-get install -y curl wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/orchestrator /bin/orchestrator
 RUN chmod +x /bin/orchestrator

--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it \
+    &&  apt-get install -y curl wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/sequencer /bin/sequencer
 RUN chmod +x /bin/sequencer

--- a/docker/web-server.Dockerfile
+++ b/docker/web-server.Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it \
+    &&  apt-get install -y curl wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/web-server /bin/web-server
 RUN chmod +x /bin/web-server


### PR DESCRIPTION
This will allow SIGTERM (sent by docker) to terminate the program if the binaries don't register handlers for it. This doesn't normally work inside docker because process 1 is special.

See https://github.com/Yelp/dumb-init#why-you-need-an-init-system for further information.

A solution for #250 until we need the binaries to actually handle signals.