### PR TITLE
Activate features in contract-bindings

### DIFF
--- a/contract-bindings/Cargo.toml
+++ b/contract-bindings/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.71"
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.3.0", features = [
+    "async-std-executor",
+    "channel-async-std",
     "logging-utils",
 ] }
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }


### PR DESCRIPTION
These features should be used in the tag 1.3.0 of `async-compatibility-layer` but somehow it works.
But when the [example repo](https://github.com/EspressoSystems/sequencer-example-l2) uses this crate, it will occur compile errors.