### PR TITLE
Enable ws feature for ethers in sequencer crate

### DIFF
--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -29,7 +29,7 @@ contract-bindings = { path = "../contract-bindings" }
 derivative = "2.2"
 derive_more = "0.99.17"
 either = "1.8.1"
-ethers = "2.0"
+ethers = { version = "2.0", features = ["ws"] }
 futures = "0.3"
 lazy_static = "1.4"
 time = "0.3"


### PR DESCRIPTION
This feature is enabled by other crates in the workspace that depend on ethers, but it is needed here, which breaks downstream projects that only compile this crate.