### PR TITLE
Abandon infinite retry loop for contract calls

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -375,7 +375,7 @@ async fn wait_for_transaction_to_be_mined(provider: &Provider<Http>, hash: H256)
                 );
             }
             Ok(Some(tx)) if tx.block_number.is_none() => {
-                tracing::info!("contract call {hash:?} (retry {i}/{retries}): pending");
+                tracing::error!("contract call {hash:?} (retry {i}/{retries}): pending");
             }
             Ok(Some(_)) => return true,
         }


### PR DESCRIPTION
A comment argued that we could retry indefinitely as long as the transaction is pending in the mempool, because eventually it will either be mined or dropped. While this sounds reasonable, it is evidently not the case, as we hit an issue on Sepolia where this case led to infinite retries. It is safer to always consider the transaction failed after a finite number of retries.