### PR TITLE
Point at HotShot main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,50 +678,14 @@ dependencies = [
 [[package]]
 name = "async-compatibility-layer"
 version = "1.0.0"
-source = "git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.3.0#f5478b9b33b8c5b81bfc029c84de9079fc8a64f7"
+source = "git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.4.1#568122b0ef39648daee91d16546985d41c3b0b15"
 dependencies = [
  "async-channel",
  "async-lock",
  "async-std",
  "async-trait",
  "color-eyre",
- "futures",
- "tracing",
- "tracing-error",
- "tracing-subscriber 0.3.17",
-]
-
-[[package]]
-name = "async-compatibility-layer"
-version = "1.0.0"
-source = "git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1#568122b0ef39648daee91d16546985d41c3b0b15"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-std",
- "async-trait",
- "color-eyre",
- "console-subscriber 0.1.10",
- "flume 0.11.0",
- "futures",
- "tokio",
- "tokio-stream",
- "tracing",
- "tracing-error",
- "tracing-subscriber 0.3.17",
-]
-
-[[package]]
-name = "async-compatibility-layer"
-version = "1.0.0"
-source = "git+https://github.com/EspressoSystems/async-compatibility-layer#f598499687f661327aa1c2e026e5f1c4e9822aee"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-std",
- "async-trait",
- "color-eyre",
- "console-subscriber 0.2.0",
+ "console-subscriber",
  "flume 0.11.0",
  "futures",
  "tokio",
@@ -1655,22 +1619,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
- "prost 0.11.9",
- "prost-types 0.11.9",
- "tonic 0.9.2",
- "tracing-core",
-]
-
-[[package]]
-name = "console-api"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
-dependencies = [
- "futures-core",
- "prost 0.12.1",
- "prost-types 0.12.1",
- "tonic 0.10.2",
+ "prost",
+ "prost-types",
+ "tonic",
  "tracing-core",
 ]
 
@@ -1680,43 +1631,19 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
 dependencies = [
- "console-api 0.5.0",
+ "console-api",
  "crossbeam-channel",
  "crossbeam-utils",
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types 0.11.9",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.17",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
-dependencies = [
- "console-api 0.6.0",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "prost-types 0.12.1",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic 0.10.2",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.17",
@@ -3487,7 +3414,7 @@ name = "hotshot"
 version = "0.3.3"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -3530,7 +3457,7 @@ name = "hotshot-orchestrator"
 version = "0.1.1"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -3583,9 +3510,9 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems//hotshot-query-service?rev=271a0c2d8bca7e6bd39998534c72e20ce3d74b1b#271a0c2d8bca7e6bd39998534c72e20ce3d74b1b"
+source = "git+https://github.com/EspressoSystems//hotshot-query-service?rev=6427bc77f17bfa80fd9112b663cd36f49a76f66b#6427bc77f17bfa80fd9112b663cd36f49a76f66b"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer)",
+ "async-compatibility-layer",
  "async-std",
  "atomic_store",
  "bincode",
@@ -3636,7 +3563,7 @@ name = "hotshot-task"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -3656,7 +3583,7 @@ name = "hotshot-task-impls"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-stream",
@@ -3687,7 +3614,7 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "ark-bls12-381 0.4.0",
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-std",
  "async-trait",
  "bitvec",
@@ -3719,7 +3646,7 @@ dependencies = [
  "arbitrary",
  "ark-serialize 0.3.0",
  "ark-std 0.4.0",
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -3769,7 +3696,7 @@ version = "0.1.1"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "ark-bls12-381 0.4.0",
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -3804,7 +3731,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.3.0)",
+ "async-compatibility-layer",
  "async-std",
  "contract-bindings",
  "digest 0.10.7",
@@ -4785,7 +4712,7 @@ name = "libp2p-networking"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
+ "async-compatibility-layer",
  "async-lock",
  "async-std",
  "async-trait",
@@ -6251,17 +6178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.5.0",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
-dependencies = [
- "bytes 1.5.0",
- "prost-derive 0.12.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -6278,34 +6195,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
-dependencies = [
- "prost 0.12.1",
+ "prost",
 ]
 
 [[package]]
@@ -7042,7 +6937,7 @@ dependencies = [
  "anyhow",
  "ark-bls12-381 0.3.0",
  "ark-serialize 0.4.2",
- "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer)",
+ "async-compatibility-layer",
  "async-std",
  "async-trait",
  "bincode",
@@ -8427,34 +8322,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.4",
- "bytes 1.5.0",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.12.1",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
  "async-lock",
@@ -3508,7 +3508,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "hotshot-web-server",
  "libp2p",
  "libp2p-identity",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
  "async-lock",
@@ -3539,7 +3539,7 @@ dependencies = [
  "clap",
  "futures",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "libp2p",
  "libp2p-core",
  "libp2p-networking",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "hotshot-qc"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -3583,7 +3583,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service#1e5633a0df180a24d9ffe77b9df41ebf0168fa94"
+source = "git+https://github.com/EspressoSystems//hotshot-query-service?rev=271a0c2d8bca7e6bd39998534c72e20ce3d74b1b#271a0c2d8bca7e6bd39998534c72e20ce3d74b1b"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer)",
  "async-std",
@@ -3598,7 +3598,7 @@ dependencies = [
  "hotshot",
  "hotshot-signature-key",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems/hotshot?tag=0.4.14)",
+ "hotshot-utils",
  "itertools 0.11.0",
  "prometheus",
  "serde",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "hotshot-signature-key"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "bincode",
  "bitvec",
@@ -3622,7 +3622,7 @@ dependencies = [
  "ethereum-types",
  "hotshot-qc",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "jf-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3634,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
  "async-lock",
@@ -3654,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
  "async-lock",
@@ -3669,7 +3669,7 @@ dependencies = [
  "futures",
  "hotshot-task",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "jf-primitives",
  "nll",
  "pin-project",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "ark-bls12-381 0.4.0",
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
@@ -3700,7 +3700,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "jf-primitives",
  "nll",
  "rand 0.8.5",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.3.0",
@@ -3740,7 +3740,7 @@ dependencies = [
  "generic-array",
  "hex_fmt",
  "hotshot-task",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "jf-primitives",
  "libp2p-networking",
  "nll",
@@ -3758,15 +3758,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.4.14#f92e68aaade1794f8ba99dc67c7fc8869948d328"
-dependencies = [
- "bincode",
-]
-
-[[package]]
-name = "hotshot-utils"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "bincode",
 ]
@@ -3774,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "ark-bls12-381 0.4.0",
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
@@ -3785,7 +3777,7 @@ dependencies = [
  "clap",
  "futures",
  "hotshot-types",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "jf-primitives",
  "libp2p-core",
  "nll",
@@ -4255,7 +4247,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#1626a8448e7af8ea153241004375deff9fd961da"
+source = "git+https://github.com/EspressoSystems/jellyfish#c0b88424ac1c362c2066971d0da5c43e8832ed5f"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4299,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#1626a8448e7af8ea153241004375deff9fd961da"
+source = "git+https://github.com/EspressoSystems/jellyfish#c0b88424ac1c362c2066971d0da5c43e8832ed5f"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -4340,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#1626a8448e7af8ea153241004375deff9fd961da"
+source = "git+https://github.com/EspressoSystems/jellyfish#c0b88424ac1c362c2066971d0da5c43e8832ed5f"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -4791,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
 dependencies = [
  "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.1)",
  "async-lock",
@@ -4804,7 +4796,7 @@ dependencies = [
  "derive_builder",
  "either",
  "futures",
- "hotshot-utils 0.1.0 (git+https://github.com/EspressoSystems//hotshot?branch=ed/timeout-hotfix)",
+ "hotshot-utils",
  "libp2p",
  "libp2p-identity",
  "libp2p-noise",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems//hotshot-query-service?rev=6427bc77f17bfa80fd9112b663cd36f49a76f66b#6427bc77f17bfa80fd9112b663cd36f49a76f66b"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service#edbb0857e7595312dd042d130f6f21cbaf8a761c"
 dependencies = [
  "async-compatibility-layer",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ members = [
   "sequencer",
   "utils",
 ]
-
-[patch."https://github.com/EspressoSystems/hotshot-query-service"]
-hotshot-query-service = { git = "https://github.com/EspressoSystems//hotshot-query-service", rev = "6427bc77f17bfa80fd9112b663cd36f49a76f66b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = [
 ]
 
 [patch."https://github.com/EspressoSystems/hotshot-query-service"]
-hotshot-query-service = { git = "https://github.com/EspressoSystems//hotshot-query-service", rev = "271a0c2d8bca7e6bd39998534c72e20ce3d74b1b" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems//hotshot-query-service", rev = "6427bc77f17bfa80fd9112b663cd36f49a76f66b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,5 @@ members = [
   "utils",
 ]
 
-[patch."https://github.com/EspressoSystems/hotshot"]
-hotshot = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
-hotshot-signature-key = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
-hotshot-testing = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
-hotshot-types = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems//hotshot", branch = "ed/timeout-hotfix" }
+[patch."https://github.com/EspressoSystems/hotshot-query-service"]
+hotshot-query-service = { git = "https://github.com/EspressoSystems//hotshot-query-service", rev = "271a0c2d8bca7e6bd39998534c72e20ce3d74b1b" }

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -12,10 +12,8 @@ ark-ec = { version = "0.4.2" }
 ark-ff = "0.4.2"
 ark-serialize = "0.4.2"
 ark-std = { version = "0.4.0", default-features = false }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.3.0", features = [
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
     "logging-utils",
-    "async-std-executor",
-    "channel-async-std",
 ] }
 async-std = "1.12.0"
 contract-bindings = { path = "../../contract-bindings" }

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -34,12 +34,12 @@ futures = "0.3"
 lazy_static = "1.4"
 time = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
-hotshot-signature-key = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.4.14" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
+hotshot-signature-key = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
+hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
 
 hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service" }
 

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -18,7 +18,9 @@ tempfile = "3.7.1"
 anyhow = "1.0"
 ark-bls12-381 = "0.3.0"
 ark-serialize = { version = "0.4.0", features = ["derive"] }
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer" }
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
+	"logging-utils",
+] }
 async-std = "1.12.0"
 async-trait = "0.1.71"
 bincode = "1.3.3"


### PR DESCRIPTION
Per the new methodology described by @elliedavidson, main will always be the latest stable HotShot release, while the new develop branch will be used for unstable development. Thus, we can point at main and not an (old) stable release tag.