### PR TITLE
Optimize docker builds

### DIFF
--- a/docker/commitment-task.Dockerfile
+++ b/docker/commitment-task.Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:jammy
 
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y curl libcurl4 tini
+RUN apt-get update \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
+    &&  rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["tini", "--"]
 
 COPY target/$TARGETARCH/release/commitment-task /bin/commitment-task

--- a/docker/orchestrator.Dockerfile
+++ b/docker/orchestrator.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it tini \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["tini", "--"]
 

--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it tini \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["tini", "--"]
 

--- a/docker/web-server.Dockerfile
+++ b/docker/web-server.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl wait-for-it tini \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
     &&  rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["tini", "--"]
 


### PR DESCRIPTION
Reduce build times by a minute by homogenizing installed packages. This means we only spend time fetching packages and installing on the first docker and the rest are fully cached.