### PR TITLE
Add temporary route to return block header

### DIFF
--- a/sequencer/api/availability.toml
+++ b/sequencer/api/availability.toml
@@ -45,11 +45,15 @@ where a `Header` has the schema:
 
 ```json
 {
-    "timestamp": "integer",
-    "l1_block": {
-        "timestamp": "integer",
-        "number": "integer",
-    },
+    "metadata": {
+      "timestamp": "integer",
+      "l1_head": "integer",
+      "l1_finalized": {
+          "timestamp": "integer",
+          "number": "integer",
+          "hash": "TaggedBase64"
+      },
+    }
     "transactions_root": {
         "root": ["integer"]
     }
@@ -67,13 +71,18 @@ If the header at the provided height is available, returns
 
 ```json
 {
-    "timestamp": "integer",
-    "l1_block": {
-        "timestamp": "integer",
-        "number": "integer",
-    },
+    "metadata": {
+      "timestamp": "integer",
+      "l1_head": "integer",
+      "l1_finalized": {
+          "timestamp": "integer",
+          "number": "integer",
+          "hash": "TaggedBase64"
+      },
+    }
     "transactions_root": {
         "root": ["integer"]
     }
 }
+```
 """

--- a/sequencer/api/availability.toml
+++ b/sequencer/api/availability.toml
@@ -60,7 +60,7 @@ All timestamps are denominated in an integer number of seconds.
 """
 
 [route.getheader]
-PATH = ["headers/window/:height"]
+PATH = ["header/:height"]
 ":height" = "Integer"
 DOC = """
 If the header at the provided height is available, returns

--- a/sequencer/api/availability.toml
+++ b/sequencer/api/availability.toml
@@ -58,3 +58,22 @@ where a `Header` has the schema:
 
 All timestamps are denominated in an integer number of seconds.
 """
+
+[route.getheader]
+PATH = ["headers/window/:height"]
+":height" = "Integer"
+DOC = """
+If the header at the provided height is available, returns
+
+```json
+{
+    "timestamp": "integer",
+    "l1_block": {
+        "timestamp": "integer",
+        "number": "integer",
+    },
+    "transactions_root": {
+        "root": ["integer"]
+    }
+}
+"""

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -133,7 +133,6 @@ impl Options {
         // the two cases differently.
         let (handle, node_index, update_task) = if let Some(query) = self.query {
             type StateType<N> = Arc<RwLock<AppState<N>>>;
-            dbg!("attemtping to run query server");
 
             let storage_path = Path::new(&query.storage_path);
             let query_state = {
@@ -155,7 +154,6 @@ impl Options {
                     }),
                 );
             }
-            dbg!("attemtping to run query server2");
 
             let metrics: Box<dyn Metrics> = query_state.metrics();
 
@@ -174,7 +172,6 @@ impl Options {
                 query_state,
                 blocks_by_time,
             }));
-            dbg!("attemtping to run query server3");
 
             let mut app = App::<_, hotshot_query_service::Error>::with_state(state.clone());
 
@@ -195,7 +192,6 @@ impl Options {
             let status_api = status::define_api::<StateType<N>>(&Default::default())
                 .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
 
-            dbg!("attemtping to run query server4");
             availability_api
                 .get("getnamespaceproof", |req, state| {
                     async move {
@@ -331,11 +327,9 @@ impl Options {
                 )
                 .0
             });
-            dbg!("attemtping to run query server6");
 
             (handle, node_index, task)
         } else {
-            dbg!("not attemtping to run query server");
             let (handle, node_index) = init_handle(Box::new(NoMetrics)).await;
             let mut app =
                 App::<_, hotshot_query_service::Error>::with_state(RwLock::new(handle.clone()));

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -133,6 +133,7 @@ impl Options {
         // the two cases differently.
         let (handle, node_index, update_task) = if let Some(query) = self.query {
             type StateType<N> = Arc<RwLock<AppState<N>>>;
+            dbg!("attemtping to run query server");
 
             let storage_path = Path::new(&query.storage_path);
             let query_state = {
@@ -154,6 +155,7 @@ impl Options {
                     }),
                 );
             }
+            dbg!("attemtping to run query server2");
 
             let metrics: Box<dyn Metrics> = query_state.metrics();
 
@@ -172,6 +174,7 @@ impl Options {
                 query_state,
                 blocks_by_time,
             }));
+            dbg!("attemtping to run query server3");
 
             let mut app = App::<_, hotshot_query_service::Error>::with_state(state.clone());
 
@@ -192,6 +195,7 @@ impl Options {
             let status_api = status::define_api::<StateType<N>>(&Default::default())
                 .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
 
+            dbg!("attemtping to run query server4");
             availability_api
                 .get("getnamespaceproof", |req, state| {
                     async move {
@@ -213,6 +217,19 @@ impl Options {
                             proof,
                             header: block.block().header(),
                         })
+                    }
+                    .boxed()
+                })
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, Error::internal(err)))?
+                .get("getheader", |req, state| {
+                    async move {
+                        let height: u64 = req.integer_param("height")?;
+                        let block = state
+                            .get_nth_block_iter(height as usize)
+                            .next()
+                            .ok_or(AvailabilityError::InvalidLeafHeight { height })?
+                            .ok_or(AvailabilityError::MissingBlock { height })?;
+                        Ok(block.block().header())
                     }
                     .boxed()
                 })
@@ -314,9 +331,11 @@ impl Options {
                 )
                 .0
             });
+            dbg!("attemtping to run query server6");
 
             (handle, node_index, task)
         } else {
+            dbg!("not attemtping to run query server");
             let (handle, node_index) = init_handle(Box::new(NoMetrics)).await;
             let mut app =
                 App::<_, hotshot_query_service::Error>::with_state(RwLock::new(handle.clone()));


### PR DESCRIPTION
Necessary for our Arbitrum integration, which iteratively fetches block headers for sequencing purposes