### PR TITLE
Add non-nix installation instructions

### DIFF
--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * MON"
   workflow_dispatch:
-  pull_request: # TODO remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -17,6 +17,7 @@ jobs:
     container:
       image: ubuntu:latest
     steps:
+      - uses: actions/checkout@v4
       - name: Install and test
         # Execute all lines that start with four spaces, and remove leading 'sudo '
         # because we're in a container and already root.

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * MON"
   workflow_dispatch:
+  pull_request: # TODO: remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * MON"
   workflow_dispatch:
-  pull_request: # TODO: remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -1,0 +1,26 @@
+name: Ubuntu install without nix
+
+on:
+  schedule:
+    - cron: "0 0 * * MON"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Install and test
+        # Execute all lines that start with four spaces, and remove leading 'sudo '
+        # because we're in a container and already root.
+        run: |
+          grep '^    ' doc/ubuntu.md \
+            | sed 's/^    //' \
+            | sed 's/^sudo //' \
+            | bash -exo pipefail

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * MON"
   workflow_dispatch:
+  pull_request: # TODO remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ a dockerized Espresso Sequencer network with an example Layer 2 rollup applicati
 - Obtain code: `git clone git@github.com:EspressoSystems/espresso-sequencer`.
 - Make sure [nix](https://nixos.org/download.html) is installed.
 - Activate the environment with `nix-shell`, or `nix develop`, or `direnv allow` if using [direnv](https://direnv.net/).
+- For installation without nix please see [ubuntu.md](./doc/ubuntu.md).
 
 ## Run the tests
 

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -1,0 +1,36 @@
+# Installing on ubuntu (without nix)
+
+<!-- Note that all lines that start with four spaces will be executed in the CI -->
+
+## Install system dependencies
+
+    sudo apt update
+    sudo apt install -y curl cmake pkg-config libssl-dev protobuf-compiler git
+
+## Install rustup
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+    source $HOME/.cargo/env
+
+## Install foundry
+
+    curl --proto '=https' --tlsv1.2 -sSf -L https://foundry.paradigm.xyz | bash
+    source $HOME/.bashrc
+    foundryup
+
+## Clone the repository
+
+    git clone https://github.com/EspressoSystems/espresso-sequencer/
+    cd espresso-sequencer
+
+## Run the rust tests
+
+    export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
+    cargo test --release
+
+## Run the foundry tests
+
+    cargo build --release --bin diff-test
+    export PATH=$PWD/target/release:$PATH
+    forge test -v
+

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -4,8 +4,8 @@
 
 ## Install system dependencies
 
-    sudo apt update
-    sudo apt install -y curl cmake pkg-config libssl-dev protobuf-compiler git
+    sudo apt-get update
+    sudo apt-get install -y curl cmake pkg-config libssl-dev protobuf-compiler git
 
 ## Install rustup
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.73.0"
+components = [ "rustfmt", "llvm-tools-preview", "rust-src" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.73.0"
-components = [ "rustfmt", "llvm-tools-preview", "rust-src" ]
+components = [ "rustfmt", "llvm-tools-preview", "rust-src", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
- Add instructions
- Run weekly CI job to execute installation instructions and run tests.

Room for improvement: currently the toolchain file is not read by nix so there is potentital for the toolchain file to go out of sync. It would be easy to do that however, in that case `nix flake update` won't update rust anymore. I read dependabot doesn't handle toolchain files so we'd have to manually update it. We could also use "stable" instead of a specific version tag.