### PR TITLE
Don't use `NonceManagerMiddleware` in commitment task

### DIFF
--- a/utils/src/test_utils.rs
+++ b/utils/src/test_utils.rs
@@ -1,17 +1,17 @@
-use crate::EthMiddleware;
+use crate::Signer;
 use anyhow::Result;
 use contract_bindings::hot_shot::HotShot;
 use ethers::{
     prelude::{Address, SignerMiddleware},
     providers::{Http, Middleware, Provider},
-    signers::{coins_bip39::English, MnemonicBuilder, Signer},
+    signers::{coins_bip39::English, MnemonicBuilder, Signer as _},
 };
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TestClient {
     pub index: u32,
-    pub provider: Arc<EthMiddleware>,
+    pub provider: Arc<Signer>,
 }
 
 impl TestClient {
@@ -59,7 +59,7 @@ impl TestClients {
 #[derive(Debug, Clone)]
 pub struct TestL1System {
     pub clients: TestClients,
-    pub hotshot: HotShot<EthMiddleware>,
+    pub hotshot: HotShot<Signer>,
     pub provider: Provider<Http>,
 }
 


### PR DESCRIPTION
We don't need it, since we never have multiple transactions in flight at once, and it causes problems when a transaction fails and the nonce manager gets out of sync with the L1.

Also use less confusing names for the nonce manager and signer type aliases, and make it so that nonce manager is not the default L1 connection.