### PR TITLE
Modularize API storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
- "ark-serialize-derive 0.3.0",
  "ark-std 0.3.0",
  "digest 0.9.0",
 ]
@@ -480,21 +479,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive 0.4.2",
+ "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -982,7 +970,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.9",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -1523,19 +1511,18 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "commit"
 version = "0.2.2"
-source = "git+https://github.com/EspressoSystems/commit?tag=0.2.2#7e938186607f87da5fd642ce36313aaeab0cfaca"
+source = "git+https://github.com/EspressoSystems/commit?tag=0.2.3#fa1d0cb00bda1cc06c239aaf3a692014489d88c8"
 dependencies = [
  "arbitrary",
- "ark-serialize 0.3.0",
+ "ark-serialize 0.4.2",
  "bitvec",
  "derivative",
  "derive_more",
  "funty",
- "generic-array",
  "hex",
  "serde",
  "sha3",
- "tagged-base64 0.2.4",
+ "tagged-base64",
 ]
 
 [[package]]
@@ -1770,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "crs"
 version = "0.1.0"
-source = "git+https://github.com/alxiong/crs#5d1142432e4045c3c0847b6481c89afddf6bb2c2"
+source = "git+https://github.com/alxiong/crs#c160ef05c936c3d44b08b27e4f9ab540506cb5a4"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2215,20 +2202,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2239,17 +2217,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2695,7 +2662,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum",
  "syn 2.0.37",
  "tempfile",
  "thiserror",
@@ -2810,7 +2777,7 @@ checksum = "de34e484e7ae3cab99fbfd013d6c5dc7f9013676a4e0e414d8b12e1213e8b3ba"
 dependencies = [
  "cfg-if",
  "const-hex",
- "dirs 5.0.1",
+ "dirs",
  "dunce",
  "ethers-core",
  "glob",
@@ -2851,6 +2818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +2853,12 @@ name = "fiat-crypto"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixed-hash"
@@ -3124,7 +3103,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -3380,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -3423,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -3443,16 +3421,16 @@ dependencies = [
  "serde_json",
  "snafu",
  "surf-disco",
- "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.1)",
+ "tide-disco",
  "tokio",
- "toml 0.5.11",
+ "toml 0.8.8",
  "tracing",
 ]
 
 [[package]]
 name = "hotshot-qc"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3478,15 +3456,18 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?rev=fa6638821573c61320fcd281685a338a795d174f#fa6638821573c61320fcd281685a338a795d174f"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=feat/sql-data-source#c0f2c6c027a33a011cf4bbbd66e106f7b9e27eeb"
 dependencies = [
+ "anyhow",
  "async-compatibility-layer",
  "async-std",
+ "async-trait",
  "atomic_store",
  "bincode",
  "clap",
  "commit",
  "custom_debug",
+ "derivative",
  "derive_more",
  "either",
  "futures",
@@ -3494,21 +3475,25 @@ dependencies = [
  "hotshot-signature-key",
  "hotshot-types",
  "hotshot-utils",
+ "include_dir",
  "itertools 0.11.0",
  "prometheus",
+ "refinery",
  "serde",
+ "serde_json",
  "snafu",
- "spin_sleep",
- "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.2)",
+ "tide-disco",
  "time 0.3.29",
- "toml 0.7.8",
+ "tokio",
+ "tokio-postgres",
+ "toml 0.8.8",
  "tracing",
 ]
 
 [[package]]
 name = "hotshot-signature-key"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "bincode",
  "bitvec",
@@ -3529,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -3549,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -3579,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "ark-bls12-381",
  "async-compatibility-layer",
@@ -3609,10 +3594,10 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "arbitrary",
- "ark-serialize 0.3.0",
+ "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "async-compatibility-layer",
  "async-lock",
@@ -3643,7 +3628,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "snafu",
- "tagged-base64 0.2.4",
+ "tagged-base64",
  "time 0.3.29",
  "tokio",
  "tracing",
@@ -3653,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "bincode",
 ]
@@ -3661,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "ark-bls12-381",
  "async-compatibility-layer",
@@ -3683,9 +3668,9 @@ dependencies = [
  "snafu",
  "surf-disco",
  "tide",
- "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.1)",
+ "tide-disco",
  "tokio",
- "toml 0.7.8",
+ "toml 0.8.8",
  "tracing",
 ]
 
@@ -3729,7 +3714,7 @@ checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
- "itoa 1.0.9",
+ "itoa",
 ]
 
 [[package]]
@@ -3812,7 +3797,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.9",
+ "itoa",
  "pin-project-lite 0.2.13",
  "socket2 0.4.9",
  "tokio",
@@ -4062,7 +4047,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "widestring",
  "windows-sys",
  "winreg",
@@ -4137,12 +4122,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
@@ -4150,7 +4129,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#265eaaa059e0a501824e5aadf7ac5f32d9e4a6b8"
+source = "git+https://github.com/EspressoSystems/jellyfish#833d7ca3acdce33ae29dbd319a86cce9e69e2fd1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4173,13 +4152,13 @@ dependencies = [
  "rayon",
  "serde",
  "sha3",
- "tagged-base64 0.3.4",
+ "tagged-base64",
 ]
 
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#265eaaa059e0a501824e5aadf7ac5f32d9e4a6b8"
+source = "git+https://github.com/EspressoSystems/jellyfish#833d7ca3acdce33ae29dbd319a86cce9e69e2fd1"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4215,7 +4194,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sha3",
- "tagged-base64 0.3.4",
+ "tagged-base64",
  "typenum",
  "zeroize",
 ]
@@ -4223,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#265eaaa059e0a501824e5aadf7ac5f32d9e4a6b8"
+source = "git+https://github.com/EspressoSystems/jellyfish#833d7ca3acdce33ae29dbd319a86cce9e69e2fd1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -4249,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#265eaaa059e0a501824e5aadf7ac5f32d9e4a6b8"
+source = "git+https://github.com/EspressoSystems/jellyfish#833d7ca3acdce33ae29dbd319a86cce9e69e2fd1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4259,7 +4238,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.8",
- "tagged-base64 0.3.4",
+ "tagged-base64",
 ]
 
 [[package]]
@@ -4373,9 +4352,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -4672,7 +4651,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -4700,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=main#b5c6026912256bd601db5c6f9a792664c360aaff"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=main#c406a15c119e99215b96e7b73ec4a526695586a9"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -4821,7 +4800,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rustls",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "thiserror",
  "tokio",
 ]
@@ -4943,7 +4922,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "log",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio",
 ]
 
@@ -5179,36 +5158,13 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maud"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19aff2cd19eb4b93df29efa602652513b0f731f1d3474f6e377f763fddf61e58"
-dependencies = [
- "itoa 0.4.8",
- "maud_macros 0.24.0",
- "tide",
-]
-
-[[package]]
-name = "maud"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0bab19cef8a7fe1c18a43e881793bfc9d4ea984befec3ae5bd0415abf3ecf00"
 dependencies = [
- "itoa 1.0.9",
- "maud_macros 0.25.0",
+ "itoa",
+ "maud_macros",
  "tide",
-]
-
-[[package]]
-name = "maud_macros"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c114f6f24b08fdd4a25d2fb87a8b140df56b577723247b382e8b04c583f2eb"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5293,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5453,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "nll"
 version = "1.0.0"
-source = "git+https://github.com/EspressoSystems/nll#c84499eb8de11beee5caa9390deff8a8ca3b9514"
+source = "git+https://github.com/EspressoSystems/nll#8e7926789f8eb464cbbbb1858ba4292a6ec6d900"
 
 [[package]]
 name = "nohash-hasher"
@@ -5868,7 +5824,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5877,7 +5833,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -6028,6 +5984,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64 0.21.4",
+ "byteorder",
+ "bytes 1.5.0",
+ "fallible-iterator",
+ "hmac 0.12.1",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "bytes 1.5.0",
+ "fallible-iterator",
+ "postgres-protocol",
+ "serde",
+ "serde_json",
+ "time 0.3.29",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6070,7 +6058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -6145,7 +6133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
 dependencies = [
  "dtoa",
- "itoa 1.0.9",
+ "itoa",
  "parking_lot",
  "prometheus-client-derive-encode",
 ]
@@ -6283,7 +6271,7 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes 1.5.0",
  "libc",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tracing",
  "windows-sys",
 ]
@@ -6433,6 +6421,51 @@ dependencies = [
  "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "refinery"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529664dbccc0a296947615c997a857912d72d1c44be1fafb7bae54ecfa7a8c24"
+dependencies = [
+ "refinery-core",
+ "refinery-macros",
+]
+
+[[package]]
+name = "refinery-core"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e895cb870cf06e92318cbbeb701f274d022d5ca87a16fa8244e291cd035ef954"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "lazy_static",
+ "log",
+ "regex",
+ "serde",
+ "siphasher 1.0.0",
+ "thiserror",
+ "time 0.3.29",
+ "tokio",
+ "tokio-postgres",
+ "toml 0.7.8",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "refinery-macros"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123e8b80f8010c3ae38330c81e76938fc7adf6cdbfbaad20295bb8c22718b4f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "refinery-core",
+ "regex",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6934,9 +6967,9 @@ dependencies = [
  "snafu",
  "surf-disco",
  "tempfile",
- "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.2)",
+ "tide-disco",
  "time 0.3.29",
- "toml 0.7.8",
+ "toml 0.8.8",
  "tracing",
  "typenum",
  "url",
@@ -6947,7 +6980,7 @@ name = "sequencer-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ark-serialize 0.3.0",
+ "ark-serialize 0.4.2",
  "async-std",
  "commit",
  "contract-bindings",
@@ -6994,7 +7027,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "itoa 1.0.9",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -7012,9 +7045,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -7026,25 +7059,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.9",
+ "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time 0.3.29",
 ]
 
 [[package]]
@@ -7060,20 +7077,8 @@ dependencies = [
  "indexmap 2.0.2",
  "serde",
  "serde_json",
- "serde_with_macros 3.3.0",
+ "serde_with_macros",
  "time 0.3.29",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.3",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
 ]
 
 [[package]]
@@ -7182,20 +7187,11 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs 4.0.0",
-]
-
-[[package]]
-name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
 ]
 
 [[package]]
@@ -7265,6 +7261,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "slab"
@@ -7381,9 +7383,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -7431,16 +7433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spin_sleep"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafa7900db085f4354dbc7025e25d7a839a14360ea13b5fc4fd717f2d3b23134"
-dependencies = [
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -7540,6 +7532,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7547,30 +7550,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7617,8 +7601,8 @@ dependencies = [
 
 [[package]]
 name = "surf-disco"
-version = "0.4.1"
-source = "git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.2#edcfa5532bca5f619e87129f801690b56d8d080e"
+version = "0.4.3"
+source = "git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3#44de23cb7d43893174b00e01148c7ccd100c6c26"
 dependencies = [
  "async-std",
  "async-tungstenite 0.15.0",
@@ -7629,7 +7613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
- "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.2)",
+ "tide-disco",
 ]
 
 [[package]]
@@ -7663,7 +7647,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad53f8eb502b0a3051fea001ae2e3723044699868ebfe06ea81b45545db392c2"
 dependencies = [
- "itoa 1.0.9",
+ "itoa",
  "ryu",
  "sval",
 ]
@@ -7674,7 +7658,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f913253c9f6cd27645ba9a0b6788039b5d4338eae0833c64b42ef178168d2862"
 dependencies = [
- "itoa 1.0.9",
+ "itoa",
  "ryu",
  "sval",
 ]
@@ -7706,7 +7690,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597e3a746727984cb7ea2487b6a40726cad0dbe86628e7d429aa6b8c4c153db4"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "fs2",
  "hex",
  "once_cell",
@@ -7783,20 +7767,6 @@ dependencies = [
 
 [[package]]
 name = "tagged-base64"
-version = "0.2.4"
-source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.4#9b9a5fae1e2fd41db8573657cfe169e8284eb6c9"
-dependencies = [
- "ark-serialize 0.3.0",
- "base64 0.13.1",
- "crc-any",
- "serde",
- "snafu",
- "tagged-base64-macros 0.2.0",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tagged-base64"
 version = "0.3.4"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.3.4#93be6f0f5c0ec8458f13dede3d2b68dcce12a608"
 dependencies = [
@@ -7806,18 +7776,8 @@ dependencies = [
  "crc-any",
  "serde",
  "snafu",
- "tagged-base64-macros 0.3.3",
+ "tagged-base64-macros",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "tagged-base64-macros"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.4#9b9a5fae1e2fd41db8573657cfe169e8284eb6c9"
-dependencies = [
- "ark-std 0.3.0",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7912,8 +7872,8 @@ dependencies = [
 
 [[package]]
 name = "tide-disco"
-version = "0.4.1"
-source = "git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.1#cdd9b1ec3f8566a96dcbbcffa5e5ea5d65135ea6"
+version = "0.4.3"
+source = "git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.3#0863f714a61630ee6da6812f917c684e0df1777b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7921,7 +7881,7 @@ dependencies = [
  "clap",
  "config",
  "derive_more",
- "dirs 4.0.0",
+ "dirs",
  "edit-distance",
  "futures",
  "futures-util",
@@ -7930,70 +7890,24 @@ dependencies = [
  "lazy_static",
  "libc",
  "markdown",
- "maud 0.24.0",
+ "maud",
  "parking_lot",
  "routefinder",
  "semver 1.0.19",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
- "shellexpand 2.1.2",
+ "serde_with",
+ "shellexpand",
  "signal-hook",
  "signal-hook-async-std",
  "snafu",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "surf",
- "tagged-base64 0.2.4",
+ "tagged-base64",
  "tide",
  "tide-websockets",
- "toml 0.5.11",
- "tracing",
- "tracing-distributed",
- "tracing-futures",
- "tracing-log",
- "tracing-subscriber 0.3.17",
- "url",
-]
-
-[[package]]
-name = "tide-disco"
-version = "0.4.1"
-source = "git+https://github.com/EspressoSystems/tide-disco?tag=v0.4.2#780f37a659d64bc4311112e20ae516fadc0a35c2"
-dependencies = [
- "async-std",
- "async-trait",
- "bincode",
- "clap",
- "config",
- "derive_more",
- "dirs 5.0.1",
- "edit-distance",
- "futures",
- "futures-util",
- "http",
- "include_dir",
- "lazy_static",
- "libc",
- "markdown",
- "maud 0.25.0",
- "parking_lot",
- "routefinder",
- "semver 1.0.19",
- "serde",
- "serde_json",
- "serde_with 3.3.0",
- "shellexpand 3.1.0",
- "signal-hook",
- "signal-hook-async-std",
- "snafu",
- "strum 0.25.0",
- "strum_macros 0.25.2",
- "surf",
- "tagged-base64 0.2.4",
- "tide",
- "tide-websockets",
- "toml 0.7.8",
+ "toml 0.8.8",
  "tracing",
  "tracing-distributed",
  "tracing-futures",
@@ -8042,7 +7956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
- "itoa 1.0.9",
+ "itoa",
  "serde",
  "time-core",
  "time-macros 0.2.15",
@@ -8112,9 +8026,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -8124,7 +8038,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.13",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "tracing",
  "windows-sys",
@@ -8142,13 +8056,39 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes 1.5.0",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite 0.2.13",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.8.5",
+ "socket2 0.5.5",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -8219,14 +8159,26 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -8236,6 +8188,19 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.0.2",
  "serde",
@@ -8842,6 +8807,16 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "widestring"

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
-ark-bn254 = "0.4.0"
-ark-ec = "0.4.2"
-ark-ff = "0.4.2"
-ark-poly = "0.4.2"
-ark-serialize = "0.4.2"
-ark-std = { version = "0.4.0", default-features = false }
+ark-bn254 = "0.4"
+ark-ec = "0.4"
+ark-ff = "0.4"
+ark-poly = "0.4"
+ark-serialize = "0.4"
+ark-std = { version = "0.4", default-features = false }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
     "logging-utils",
 ] }

--- a/contracts/rust/src/bin/diff_test.rs
+++ b/contracts/rust/src/bin/diff_test.rs
@@ -458,7 +458,16 @@ fn open_key() -> OpenKey<Bn254> {
         ),
     );
 
-    OpenKey { g, h, beta_h }
+    let powers_of_g = vec![g];
+    let powers_of_h = vec![h, beta_h];
+
+    OpenKey {
+        g,
+        h,
+        beta_h,
+        powers_of_g,
+        powers_of_h,
+    }
 }
 
 fn field_to_u256<F: PrimeField>(f: F) -> U256 {
@@ -916,9 +925,11 @@ fn gen_plonk_proof_for_test(
     let rng = &mut jf_utils::test_rng();
     let srs = {
         let aztec_srs = crs::aztec20::kzg10_setup(1024).expect("Aztec SRS fail to load");
+        let powers_of_h = vec![aztec_srs.h, aztec_srs.beta_h];
 
         UnivariateUniversalParams {
             powers_of_g: aztec_srs.powers_of_g,
+            powers_of_h,
             h: aztec_srs.h,
             beta_h: aztec_srs.beta_h,
         }

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -16,8 +16,8 @@ tempfile = "3.7.1"
 
 [dependencies]
 anyhow = "1.0"
-ark-bls12-381 = "0.4.0"
-ark-serialize = { version = "0.4.0", features = ["derive"] }
+ark-bls12-381 = "0.4"
+ark-serialize = { version = "0.4", features = ["derive"] }
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
     "logging-utils",
 ] }
@@ -26,7 +26,7 @@ async-trait = "0.1.71"
 bincode = "1.3.3"
 clap = { version = "4.3", features = ["derive", "env"] }
 cld = "0.5"
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.3" }
 contract-bindings = { path = "../contract-bindings" }
 derivative = "2.2"
 derive_more = "0.99.17"
@@ -45,7 +45,7 @@ hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", branch =
 hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
 hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", branch = "main" }
 
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", rev = "fa6638821573c61320fcd281685a338a795d174f" } # TODO remove `rev` and upgrade to latest main
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", branch = "feat/sql-data-source" }
 
 jf-primitives = { workspace = true }
 jf-utils = { workspace = true } # TODO temporary: used only for test_rng()
@@ -54,9 +54,9 @@ rand = "0.8.5"
 sequencer-utils = { path = "../utils" }
 serde = { version = "1.0.192", features = ["derive"] }
 snafu = "0.7.4"
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.2" }
-tide-disco = { git = "https://github.com/EspressoSystems/tide-disco", tag = "v0.4.2" }
-toml = "0.7"
+surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.3" }
+tide-disco = { git = "https://github.com/EspressoSystems/tide-disco", tag = "v0.4.3" }
+toml = "0.8"
 tracing = "0.1"
 typenum = { version = "1.15.0", default-features = false, features = [
     "no_std",

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -1,0 +1,33 @@
+use super::TimeWindowQueryData;
+use crate::{network, Node, SeqTypes};
+use async_trait::async_trait;
+use hotshot::types::SystemContextHandle;
+use hotshot_query_service::{
+    availability::{AvailabilityDataSource, BlockId},
+    data_source::{UpdateDataSource, VersionedDataSource},
+    status::StatusDataSource,
+    QueryResult,
+};
+
+#[async_trait]
+pub(super) trait SequencerDataSource<N: network::Type>:
+    AvailabilityDataSource<SeqTypes, Node<N>>
+    + StatusDataSource
+    + UpdateDataSource<SeqTypes, Node<N>>
+    + VersionedDataSource
+    + Sized
+{
+    type Options;
+
+    async fn create(opt: Self::Options) -> anyhow::Result<Self>;
+    async fn refresh_indices(&mut self, from_block: usize) -> anyhow::Result<()>;
+
+    async fn window(&self, start: u64, end: u64) -> QueryResult<TimeWindowQueryData>;
+    async fn window_from<ID>(&self, from: ID, end: u64) -> QueryResult<TimeWindowQueryData>
+    where
+        ID: Into<BlockId<SeqTypes>> + Send + Sync;
+}
+
+pub(super) trait SubmitDataSource<N: network::Type> {
+    fn handle(&self) -> &SystemContextHandle<SeqTypes, Node<N>>;
+}

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -1,4 +1,4 @@
-use super::TimeWindowQueryData;
+use super::endpoints::TimeWindowQueryData;
 use crate::{network, Node, SeqTypes};
 use async_trait::async_trait;
 use hotshot::types::SystemContextHandle;

--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -1,0 +1,133 @@
+//! Sequencer-specific API endpoint handlers.
+
+use super::{
+    data_source::{SequencerDataSource, SubmitDataSource},
+    AppState,
+};
+use crate::{network, Header, NamespaceProofType, Node, SeqTypes, Transaction};
+use async_std::sync::{Arc, RwLock};
+use futures::FutureExt;
+use hotshot_query_service::{
+    availability::{self, AvailabilityDataSource, BlockHash, QueryBlockSnafu},
+    Error,
+};
+use jf_primitives::merkle_tree::namespaced_merkle_tree::NamespaceProof;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tide_disco::{method::WriteState, Api};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamespaceProofQueryData {
+    pub proof: NamespaceProofType,
+    pub header: Header,
+    pub transactions: Vec<Transaction>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimeWindowQueryData {
+    pub from: u64,
+    pub window: Vec<Header>,
+    pub prev: Option<Header>,
+    pub next: Option<Header>,
+}
+
+impl TimeWindowQueryData {
+    pub fn new(from: u64) -> Self {
+        Self {
+            from,
+            window: vec![],
+            prev: None,
+            next: None,
+        }
+    }
+}
+
+pub(super) type AvailState<N, D> = Arc<RwLock<AppState<N, D>>>;
+
+pub(super) fn availability<N, D>() -> anyhow::Result<Api<AvailState<N, D>, availability::Error>>
+where
+    N: network::Type,
+    D: SequencerDataSource<N> + Send + Sync + 'static,
+{
+    let mut options = availability::Options::default();
+    let extension = toml::from_str(include_str!("../../api/availability.toml"))?;
+    options.extensions.push(extension);
+    let mut api = availability::define_api::<AvailState<N, D>, SeqTypes, Node<N>>(&options)?;
+
+    api.get("getnamespaceproof", |req, state| {
+        async move {
+            let height: usize = req.integer_param("height")?;
+            let namespace: u64 = req.integer_param("namespace")?;
+            let block = state.get_block(height).await.context(QueryBlockSnafu {
+                resource: height.to_string(),
+            })?;
+
+            let proof = block.block().get_namespace_proof(namespace.into());
+            Ok(NamespaceProofQueryData {
+                transactions: proof.get_namespace_leaves().into_iter().cloned().collect(),
+                proof,
+                header: block.block().header(),
+            })
+        }
+        .boxed()
+    })?
+    .get("getheader", |req, state| {
+        async move {
+            let height: usize = req.integer_param("height")?;
+            let block = state.get_block(height).await.context(QueryBlockSnafu {
+                resource: height.to_string(),
+            })?;
+            Ok(block.block().header())
+        }
+        .boxed()
+    })?
+    .get("gettimestampwindow", |req, state| {
+        async move {
+            let end = req.integer_param("end")?;
+            let res = if let Some(height) = req.opt_integer_param("height")? {
+                state.inner().window_from::<usize>(height, end).await
+            } else if let Some(hash) = req.opt_blob_param("hash")? {
+                state
+                    .inner()
+                    .window_from::<BlockHash<SeqTypes>>(hash, end)
+                    .await
+            } else {
+                let start: u64 = req.integer_param("start")?;
+                state.inner().window(start, end).await
+            };
+            res.map_err(|err| availability::Error::Custom {
+                message: err.to_string(),
+                status: err.status(),
+            })
+        }
+        .boxed()
+    })?;
+
+    Ok(api)
+}
+
+pub(super) fn submit<N, S>() -> anyhow::Result<Api<S, Error>>
+where
+    N: network::Type,
+    S: 'static + Send + Sync + WriteState,
+    S::State: Send + Sync + SubmitDataSource<N>,
+{
+    let toml = toml::from_str::<toml::Value>(include_str!("../../api/submit.toml"))?;
+    let mut api = Api::<S, Error>::new(toml)?;
+
+    api.post("submit", |req, state| {
+        async move {
+            state
+                .handle()
+                .submit_transaction(
+                    req.body_auto::<Transaction>()
+                        .map_err(|err| Error::internal(err.to_string()))?,
+                )
+                .await
+                .map_err(|err| Error::internal(err.to_string()))
+        }
+        .boxed()
+    })?;
+
+    Ok(api)
+}

--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -1,0 +1,143 @@
+use super::{SequencerDataSource, TimeWindowQueryData};
+use crate::{network, Node, SeqTypes};
+use async_trait::async_trait;
+use clap::Parser;
+use futures::StreamExt;
+use hotshot_query_service::{
+    availability::{AvailabilityDataSource, BlockId, BlockQueryData, ResourceId},
+    data_source::{ExtensibleDataSource, FileSystemDataSource},
+    NotFoundSnafu, QueryResult,
+};
+use snafu::OptionExt;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+/// Options for the query API module backed by the file system.
+#[derive(Parser, Clone, Debug)]
+pub struct Options {
+    /// Storage path for HotShot query service data.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_STORAGE_PATH")]
+    pub storage_path: PathBuf,
+
+    /// Create new query storage instead of opening existing one.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_RESET_STORE")]
+    pub reset_store: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Index {
+    blocks_by_time: BTreeMap<u64, Vec<u64>>,
+}
+
+pub type DataSource<N> = ExtensibleDataSource<FileSystemDataSource<SeqTypes, Node<N>>, Index>;
+
+#[async_trait]
+impl<N: network::Type> SequencerDataSource<N> for DataSource<N> {
+    type Options = Options;
+
+    async fn create(opt: Self::Options) -> anyhow::Result<Self> {
+        let storage_path = Path::new(&opt.storage_path);
+        let data_source = {
+            if opt.reset_store {
+                FileSystemDataSource::create(storage_path)?
+            } else {
+                FileSystemDataSource::open(storage_path)?
+            }
+        };
+        let mut index = Index::default();
+
+        // Index blocks by timestamp.
+        let mut blocks = data_source.get_block_range(..).await?;
+        while let Some(block) = blocks.next().await {
+            index_block_by_time(&mut index.blocks_by_time, &block?);
+        }
+        drop(blocks);
+
+        Ok(ExtensibleDataSource::new(data_source, index))
+    }
+
+    async fn refresh_indices(&mut self, from_block: usize) -> anyhow::Result<()> {
+        // We can't update the index in `self.as_mut()` at the same time as the stream
+        // `self.get_block_range()` is live, since that would require conflicting borrows against
+        // `self`. By collecting the stream into a vector, we drop our borrow of `self`. This
+        // function is called every time a new block is added so this usually requires loading only
+        // one block into memory, and rarely very many.
+        let blocks: Vec<_> = self
+            .get_block_range(from_block..)
+            .await?
+            .enumerate()
+            .collect()
+            .await;
+        for (i, block) in blocks {
+            let Ok(block) = block else {
+                tracing::warn!("missing block {}, index may be out of date", from_block + i);
+                continue;
+            };
+            index_block_by_time(&mut self.as_mut().blocks_by_time, &block);
+        }
+
+        Ok(())
+    }
+
+    async fn window(&self, start: u64, end: u64) -> QueryResult<TimeWindowQueryData> {
+        // Find the minimum timestamp which is at least `start`, and all the blocks with that
+        // timestamp.
+        let blocks = self
+            .as_ref()
+            .blocks_by_time
+            .range(start..)
+            .next()
+            .context(NotFoundSnafu)?
+            .1;
+        // Multiple blocks can have the same timestamp (when truncated to seconds); we want the
+        // first one. It is an invariant that any timestamp which has an entry in `blocks_by_time`
+        // has a non-empty list associated with it, so this indexing is safe.
+        let first_block = blocks[0];
+        self.window_from(first_block as usize, end).await
+    }
+
+    async fn window_from<ID>(&self, from: ID, end: u64) -> QueryResult<TimeWindowQueryData>
+    where
+        ID: Into<BlockId<SeqTypes>> + Send + Sync,
+    {
+        let first_block = match from.into() {
+            ResourceId::Number(n) => n,
+            ResourceId::Hash(h) => self.get_block(h).await?.height() as usize,
+        };
+
+        let mut res = TimeWindowQueryData::new(first_block as u64);
+
+        // Include the block just before the start of the window, if there is one.
+        if first_block > 0 {
+            let prev = self.get_block(first_block - 1).await?;
+            res.prev = Some(prev.block().header());
+        }
+
+        // Add blocks to the window, starting from `first_block`, until we reach the end of the
+        // requested time window.
+        let mut blocks = self.get_block_range(first_block..).await?;
+        while let Some(block) = blocks.next().await {
+            let block = block?;
+            let header = block.block().header();
+            if header.timestamp() >= end {
+                res.next = Some(header);
+                break;
+            }
+            res.window.push(header);
+        }
+
+        Ok(res)
+    }
+}
+
+fn index_block_by_time(
+    blocks_by_time: &mut BTreeMap<u64, Vec<u64>>,
+    block: &BlockQueryData<SeqTypes>,
+) {
+    blocks_by_time
+        .entry(block.block().timestamp())
+        .or_default()
+        .push(block.height());
+}

--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -1,7 +1,8 @@
-use super::{SequencerDataSource, TimeWindowQueryData};
+use super::{
+    data_source::SequencerDataSource, endpoints::TimeWindowQueryData, options::Fs as Options,
+};
 use crate::{network, Node, SeqTypes};
 use async_trait::async_trait;
-use clap::Parser;
 use futures::StreamExt;
 use hotshot_query_service::{
     availability::{AvailabilityDataSource, BlockId, BlockQueryData, ResourceId},
@@ -9,22 +10,7 @@ use hotshot_query_service::{
     NotFoundSnafu, QueryResult,
 };
 use snafu::OptionExt;
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-};
-
-/// Options for the query API module backed by the file system.
-#[derive(Parser, Clone, Debug)]
-pub struct Options {
-    /// Storage path for HotShot query service data.
-    #[clap(long, env = "ESPRESSO_SEQUENCER_STORAGE_PATH")]
-    pub storage_path: PathBuf,
-
-    /// Create new query storage instead of opening existing one.
-    #[clap(long, env = "ESPRESSO_SEQUENCER_RESET_STORE")]
-    pub reset_store: bool,
-}
+use std::{collections::BTreeMap, path::Path};
 
 #[derive(Clone, Debug, Default)]
 pub struct Index {

--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -1,0 +1,183 @@
+//! Sequencer-specific API options and initialization.
+
+use super::{
+    data_source::SequencerDataSource, endpoints, fs, update::update_loop, AppState, Consensus,
+    NodeIndex, SequencerNode,
+};
+use crate::network;
+use async_std::{
+    sync::{Arc, RwLock},
+    task::spawn,
+};
+use clap::Parser;
+use futures::future::{BoxFuture, TryFutureExt};
+use hotshot_query_service::{data_source::ExtensibleDataSource, status, Error};
+use hotshot_types::traits::metrics::{Metrics, NoMetrics};
+use std::path::PathBuf;
+use tide_disco::App;
+
+#[derive(Clone, Debug)]
+pub struct Options {
+    pub http: Http,
+    pub query_fs: Option<Fs>,
+    pub submit: Option<Submit>,
+}
+
+impl From<Http> for Options {
+    fn from(http: Http) -> Self {
+        Self {
+            http,
+            query_fs: None,
+            submit: None,
+        }
+    }
+}
+
+impl Options {
+    /// Add a query API module backed by the file system.
+    pub fn query_fs(mut self, opt: Fs) -> Self {
+        self.query_fs = Some(opt);
+        self
+    }
+
+    /// Add a submit API module.
+    pub fn submit(mut self, opt: Submit) -> Self {
+        self.submit = Some(opt);
+        self
+    }
+
+    /// Whether these options will run the query API.
+    pub fn has_query_module(&self) -> bool {
+        self.query_fs.is_some()
+    }
+
+    /// Start the server.
+    ///
+    /// The function `init_handle` is used to create a consensus handle from a metrics object. The
+    /// metrics object is created from the API data source, so that consensus will populuate metrics
+    /// that can then be read and served by the API.
+    pub async fn serve<N, F>(self, init_handle: F) -> anyhow::Result<SequencerNode<N>>
+    where
+        N: network::Type,
+        F: FnOnce(Box<dyn Metrics>) -> BoxFuture<'static, (Consensus<N>, NodeIndex)>,
+    {
+        // The server state type depends on whether we are running a query API or not, so we handle
+        // the two cases differently.
+        let node = if let Some(opt) = self.query_fs {
+            init_with_query_module::<N, fs::DataSource<N>>(
+                opt,
+                init_handle,
+                self.submit.is_some(),
+                self.http.port,
+            )
+            .await?
+        } else {
+            let (handle, node_index) = init_handle(Box::new(NoMetrics)).await;
+            let mut app = App::<_, Error>::with_state(RwLock::new(handle.clone()));
+
+            // Initialize submit API
+            if self.submit.is_some() {
+                let submit_api = endpoints::submit::<N, RwLock<Consensus<N>>>()?;
+                app.register_module("submit", submit_api)?;
+            }
+
+            SequencerNode {
+                handle,
+                node_index,
+                update_task: spawn(
+                    app.serve(format!("0.0.0.0:{}", self.http.port))
+                        .map_err(anyhow::Error::from),
+                ),
+            }
+        };
+
+        // Start consensus.
+        node.handle.hotshot.start_consensus().await;
+        Ok(node)
+    }
+}
+
+/// The minimal HTTP API.
+///
+/// The API automatically includes health and version endpoints. Additional API modules can be
+/// added by including the query-api or submit-api modules.
+#[derive(Parser, Clone, Debug)]
+pub struct Http {
+    /// Port that the HTTP API will use.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_API_PORT")]
+    pub port: u16,
+}
+
+/// Options for the submission API module.
+#[derive(Parser, Clone, Copy, Debug, Default)]
+pub struct Submit;
+
+/// Options for the query API module backed by the file system.
+#[derive(Parser, Clone, Debug)]
+pub struct Fs {
+    /// Storage path for HotShot query service data.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_STORAGE_PATH")]
+    pub storage_path: PathBuf,
+
+    /// Create new query storage instead of opening existing one.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_RESET_STORE")]
+    pub reset_store: bool,
+}
+
+async fn init_with_query_module<N, D>(
+    opt: D::Options,
+    init_handle: impl FnOnce(Box<dyn Metrics>) -> BoxFuture<'static, (Consensus<N>, NodeIndex)>,
+    submit: bool,
+    port: u16,
+) -> anyhow::Result<SequencerNode<N>>
+where
+    N: network::Type,
+    D: SequencerDataSource<N> + Send + Sync + 'static,
+{
+    type State<N, D> = Arc<RwLock<AppState<N, D>>>;
+
+    let ds = D::create(opt).await?;
+    let metrics = ds.populate_metrics();
+
+    // Start up handle
+    let (mut handle, node_index) = init_handle(metrics).await;
+
+    // Get an event stream from the handle to use for populating the query data with
+    // consensus events.
+    //
+    // We must do this _before_ starting consensus on the handle, otherwise we could miss
+    // the first events emitted by consensus.
+    let events = handle.get_event_stream(Default::default()).await.0;
+
+    let state: State<N, D> = Arc::new(RwLock::new(ExtensibleDataSource::new(ds, handle.clone())));
+    let mut app = App::<_, Error>::with_state(state.clone());
+
+    // Initialize submit API
+    if submit {
+        let submit_api = endpoints::submit::<N, State<N, D>>()?;
+        app.register_module("submit", submit_api)?;
+    }
+
+    // Initialize availability and status APIs
+    let availability_api = endpoints::availability::<N, D>()?;
+    let status_api = status::define_api::<State<N, D>>(&Default::default())?;
+
+    // Register modules in app
+    app.register_module("availability", availability_api)?
+        .register_module("status", status_api)?;
+
+    let update_task = spawn(async move {
+        futures::join!(
+            app.serve(format!("0.0.0.0:{port}"))
+                .map_err(anyhow::Error::from),
+            update_loop(state, events),
+        )
+        .0
+    });
+
+    Ok(SequencerNode {
+        handle,
+        node_index,
+        update_task,
+    })
+}

--- a/sequencer/src/api/update.rs
+++ b/sequencer/src/api/update.rs
@@ -1,0 +1,54 @@
+//! Update loop for query API state.
+
+use super::{data_source::SequencerDataSource, AppState};
+use crate::{network, Leaf, SeqTypes};
+use async_std::sync::{Arc, RwLock};
+use futures::stream::{Stream, StreamExt};
+use hotshot::types::Event;
+use hotshot_query_service::{
+    data_source::{UpdateDataSource, VersionedDataSource},
+    status::StatusDataSource,
+};
+
+pub(super) async fn update_loop<N, D>(
+    state: Arc<RwLock<AppState<N, D>>>,
+    mut events: impl Stream<Item = Event<SeqTypes, Leaf>> + Unpin,
+) where
+    N: network::Type,
+    D: SequencerDataSource<N> + Send + Sync,
+{
+    tracing::debug!("waiting for event");
+    while let Some(event) = events.next().await {
+        tracing::info!("got event {:?}", event);
+
+        // If update results in an error, program state is unrecoverable
+        if let Err(err) = update_state(&mut *state.write().await, &event).await {
+            tracing::error!(
+                "failed to update event {:?}: {}; updater task will exit",
+                event,
+                err
+            );
+            panic!();
+        }
+    }
+    tracing::warn!("end of HotShot event stream, updater task will exit");
+}
+
+async fn update_state<N, D>(
+    state: &mut AppState<N, D>,
+    event: &Event<SeqTypes, Leaf>,
+) -> anyhow::Result<()>
+where
+    N: network::Type,
+    D: SequencerDataSource<N> + Send + Sync,
+{
+    // Remember the current block height, so we can update our local index
+    // based on any new blocks that get added.
+    let prev_block_height = state.block_height().await?;
+
+    state.update(event).await?;
+    state.inner_mut().refresh_indices(prev_block_height).await?;
+    state.commit().await?;
+
+    Ok(())
+}

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
 
             // Save the port if we are running a query API. This can be used later when starting the
             // commitment task; otherwise the user must give us the URL of an external query API.
-            let query_api_port = if opt.query_fs.is_some() {
+            let query_api_port = if opt.has_query_module() {
                 Some(opt.http.port)
             } else {
                 None

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -40,8 +40,8 @@ async fn main() {
         Some(opt) => {
             // Add optional API modules as requested.
             let mut opt = api::Options::from(opt);
-            if let Some(query) = modules.query {
-                opt = opt.query(query);
+            if let Some(query_fs) = modules.query_fs {
+                opt = opt.query_fs(query_fs);
             }
             if let Some(submit) = modules.submit {
                 opt = opt.submit(submit);
@@ -49,7 +49,7 @@ async fn main() {
 
             // Save the port if we are running a query API. This can be used later when starting the
             // commitment task; otherwise the user must give us the URL of an external query API.
-            let query_api_port = if opt.query.is_some() {
+            let query_api_port = if opt.query_fs.is_some() {
                 Some(opt.http.port)
             } else {
                 None

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -137,9 +137,9 @@ macro_rules! module {
     };
 }
 
-module!("http", api::HttpOptions);
-module!("query-fs", api::fs::Options, requires: "http");
-module!("submit", api::SubmitOptions, requires: "http");
+module!("http", api::options::Http);
+module!("query-fs", api::options::Fs, requires: "http");
+module!("submit", api::options::Submit, requires: "http");
 module!("commitment-task", CommitmentTaskOptions);
 
 #[derive(Clone, Debug, Args)]
@@ -187,24 +187,24 @@ enum SequencerModule {
     /// by enabling additional modules:
     /// * query: add query service endpoints
     /// * submit: add transaction submission endpoints
-    Http(Module<api::HttpOptions>),
+    Http(Module<api::options::Http>),
     /// Alias for query-fs.
-    Query(Module<api::fs::Options>),
+    Query(Module<api::options::Fs>),
     /// Run the query service API module, backed by the file system.
     ///
     /// This modules requires the http module to be started.
-    QueryFs(Module<api::fs::Options>),
+    QueryFs(Module<api::options::Fs>),
     /// Run the transaction submission API module.
     ///
     /// This modules requires the http module to be started.
-    Submit(Module<api::SubmitOptions>),
+    Submit(Module<api::options::Submit>),
     CommitmentTask(Module<CommitmentTaskOptions>),
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct Modules {
-    pub http: Option<api::HttpOptions>,
-    pub query_fs: Option<api::fs::Options>,
-    pub submit: Option<api::SubmitOptions>,
+    pub http: Option<api::options::Http>,
+    pub query_fs: Option<api::options::Fs>,
+    pub submit: Option<api::options::Submit>,
     pub commitment_task: Option<CommitmentTaskOptions>,
 }

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -138,7 +138,7 @@ macro_rules! module {
 }
 
 module!("http", api::HttpOptions);
-module!("query-fs", api::FsQueryOptions, requires: "http");
+module!("query-fs", api::fs::Options, requires: "http");
 module!("submit", api::SubmitOptions, requires: "http");
 module!("commitment-task", CommitmentTaskOptions);
 
@@ -189,11 +189,11 @@ enum SequencerModule {
     /// * submit: add transaction submission endpoints
     Http(Module<api::HttpOptions>),
     /// Alias for query-fs.
-    Query(Module<api::FsQueryOptions>),
+    Query(Module<api::fs::Options>),
     /// Run the query service API module, backed by the file system.
     ///
     /// This modules requires the http module to be started.
-    QueryFs(Module<api::FsQueryOptions>),
+    QueryFs(Module<api::fs::Options>),
     /// Run the transaction submission API module.
     ///
     /// This modules requires the http module to be started.
@@ -204,7 +204,7 @@ enum SequencerModule {
 #[derive(Clone, Debug, Default)]
 pub struct Modules {
     pub http: Option<api::HttpOptions>,
-    pub query_fs: Option<api::FsQueryOptions>,
+    pub query_fs: Option<api::fs::Options>,
     pub submit: Option<api::SubmitOptions>,
     pub commitment_task: Option<CommitmentTaskOptions>,
 }

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -105,7 +105,10 @@ impl ModuleArgs {
             )?;
             match module {
                 SequencerModule::Http(m) => curr = m.add(&mut modules.http, &mut provided)?,
-                SequencerModule::Query(m) => curr = m.add(&mut modules.query, &mut provided)?,
+                SequencerModule::Query(m) => curr = m.add(&mut modules.query_fs, &mut provided)?,
+                SequencerModule::QueryFs(m) => {
+                    curr = m.add(&mut modules.query_fs, &mut provided)?
+                }
                 SequencerModule::Submit(m) => curr = m.add(&mut modules.submit, &mut provided)?,
                 SequencerModule::CommitmentTask(m) => {
                     curr = m.add(&mut modules.commitment_task, &mut provided)?
@@ -135,7 +138,7 @@ macro_rules! module {
 }
 
 module!("http", api::HttpOptions);
-module!("query", api::QueryOptions, requires: "http");
+module!("query-fs", api::FsQueryOptions, requires: "http");
 module!("submit", api::SubmitOptions, requires: "http");
 module!("commitment-task", CommitmentTaskOptions);
 
@@ -185,10 +188,12 @@ enum SequencerModule {
     /// * query: add query service endpoints
     /// * submit: add transaction submission endpoints
     Http(Module<api::HttpOptions>),
-    /// Run the query service API module.
+    /// Alias for query-fs.
+    Query(Module<api::FsQueryOptions>),
+    /// Run the query service API module, backed by the file system.
     ///
     /// This modules requires the http module to be started.
-    Query(Module<api::QueryOptions>),
+    QueryFs(Module<api::FsQueryOptions>),
     /// Run the transaction submission API module.
     ///
     /// This modules requires the http module to be started.
@@ -199,7 +204,7 @@ enum SequencerModule {
 #[derive(Clone, Debug, Default)]
 pub struct Modules {
     pub http: Option<api::HttpOptions>,
-    pub query: Option<api::QueryOptions>,
+    pub query_fs: Option<api::FsQueryOptions>,
     pub submit: Option<api::SubmitOptions>,
     pub commitment_task: Option<CommitmentTaskOptions>,
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-ark-serialize = { version = "0.3.0", features = ["derive"] }
+ark-serialize = { version = "0.4", features = ["derive"] }
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
-commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.2" }
+commit = { git = "https://github.com/EspressoSystems/commit", tag = "0.2.3" }
 contract-bindings = { path = "../contract-bindings" }
 ethers = "2.0.4"
 portpicker = "0.1.1"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -311,7 +311,7 @@ pub async fn wait_for_rpc(
 
 pub fn commitment_to_u256<T: Committable>(comm: Commitment<T>) -> U256 {
     let mut buf = vec![];
-    comm.serialize(&mut buf).unwrap();
+    comm.serialize_uncompressed(&mut buf).unwrap();
     let state_comm: [u8; 32] = buf.try_into().unwrap();
     U256::from_little_endian(&state_comm)
 }
@@ -319,7 +319,7 @@ pub fn commitment_to_u256<T: Committable>(comm: Commitment<T>) -> U256 {
 pub fn u256_to_commitment<T: Committable>(comm: U256) -> Result<Commitment<T>, SerializationError> {
     let mut commit_bytes = [0; 32];
     comm.to_little_endian(&mut commit_bytes);
-    Commitment::deserialize(&*commit_bytes.to_vec())
+    Commitment::deserialize_uncompressed_unchecked(&*commit_bytes.to_vec())
 }
 
 pub async fn contract_send<M: Middleware, T: Detokenize>(


### PR DESCRIPTION
# Scope

This PR *does*:
* update dependencies including `hotshot-query-service`
* modularize the data source used to run the API server, so that it will be easy to plug in the SQL data source in place of the file system, and to toggle between them with env vars

This PR *does not* yet integrate the SQL data source. It should be easy to add with the new module structure, but I think I will do that in a separate PR to aid reviewability.

Draft: depends on https://github.com/EspressoSystems/hotshot-query-service/pull/249