### PR TITLE
Update surf-disco

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,7 +3452,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "snafu",
- "surf-disco",
+ "surf-disco 0.4.3 (git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3)",
  "time 0.3.30",
  "tokio",
  "tracing",
@@ -3486,7 +3486,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "surf-disco",
+ "surf-disco 0.4.3 (git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3)",
  "thiserror",
  "tide-disco",
  "tokio",
@@ -7266,7 +7266,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "snafu",
- "surf-disco",
+ "surf-disco 0.4.3 (git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3-patch.1)",
  "tempfile",
  "tide-disco",
  "time 0.3.30",
@@ -7895,6 +7895,23 @@ dependencies = [
 name = "surf-disco"
 version = "0.4.3"
 source = "git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3#44de23cb7d43893174b00e01148c7ccd100c6c26"
+dependencies = [
+ "async-std",
+ "async-tungstenite 0.15.0",
+ "bincode",
+ "derivative",
+ "futures",
+ "hex",
+ "serde",
+ "serde_json",
+ "surf",
+ "tide-disco",
+]
+
+[[package]]
+name = "surf-disco"
+version = "0.4.3"
+source = "git+https://github.com/EspressoSystems/surf-disco?tag=v0.4.3-patch.1#1406bf37da4824a26835afce0092b2b3f74b3dd9"
 dependencies = [
  "async-std",
  "async-tungstenite 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", features =
   "std",
 ] }
 jf-utils = { git = "https://github.com/EspressoSystems/jellyfish" }
+
+surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.3-patch.1" }
+tide-disco = { git = "https://github.com/EspressoSystems/tide-disco", tag = "v0.4.3" }

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -53,8 +53,8 @@ rand = "0.8.5"
 sequencer-utils = { path = "../utils" }
 serde = { version = "1.0.192", features = ["derive"] }
 snafu = "0.7.4"
-surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.3" }
-tide-disco = { git = "https://github.com/EspressoSystems/tide-disco", tag = "v0.4.3" }
+surf-disco = { workspace = true }
+tide-disco = { workspace = true }
 toml = "0.8"
 tracing = "0.1"
 typenum = { version = "1.15.0", default-features = false, features = [


### PR DESCRIPTION
This should allow the commit task to use WSS when connected to the sequencer via HTTPS, which _may_ fix problems we've been having with HTTPS.