### PR TITLE
Make persistence options independent of query service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=main#73193ba3f38ec4f822ccd45ed28473c617b88c4e"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=main#741279365532f44766c23443e2e672a72769c120"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3619,7 +3619,9 @@ dependencies = [
  "hotshot-utils",
  "include_dir",
  "itertools 0.12.0",
+ "native-tls",
  "portpicker",
+ "postgres-native-tls",
  "prometheus",
  "rand 0.8.5",
  "refinery",
@@ -6375,6 +6377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,6 +8630,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.42",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,8 +57,32 @@ services:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
     ports:
       - "$ESPRESSO_SEQUENCER_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
-    # Run the full API server with all modules
+    # Run the full API server with all modules, default storage
     command: sequencer -- http -- query -- status -- submit
+    environment:
+      - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
+      - ESPRESSO_SEQUENCER_DA_SERVER_URL
+      - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
+      - ESPRESSO_SEQUENCER_API_PORT
+      - ESPRESSO_SEQUENCER_STORAGE_PATH
+      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
+      - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
+      - RUST_LOG
+      - RUST_LOG_FORMAT
+    depends_on:
+      orchestrator:
+        condition: service_healthy
+      demo-l1-network:
+        condition: service_healthy
+      sequencer-db:
+        condition: service_healthy
+
+  sequencer1:
+    image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
+    ports:
+      - "$ESPRESSO_SEQUENCER1_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
+    # Run the availability API only, using postgres for persistence
+    command: sequencer -- storage-sql -- http -- query
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_DA_SERVER_URL
@@ -76,37 +100,13 @@ services:
         condition: service_healthy
       demo-l1-network:
         condition: service_healthy
-      sequencer-db:
-        condition: service_healthy
-
-  sequencer1:
-    image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
-    ports:
-      - "$ESPRESSO_SEQUENCER1_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
-    # Run the availability API only, using the local file system for persistence
-    command: sequencer -- http -- query-fs
-    environment:
-      - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
-      - ESPRESSO_SEQUENCER_DA_SERVER_URL
-      - ESPRESSO_SEQUENCER_CONSENSUS_SERVER_URL
-      - ESPRESSO_SEQUENCER_API_PORT
-      - ESPRESSO_SEQUENCER_STORAGE_PATH
-      - ESPRESSO_SEQUENCER_L1_WS_PROVIDER
-      - ESPRESSO_SEQUENCER_L1_USE_LATEST_BLOCK_TAG
-      - RUST_LOG
-      - RUST_LOG_FORMAT
-    depends_on:
-      orchestrator:
-        condition: service_healthy
-      demo-l1-network:
-        condition: service_healthy
 
   sequencer2:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
     ports:
       - "$ESPRESSO_SEQUENCER2_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
-    # Run the status API only
-    command: sequencer -- http -- status
+    # Run the status API only. Load config from the file system.
+    command: sequencer -- storage-fs -- http -- status
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_DA_SERVER_URL
@@ -126,8 +126,8 @@ services:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
     ports:
       - "$ESPRESSO_SEQUENCER3_API_PORT:$ESPRESSO_SEQUENCER_API_PORT"
-    # Run the submit API only
-    command: sequencer -- http -- submit
+    # Run the submit API only. Load config from the file system.
+    command: sequencer -- storage-fs -- http -- submit
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_DA_SERVER_URL

--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /bin/reset-storage
 # Upon restart, the config will be loaded from this file and the node will be able to resume
 # progress. The user should connect this path to a Docker volume to ensure persistence of the
 # configuration beyond the lifetime of the Docker container itself.
-ENV ESPRESSO_SEQUENCER_CONFIG_PATH=/config/hotshot.cfg
+ENV ESPRESSO_SEQUENCER_STORAGE_PATH=/store/sequencer
 
 CMD ["/bin/sequencer", "--", "http"]
 HEALTHCHECK --interval=1s --timeout=1s --retries=100 CMD curl --fail http://localhost:${ESPRESSO_SEQUENCER_API_PORT}/healthcheck  || exit 1

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -36,7 +36,7 @@ processes:
         condition: service_healthy
 
   sequencer0:
-    command: sequencer -- http -- query-fs -- status -- submit
+    command: sequencer -- http -- query -- status -- submit
     environment:
       - ESPRESSO_SEQUENCER_API_PORT=$ESPRESSO_SEQUENCER_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH=$ESPRESSO_BASE_STORAGE_PATH/seq0
@@ -47,7 +47,7 @@ processes:
         condition: service_healthy
 
   sequencer1:
-    command: sequencer -- http -- query-fs -- status
+    command: sequencer -- http -- query -- status
     environment:
       - ESPRESSO_SEQUENCER_API_PORT=$ESPRESSO_SEQUENCER1_API_PORT
       - ESPRESSO_SEQUENCER_STORAGE_PATH=$ESPRESSO_BASE_STORAGE_PATH/seq1

--- a/sequencer/api/migrations/V12__network_config.sql
+++ b/sequencer/api/migrations/V12__network_config.sql
@@ -1,0 +1,4 @@
+CREATE TABLE network_config (
+    id     SERIAL PRIMARY KEY,
+    config JSONB
+);

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -1,21 +1,19 @@
-use crate::{api, hotshot_commitment::CommitmentTaskOptions};
+use crate::{api, persistence};
 use clap::{error::ErrorKind, Args, FromArgMatches, Parser};
 use cld::ClDuration;
 use snafu::Snafu;
 use std::collections::HashSet;
 use std::iter::once;
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use url::Url;
 
 // This options struct is a bit unconventional. The sequencer has multiple optional modules which
-// can be added, in any combination, to the service. These include, for example, the HotShot
-// commitment task and the API server. Each of these modules has its own options, which are all
-// required if the module is added but can be omitted otherwise. Clap doesn't have a good way to
-// handle "grouped" arguments like this (they have something called an argument group, but it's
-// different). Sub-commands do exactly this, but you can't have multiple sub-commands in a single
-// command.
+// can be added, in any combination, to the service. These include, for example, the API server.
+// Each of these modules has its own options, which are all required if the module is added but can
+// be omitted otherwise. Clap doesn't have a good way to handle "grouped" arguments like this (they
+// have something called an argument group, but it's different). Sub-commands do exactly this, but
+// you can't have multiple sub-commands in a single command.
 //
 // What we do, then, is take the optional modules as if they were sub-commands, but we use a Clap
 // `raw` argument to collect all the module commands and their options into a single string. This
@@ -61,12 +59,6 @@ pub struct Options {
         default_value = "http://localhost:8082"
     )]
     pub consensus_server_url: Url,
-
-    /// Path to save and load consensus configuration.
-    ///
-    /// Allows for rejoining the network on a complete state loss.
-    #[clap(short, long, env = "ESPRESSO_SEQUENCER_CONFIG_PATH")]
-    pub config_path: Option<PathBuf>,
 
     /// The amount of time to wait between each request to the HotShot
     /// consensus or DA web servers during polling.
@@ -139,19 +131,19 @@ impl ModuleArgs {
                 once("sequencer --").chain(curr.iter().map(|s| s.as_str())),
             )?;
             match module {
+                SequencerModule::Storage(m) => {
+                    curr = m.add(&mut modules.storage_fs, &mut provided)?
+                }
+                SequencerModule::StorageFs(m) => {
+                    curr = m.add(&mut modules.storage_fs, &mut provided)?
+                }
+                SequencerModule::StorageSql(m) => {
+                    curr = m.add(&mut modules.storage_sql, &mut provided)?
+                }
                 SequencerModule::Http(m) => curr = m.add(&mut modules.http, &mut provided)?,
-                SequencerModule::Query(m) => curr = m.add(&mut modules.query_sql, &mut provided)?,
-                SequencerModule::QuerySql(m) => {
-                    curr = m.add(&mut modules.query_sql, &mut provided)?
-                }
-                SequencerModule::QueryFs(m) => {
-                    curr = m.add(&mut modules.query_fs, &mut provided)?
-                }
+                SequencerModule::Query(m) => curr = m.add(&mut modules.query, &mut provided)?,
                 SequencerModule::Submit(m) => curr = m.add(&mut modules.submit, &mut provided)?,
                 SequencerModule::Status(m) => curr = m.add(&mut modules.status, &mut provided)?,
-                SequencerModule::CommitmentTask(m) => {
-                    curr = m.add(&mut modules.commitment_task, &mut provided)?
-                }
             }
         }
 
@@ -176,12 +168,12 @@ macro_rules! module {
     };
 }
 
+module!("storage-fs", persistence::fs::Options);
+module!("storage-sql", persistence::sql::Options);
 module!("http", api::options::Http);
-module!("query-sql", api::options::Sql, requires: "http");
-module!("query-fs", api::options::Fs, requires: "http");
+module!("query", api::options::Query, requires: "http");
 module!("submit", api::options::Submit, requires: "http");
 module!("status", api::options::Status, requires: "http");
-module!("commitment-task", CommitmentTaskOptions);
 
 #[derive(Clone, Debug, Args)]
 struct Module<Options: ModuleInfo> {
@@ -229,16 +221,16 @@ enum SequencerModule {
     /// * query: add query service endpoints
     /// * submit: add transaction submission endpoints
     Http(Module<api::options::Http>),
-    /// Alias for query-sql.
-    Query(Module<api::options::Sql>),
-    /// Run the query service API module, backed by a Postgres database.
-    ///
-    /// This modules requires the http module to be started.
-    QuerySql(Module<api::options::Sql>),
-    /// Run the query service API module, backed by the file system.
+    /// Alias for storage-fs.
+    Storage(Module<persistence::fs::Options>),
+    /// Use the file system for persistent storage.
+    StorageFs(Module<persistence::fs::Options>),
+    /// Use a Postgres database for persistent storage.
+    StorageSql(Module<persistence::sql::Options>),
+    /// Run the query API module.
     ///
     /// This module requires the http module to be started.
-    QueryFs(Module<api::options::Fs>),
+    Query(Module<api::options::Query>),
     /// Run the transaction submission API module.
     ///
     /// This module requires the http module to be started.
@@ -247,15 +239,14 @@ enum SequencerModule {
     ///
     /// This module requires the http module to be started.
     Status(Module<api::options::Status>),
-    CommitmentTask(Module<CommitmentTaskOptions>),
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct Modules {
+    pub storage_fs: Option<persistence::fs::Options>,
+    pub storage_sql: Option<persistence::sql::Options>,
     pub http: Option<api::options::Http>,
-    pub query_sql: Option<api::options::Sql>,
-    pub query_fs: Option<api::options::Fs>,
+    pub query: Option<api::options::Query>,
     pub submit: Option<api::options::Submit>,
     pub status: Option<api::options::Status>,
-    pub commitment_task: Option<CommitmentTaskOptions>,
 }

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1,0 +1,37 @@
+//! Sequencer node persistence.
+//!
+//! This module implements the persistence required for a sequencer node to rejoin the network and
+//! resume participating in consensus, in the event that its process crashes or is killed and loses
+//! all in-memory state.
+//!
+//! This is distinct from the query service persistent storage found in the `api` module, which is
+//! an extension that node operators can opt into. This module defines the minimum level of
+//! persistence which is _required_ to run a node.
+
+use crate::{ElectionConfig, PubKey};
+use async_trait::async_trait;
+
+pub mod fs;
+pub mod sql;
+
+pub type NetworkConfig = hotshot_orchestrator::config::NetworkConfig<PubKey, ElectionConfig>;
+
+#[async_trait]
+pub trait PersistenceOptions: Clone {
+    type Persistence: SequencerPersistence;
+
+    async fn create(self) -> anyhow::Result<Self::Persistence>;
+    async fn reset(self) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+pub trait SequencerPersistence: Send + Sync + 'static {
+    /// Load the orchestrator config from storage.
+    ///
+    /// Returns `None` if no config exists (we are joining a network for the first time). Fails with
+    /// `Err` if it could not be determined whether a config exists or not.
+    async fn load_config(&self) -> anyhow::Result<Option<NetworkConfig>>;
+
+    /// Save the orchestrator config to storage.
+    async fn save_config(&mut self, cfg: &NetworkConfig) -> anyhow::Result<()>;
+}

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1,0 +1,57 @@
+use super::{NetworkConfig, PersistenceOptions, SequencerPersistence};
+use async_trait::async_trait;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Options for file system backed persistence.
+#[derive(Parser, Clone, Debug)]
+pub struct Options {
+    /// Storage path for persistent data.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_STORAGE_PATH")]
+    pub path: PathBuf,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self::parse_from(std::iter::empty::<String>())
+    }
+}
+
+#[async_trait]
+impl PersistenceOptions for Options {
+    type Persistence = Persistence;
+
+    async fn create(self) -> anyhow::Result<Persistence> {
+        Ok(Persistence(self.path))
+    }
+
+    async fn reset(self) -> anyhow::Result<()> {
+        todo!()
+    }
+}
+
+/// File system backed persistence.
+#[derive(Clone, Debug)]
+pub struct Persistence(PathBuf);
+
+impl Persistence {
+    fn config_path(&self) -> PathBuf {
+        self.0.join("hotshot.cfg")
+    }
+}
+
+#[async_trait]
+impl SequencerPersistence for Persistence {
+    async fn load_config(&self) -> anyhow::Result<Option<NetworkConfig>> {
+        if !self.config_path().is_file() {
+            return Ok(None);
+        }
+        Ok(Some(NetworkConfig::from_file(
+            self.config_path().display().to_string(),
+        )?))
+    }
+
+    async fn save_config(&mut self, cfg: &NetworkConfig) -> anyhow::Result<()> {
+        Ok(cfg.to_file(self.config_path().display().to_string())?)
+    }
+}

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -1,0 +1,74 @@
+use super::{NetworkConfig, PersistenceOptions, SequencerPersistence};
+use crate::api::{data_source::SequencerDataSource, sql::DataSource};
+use async_trait::async_trait;
+use clap::Parser;
+use hotshot_query_service::data_source::sql::Query;
+
+/// Options for Postgres-backed persistence.
+#[derive(Parser, Clone, Debug, Default)]
+pub struct Options {
+    /// Hostname for the remote Postgres database server.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_HOST")]
+    pub host: Option<String>,
+
+    /// Port for the remote Postgres database server.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_PORT")]
+    pub port: Option<u16>,
+
+    /// Name of database to connect to.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_DATABASE")]
+    pub database: Option<String>,
+
+    /// Postgres user to connect as.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_USER")]
+    pub user: Option<String>,
+
+    /// Password for Postgres user.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_PASSWORD")]
+    pub password: Option<String>,
+
+    /// Use TLS for an encrypted connection to the database.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_POSTGRES_USE_TLS")]
+    pub use_tls: bool,
+}
+
+#[async_trait]
+impl PersistenceOptions for Options {
+    type Persistence = Persistence;
+
+    async fn create(self) -> anyhow::Result<Persistence> {
+        DataSource::create(self, false).await
+    }
+
+    async fn reset(self) -> anyhow::Result<()> {
+        DataSource::create(self, true).await?;
+        Ok(())
+    }
+}
+
+/// Postgres-backed persistence.
+pub type Persistence = DataSource;
+
+#[async_trait]
+impl SequencerPersistence for Persistence {
+    async fn load_config(&self) -> anyhow::Result<Option<NetworkConfig>> {
+        // Select the most recent config (although there should only be one).
+        let Some(row) = self
+            .query_opt_static("SELECT config FROM network_config ORDER BY id DESC LIMIT 1")
+            .await?
+        else {
+            return Ok(None);
+        };
+        let config = row.try_get("config")?;
+        Ok(serde_json::from_value(config)?)
+    }
+
+    async fn save_config(&mut self, cfg: &NetworkConfig) -> anyhow::Result<()> {
+        let json = serde_json::to_value(cfg)?;
+        self.transaction()
+            .await?
+            .execute("INSERT INTO network_config (config) VALUES ($1)", [&json])
+            .await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit restructures the configuration of persistence so it is now a separate optional module from the query service. The user can choose between SQL and file system persistence, as before, and it will be used to persist data which is required for the node to run. Currently, this is just the network config file from the orchestrator. If no persistence is chosen, it defaults to the local file system.

There is now only a single command to start the query service, no more `query-fs` and `query-sql`. If enabled it will use whatever persistence was previously chosen.

Interface changes:
* Sequencer command line requires `query`, not `query-fs` or `query-sql`
* Sequencer command line requires `storage-sql` if you want to use SQL
* There is no longer an option to run the commitment task with the sequencer (this was tech debt anyway, and it was easier to remove it than fix it)
* `ESPRESSO_SEQUENCER_CONFIG_PATH` is gone. The config file will be persisted in whatever persistence is chosen (`ESPRESSO_SEQUENCER_CONFIG_PATH` if using the file system)
* New flag `ESPRESSO_SEQUENCER_POSTGRES_USE_TLS`. This just came from updating the query service
* Removed `ESPRESSO_SEQUENCER_RESET_STORE`. It was never usable how it was intended and is no longer needed with the `reset-storage` tool. The new persistence trait is design with an explicit reset method so this flag no longer makes any sense at all

Closes #804
Closes #886