### PR TITLE
add block_merkle_tree to `Header`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7522,6 +7522,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "sha3",
  "snafu",
  "surf-disco",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,7 +4340,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#e33a7395459fbdd0c56c1c6815590f25631e9d3d"
+source = "git+https://github.com/EspressoSystems/jellyfish#20f69297113c72ac023657d373ffe49e85bf33c6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#e33a7395459fbdd0c56c1c6815590f25631e9d3d"
+source = "git+https://github.com/EspressoSystems/jellyfish#20f69297113c72ac023657d373ffe49e85bf33c6"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#e33a7395459fbdd0c56c1c6815590f25631e9d3d"
+source = "git+https://github.com/EspressoSystems/jellyfish#20f69297113c72ac023657d373ffe49e85bf33c6"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#e33a7395459fbdd0c56c1c6815590f25631e9d3d"
+source = "git+https://github.com/EspressoSystems/jellyfish#20f69297113c72ac023657d373ffe49e85bf33c6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -7522,7 +7522,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sha3",
  "snafu",
  "surf-disco",
  "tempfile",

--- a/data/header.json
+++ b/data/header.json
@@ -10,5 +10,13 @@
     "payload_commitment": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
     "transactions_root": {
         "root": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-    }
+    },
+      "block_merkle_tree_root": "MERKLE_COMM~AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAQA",
+  "block_merkle_tree": {
+    "root": "Empty",
+    "height": 32,
+    "num_leaves": 0,
+    "_phantom_h": null,
+    "_phantom_ta": null
+  }
 }

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static = "1.4"
 rand_chacha = "0.3"
 serde_json = "1.0"
 sha2 = "0.10" # TODO temporary, used only for VID, should be set in hotshot
+sha3 = "0.10.8"
 time = "0.3"
 tokio-postgres = { version = "0.7", default-features = false, features = [ # disabling the default features removes dependence on the tokio runtime
 	"with-serde_json-1",
@@ -73,4 +74,3 @@ url = "2.3"
 
 # Dependencies for feature `testing`
 hotshot-testing = { workspace = true, optional = true }
-sha3 = "0.10.8"

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -43,7 +43,6 @@ lazy_static = "1.4"
 rand_chacha = "0.3"
 serde_json = "1.0"
 sha2 = "0.10" # TODO temporary, used only for VID, should be set in hotshot
-sha3 = "0.10.8"
 time = "0.3"
 tokio-postgres = { version = "0.7", default-features = false, features = [ # disabling the default features removes dependence on the tokio runtime
 	"with-serde_json-1",

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -73,3 +73,4 @@ url = "2.3"
 
 # Dependencies for feature `testing`
 hotshot-testing = { workspace = true, optional = true }
+sha3 = "0.10.8"

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -78,7 +78,9 @@ impl Valid for Sha3Node {
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Sha3Digest();
 
-impl<E: Element + CanonicalSerialize, I: Index> DigestAlgorithm<E, I, Sha3Node> for Sha3Digest {
+impl<E: Element + CanonicalSerialize + AsRef<[u8]>, I: Index> DigestAlgorithm<E, I, Sha3Node>
+    for Sha3Digest
+{
     fn digest(data: &[Sha3Node]) -> Result<Sha3Node, PrimitivesError> {
         let mut hasher = Sha3_256::new();
         for value in data {
@@ -89,7 +91,7 @@ impl<E: Element + CanonicalSerialize, I: Index> DigestAlgorithm<E, I, Sha3Node> 
 
     fn digest_leaf(_pos: &I, elem: &E) -> Result<Sha3Node, PrimitivesError> {
         let mut writer = Vec::new();
-        elem.serialize_compressed(&mut writer).unwrap();
+        writer.write_all(elem.as_ref()).unwrap();
         let mut hasher = Sha3_256::new();
         hasher.update(writer);
         Ok(Sha3Node(hasher.finalize().into()))

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -21,6 +21,7 @@ use std::{
 use time::OffsetDateTime;
 
 pub type SHA3MerkleTree = LightWeightSHA3MerkleTree<Commitment<Header>>;
+pub type SHA3MerkleCommitment = <SHA3MerkleTree as MerkleTreeScheme>::Commitment;
 
 /// A header is like a [`Block`] with the body replaced by a digest.
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, PartialEq, Eq)]
@@ -72,7 +73,7 @@ pub struct Header {
     pub payload_commitment: VidCommitment,
     pub transactions_root: NMTRoot,
     /// Root Commitment of Block Merkle Tree
-    pub block_merkle_tree_root: <SHA3MerkleTree as MerkleTreeScheme>::Commitment,
+    pub block_merkle_tree_root: SHA3MerkleCommitment,
     /// Frontier of Block Merkle Tree
     pub block_merkle_tree: SHA3MerkleTree,
 }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -53,8 +53,8 @@ use typenum::U2;
 pub use block::{Header, Payload};
 pub use chain_variables::ChainVariables;
 use jf_primitives::merkle_tree::{
-    examples::{Sha3Digest, Sha3Node},
     namespaced_merkle_tree::NMT,
+    prelude::{Sha3Digest, Sha3Node},
 };
 pub use l1_client::L1BlockInfo;
 pub use options::Options;


### PR DESCRIPTION
WIP to address #925. `block_merkle_tree` field has been added to `Header` struct. MerkleTree details have been lifted from upstream examples.