### PR TITLE
Bump solc version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        # TODO: remove version pinning once our tests work again
-        with:
-          version: "nightly-60ec00296f00754bc21ed68fd05ab6b54b50e024"
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -3892,7 +3892,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.13",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ broadcast = "contracts/broadcast"
 cache_path = "contracts/cache"
 # Version should match the solc installed via flake, otherwise the contract
 # artifacts may differ slightly.
-solc = "0.8.20"
+solc = "0.8.23"
 # The bytecode hash is no longer deterministic and prevents us from generating
 # deterministic bindings. The "none" setting prevents solc from appending the
 # IPFS hash to the bytecode.


### PR DESCRIPTION
I was running `just bind` in [espresso-sequencer-go](https://github.com/EspressoSystems/espresso-sequencer-go), which does `forge build --force` in this repo (as a submodule). It wasn't working, and I realized that when I run `forge build` manually from a Nix shell, it uses solc 0.8.23, which works, but when I run it via `just`, it uses 0.8.20, which doesn't work. I'm not exactly sure what's going on, but this change seems to fix the problem.