### PR TITLE
chore: upgrade hotshot to 0.5.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "commit"
 version = "0.2.2"
-source = "git+https://github.com/EspressoSystems/commit#fa1d0cb00bda1cc06c239aaf3a692014489d88c8"
+source = "git+https://github.com/EspressoSystems/commit#dd9f16e084d45e9ea52459c776f5fdcb6b000889"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.4.2",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3505,12 +3505,15 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3521,6 +3524,7 @@ dependencies = [
  "hotshot-types",
  "libp2p",
  "serde",
+ "serde-inline-default",
  "serde_json",
  "surf-disco",
  "thiserror",
@@ -3533,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.7"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=main#bbb1327fa69e68df0f039009ac7e5f15001748d2"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=main#9d8f10a076624748ea4b7694b2a0830084e9e2d6"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3577,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3596,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "hotshot-state-prover"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3615,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3634,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3659,14 +3663,19 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
+ "async-lock 2.8.0",
  "async-std",
+ "bincode",
+ "bitvec",
  "commit",
  "either",
+ "ethereum-types",
  "futures",
  "hotshot",
+ "hotshot-constants",
  "hotshot-orchestrator",
  "hotshot-task",
  "hotshot-task-impls",
@@ -3683,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -3707,6 +3716,7 @@ dependencies = [
  "espresso-systems-common 0.4.1",
  "ethereum-types",
  "generic-array",
+ "hotshot-constants",
  "hotshot-task",
  "hotshot-utils",
  "jf-plonk",
@@ -3728,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "bincode",
 ]
@@ -3736,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3892,7 +3902,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.13",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -4260,7 +4270,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9716f9d376f08f3e6293142352928d18292bb30"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4289,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9716f9d376f08f3e6293142352928d18292bb30"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4334,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9716f9d376f08f3e6293142352928d18292bb30"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -4360,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#d9716f9d376f08f3e6293142352928d18292bb30"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4822,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -7386,6 +7396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-inline-default"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa824cde50b5f01ff28a955114d8152a07cd62d81f53459dad0f2610136be844"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ resolver = "2"
 members = ["contract-bindings", "contracts/rust", "sequencer", "utils"]
 
 [workspace.dependencies]
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-state-prover = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-state-prover = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.7.1" }
 
 hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", branch = "main" }
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -281,7 +281,7 @@ pub async fn init_node(
     };
     // This "public" IP only applies to libp2p network configurations, so we can supply any value here
     let public_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let orchestrator_client = OrchestratorClient::new(validator_args, public_ip.to_string()).await;
+    let orchestrator_client = OrchestratorClient::new(validator_args, public_ip.to_string());
 
     let mut config = match persistence.load_config().await? {
         Some(config) => {

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -20,24 +20,16 @@ impl HotShotState for State {
 
     type Time = ViewNumber;
 
-    fn validate_block(&self, _header: &Self::BlockHeader, _view_number: &Self::Time) -> bool {
-        unimplemented!("Using sequencing consensus, no validation")
-    }
+    fn on_commit(&self) {}
 
-    fn initialize() -> Self {
-        Default::default()
-    }
-
-    // This function is called exactly once, with the first block.
-    fn append(
+    fn validate_and_apply_header(
         &self,
-        _header: &Self::BlockHeader,
+        _proposed_header: &Self::BlockHeader,
+        _parent_header: &Self::BlockHeader,
         _view_number: &Self::Time,
     ) -> Result<Self, Self::Error> {
-        Ok(self.clone())
+        todo!("Tracking issue: [https://github.com/EspressoSystems/espresso-sequencer/issues/968]")
     }
-
-    fn on_commit(&self) {}
 }
 
 // Required for TestableState


### PR DESCRIPTION
Newest hotshot allows us to derive serialize for structs containing `LightClientState`.

Also there's an interface change to `hotshot::traits::State`. Left a todo with link to the tracking issue.