### PR TITLE
chore: placeholder for etherscan api key in .env

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ RUST_LOG_FORMAT=full
 L1_BLOCK_TIME_SEC=3
 
 # Internal port inside container
-ESPRESSO_WEB_SERVER_PORT=40000 
+ESPRESSO_WEB_SERVER_PORT=40000
 ESPRESSO_ORCHESTRATOR_PORT=40001
 ESPRESSO_ORCHESTRATOR_NUM_NODES=5
 ESPRESSO_ORCHESTRATOR_START_DELAY=5s
@@ -51,4 +51,4 @@ MNEMONIC="test test test test test test test test test test test junk"
 # The RPC URL for deploying to the sepolia network.
 SEPOLIA_RPC_URL=
 # The etherscan API key is needed to verify contracts on etherscan.
-ETHERSCAN_API_KEY=
+ETHERSCAN_API_KEY="placeholder"

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -73,4 +73,4 @@ jobs:
       - name: Run tests
         run: |
           nix develop --accept-flake-config -c cargo build --bin diff-test --release
-          nix develop --accept-flake-config -c forge test -vvv --etherscan-api-key invalid_key
+          nix develop --accept-flake-config -c forge test -vvv

--- a/justfile
+++ b/justfile
@@ -70,4 +70,4 @@ sol-lint:
 # Note: we use an invalid etherscan api key in order to avoid annoying warnings. See https://github.com/EspressoSystems/espresso-sequencer/issues/979
 sol-test:
     cargo build --bin diff-test --release
-    forge test --etherscan-api-key invalid_key
+    forge test


### PR DESCRIPTION
Follow up on #996 

Instead of having to add `--etherscan-api-key` flag on every command (not just running `just sol-test`, we might as well set the env var to our nix shell with a placeholder key. 

All you need to do is exit and re-enter nix shell with the updated env var. warning should be suppressed as expected.