### PR TITLE
Improvements for `submit-transactions` utility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
             target/release/sequencer
             target/release/cli
             target/release/commitment-task
+            target/release/submit-transactions
             target/release/reset-storage
 
   build-arm:
@@ -99,6 +100,7 @@ jobs:
             target/release/sequencer
             target/release/cli
             target/release/commitment-task
+            target/release/submit-transactions
             target/release/reset-storage
 
   build-dockers:
@@ -155,6 +157,12 @@ jobs:
         with:
           images: ghcr.io/espressosystems/espresso-sequencer/commitment-task
 
+      - name: Generate submit-transactions docker metadata
+        uses: docker/metadata-action@v5
+        id: submit-transactions
+        with:
+          images: ghcr.io/espressosystems/espresso-sequencer/submit-transactions
+
       - name: Generate example rollup metadata
         uses: docker/metadata-action@v5
         id: example-rollup
@@ -200,3 +208,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.commitment-task.outputs.tags }}
           labels: ${{ steps.commitment-task.outputs.labels }}
+
+      - name: Build and push submit-transactions docker
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          file: ./docker/submit-transactions.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.submit-transactions.outputs.tags }}
+          labels: ${{ steps.submit-transactions.outputs.labels }}

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -80,7 +80,7 @@ jobs:
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/sequencer
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/cli
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/commitment-task
-            ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/count-transactions
+            ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/submit-transactions
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/reset-storage
 
   static-dockers:
@@ -141,11 +141,11 @@ jobs:
           images: ghcr.io/espressosystems/espresso-sequencer/commitment-task
           flavor: suffix=musl
 
-      - name: Generate count-transactions docker metadata
+      - name: Generate submit-transactions docker metadata
         uses: docker/metadata-action@v5
-        id: count-transactions
+        id: submit-transactions
         with:
-          images: ghcr.io/espressosystems/espresso-sequencer/count-transactions
+          images: ghcr.io/espressosystems/espresso-sequencer/submit-transactions
           flavor: suffix=musl
 
       - name: Generate example rollup metadata
@@ -195,12 +195,12 @@ jobs:
           tags: ${{ steps.commitment-task.outputs.tags }}
           labels: ${{ steps.commitment-task.outputs.labels }}
 
-      - name: Build and push count-transactions docker
+      - name: Build and push submit-transactions docker
         uses: docker/build-push-action@v5
         with:
           context: ./
-          file: ./docker/count-transactions.Dockerfile
+          file: ./docker/submit-transactions.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.count-transactions.outputs.tags }}
-          labels: ${{ steps.count-transactions.outputs.labels }}
+          tags: ${{ steps.submit-transactions.outputs.tags }}
+          labels: ${{ steps.submit-transactions.outputs.labels }}

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -80,6 +80,7 @@ jobs:
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/sequencer
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/cli
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/commitment-task
+            ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/count-transactions
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/reset-storage
 
   static-dockers:
@@ -140,6 +141,13 @@ jobs:
           images: ghcr.io/espressosystems/espresso-sequencer/commitment-task
           flavor: suffix=musl
 
+      - name: Generate count-transactions docker metadata
+        uses: docker/metadata-action@v5
+        id: count-transactions
+        with:
+          images: ghcr.io/espressosystems/espresso-sequencer/count-transactions
+          flavor: suffix=musl
+
       - name: Generate example rollup metadata
         uses: docker/metadata-action@v5
         id: example-rollup
@@ -186,3 +194,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.commitment-task.outputs.tags }}
           labels: ${{ steps.commitment-task.outputs.labels }}
+
+      - name: Build and push count-transactions docker
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          file: ./docker/count-transactions.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.count-transactions.outputs.tags }}
+          labels: ${{ steps.count-transactions.outputs.labels }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -184,6 +184,16 @@ services:
       demo-l1-network:
         condition: service_healthy
 
+  submit-transactions:
+    image: ghcr.io/espressosystems/espresso-sequencer/submit-transactions:main
+    env:
+      - ESPRESSO_SUBMIT_TRANSACTIONS_SUBMIT_URL=$ESPRESSO_SEQUENCER_URL
+      - RUST_LOG
+      - RUST_LOG_FORMAT
+    depends_on:
+      sequencer0:
+        condition: service_healthy
+
   sequencer-db:
     image: postgres
     ports:

--- a/docker/submit-transactions.Dockerfile
+++ b/docker/submit-transactions.Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:jammy
+
+ARG TARGETARCH
+
+RUN apt-get update \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
+    &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
+
+COPY target/$TARGETARCH/release/submit-transactions /bin/submit-transactions
+RUN chmod +x /bin/submit-transactions
+
+CMD [ "/bin/submit-transactions"]

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -31,7 +31,7 @@ for ARCH in "amd64" "arm64"; do
       ;;
   esac
   mkdir -p ${WORKDIR}/target/$ARCH/release
-  for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "reset-storage"; do
+  for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage"; do
     cp -v "${CARGO_TARGET_DIR}/${TARGET}/release/$binary" ${WORKDIR}/target/$ARCH/release
   done
 done
@@ -41,3 +41,4 @@ docker build -t ghcr.io/espressosystems/espresso-sequencer/orchestrator:main -f 
 docker build -t ghcr.io/espressosystems/espresso-sequencer/web-server:main -f docker/web-server.Dockerfile ${WORKDIR}
 docker build -t ghcr.io/espressosystems/espresso-sequencer/sequencer:main -f docker/sequencer.Dockerfile ${WORKDIR}
 docker build -t ghcr.io/espressosystems/espresso-sequencer/commitment-task:main -f docker/commitment-task.Dockerfile ${WORKDIR}
+docker build -t ghcr.io/espressosystems/espresso-sequencer/submit-transactions:main -f docker/submit-transactions.Dockerfile ${WORKDIR}

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -71,7 +71,7 @@ cleanup(){
 }
 
 mkdir -p ${WORKDIR}/target/$ARCH/release
-for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "reset-storage"; do
+for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage"; do
   cp -v "${CARGO_TARGET_DIR}/release/$binary" ${WORKDIR}/target/$ARCH/release
   # Patch the interpreter for running without nix inside the ubuntu based docker image.
   if [ $KERNEL == "linux" ]; then
@@ -84,3 +84,4 @@ docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/
 docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/web-server:main -f docker/web-server.Dockerfile ${WORKDIR}
 docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/sequencer:main -f docker/sequencer.Dockerfile ${WORKDIR}
 docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/commitment-task:main -f docker/commitment-task.Dockerfile ${WORKDIR}
+docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/submit-transactions:main -f docker/submit-transactions.Dockerfile ${WORKDIR}

--- a/sequencer/src/bin/submit-transactions.rs
+++ b/sequencer/src/bin/submit-transactions.rs
@@ -16,50 +16,81 @@ use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use sequencer::{options::parse_duration, SeqTypes, Transaction};
 use snafu::Snafu;
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 use surf_disco::{Client, Url};
 
 /// Submit random transactions to an Espresso Sequencer.
 #[derive(Clone, Debug, Parser)]
 struct Options {
     /// Minimum size of transaction to submit.
-    #[clap(long, default_value = "1", value_parser = parse_size)]
+    ///
+    /// The size of each transaction will be chosen uniformly between MIN_SIZE and MAX_SIZE.
+    #[clap(long, name = "MIN_SIZE", default_value = "1", value_parser = parse_size, env = "ESPRESSO_SUBMIT_TRANSACTIONS_MIN_SIZE")]
     min_size: usize,
 
     /// Maximum size of transaction to submit.
-    #[clap(long, default_value = "1kb", value_parser = parse_size)]
+    ///
+    /// The size of each transaction will be chosen uniformly between MIN_SIZE and MAX_SIZE.
+    #[clap(long, name = "MAX_SIZE", default_value = "1kb", value_parser = parse_size, env = "ESPRESSO_SUBMIT_TRANSACTIONS_MAX_SIZE")]
     max_size: usize,
 
     /// Minimum namespace ID to submit to.
-    #[clap(long, default_value = "10000")]
+    #[clap(
+        long,
+        default_value = "10000",
+        env = "ESPRESSO_SUBMIT_TRANSACTIONS_MIN_NAMESPACE"
+    )]
     min_namespace: u64,
 
     /// Maximum namespace ID to submit to.
-    #[clap(long, default_value = "10010")]
+    #[clap(
+        long,
+        default_value = "10010",
+        env = "ESPRESSO_SUBMIT_TRANSACTIONS_MAX_NAMESPACE"
+    )]
     max_namespace: u64,
 
-    /// Optional delay between submitting transactions.
+    /// Minimum delay between submitting transactions.
     ///
-    /// Can be used to moderate the rate of submission.
-    #[clap(long, value_parser = parse_duration)]
-    delay: Option<Duration>,
+    /// The delay after each transaction will be chosen uniformly between MIN_DELAY and MAX_DELAY.
+    #[clap(long, name = "MIN_DELAY", value_parser = parse_duration, default_value = "100ms", env = "ESPRESSO_SUBMIT_TRANSACTIONS_MIN_DELAY")]
+    min_delay: Duration,
+
+    /// Maximum delay between submitting transactions.
+    ///
+    /// The delay after each transaction will be chosen uniformly between MIN_DELAY and MAX_DELAY.
+    #[clap(long, name = "MAX_DELAY", value_parser = parse_duration, default_value = "10m", env = "ESPRESSO_SUBMIT_TRANSACTIONS_MAX_DELAY")]
+    max_delay: Duration,
 
     /// Maximum number of unprocessed transaction submissions.
     ///
     /// This can be used to apply backpressure so that the tasks submitting transactions do not get
     /// too far ahead of the task processing results.
-    #[clap(long, default_value = "1000")]
+    #[clap(
+        long,
+        default_value = "1000",
+        env = "ESPRESSO_SUBMIT_TRANSACTIONS_CHANNEL_BOUND"
+    )]
     channel_bound: usize,
 
     /// Seed for reproducible randomness.
-    #[clap(long)]
+    #[clap(long, env = "ESPRESSO_SUBMIT_TRANSACTIONS_SEED")]
     seed: Option<u64>,
 
     /// Number of parallel tasks to run.
-    #[clap(short, long, default_value = "1")]
+    #[clap(
+        short,
+        long,
+        default_value = "1",
+        env = "ESPRESSO_SUBMIT_TRANSACTIONS_JOBS"
+    )]
     jobs: usize,
 
     /// URL of the query service.
+    #[clap(env = "ESPRESSO_SUBMIT_TRANSACTIONS_SUBMIT_URL")]
     url: Url,
 }
 
@@ -86,11 +117,7 @@ async fn main() {
 
     // Subscribe to block stream so we can check that our transactions are getting sequenced.
     let client = Client::<Error>::new(opt.url.clone());
-    let block_height: usize = client
-        .get("status/latest_block_height")
-        .send()
-        .await
-        .unwrap();
+    let block_height: usize = client.get("status/block-height").send().await.unwrap();
     let mut blocks = client
         .socket(&format!("availability/stream/blocks/{}", block_height - 1))
         .subscribe()
@@ -108,7 +135,9 @@ async fn main() {
     }
 
     // Keep track of the results.
-    let mut pending = HashSet::new();
+    let mut pending = HashMap::new();
+    let mut total_latency = Duration::default();
+    let mut total_transactions = 0;
     while let Some(block) = blocks.next().await {
         let block: BlockQueryData<SeqTypes> = match block {
             Ok(block) => block,
@@ -117,21 +146,26 @@ async fn main() {
                 continue;
             }
         };
-        tracing::info!("got block {}", block.height());
+        let received_at = Instant::now();
+        tracing::debug!("got block {}", block.height());
 
         // Get all transactions which were submitted before this block.
         while let Ok(Some(tx)) = receiver.try_next() {
-            pending.insert(tx);
+            pending.insert(tx.hash, tx.submitted_at);
         }
 
         // Clear pending transactions from the block.
         for (_, tx) in block.enumerate() {
-            if pending.remove(&tx.commit()) {
-                tracing::debug!("got transaction {}", tx.commit());
+            if let Some(submitted_at) = pending.remove(&tx.commit()) {
+                let latency = received_at - submitted_at;
+                tracing::info!("got transaction {}, latency {latency:?}", tx.commit());
+                total_latency += latency;
+                total_transactions += 1;
+                tracing::info!("average latency: {:?}", total_latency / total_transactions);
             }
         }
 
-        tracing::info!("{} transactions still pending", pending.len());
+        tracing::debug!("{} transactions still pending", pending.len());
     }
     tracing::info!(
         "block stream ended with {} transactions still pending",
@@ -139,16 +173,21 @@ async fn main() {
     );
 }
 
+struct SubmittedTransaction {
+    hash: Commitment<Transaction>,
+    submitted_at: Instant,
+}
+
 async fn submit_transactions(
     opt: Options,
-    mut sender: Sender<Commitment<Transaction>>,
+    mut sender: Sender<SubmittedTransaction>,
     mut rng: ChaChaRng,
 ) {
     let client = Client::<Error>::new(opt.url.clone());
     loop {
         let tx = random_transaction(&opt, &mut rng);
         let hash = tx.commit();
-        tracing::debug!(
+        tracing::info!(
             "submitting transaction {hash} for namespace {} of size {}",
             tx.vm(),
             tx.payload().len()
@@ -162,11 +201,15 @@ async fn submit_transactions(
         {
             tracing::error!("failed to submit transaction: {err}");
         }
-        sender.send(hash).await.ok();
+        let submitted_at = Instant::now();
+        sender
+            .send(SubmittedTransaction { hash, submitted_at })
+            .await
+            .ok();
 
-        if let Some(delay) = opt.delay {
-            sleep(delay).await;
-        }
+        let delay = rng.gen_range(opt.min_delay..=opt.max_delay);
+        tracing::info!("sleeping for {delay:?}");
+        sleep(delay).await;
     }
 }
 


### PR DESCRIPTION
* Create Docker image and add to local demo
* Improve default options somewhat, particularly handling of delays between transactions. I chose a very low minimum delay and a very high max delay, so we get a lot of variety, and today we encountered a bug which only happened when we had both non-empty blocks and very long sequences of empty blocks.
* Track and log latency of transactions