### PR TITLE
Add delay param to commitment task

### DIFF
--- a/sequencer/src/bin/commitment-task.rs
+++ b/sequencer/src/bin/commitment-task.rs
@@ -5,8 +5,10 @@ use contract_bindings::hot_shot::HotShot;
 use ethers::{prelude::*, providers::Provider, signers::coins_bip39::English};
 use futures::FutureExt;
 use sequencer::hotshot_commitment::{run_hotshot_commitment_task, CommitmentTaskOptions};
+use sequencer::options::parse_duration;
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 use tide_disco::error::ServerError;
 use tide_disco::Api;
 use url::Url;
@@ -65,6 +67,10 @@ pub struct Options {
     /// The server provides healthcheck and version endpoints.
     #[clap(short, long, env = "ESPRESSO_COMMITMENT_TASK_PORT")]
     pub port: Option<u16>,
+
+    /// If specified, sequencing attempts will be delayed by duration sampled from an exponential distribution with mean DELAY.
+    #[clap(long, name = "DELAY", value_parser = parse_duration, default_value = "0s", env = "ESPRESSO_COMMITMENT_TASK_DELAY")]
+    pub delay: Duration,
 }
 #[async_std::main]
 async fn main() {
@@ -120,6 +126,7 @@ async fn main() {
         hotshot_address,
         l1_chain_id: None,
         l1_provider: opt.l1_provider.clone(),
+        delay: opt.delay,
         sequencer_mnemonic: opt.eth_mnemonic,
         sequencer_account_index: opt.hotshot_account_index,
         query_service_url: Some(opt.sequencer_url),

--- a/sequencer/src/bin/commitment-task.rs
+++ b/sequencer/src/bin/commitment-task.rs
@@ -69,8 +69,8 @@ pub struct Options {
     pub port: Option<u16>,
 
     /// If specified, sequencing attempts will be delayed by duration sampled from an exponential distribution with mean DELAY.
-    #[clap(long, name = "DELAY", value_parser = parse_duration, default_value = "0s", env = "ESPRESSO_COMMITMENT_TASK_DELAY")]
-    pub delay: Duration,
+    #[clap(long, name = "DELAY", value_parser = parse_duration, env = "ESPRESSO_COMMITMENT_TASK_DELAY")]
+    pub delay: Option<Duration>,
 }
 #[async_std::main]
 async fn main() {

--- a/sequencer/src/hotshot_commitment.rs
+++ b/sequencer/src/hotshot_commitment.rs
@@ -6,12 +6,15 @@ use contract_bindings::hot_shot::{HotShot, Qc};
 use ethers::prelude::*;
 use futures::{future::join_all, stream::StreamExt};
 use hotshot_query_service::availability::LeafQueryData;
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+use rand_distr::Distribution;
 use sequencer_utils::{commitment_to_u256, connect_rpc, contract_send, Signer};
 use std::error::Error;
 use std::time::Duration;
 use surf_disco::Url;
 
-use crate::{Header, SeqTypes};
+use crate::{options::parse_duration, Header, SeqTypes};
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
@@ -56,6 +59,10 @@ pub struct CommitmentTaskOptions {
     /// passing the options to `run_hotshot_commitment_task`.
     #[clap(long, env = "ESPRESSO_SEQUENCER_QUERY_SERVICE_URL")]
     pub query_service_url: Option<Url>,
+
+    /// If specified, sequencing attempts will be delayed by duration sampled from an exponential distribution with mean DELAY.
+    #[clap(long, name = "DELAY", value_parser = parse_duration, default_value = "0s", env = "ESPRESSO_COMMITMENT_TASK_DELAY")]
+    pub delay: Duration,
 }
 
 pub async fn run_hotshot_commitment_task(opt: &CommitmentTaskOptions) {
@@ -81,15 +88,21 @@ pub async fn run_hotshot_commitment_task(opt: &CommitmentTaskOptions) {
             panic!("hotshot commitment task will exit");
         }
     };
-    sequence(max, hotshot, contract).await;
+    sequence(max, hotshot, contract, opt.delay).await;
 }
 
-async fn sequence(hard_block_limit: usize, hotshot: HotShotClient, contract: HotShot<Signer>) {
+async fn sequence(
+    hard_block_limit: usize,
+    hotshot: HotShotClient,
+    contract: HotShot<Signer>,
+    delay: Duration,
+) {
     // This is the number of blocks we attempt to sequence
     // If we fail to submit soft_block_limit leaves, we assume we have hit
     // A gas limit exception and decrease the limit
     // If we succeed, we increase the limit towards the hard_block_limit
     let mut soft_block_limit = hard_block_limit;
+    let mut rng = ChaChaRng::from_entropy();
     loop {
         if let Err(sync_err) = sync_with_l1(soft_block_limit, &hotshot, &contract).await {
             match sync_err {
@@ -106,7 +119,12 @@ async fn sequence(hard_block_limit: usize, hotshot: HotShotClient, contract: Hot
             sleep(RETRY_DELAY).await;
         } else {
             // If we succeed, increase the limit
-            soft_block_limit = std::cmp::min(soft_block_limit * 2, hard_block_limit)
+            soft_block_limit = std::cmp::min(soft_block_limit * 2, hard_block_limit);
+            // Create an exponential distribution for sampling delay times. The distribution should have
+            // mean `delay`, or parameter `\lambda = 1 / delay`.
+            let delay_distr = rand_distr::Exp::<f64>::new(1f64 / delay.as_millis() as f64).unwrap();
+            let delay = Duration::from_millis(delay_distr.sample(&mut rng) as u64);
+            sleep(delay).await;
         }
     }
 }


### PR DESCRIPTION
Copied the submit transactions submit logic to add a chaos testing delay param to the commitment task. 

Closes #1026 