### PR TITLE
Move wait for orchestrator after query service initialization

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -106,7 +106,6 @@ mod test_helpers {
                     0,
                     Default::default(),
                     Default::default(),
-                    None,
                 )
             }
             .boxed()
@@ -173,7 +172,6 @@ mod test_helpers {
                         0,
                         Default::default(),
                         Default::default(),
-                        None,
                     )
                 }
                 .boxed()
@@ -226,7 +224,6 @@ mod test_helpers {
                         0,
                         Default::default(),
                         Default::default(),
-                        None,
                     )
                 }
                 .boxed()
@@ -305,7 +302,7 @@ mod generic_tests {
             .status(Default::default())
             .serve(|_| {
                 async move {
-                    SequencerContext::new(handle, 0, Default::default(), Default::default(), None)
+                    SequencerContext::new(handle, 0, Default::default(), Default::default())
                 }
                 .boxed()
             })
@@ -516,7 +513,6 @@ mod test {
                         0,
                         Default::default(),
                         Default::default(),
-                        None,
                     )
                 }
                 .boxed()

--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -180,7 +180,7 @@ impl Options {
         };
 
         // Start consensus.
-        node.context.consensus().hotshot.start_consensus().await;
+        node.context.start_consensus().await;
         Ok(node)
     }
 }

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Start doing consensus.
-    context.consensus().hotshot.start_consensus().await;
+    context.start_consensus().await;
 
     // Wait for events just to keep the process from exiting before consensus exits.
     let mut events = context


### PR DESCRIPTION
This is necessary to make restarts work properly, since we will need to fetch the latest state from a query service (our own or a peer's) in order to start consensus in the first place. This also makes it so that nodes are healthy even before they have all started consensus, which makes coordinated starts easier