### PR TITLE
Add builder and fee

### DIFF
--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -198,6 +198,9 @@ pub struct Header {
     pub fee_merkle_tree_root: FeeMerkleCommitment,
     // TODO remove from `Header` when real `ValidatedState` becomes available
     pub validated_state: ValidatedState,
+    pub builder_address: Address,
+    pub builder_signature: String,
+    pub builder_fee_amount: String
 }
 
 impl Committable for Header {


### PR DESCRIPTION
Add builder info and fee amount to block header. Closes #1044 

So far this PR adds builder related fields to `Header` and implements rudimentary logic for signing the header.  Some remaining tasks are:

  * get the mnemonic from config
  * deduct fee from account
  * more things probably