### PR TITLE
state catchup APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7387,6 +7387,7 @@ dependencies = [
  "toml 0.8.10",
  "tracing",
  "trait-set",
+ "trait-variant",
  "typenum",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ snafu = "0.7.4"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.6" }
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco", tag = "v0.4.6" }
 tracing = "0.1"
+trait-variant = "0.1"
 bytesize = "1.3"
 itertools = "0.12"
 rand_chacha = "0.3"

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -47,6 +47,7 @@ time = "0.3"
 tokio-postgres = { version = "0.7", default-features = false, features = [ # disabling the default features removes dependence on the tokio runtime
     "with-serde_json-1",
 ] }
+trait-variant = { workspace = true }
 
 hotshot = { workspace = true }
 hotshot-orchestrator = { workspace = true }

--- a/sequencer/api/state.toml
+++ b/sequencer/api/state.toml
@@ -1,0 +1,36 @@
+[route.account]
+PATH = ["/catchup/:view/account/:address", "/account/:address"]
+":view" = "Integer"
+":address" = "Literal"
+DOC = """
+Get the fee account balance for `address`.
+
+This endpoint can be used to catch up to the current state from a recent state by fetching the
+balance (with proof) at the given `:view` number. It can also be used to query the latest finalized
+state.
+
+Returns the account balance and a Merkle proof relative to the fee state root at the requested view.
+If there is no entry for this account in the requested fee state (note: this is distinct from the
+server _not knowing_ the entry for this account), the returned balance is 0 and the proof is a
+Merkle _non-membership_ proof.
+
+```
+{
+    "balance": "integer",
+    "proof": { ... },
+}
+```
+"""
+
+[route.blocks]
+PATH = ["/catchup/:view/blocks", "/blocks"]
+":view" = "Integer"
+DOC = """
+Get the blocks Merkle tree frontier.
+
+This endpoint can be used to catch up to the current state from a recent state by fetching the
+frontier at the given `:view` number. It can also be used to query the latest finalized state.
+
+Returns the blocks Merkle tree frontier -- the path to the most recently appended leaf, relative to
+root node at the requested view.
+"""

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1,11 +1,16 @@
 use self::data_source::StateSignatureDataSource;
-use crate::{context::SequencerContext, network, state_signature, Node, SeqTypes};
-use async_std::task::JoinHandle;
+use crate::{
+    context::SequencerContext, network, state::ValidatedState, state_signature, Node, SeqTypes,
+};
+use async_std::{sync::Arc, task::JoinHandle};
 use async_trait::async_trait;
-use data_source::SubmitDataSource;
+use data_source::{StateDataSource, SubmitDataSource};
 use hotshot::types::SystemContextHandle;
 use hotshot_query_service::data_source::ExtensibleDataSource;
-use hotshot_types::light_client::{LightClientState, StateSignature, StateSignatureRequestBody};
+use hotshot_types::{
+    data::ViewNumber,
+    light_client::{LightClientState, StateSignature, StateSignatureRequestBody},
+};
 
 pub mod data_source;
 pub mod endpoints;
@@ -35,6 +40,26 @@ impl<N: network::Type> SubmitDataSource<N> for SequencerContext<N> {
     }
 }
 
+impl<N: network::Type, D: Send + Sync> StateDataSource for AppState<N, D> {
+    async fn get_decided_state(&self) -> Arc<ValidatedState> {
+        self.as_ref().consensus().get_decided_state().await
+    }
+
+    async fn get_undecided_state(&self, view: ViewNumber) -> Option<Arc<ValidatedState>> {
+        self.as_ref().consensus().get_state(view).await
+    }
+}
+
+impl<N: network::Type> StateDataSource for SequencerContext<N> {
+    async fn get_decided_state(&self) -> Arc<ValidatedState> {
+        self.consensus().get_decided_state().await
+    }
+
+    async fn get_undecided_state(&self, view: ViewNumber) -> Option<Arc<ValidatedState>> {
+        self.consensus().get_state(view).await
+    }
+}
+
 #[async_trait]
 impl<N: network::Type, D: Sync> StateSignatureDataSource<N> for AppState<N, D> {
     async fn get_state_signature(&self, height: u64) -> Option<StateSignatureRequestBody> {
@@ -61,6 +86,7 @@ impl<N: network::Type> StateSignatureDataSource<N> for SequencerContext<N> {
 mod test_helpers {
     use super::*;
     use crate::{
+        api::endpoints::AccountQueryData,
         testing::{
             init_hotshot_handles, init_hotshot_handles_with_metrics, wait_for_decide_on_handle,
         },
@@ -69,7 +95,11 @@ mod test_helpers {
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use async_std::task::sleep;
     use commit::Committable;
-    use futures::FutureExt;
+    use ethers::prelude::Address;
+    use futures::{FutureExt, StreamExt};
+    use hotshot::types::{Event, EventType};
+    use hotshot_types::traits::node_implementation::ConsensusTime;
+    use jf_primitives::merkle_tree::MerkleTreeScheme;
     use portpicker::pick_unused_port;
     use std::time::Duration;
     use surf_disco::Client;
@@ -210,7 +240,7 @@ mod test_helpers {
             handle.hotshot.start_consensus().await;
         }
 
-        let options = opt(Options::from(options::Http { port }).submit(Default::default()));
+        let options = opt(Options::from(options::Http { port }).state(Default::default()));
         let SequencerNode { context, .. } = options
             .serve(|_| {
                 async move {
@@ -243,12 +273,127 @@ mod test_helpers {
             .await
             .is_ok());
     }
+
+    /// Test the state API with custom options.
+    ///
+    /// The `opt` function can be used to modify the [`Options`] which are used to start the server.
+    /// By default, the options are the minimal required to run this test (configuring a port and
+    /// enabling the state API). `opt` may add additional functionality (e.g. adding a query module
+    /// to test a different initialization path) but should not remove or modify the existing
+    /// functionality (e.g. removing the state module or changing the port).
+    pub async fn state_test_helper(opt: impl FnOnce(Options) -> Options) {
+        setup_logging();
+        setup_backtrace();
+
+        let port = pick_unused_port().expect("No ports free");
+        let url = format!("http://localhost:{port}").parse().unwrap();
+        let client: Client<ServerError> = Client::new(url);
+
+        // Get list of HotShot handles and take the first one.
+        let handles = init_hotshot_handles().await;
+        for handle in handles.iter() {
+            handle.hotshot.start_consensus().await;
+        }
+
+        let options = opt(Options::from(options::Http { port }).state(Default::default()));
+        let mut node = options
+            .serve(|_| {
+                async move {
+                    SequencerContext::new(
+                        handles[0].clone(),
+                        0,
+                        Default::default(),
+                        Default::default(),
+                    )
+                }
+                .boxed()
+            })
+            .await
+            .unwrap();
+        client.connect(None).await;
+
+        // Wait for a few blocks to be decided.
+        let mut events = node
+            .context
+            .consensus_mut()
+            .get_event_stream(Default::default())
+            .await
+            .0;
+        loop {
+            if let Event {
+                event: EventType::Decide { leaf_chain, .. },
+                ..
+            } = events.next().await.unwrap()
+            {
+                if leaf_chain.iter().any(|leaf| leaf.block_header.height > 2) {
+                    break;
+                }
+            }
+        }
+
+        // Stop consensus running on the node so we freeze the decided and undecided states.
+        node.context.consensus_mut().shut_down().await;
+
+        // Decided fee state: absent account.
+        let res = client
+            .get::<AccountQueryData>(&format!("state/account/{:x}", Address::default()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.balance, 0.into());
+        assert_eq!(
+            res.proof
+                .verify(
+                    &node
+                        .context
+                        .consensus()
+                        .get_decided_state()
+                        .await
+                        .fee_merkle_tree
+                        .commitment()
+                )
+                .unwrap(),
+            0.into()
+        );
+
+        // Undecided fee state: absent account.
+        let leaf = node.context.consensus().get_decided_leaf().await;
+        let view = leaf.view_number + 1;
+        let res = client
+            .get::<AccountQueryData>(&format!(
+                "state/catchup/{}/account/{:x}",
+                view.get_u64(),
+                Address::default()
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.balance, 0.into());
+        assert_eq!(
+            res.proof
+                .verify(
+                    &node
+                        .context
+                        .consensus()
+                        .get_state(view)
+                        .await
+                        .unwrap()
+                        .fee_merkle_tree
+                        .commitment()
+                )
+                .unwrap(),
+            0.into()
+        );
+    }
 }
 
 #[cfg(test)]
 #[espresso_macros::generic_tests]
 mod generic_tests {
-    use super::{test_helpers::state_signature_test_helper, *};
+    use super::{
+        test_helpers::{state_signature_test_helper, state_test_helper},
+        *,
+    };
     use crate::{testing::init_hotshot_handles, Header};
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use async_std::task::sleep;
@@ -279,6 +424,12 @@ mod generic_tests {
     pub(crate) async fn state_signature_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
         state_signature_test_helper(|opt| D::options(&storage, opt)).await
+    }
+
+    #[async_std::test]
+    pub(crate) async fn state_test_with_query_module<D: TestableSequencerDataSource>() {
+        let storage = D::create_storage().await;
+        state_test_helper(|opt| D::options(&storage, opt)).await
     }
 
     #[async_std::test]
@@ -476,7 +627,10 @@ mod generic_tests {
 
 #[cfg(test)]
 mod test {
-    use super::{test_helpers::state_signature_test_helper, *};
+    use super::{
+        test_helpers::{state_signature_test_helper, state_test_helper},
+        *,
+    };
     use crate::testing::init_hotshot_handles;
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use futures::FutureExt;
@@ -533,5 +687,10 @@ mod test {
     #[async_std::test]
     async fn state_signature_test_without_query_module() {
         state_signature_test_helper(|opt| opt).await
+    }
+
+    #[async_std::test]
+    async fn state_test_without_query_module() {
+        state_test_helper(|opt| opt).await
     }
 }

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -1,6 +1,5 @@
 use crate::{NMTRoot, NamespaceProofType, Transaction, TransactionNMT, VmId, MAX_NMT_DEPTH};
 use commit::{Commitment, Committable};
-
 use hotshot_query_service::availability::QueryablePayload;
 use hotshot_types::{traits::block_contents::BlockPayload, utils::BuilderCommitment};
 use jf_primitives::merkle_tree::{namespaced_merkle_tree::NamespacedMerkleTreeScheme, prelude::*};


### PR DESCRIPTION
Implements endpoints to fetch fee and block state from the most recent decided view and later undecided views.

Only thing that's missing is an end-to-end test for non-empty fee accounts, because we don't yet have a good way of initializing the fee ledger with some pre-funded accounts. However, we have a separate unit test to make sure the membership proofs work, and we have an end-to-end test for absence proofs. So I think we can merge this as-is, and I will add the end-to-end membership proof test later after #1048 