### PR TITLE
feat: RPC-friendly verification of namespace proofs

### DIFF
--- a/sequencer/src/block2/payload.rs
+++ b/sequencer/src/block2/payload.rs
@@ -9,7 +9,7 @@ use jf_primitives::pcs::prelude::UnivariateKzgPCS;
 use jf_primitives::pcs::{checked_fft_size, PolynomialCommitmentScheme};
 use jf_primitives::vid::advz::payload_prover::{LargeRangeProof, SmallRangeProof};
 use jf_primitives::vid::advz::Advz;
-use jf_primitives::vid::payload_prover::PayloadProver;
+use jf_primitives::vid::{payload_prover::PayloadProver, VidScheme};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
@@ -288,6 +288,17 @@ pub(super) type RangeProof =
 /// but that's still pretty crufty.
 pub type JellyfishNamespaceProof =
     LargeRangeProof<<UnivariateKzgPCS<Bls12_381> as PolynomialCommitmentScheme>::Evaluation>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NamespaceProof<V>
+where
+    V: PayloadProver<JellyfishNamespaceProof>,
+{
+    ns_payload_flat: Vec<u8>,
+    ns_index: u32,
+    ns_proof: JellyfishNamespaceProof,
+    vid_common: <V as VidScheme>::Common,
+}
 
 // TODO find a home for this function
 fn parse_ns_payload(ns_payload_flat: &[u8], ns_id: VmId) -> Vec<Transaction> {

--- a/sequencer/src/block2/payload.rs
+++ b/sequencer/src/block2/payload.rs
@@ -98,7 +98,7 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
         &self,
         meta: &[u8], //&<Self as hotshot_types::traits::BlockPayload>::Metadata, TODO
         ns_index: usize,
-    ) -> Option<(Vec<u8>, NamespaceProof)> {
+    ) -> Option<(Vec<u8>, JellyfishNamespaceProof)> {
         let ns_table = NameSpaceTable::<TableWord>::from_bytes(meta);
         if ns_index >= ns_table.len() {
             return None; // error: index out of bounds
@@ -284,7 +284,7 @@ pub(super) type RangeProof =
 /// LargeRangeProof<KzgEval<Bls12_281>>
 /// ```
 /// but that's still pretty crufty.
-pub type NamespaceProof =
+pub type JellyfishNamespaceProof =
     LargeRangeProof<<UnivariateKzgPCS<Bls12_381> as PolynomialCommitmentScheme>::Evaluation>;
 
 #[cfg(test)]

--- a/sequencer/src/block2/queryable.rs
+++ b/sequencer/src/block2/queryable.rs
@@ -13,6 +13,7 @@ use super::{
     tx_iterator::{TxIndex, TxIterator},
 };
 
+// TODO don't hard-code TxTableEntryWord generic param
 impl QueryablePayload for Payload<TxTableEntryWord> {
     type TransactionIndex = TxIndex;
     type Iter<'a> = TxIterator<'a, TxTableEntryWord>;

--- a/sequencer/src/block2/tables.rs
+++ b/sequencer/src/block2/tables.rs
@@ -113,10 +113,10 @@ impl<TableWord: TableWordTraits> NameSpaceTable<TableWord> {
         std::cmp::min(left, right)
     }
 
-    // returns (ns_id, payload_offset)
-    // payload_offset is not checked, could be anything
+    // returns (ns_id, ns_offset)
+    // ns_offset is not checked, could be anything
     pub fn get_table_entry(&self, ns_index: usize) -> (VmId, usize) {
-        // range for ns_id bytes in ns table
+        // get the range for ns_id bytes in ns table
         // ensure `range` is within range for ns_table_bytes
         let start = std::cmp::min(
             ns_index
@@ -139,7 +139,7 @@ impl<TableWord: TableWordTraits> NameSpaceTable<TableWord> {
             VmId::try_from(TxTableEntry::from_bytes(&ns_id_bytes).unwrap_or(TxTableEntry::zero()))
                 .unwrap_or(VmId(0));
 
-        // range for ns_offset bytes in ns table
+        // get the range for ns_offset bytes in ns table
         // ensure `range` is within range for ns_table_bytes
         // TODO refactor range checking code
         let start = end;

--- a/sequencer/src/block2/tables.rs
+++ b/sequencer/src/block2/tables.rs
@@ -197,10 +197,21 @@ impl TxTable {
         TxTableEntry::from_bytes_array(entry_bytes)
     }
 
+    // Parse the table length from the beginning of the tx table inside `ns_bytes`.
+    //
+    // Returned value is guaranteed to be no larger than the number of tx table entries that could possibly fit into `ns_bytes`.
+    // TODO tidy this is a sloppy wrapper for get_len
+    pub(crate) fn get_tx_table_len(ns_bytes: &[u8]) -> usize {
+        std::cmp::min(
+            Self::get_len(ns_bytes, 0).try_into().unwrap_or(0),
+            (ns_bytes.len().saturating_sub(TxTableEntry::byte_len())) / TxTableEntry::byte_len(),
+        )
+    }
+
     // returns tx_offset
     // if tx_index would reach beyond ns_bytes then return 0.
     // tx_offset is not checked, could be anything
-    pub(crate) fn _get_table_entry(ns_bytes: &[u8], tx_index: usize) -> usize {
+    pub(crate) fn get_table_entry(ns_bytes: &[u8], tx_index: usize) -> usize {
         // get the range for tx_offset bytes in tx table
         let tx_offset_range = {
             let start = std::cmp::min(

--- a/sequencer/src/block2/tx_iterator.rs
+++ b/sequencer/src/block2/tx_iterator.rs
@@ -12,6 +12,9 @@ pub struct TxIndex {
     pub tx_idx: usize,
 }
 
+/// TODO Decompose this iterator into
+/// - a tx iterator `T` over only 1 namespace
+/// - a namespace-tx iterator that reuses `T` over all namespaces
 pub struct TxIterator<'a, TableWord: TableWordTraits> {
     ns_idx: usize, // simpler than using `Peekable`
     ns_iter: Range<usize>,


### PR DESCRIPTION
close #1067 

- type alias `NamespaceProof` replaced with a new struct with that name
- new method `NamespaceProof::verify` with API from #1067 + additional args `vid`, `commit`.
- test demos use of `verify`
- tech debt to refactor in the future:
  - resurrect function `_get_tx_table_entry`, make it like `get_ns_table_entry`
  - new function `parse_ns_payload`