### PR TITLE
Fix bug in startup using orchestrator

### DIFF
--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -176,8 +176,6 @@ impl Options {
             }
         };
 
-        // Start consensus.
-        node.context.start_consensus().await;
         Ok(node)
     }
 


### PR DESCRIPTION
We were calling `start_consensus` twice, once in the API startup and once in `main`. `start_consensus` waits for the orchestrator. This is why we were seeing 10 nodes connected to the orchestrator when we only started 5. This can also keep some nodes from starting up, if one node connects to the orchestrator twice before another node connects once.