### PR TITLE
CI: move cargo test to separate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
 
       - name: Build
         # Build in release without `testing` feature, this should work without `hotshot_example` config.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,14 +50,6 @@ jobs:
         run: |
           cargo build --release --workspace
 
-      - name: Test
-        # Build test binary with `testing` feature, which requires `hotshot_example` config
-        run: |
-          export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
-          cargo test --release --workspace --all-features --no-run
-          cargo test --release --workspace --all-features --verbose -- --test-threads 1 --nocapture
-        timeout-minutes: 30
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-demo-native.yml
+++ b/.github/workflows/test-demo-native.yml
@@ -51,4 +51,3 @@ jobs:
           export PATH="$PWD/target/release:$PATH"
           scripts/demo-native --tui=false &
           scripts/smoke-test-demo
-          process-compose down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
+  RUST_LOG: info,libp2p=off,node=error
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ env:
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Fix submodule permissions check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+    tags:
+      # YYYYMMDD
+      - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
+  schedule:
+    - cron: "0 0 * * 1"
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fix submodule permissions check
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install just command runner
+        run: |
+          sudo snap install --edge --classic just
+          just --version
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Enable Rust Caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        # Build test binary with `testing` feature, which requires `hotshot_example` config
+        run: |
+          export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
+          cargo test --release --workspace --all-features --no-run
+          cargo test --release --workspace --all-features --verbose -- --test-threads 1 --nocapture
+        timeout-minutes: 30


### PR DESCRIPTION
Make the rust cache work again and save a lot of compilation time.

Close #1134