### PR TITLE
CI: fix docker demo test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,9 +296,7 @@ jobs:
           docker tag ${{ needs.build-dockers.outputs.commitment-task-tag }} ghcr.io/espressosystems/espresso-sequencer/commitment-task:main
           docker tag ${{ needs.build-dockers.outputs.submit-transactions-tag }} ghcr.io/espressosystems/espresso-sequencer/submit-transactions:main
 
-      - name: Start Demo
-        run: just demo --wait
-      - name: Test Demo
-        run: scripts/smoke-test-demo
-      - name: Stop Demo
-        run: just down -v
+      - name: Test docker demo
+        run: |
+          just demo &
+          timeout 600 scripts/smoke-test-demo

--- a/docker/prover-service.Dockerfile
+++ b/docker/prover-service.Dockerfile
@@ -3,9 +3,13 @@ FROM ubuntu:jammy
 ARG TARGETARCH
 
 RUN apt-get update \
-    &&  apt-get install -y curl git cargo libcurl4 wait-for-it tini jq \
+    &&  apt-get install -y curl git libcurl4 wait-for-it tini jq \
     &&  rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["tini", "--"]
+
+# install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH "$PATH:/root/.cargo/bin"
 
 # install foundry toolchain
 RUN curl -L https://foundry.paradigm.xyz | bash
@@ -13,22 +17,22 @@ ENV PATH "$PATH:/root/.foundry/bin"
 RUN foundryup
 
 # copy the contracts
-WORKDIR /usr/local/prover-service/contracts
-COPY foundry.toml /usr/local/prover-service/foundry.toml
-COPY contracts/ /usr/local/prover-service/contracts/
+RUN mkdir /work
+WORKDIR /work
+COPY foundry.toml /work/foundry.toml
+COPY contracts/ /work/contracts/
+
 # copy the binaries
-COPY target/$TARGETARCH/release/state-prover /usr/local/prover-service/state-prover
-COPY target/$TARGETARCH/release/gen-demo-contract /usr/local/prover-service/gen-demo-contract
-RUN chmod +x /usr/local/prover-service/state-prover
-RUN chmod +x /usr/local/prover-service/gen-demo-contract
-# copy the launching script
-COPY scripts/launch-prover-service /usr/local/prover-service/launch-prover-service
-RUN chmod +x /usr/local/prover-service/launch-prover-service
+COPY target/$TARGETARCH/release/state-prover /usr/local/bin/state-prover
+COPY target/$TARGETARCH/release/gen-demo-contract /usr/local/bin/gen-demo-contract
+COPY scripts/launch-prover-service /usr/local/bin/launch-prover-service
+RUN chmod +x /usr/local/bin/state-prover
+RUN chmod +x /usr/local/bin/gen-demo-contract
+RUN chmod +x /usr/local/bin/launch-prover-service
 
 # When running as a Docker service, we always want a healthcheck endpoint, so set a default for the
 # port that the HTTP server will run on. This can be overridden in any given deployment environment.
 ENV ESPRESSO_COMMITMENT_TASK_PORT=80
 HEALTHCHECK --interval=1s --timeout=1s --retries=100 CMD curl --fail http://localhost:${ESPRESSO_COMMITMENT_TASK_PORT}/healthcheck || exit 1
 
-WORKDIR /usr/local/prover-service
-CMD ["/usr/local/prover-service/launch-prover-service"]
+CMD [ "launch-prover-service" ]

--- a/hotshot-state-prover/src/bin/gen-demo-contract.rs
+++ b/hotshot-state-prover/src/bin/gen-demo-contract.rs
@@ -144,9 +144,8 @@ fn main() {
                     stakeTableAmountComm,
                     threshold
                 );
-                new LC();
-                new LC.initialize(genesis, blocksPerEpoch);
-        
+                new LC(genesis, blocksPerEpoch);
+
                 vm.stopBroadcast();
             }}
         }}

--- a/hotshot-state-prover/src/bin/gen-demo-contract.rs
+++ b/hotshot-state-prover/src/bin/gen-demo-contract.rs
@@ -144,7 +144,8 @@ fn main() {
                     stakeTableAmountComm,
                     threshold
                 );
-                new LC(genesis, blocksPerEpoch);
+                new LC();
+                new LC.initialize(genesis, blocksPerEpoch);
         
                 vm.stopBroadcast();
             }}

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -80,6 +80,23 @@ processes:
         port: $ESPRESSO_STATE_RELAY_SERVER_PORT
         path: /healthcheck
 
+  prover-service:
+    command: ./scripts/launch-prover-service
+    environment:
+      - ESPRESSO_STATE_RELAY_SERVER_URL
+      - ESPRESSO_ORCHESTRATOR_NUM_NODES
+      - ESPRESSO_ORCHESTRATOR_KEYGEN_SEED
+      - ESPRESSO_STATE_PROVER_UPDATE_INTERVAL
+      - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_ETH_MNEMONIC
+      - ESPRESSO_SEQUENCER_DEPLOY_LIGHTCLIENT_CONTRACT
+      - MNEMONIC=$ESPRESSO_SEQUENCER_ETH_MNEMONIC
+    depends_on:
+      state-relay-server:
+        condition: process_healthy
+      demo-l1-network:
+        condition: process_healthy
+
   sequencer0:
     command: sequencer -- http -- query -- status -- submit
     environment:

--- a/scripts/launch-prover-service
+++ b/scripts/launch-prover-service
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # If ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS is unset and
 # ESPRESSO_SEQUENCER_DEPLOY_LIGHTCLIENT_CONTRACT is "yes" or "1" the light
 # client contract will be deployed. This feature is intended for demo or testnet
@@ -8,15 +8,16 @@ set -eo pipefail
 if [[ -z "${ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS}" ]]; then
   if [[ "${ESPRESSO_SEQUENCER_DEPLOY_LIGHTCLIENT_CONTRACT}" == "yes" || "${ESPRESSO_SEQUENCER_DEPLOY_LIGHTCLIENT_CONTRACT}" == "1" ]]; then
     echo "Light client contract address not found, deploying it now."
-    ./gen-demo-contract --contracts-root-dir="./contracts"
+    gen-demo-contract --contracts-root-dir="./contracts"
     forge fmt
     forge build
     forge script DeployLightClientDemoScript --fork-url $ESPRESSO_SEQUENCER_L1_PROVIDER --broadcast
     ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS=$(cat contracts/broadcast/LightClientDemo.s.sol/*/run-latest.json | jq -r '.receipts[1].contractAddress')
     echo "Light client contract address: $ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS"
   else
-    echo "Light client contract address not found"
+    echo "ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS not provided and deployment is not enabled. Exiting."
+    exit 1
   fi
 fi
 
-./state-prover -d --light-client-address $ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS
+state-prover -d --light-client-address $ESPRESSO_SEQUENCER_LIGHTCLIENT_ADDRESS


### PR DESCRIPTION
- Re-organize docker container: put binaries into path.
- Use stable rust.
- Don't use `--wait` for demo test so we get logs.
- ~Fix light client constructor.~
- Add prover-service to process compose.

This doesn't actually fix the deployment script but since @philippecamacho is working to remove that I think that's fine. It should "fix" the docker demo test because it should no longer fail due to failing prover-service because `--wait` is removed. If not, this way we should at least get some logs.

Unfortunately couldn't figure out how one could make process-compose exit if one of the processes exits.