### PR TITLE
Add num storage parameter to the `GetNamespaceProof` endpoint

### DIFF
--- a/sequencer/api/availability.toml
+++ b/sequencer/api/availability.toml
@@ -1,8 +1,9 @@
 [route.getnamespaceproof]
-PATH = ["block/:height/namespace/:namespace"]
+PATH = ["block/:height/namespace/:namespace/nodes/:nodes"]
 ":height" = "Integer"
 ":namespace" = "Integer"
-DOC = "Get the namespace proof for a set of VM transactions and the NMT root"
+":nodes" = "Integer"
+DOC = "Get the namespace proof for a set of VM transactions. The `:nodes` parameter specifies the chunk size for the ADVZ scheme. "
 
 [route.gettimestampwindow]
 PATH = [

--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -79,6 +79,7 @@ where
         async move {
             let height: usize = req.integer_param("height")?;
             let ns_id = VmId(req.integer_param("namespace")?);
+            let num_storage_nodes = req.integer_param("nodes")?;
             let block = state.get_block(height).await.context(FetchBlockSnafu {
                 resource: height.to_string(),
             })?;
@@ -87,7 +88,7 @@ where
             // https://github.com/EspressoSystems/espresso-sequencer/issues/1047
             // TODO do not disperse here!
             // https://github.com/EspressoSystems/espresso-sequencer/issues/1093
-            let vid = crate::block::payload::test_vid_factory();
+            let vid = crate::block::payload::test_vid_factory(Some(num_storage_nodes));
             use hotshot::traits::BlockPayload;
             let disperse_data = vid
                 .disperse(

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -271,9 +271,10 @@ impl<TableWord: TableWordTraits> Committable for Payload<TableWord> {
 /// https://stackoverflow.com/a/52886787
 ///
 /// TODO temporary VID constructor.
-pub(crate) fn test_vid_factory() -> VidScheme {
+pub(crate) fn test_vid_factory(num_storage_nodes: Option<usize>) -> VidScheme {
     // -> impl PayloadProver<RangeProof, Common = impl LengthGetter + CommitChecker<Self>> {
-    let (payload_chunk_size, num_storage_nodes) = (8, 10);
+    let num_storage_nodes = num_storage_nodes.unwrap_or(10);
+    let payload_chunk_size = 1 << num_storage_nodes.ilog2();
 
     let mut rng = jf_utils::test_rng();
     let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
@@ -480,7 +481,7 @@ mod test {
             tx_payloads: Vec<Vec<u8>>,
         }
 
-        let vid = test_vid_factory();
+        let vid = test_vid_factory(None);
         let num_test_cases = test_cases.len();
         for (t, test_case) in test_cases.iter().enumerate() {
             // DERIVE A BUNCH OF STUFF FOR THIS TEST CASE
@@ -779,7 +780,7 @@ mod test {
         setup_logging();
         setup_backtrace();
 
-        let vid = test_vid_factory();
+        let vid = test_vid_factory(None);
         let num_test_cases = test_cases.len();
         for (t, test_case) in test_cases.into_iter().enumerate() {
             let payload_byte_len = test_case.payload.len();
@@ -848,7 +849,7 @@ mod test {
         // test: cannot make a proof for such a small block
         // assert!(block.transaction_with_proof(&0).is_none());
 
-        let vid = test_vid_factory();
+        let vid = test_vid_factory(None);
         let disperse_data = vid.disperse(&block.raw_payload).unwrap();
 
         // make a fake proof for a nonexistent tx in the small block

--- a/sequencer/src/block/queryable.rs
+++ b/sequencer/src/block/queryable.rs
@@ -74,7 +74,7 @@ impl QueryablePayload for Payload<TxTableEntryWord> {
             return None; // error: index out of bounds
         }
 
-        let vid = test_vid_factory(); // TODO temporary VID construction
+        let vid = test_vid_factory(None); // TODO temporary VID construction
 
         // Read the tx payload range from the tx table into `tx_table_range_[start|end]` and compute a proof that this range is correct.
         //


### PR DESCRIPTION
This is a small hack to ensure that the scheme that constructs the proof is consistent with the commitment generated by HotShot. Necessary until we have a single source of truth for the VID scheme. The chunk size is generated deterministically based on the following hardcoded logic in HotShot:
```
let num_chunks = 1 << num_storage_nodes.ilog2();
```