### PR TITLE
chore: update hotshot 0.5.19, hotshot-query-service 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,8 +2386,8 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
-source = "git+https://github.com/dtolnay/dyn-clone?tag=1.0.16#f2f0a02f1f7190048153e5ea8f554db7377a50a9"
+version = "1.0.17"
+source = "git+https://github.com/dtolnay/dyn-clone?tag=1.0.17#51bf8816be5a73e38b59fd4d9dda2bc18e9c2429"
 
 [[package]]
 name = "ecdsa"
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "serde",
 ]
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.0.9"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.0.9#095af5ee3c46a0a1a5a2cfda464aeafbc57ef199"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.0.10#0e92012fb80e0a7335d66f6a3b528e1f92662d35"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3753,6 +3753,7 @@ dependencies = [
  "hotshot-utils",
  "include_dir",
  "itertools 0.12.1",
+ "jf-primitives",
  "native-tls",
  "portpicker",
  "postgres-native-tls",
@@ -3777,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3840,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3853,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3870,6 +3871,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
+ "jf-primitives",
  "sha2 0.10.8",
  "snafu",
  "time 0.3.34",
@@ -3880,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3900,6 +3902,7 @@ dependencies = [
  "hotshot-task-impls",
  "hotshot-types",
  "hotshot-utils",
+ "jf-primitives",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -3912,9 +3915,10 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "ark-bls12-381",
+ "ark-ec",
  "ark-ed-on-bn254",
  "ark-ff",
  "ark-serialize 0.4.2",
@@ -3931,7 +3935,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "displaydoc",
- "dyn-clone 1.0.16 (git+https://github.com/dtolnay/dyn-clone?tag=1.0.16)",
+ "dyn-clone 1.0.17",
  "either",
  "espresso-systems-common 0.4.1",
  "ethereum-types",
@@ -3941,6 +3945,7 @@ dependencies = [
  "jf-plonk",
  "jf-primitives",
  "jf-utils",
+ "lazy_static",
  "libp2p-networking",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3957,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3966,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4452,7 +4457,7 @@ dependencies = [
  "derivative",
  "displaydoc",
  "downcast-rs",
- "dyn-clone 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dyn-clone 1.0.16",
  "espresso-systems-common 0.4.0",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
@@ -4530,7 +4535,7 @@ dependencies = [
  "derivative",
  "displaydoc",
  "downcast-rs",
- "dyn-clone 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dyn-clone 1.0.16",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
  "jf-utils",
@@ -4995,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2021"
 resolver = "2"
 
 members = [
-    "contract-bindings",
-    "contracts/rust/adapter",
-    "contracts/rust/diff-test",
-    "contracts/rust/gen-vk-contract",
-    "hotshot-state-prover",
-    "sequencer",
-    "utils"
+  "contract-bindings",
+  "contracts/rust/adapter",
+  "contracts/rust/diff-test",
+  "contracts/rust/gen-vk-contract",
+  "hotshot-state-prover",
+  "sequencer",
+  "utils",
 ]
 
 [workspace.dependencies]
@@ -28,7 +28,7 @@ ark-ff = "0.4"
 ark-poly = "0.4"
 ark-serialize = "0.4"
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
-    "logging-utils",
+  "logging-utils",
 ] }
 async-std = "1.12.0"
 async-trait = "0.1.77"
@@ -37,15 +37,15 @@ cld = "0.5"
 derive_more = "0.99.17"
 ethers = { version = "2.0", features = ["ws"] }
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.17" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.19" }
 
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.0.9" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.0.10" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0", features = [
   "test-apis",
   "test-srs",

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -499,7 +499,7 @@ mod generic_tests {
 
         // Wait for at least one empty block to be sequenced (after consensus starts VID).
         client
-            .socket(&format!("availability/stream/leaves/0"))
+            .socket("availability/stream/leaves/0")
             .subscribe::<LeafQueryData<SeqTypes>>()
             .await
             .unwrap()

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -425,7 +425,6 @@ mod generic_tests {
         *,
     };
     use crate::{
-        block::payload::test_vid_factory,
         testing::{init_hotshot_handles, wait_for_decide_on_handle},
         Header, Transaction, VmId,
     };
@@ -435,10 +434,8 @@ mod generic_tests {
     use data_source::testing::TestableSequencerDataSource;
     use endpoints::{NamespaceProofQueryData, TimeWindowQueryData};
     use futures::{FutureExt, StreamExt};
-    use hotshot_query_service::{
-        availability::{BlockQueryData, LeafQueryData},
-        testing::FIRST_VID_VIEW,
-    };
+    use hotshot_query_service::availability::{BlockQueryData, LeafQueryData};
+    use hotshot_types::vid::vid_scheme;
     use portpicker::pick_unused_port;
     use std::time::Duration;
     use surf_disco::Client;
@@ -468,7 +465,7 @@ mod generic_tests {
         setup_logging();
         setup_backtrace();
 
-        let vid = test_vid_factory(5);
+        let vid = vid_scheme(5);
         let txn = Transaction::new(VmId(0), vec![1, 2, 3, 4]);
 
         // Create sequencer network.
@@ -502,7 +499,7 @@ mod generic_tests {
 
         // Wait for at least one empty block to be sequenced (after consensus starts VID).
         client
-            .socket(&format!("availability/stream/leaves/{FIRST_VID_VIEW}"))
+            .socket(&format!("availability/stream/leaves/0"))
             .subscribe::<LeafQueryData<SeqTypes>>()
             .await
             .unwrap()
@@ -525,7 +522,7 @@ mod generic_tests {
         tracing::info!(block_height, "transaction sequenced");
         let mut found_txn = false;
         let mut found_empty_block = false;
-        for block_num in FIRST_VID_VIEW..=block_height {
+        for block_num in 0..=block_height {
             let ns_query_res: NamespaceProofQueryData = client
                 .get(&format!("availability/block/{block_num}/namespace/0"))
                 .send()

--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -21,10 +21,11 @@ use hotshot_query_service::{
     node, Error,
 };
 use hotshot_types::{
-    data::{VidScheme, VidSchemeTrait, ViewNumber},
+    data::ViewNumber,
     traits::node_implementation::ConsensusTime,
+    vid::{vid_scheme, VidSchemeType},
 };
-use jf_primitives::merkle_tree::MerkleTreeScheme;
+use jf_primitives::{merkle_tree::MerkleTreeScheme, vid::VidScheme};
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use tide_disco::{
@@ -107,11 +108,9 @@ where
                 }
             )?;
             let num_storage_nodes =
-                <VidScheme as VidSchemeTrait>::get_num_storage_nodes(common.common());
+                <VidSchemeType as VidScheme>::get_num_storage_nodes(common.common());
 
-            // TODO fake VidScheme construction
-            // https://github.com/EspressoSystems/espresso-sequencer/issues/1047
-            let vid = crate::block::payload::test_vid_factory(num_storage_nodes);
+            let vid = vid_scheme(num_storage_nodes);
 
             let proof = block
                 .payload()

--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -20,12 +20,8 @@ use hotshot_query_service::{
     availability::{self, AvailabilityDataSource, BlockHash, CustomSnafu, FetchBlockSnafu},
     node, Error,
 };
-use hotshot_types::{
-    data::ViewNumber,
-    traits::node_implementation::ConsensusTime,
-    vid::{vid_scheme, VidSchemeType},
-};
-use jf_primitives::{merkle_tree::MerkleTreeScheme, vid::VidScheme};
+use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
+use jf_primitives::merkle_tree::MerkleTreeScheme;
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use tide_disco::{
@@ -107,17 +103,12 @@ where
                         })
                 }
             )?;
-            let num_storage_nodes =
-                <VidSchemeType as VidScheme>::get_num_storage_nodes(common.common());
-
-            let vid = vid_scheme(num_storage_nodes);
 
             let proof = block
                 .payload()
                 .namespace_with_proof(
                     block.payload().get_ns_table(),
                     ns_id,
-                    &vid,
                     common.common().clone(),
                 )
                 .context(CustomSnafu {

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -1,19 +1,16 @@
 use crate::block::entry::{TxTableEntry, TxTableEntryWord};
 use crate::block::payload;
 use crate::{BlockBuildingSnafu, Error, Transaction, VmId};
-use ark_bls12_381::Bls12_381;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use commit::Committable;
 use derivative::Derivative;
 use hotshot::traits::BlockPayload;
-use hotshot_types::data::VidScheme;
-use jf_primitives::{
-    pcs::{checked_fft_size, prelude::UnivariateKzgPCS, PolynomialCommitmentScheme},
-    vid::{
-        advz::payload_prover::{LargeRangeProof, SmallRangeProof},
-        payload_prover::{PayloadProver, Statement},
-        VidScheme as VidSchemeTrait,
-    },
+use hotshot_types::vid::{
+    LargeRangeProofType, SmallRangeProofType, VidCommitment, VidCommon, VidSchemeType,
+};
+use jf_primitives::vid::{
+    payload_prover::{PayloadProver, Statement},
+    VidScheme,
 };
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize};
@@ -79,11 +76,11 @@ pub struct Payload<TableWord: TableWordTraits> {
 
     // cache frequently used items
     //
-    // TODO type should be `OnceLock<RangeProof>` instead of `OnceLock<Option<RangeProof>>`. We can correct this after `once_cell_try` is stabilized <https://github.com/rust-lang/rust/issues/109737>.
+    // TODO type should be `OnceLock<SmallRangeProofType>` instead of `OnceLock<Option<SmallRangeProofType>>`. We can correct this after `once_cell_try` is stabilized <https://github.com/rust-lang/rust/issues/109737>.
     #[derivative(Hash = "ignore")]
     #[derivative(PartialEq = "ignore")]
     #[serde(skip)]
-    pub tx_table_len_proof: OnceLock<Option<RangeProof>>,
+    pub tx_table_len_proof: OnceLock<Option<SmallRangeProofType>>,
 }
 
 impl<TableWord: TableWordTraits> Payload<TableWord> {
@@ -110,10 +107,10 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
         &self,
         ns_table: &NameSpaceTable<TxTableEntryWord>,
         ns_id: VmId,
-        vid: &VidScheme,
-        vid_common: <VidScheme as VidSchemeTrait>::Common,
+        vid: &VidSchemeType,
+        vid_common: VidCommon,
     ) -> Option<NamespaceProof> {
-        if self.raw_payload.len() != VidScheme::get_payload_byte_len(&vid_common) {
+        if self.raw_payload.len() != VidSchemeType::get_payload_byte_len(&vid_common) {
             return None; // error: vid_common inconsistent with self
         }
 
@@ -154,8 +151,8 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
     // Returns `None` if an error occurred.
     pub fn get_tx_table_len_proof(
         &self,
-        vid: &impl PayloadProver<RangeProof>,
-    ) -> Option<&RangeProof> {
+        vid: &impl PayloadProver<SmallRangeProofType>,
+    ) -> Option<&SmallRangeProofType> {
         self.tx_table_len_proof
             .get_or_init(|| {
                 vid.payload_proof(&self.raw_payload, self.tx_table_len_range())
@@ -262,61 +259,14 @@ impl<TableWord: TableWordTraits> Committable for Payload<TableWord> {
     }
 }
 
-/// Opaque (not really though) constructor to return an abstract [`PayloadProver`].
-///
-/// Unfortunately, [`PayloadProver`] has a generic type param.
-/// I'd like to return `impl PayloadProver<impl Foo>` but "nested `impl Trait` is not allowed":
-/// <https://github.com/rust-lang/rust/issues/57979#issuecomment-459387604>
-/// TODO Workaround using generic params, which is allows the caller to influence the return type:
-/// https://stackoverflow.com/a/52886787
-///
-/// TODO temporary VID constructor.
-pub(crate) fn test_vid_factory(num_storage_nodes: usize) -> VidScheme {
-    // -> impl PayloadProver<RangeProof, Common = impl LengthGetter + CommitChecker<Self>> {
-    // calculate the last power of two
-    // TODO change after https://github.com/EspressoSystems/jellyfish/issues/339
-    let chunk_size = 1 << num_storage_nodes.ilog2();
-    let multiplicity = 1;
-
-    let mut rng = jf_utils::test_rng();
-    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
-        &mut rng,
-        checked_fft_size(chunk_size - 1).unwrap(),
-    )
-    .unwrap();
-    VidScheme::new(chunk_size, num_storage_nodes, multiplicity, srs).unwrap()
-}
-
-// TODO type alias needed only because nested impl Trait is not allowed
-// TODO upstream type aliases: https://github.com/EspressoSystems/jellyfish/issues/423
-pub(super) type RangeProof =
-    SmallRangeProof<<UnivariateKzgPCS<Bls12_381> as PolynomialCommitmentScheme>::Proof>;
-
-/// Namespace proof type
-///
-/// # Type complexity
-///
-/// Jellyfish's `LargeRangeProof` type has a prime field generic parameter `F`.
-/// This `F` is determined by the pairing parameter for `Advz` currently returned by `test_vid_factory()`.
-/// Jellyfish needs a more ergonomic way for downstream users to refer to this type.
-///
-/// There is a `KzgEval` type alias in jellyfish that helps a little, but it's currently private.
-/// If it were public then we could instead use
-/// ```compile_fail
-/// LargeRangeProof<KzgEval<Bls12_281>>
-/// ```
-/// but that's still pretty crufty.
-pub type JellyfishNamespaceProof =
-    LargeRangeProof<<UnivariateKzgPCS<Bls12_381> as PolynomialCommitmentScheme>::Evaluation>;
-
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "")] // for V
 pub enum NamespaceProof {
     Existence {
         ns_payload_flat: Vec<u8>,
         ns_id: VmId,
-        ns_proof: JellyfishNamespaceProof,
-        vid_common: <VidScheme as VidSchemeTrait>::Common,
+        ns_proof: LargeRangeProofType,
+        vid_common: VidCommon,
     },
     NonExistence {
         ns_id: VmId,
@@ -330,8 +280,8 @@ impl NamespaceProof {
     #[allow(dead_code)] // TODO temporary
     pub fn verify(
         &self,
-        vid: &VidScheme,
-        commit: &<VidScheme as VidSchemeTrait>::Commit,
+        vid: &VidSchemeType,
+        commit: &VidCommitment,
         ns_table: &NameSpaceTable<TxTableEntryWord>,
     ) -> Option<(Vec<Transaction>, VmId)> {
         match self {
@@ -346,7 +296,7 @@ impl NamespaceProof {
                 // TODO rework NameSpaceTable struct
                 // TODO merge get_ns_payload_range with get_ns_table_entry ?
                 let ns_payload_range = ns_table
-                    .get_payload_range(ns_index, VidScheme::get_payload_byte_len(vid_common));
+                    .get_payload_range(ns_index, VidSchemeType::get_payload_byte_len(vid_common));
                 let ns_id = ns_table.get_table_entry(ns_index).0;
 
                 // verify self against args
@@ -419,24 +369,24 @@ impl hotshot_types::traits::block_contents::TestableBlock
 
 #[cfg(test)]
 mod test {
-
-    use super::{test_vid_factory, NamespaceProof};
-    use crate::block::payload::{Payload, TableWordTraits};
-    use crate::block::tables::{NameSpaceTable, Table};
+    use super::NamespaceProof;
+    use crate::{
+        block::{
+            entry::{TxTableEntry, TxTableEntryWord},
+            payload::{Payload, TableWordTraits},
+            queryable,
+            tables::{test::TxTableTest, NameSpaceTable, Table},
+            tx_iterator::TxIndex,
+        },
+        Transaction,
+    };
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use helpers::*;
     use hotshot_query_service::availability::QueryablePayload;
-    use hotshot_types::traits::BlockPayload;
+    use hotshot_types::{traits::BlockPayload, vid::vid_scheme};
     use jf_primitives::vid::{payload_prover::PayloadProver, VidScheme};
-
-    use crate::block::entry::{TxTableEntry, TxTableEntryWord};
-    use crate::block::queryable;
-    use crate::block::tables::test::TxTableTest;
-    use crate::block::tx_iterator::TxIndex;
-    use crate::Transaction;
     use rand::RngCore;
-    use std::marker::PhantomData;
-    use std::{collections::HashMap, ops::Range};
+    use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
     const NUM_STORAGE_NODES: usize = 10;
 
@@ -485,7 +435,7 @@ mod test {
             tx_payloads: Vec<Vec<u8>>,
         }
 
-        let vid = test_vid_factory(NUM_STORAGE_NODES);
+        let vid = vid_scheme(NUM_STORAGE_NODES);
         let num_test_cases = test_cases.len();
         for (t, test_case) in test_cases.iter().enumerate() {
             // DERIVE A BUNCH OF STUFF FOR THIS TEST CASE
@@ -784,7 +734,7 @@ mod test {
         setup_logging();
         setup_backtrace();
 
-        let vid = test_vid_factory(NUM_STORAGE_NODES);
+        let vid = vid_scheme(NUM_STORAGE_NODES);
         let num_test_cases = test_cases.len();
         for (t, test_case) in test_cases.into_iter().enumerate() {
             let payload_byte_len = test_case.payload.len();
@@ -853,7 +803,7 @@ mod test {
         // test: cannot make a proof for such a small block
         // assert!(block.transaction_with_proof(&0).is_none());
 
-        let vid = test_vid_factory(NUM_STORAGE_NODES);
+        let vid = vid_scheme(NUM_STORAGE_NODES);
         let disperse_data = vid.disperse(&block.raw_payload).unwrap();
 
         // make a fake proof for a nonexistent tx in the small block

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -6,7 +6,7 @@ use commit::Committable;
 use derivative::Derivative;
 use hotshot::traits::BlockPayload;
 use hotshot_types::vid::{
-    LargeRangeProofType, SmallRangeProofType, VidCommitment, VidCommon, VidSchemeType,
+    vid_scheme, LargeRangeProofType, SmallRangeProofType, VidCommitment, VidCommon, VidSchemeType,
 };
 use jf_primitives::vid::{
     payload_prover::{PayloadProver, Statement},
@@ -107,7 +107,6 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
         &self,
         ns_table: &NameSpaceTable<TxTableEntryWord>,
         ns_id: VmId,
-        vid: &VidSchemeType,
         vid_common: VidCommon,
     ) -> Option<NamespaceProof> {
         if self.raw_payload.len() != VidSchemeType::get_payload_byte_len(&vid_common) {
@@ -127,7 +126,7 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
         Some(NamespaceProof::Existence {
             ns_id,
             ns_payload_flat: self.raw_payload.get(ns_payload_range.clone())?.to_vec(),
-            ns_proof: vid
+            ns_proof: vid_scheme(VidSchemeType::get_num_storage_nodes(&vid_common))
                 .payload_proof(&self.raw_payload, ns_payload_range)
                 .ok()?,
             vid_common,
@@ -567,12 +566,7 @@ mod test {
 
                 // test ns proof
                 let ns_proof = block
-                    .namespace_with_proof(
-                        &actual_ns_table,
-                        ns_id,
-                        &vid,
-                        disperse_data.common.clone(),
-                    )
+                    .namespace_with_proof(&actual_ns_table, ns_id, disperse_data.common.clone())
                     .unwrap();
 
                 if let NamespaceProof::Existence {

--- a/sequencer/src/block/queryable.rs
+++ b/sequencer/src/block/queryable.rs
@@ -1,7 +1,8 @@
 use crate::block::entry::TxTableEntryWord;
-use crate::block::payload::{test_vid_factory, Payload, RangeProof};
+use crate::block::payload::Payload;
 use crate::block::tables::TxTable;
 use hotshot_query_service::availability::QueryablePayload;
+use hotshot_types::vid::{vid_scheme, SmallRangeProofType};
 use jf_primitives::vid::payload_prover::{PayloadProver, Statement};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
@@ -77,7 +78,7 @@ impl QueryablePayload for Payload<TxTableEntryWord> {
         // TODO temporary VID construction. We need to get the number of storage nodes from the VID
         // common data. May need the query service to pass common into this function along with
         // metadata.
-        let vid = test_vid_factory(10);
+        let vid = vid_scheme(10);
 
         // Read the tx payload range from the tx table into `tx_table_range_[start|end]` and compute a proof that this range is correct.
         //
@@ -177,13 +178,13 @@ fn tx_payload_range(
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TxInclusionProof {
     tx_table_len: TxTableEntry,
-    tx_table_len_proof: RangeProof,
+    tx_table_len_proof: SmallRangeProofType,
 
     tx_table_range_start: Option<TxTableEntry>, // `None` for the 0th tx
     tx_table_range_end: TxTableEntry,
-    tx_table_range_proof: RangeProof,
+    tx_table_range_proof: SmallRangeProofType,
 
-    tx_payload_proof: Option<RangeProof>, // `None` if the tx has zero length
+    tx_payload_proof: Option<SmallRangeProofType>, // `None` if the tx has zero length
 }
 
 impl TxInclusionProof {
@@ -203,7 +204,7 @@ impl TxInclusionProof {
         vid_common: &V::Common,
     ) -> Option<Result<(), ()>>
     where
-        V: PayloadProver<RangeProof>,
+        V: PayloadProver<SmallRangeProofType>,
     {
         V::is_consistent(vid_commit, vid_common).ok()?;
 
@@ -303,8 +304,8 @@ impl TxInclusionProof {
 #[cfg(test)]
 pub(crate) fn gen_tx_proof_for_testing(
     tx_table_len: TxTableEntry,
-    tx_table_len_proof: RangeProof,
-    payload_proof: RangeProof,
+    tx_table_len_proof: SmallRangeProofType,
+    payload_proof: SmallRangeProofType,
 ) -> TxInclusionProof {
     TxInclusionProof {
         tx_table_len,

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -13,11 +13,11 @@ use ethers::{
     types,
 };
 use hotshot_types::{
-    data::VidCommitment,
     traits::{
         block_contents::{vid_commitment, BlockHeader, BlockPayload},
         ValidatedState as HotShotState,
     },
+    vid::VidCommitment,
 };
 use jf_primitives::merkle_tree::prelude::*;
 use lazy_static::lazy_static;
@@ -272,14 +272,11 @@ impl BlockHeader for Header {
         )
     }
 
-    // TODO return metadata must be cloned from returned Payload; don't return metadata??
     fn genesis(
         instance_state: &<Self::State as HotShotState>::Instance,
-    ) -> (
-        Self,
-        Self::Payload,
-        <Self::Payload as BlockPayload>::Metadata,
-    ) {
+        _payload_commitment: VidCommitment,
+        _metadata: <Self::Payload as BlockPayload>::Metadata,
+    ) -> Self {
         let (payload, ns_table) = Self::Payload::genesis();
         let payload_commitment = vid_commitment(&payload.encode().unwrap().collect(), 1);
         let ValidatedState {
@@ -303,7 +300,7 @@ impl BlockHeader for Header {
             fee_info: FeeInfo::new(instance_state.builder_address.address().into()),
             builder_signature: None,
         };
-        (header, payload, ns_table)
+        header
     }
 
     fn block_number(&self) -> u64 {

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -14,7 +14,7 @@ use ethers::{
 };
 use hotshot_types::{
     traits::{
-        block_contents::{vid_commitment, BlockHeader, BlockPayload},
+        block_contents::{BlockHeader, BlockPayload},
         ValidatedState as HotShotState,
     },
     vid::VidCommitment,
@@ -274,11 +274,9 @@ impl BlockHeader for Header {
 
     fn genesis(
         instance_state: &<Self::State as HotShotState>::Instance,
-        _payload_commitment: VidCommitment,
-        _metadata: <Self::Payload as BlockPayload>::Metadata,
+        payload_commitment: VidCommitment,
+        ns_table: <Self::Payload as BlockPayload>::Metadata,
     ) -> Self {
-        let (payload, ns_table) = Self::Payload::genesis();
-        let payload_commitment = vid_commitment(&payload.encode().unwrap().collect(), 1);
         let ValidatedState {
             fee_merkle_tree,
             block_merkle_tree,
@@ -286,7 +284,7 @@ impl BlockHeader for Header {
         let block_merkle_tree_root = block_merkle_tree.commitment();
         let fee_merkle_tree_root = fee_merkle_tree.commitment();
 
-        let header = Self {
+        Self {
             // The genesis header needs to be completely deterministic, so we can't sample real
             // timestamps or L1 values.
             height: 0,
@@ -294,13 +292,12 @@ impl BlockHeader for Header {
             l1_head: 0,
             l1_finalized: None,
             payload_commitment,
-            ns_table: ns_table.clone(), // TODO forced clone
+            ns_table,
             block_merkle_tree_root,
             fee_merkle_tree_root,
             fee_info: FeeInfo::new(instance_state.builder_address.address().into()),
             builder_signature: None,
-        };
-        header
+        }
     }
 
     fn block_number(&self) -> u64 {
@@ -367,14 +364,14 @@ lazy_static! {
 
 #[cfg(test)]
 mod test_headers {
+    use super::*;
     use crate::{
         state::{validate_proposal, BlockMerkleTree, FeeMerkleTree},
         NodeState,
     };
-
-    use super::*;
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use ethers::types::RecoveryMessage;
+    use hotshot_types::traits::block_contents::{vid_commitment, GENESIS_VID_NUM_STORAGE_NODES};
 
     #[derive(Debug, Default)]
     #[must_use]
@@ -405,10 +402,20 @@ mod test_headers {
             assert!(self.expected_l1_head >= self.parent_l1_head);
             assert!(self.expected_l1_finalized >= self.parent_l1_finalized);
 
-            let state = NodeState::default();
-            let (genesis, _, metadata) = Header::genesis(&state);
+            let (genesis_payload, genesis_ns_table) = Payload::genesis();
+            let genesis_commitment = {
+                // TODO we should not need to collect payload bytes just to compute vid_commitment
+                let payload_bytes = genesis_payload
+                    .encode()
+                    .expect("unable to encode genesis payload")
+                    .collect();
+                vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
+            };
+            let genesis_state = NodeState::default();
+            let genesis_header =
+                Header::genesis(&genesis_state, genesis_commitment, genesis_ns_table.clone());
 
-            let mut parent = genesis.clone();
+            let mut parent = genesis_header.clone();
             parent.timestamp = self.parent_timestamp;
             parent.l1_head = self.parent_l1_head;
             parent.l1_finalized = self.parent_l1_finalized;
@@ -428,8 +435,8 @@ mod test_headers {
             };
 
             let header = Header::from_info(
-                genesis.payload_commitment,
-                metadata,
+                genesis_header.payload_commitment,
+                genesis_ns_table,
                 &parent,
                 L1Snapshot {
                     head: self.l1_head,
@@ -437,7 +444,7 @@ mod test_headers {
                 },
                 self.timestamp,
                 &validated_state,
-                state.builder_address,
+                genesis_state.builder_address,
             );
             assert_eq!(header.height, parent.height + 1);
             assert_eq!(header.timestamp, self.expected_timestamp);
@@ -572,16 +579,30 @@ mod test_headers {
 
     #[test]
     fn test_validate_proposal_error_cases() {
-        let (mut header, ..) = Header::genesis(&NodeState::default());
+        let mut genesis_header = {
+            // TODO refactor repeated code from other tests
+            let (genesis_payload, genesis_ns_table) = Payload::genesis();
+            let genesis_commitment = {
+                // TODO we should not need to collect payload bytes just to compute vid_commitment
+                let payload_bytes = genesis_payload
+                    .encode()
+                    .expect("unable to encode genesis payload")
+                    .collect();
+                vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
+            };
+            let genesis_state = NodeState::default();
+            Header::genesis(&genesis_state, genesis_commitment, genesis_ns_table)
+        };
+
         let mut validated_state = ValidatedState::default();
         let mut block_merkle_tree = validated_state.block_merkle_tree.clone();
 
         // Populate the tree with an initial `push`.
-        block_merkle_tree.push(header.commit()).unwrap();
+        block_merkle_tree.push(genesis_header.commit()).unwrap();
         let block_merkle_tree_root = block_merkle_tree.commitment();
         validated_state.block_merkle_tree = block_merkle_tree.clone();
-        header.block_merkle_tree_root = block_merkle_tree_root;
-        let parent = header.clone();
+        genesis_header.block_merkle_tree_root = block_merkle_tree_root;
+        let parent = genesis_header.clone();
         let mut proposal = parent.clone();
 
         // Advance `proposal.height` to trigger validation error.
@@ -603,30 +624,41 @@ mod test_headers {
 
     #[test]
     fn test_validate_proposal_success() {
-        let state = NodeState::default();
-        let (mut header, _, metadata) = Header::genesis(&state);
-        let mut parent_state = ValidatedState::genesis(&state);
+        // TODO refactor repeated code from other tests
+        let (genesis_payload, genesis_ns_table) = Payload::genesis();
+        let genesis_commitment = {
+            // TODO we should not need to collect payload bytes just to compute vid_commitment
+            let payload_bytes = genesis_payload
+                .encode()
+                .expect("unable to encode genesis payload")
+                .collect();
+            vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
+        };
+        let genesis_state = NodeState::default();
+        let mut genesis_header =
+            Header::genesis(&genesis_state, genesis_commitment, genesis_ns_table.clone());
+        let mut parent_state = ValidatedState::genesis(&genesis_state);
         let mut block_merkle_tree = parent_state.block_merkle_tree.clone();
         let fee_merkle_tree = parent_state.fee_merkle_tree.clone();
 
         // Populate the tree with an initial `push`.
-        block_merkle_tree.push(header.commit()).unwrap();
+        block_merkle_tree.push(genesis_header.commit()).unwrap();
         let block_merkle_tree_root = block_merkle_tree.commitment();
         let fee_merkle_tree_root = fee_merkle_tree.commitment();
         parent_state.block_merkle_tree = block_merkle_tree.clone();
         parent_state.fee_merkle_tree = fee_merkle_tree.clone();
-        header.block_merkle_tree_root = block_merkle_tree_root;
-        header.fee_merkle_tree_root = fee_merkle_tree_root;
+        genesis_header.block_merkle_tree_root = block_merkle_tree_root;
+        genesis_header.fee_merkle_tree_root = fee_merkle_tree_root;
 
-        let parent = header.clone();
+        let parent = genesis_header.clone();
 
         // get a proposal from a parent
         let proposal = Header::new(
             &parent_state,
-            &state,
+            &genesis_state,
             &parent,
             parent.payload_commitment,
-            metadata,
+            genesis_ns_table,
         );
 
         let mut proposal_state = parent_state.clone();

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -559,7 +559,9 @@ mod test {
     use futures::StreamExt;
     use hotshot::types::EventType::Decide;
 
-    use hotshot_types::traits::block_contents::BlockHeader;
+    use hotshot_types::traits::block_contents::{
+        vid_commitment, BlockHeader, BlockPayload, GENESIS_VID_NUM_STORAGE_NODES,
+    };
     use testing::{init_hotshot_handles, wait_for_decide_on_handle};
 
     #[async_std::test]
@@ -598,7 +600,20 @@ mod test {
             handle.hotshot.start_consensus().await;
         }
 
-        let mut parent = Header::genesis(&NodeState::default()).0;
+        let mut parent = {
+            // TODO refactor repeated code from other tests
+            let (genesis_payload, genesis_ns_table) = Payload::genesis();
+            let genesis_commitment = {
+                // TODO we should not need to collect payload bytes just to compute vid_commitment
+                let payload_bytes = genesis_payload
+                    .encode()
+                    .expect("unable to encode genesis payload")
+                    .collect();
+                vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
+            };
+            let genesis_state = NodeState::default();
+            Header::genesis(&genesis_state, genesis_commitment, genesis_ns_table)
+        };
 
         loop {
             let event = events.next().await.unwrap();


### PR DESCRIPTION
close #1047 

- update hotshot to 0.5.19, use new `vid_scheme` constructor
- update hotshot-query-service to 0.0.10, use new header genesis API

# TODO

- [x] fix header genesis API usage