### PR TITLE
Replace calls to fetch_fee_receipts with `L1Client.get_finalized_deposits`

### DIFF
--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -692,9 +692,6 @@ mod test_headers {
         .await;
 
         let mut proposal_state = parent_state.clone();
-        // The current fake implementation of fetch_fee_receipts returns
-        // some fee info. To validate the proposal we need to insert these
-        // records here.
         for fee_info in genesis_state
             .l1_client
             .get_finalized_deposits(None, 0)

--- a/sequencer/src/l1_client.rs
+++ b/sequencer/src/l1_client.rs
@@ -135,7 +135,7 @@ impl L1Client {
     }
     /// Get fee info for each `Deposit` ocurring between `prev`
     /// and `new`. Returns `Vec<FeeInfo>`
-    pub async fn _get_finalized_deposits(
+    pub async fn get_finalized_deposits(
         &self,
         prev_finalized: Option<u64>,
         new_finalized: u64,
@@ -299,7 +299,7 @@ mod test {
         // Set prev deposits to `None` so `Filter` will start at block
         // 0. The test would also succeed if we pass `0` (b/c first
         // block did not deposit).
-        let pending = l1_client._get_finalized_deposits(None, deposits + 1).await;
+        let pending = l1_client.get_finalized_deposits(None, deposits + 1).await;
 
         assert_eq!(deposits as usize, pending.len());
         assert_eq!(&wallet_address, &pending[0].account().into());
@@ -311,21 +311,25 @@ mod test {
 
         // check a few more cases
         let pending = l1_client
-            ._get_finalized_deposits(Some(0), deposits + 1)
+            .get_finalized_deposits(Some(0), deposits + 1)
             .await;
         assert_eq!(deposits as usize, pending.len());
 
-        let pending = l1_client._get_finalized_deposits(Some(0), 0).await;
+        let pending = l1_client.get_finalized_deposits(Some(0), 0).await;
         assert_eq!(0, pending.len());
 
-        let pending = l1_client._get_finalized_deposits(Some(0), 1).await;
+        let pending = l1_client.get_finalized_deposits(Some(0), 1).await;
         assert_eq!(0, pending.len());
 
-        let pending = l1_client._get_finalized_deposits(Some(1), 1).await;
+        let pending = l1_client.get_finalized_deposits(Some(1), 1).await;
         assert_eq!(0, pending.len());
 
-        let pending = l1_client._get_finalized_deposits(Some(1), 2).await;
+        let pending = l1_client.get_finalized_deposits(Some(1), 2).await;
         assert_eq!(1, pending.len());
+
+        // what happends if `new_finalized` is `0`?
+        let pending = l1_client.get_finalized_deposits(Some(1), 0).await;
+        assert_eq!(0, pending.len());
 
         Ok(())
     }


### PR DESCRIPTION
With this change `Header::new` and `validate_and_apply_header` will make real queries to the l1 to get deposit info. Previously the mock `fetch_fee_receipts` was being used as a place holder.

~This PR is a monstrosity caused by pulling upstream changes into  #1151, and adding my changes on top. I've added a couple of comments below where I have actually made the changes. When #1151 is merged this can all be cleaned up.~ Since #1151 has been updated, this PR should be reviewable now. 

Closes #1116 and #1114 