### PR TITLE
chore: update crs to ark-srs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-srs"
+version = "0.1.0"
+source = "git+https://github.com/alxiong/ark-srs?tag=v0.1.0#610ee9948116fcb4426944141b8f03086dc1b758"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly-commit",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,20 +1821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "crs"
-version = "0.1.0"
-source = "git+https://github.com/alxiong/crs#4f320d819514a50138dd114440b3b3e30e83a081"
-dependencies = [
- "anyhow",
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-poly-commit",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,9 +2250,9 @@ dependencies = [
  "ark-ed-on-bn254",
  "ark-ff",
  "ark-poly",
+ "ark-srs",
  "ark-std 0.4.0",
  "clap",
- "crs",
  "diff-test-bn254",
  "digest 0.10.7",
  "ethers",
@@ -3282,7 +3282,7 @@ dependencies = [
 name = "gen-vk-contract"
 version = "0.1.0"
 dependencies = [
- "crs",
+ "ark-srs",
  "hotshot-contract-adapter",
  "hotshot-stake-table",
  "hotshot-state-prover",
@@ -3656,9 +3656,9 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize 0.4.2",
+ "ark-srs",
  "ark-std 0.4.0",
  "contract-bindings",
- "crs",
  "diff-test-bn254",
  "ethers",
  "hotshot-stake-table",
@@ -3803,6 +3803,7 @@ dependencies = [
  "ark-ed-on-bn254",
  "ark-ff",
  "ark-serialize 0.4.2",
+ "ark-srs",
  "ark-std 0.4.0",
  "async-compatibility-layer",
  "async-std",
@@ -3811,7 +3812,6 @@ dependencies = [
  "clap",
  "cld",
  "contract-bindings",
- "crs",
  "derive_more",
  "displaydoc",
  "ethers",

--- a/contracts/rust/adapter/Cargo.toml
+++ b/contracts/rust/adapter/Cargo.toml
@@ -13,9 +13,9 @@ ark-ed-on-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
+ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
 ark-std = { workspace = true }
 contract-bindings = { path = "../../../contract-bindings" }
-crs = { git = "https://github.com/alxiong/crs" }
 diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git" }
 ethers = { version = "2.0.4" }
 hotshot-types = { workspace = true }

--- a/contracts/rust/diff-test/Cargo.toml
+++ b/contracts/rust/diff-test/Cargo.toml
@@ -12,9 +12,9 @@ ark-ec = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-poly = { workspace = true }
+ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
 ark-std = { workspace = true }
 clap = { version = "^4.4", features = ["derive"] }
-crs = { git = "https://github.com/alxiong/crs" }
 diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git" }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }
 ethers = { version = "2.0.4" }

--- a/contracts/rust/gen-vk-contract/Cargo.toml
+++ b/contracts/rust/gen-vk-contract/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-crs = { git = "https://github.com/alxiong/crs" }
+ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
 hotshot-contract-adapter = { path = "../adapter" }
 hotshot-stake-table = { workspace = true }
 hotshot-state-prover = { path = "../../../hotshot-state-prover" }

--- a/contracts/rust/gen-vk-contract/src/main.rs
+++ b/contracts/rust/gen-vk-contract/src/main.rs
@@ -14,8 +14,8 @@ use jf_primitives::pcs::prelude::UnivariateUniversalParams;
 fn main() {
     let srs = {
         // load SRS from Aztec's ceremony
-        let srs =
-            crs::aztec20::kzg10_setup(2u64.pow(20) as usize + 2).expect("Aztec SRS fail to load");
+        let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(20) as usize + 2)
+            .expect("Aztec SRS fail to load");
         // convert to Jellyfish type
         // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440
         UnivariateUniversalParams {

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -12,6 +12,7 @@ ark-ec = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
+ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
 ark-std = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-std = { workspace = true }
@@ -20,7 +21,6 @@ blake3 = "1.5"
 clap = { workspace = true }
 cld = { workspace = true }
 contract-bindings = { path = "../contract-bindings" }
-crs = { git = "https://github.com/alxiong/crs" }
 derive_more = { workspace = true }
 displaydoc = { version = "0.2.3", default-features = false }
 ethers = { workspace = true }

--- a/hotshot-state-prover/src/mock_ledger.rs
+++ b/hotshot-state-prover/src/mock_ledger.rs
@@ -243,7 +243,7 @@ impl MockLedger {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = crs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440
@@ -301,7 +301,7 @@ impl MockLedger {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = crs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440
@@ -430,7 +430,7 @@ pub fn gen_plonk_proof_for_test(
     // 1. Simulate universal setup
     let rng = &mut jf_utils::test_rng();
     let srs = {
-        let aztec_srs = crs::aztec20::kzg10_setup(1024).expect("Aztec SRS fail to load");
+        let aztec_srs = ark_srs::aztec20::kzg10_setup(1024).expect("Aztec SRS fail to load");
 
         UnivariateUniversalParams {
             powers_of_g: aztec_srs.powers_of_g,

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -107,7 +107,7 @@ pub fn load_proving_key() -> ProvingKey {
 
         std::println!("Loading SRS from Aztec's ceremony...");
         let srs_timer = Instant::now();
-        let srs = crs::aztec20::kzg10_setup(num_gates + 2).expect("Aztec SRS fail to load");
+        let srs = ark_srs::aztec20::kzg10_setup(num_gates + 2).expect("Aztec SRS fail to load");
         let srs_elapsed = srs_timer.elapsed();
         std::println!("Done in {srs_elapsed:.3}");
 
@@ -456,7 +456,7 @@ mod test {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = crs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440


### PR DESCRIPTION
due to recent renaming, `crs` is renamed to `ark-srs` (sorry!) 