### PR TITLE
Hide bindings changes in diff by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+contract-bindings/src linguist-generated=true


### PR DESCRIPTION
I don't know if this actually works, some conflicting information about it on the web.

Docs: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github