### PR TITLE
Add test-node binary

### DIFF
--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -53,6 +53,8 @@ hotshot-types = { workspace = true }
 hotshot-web-server = { workspace = true }
 include_dir = "0.7"
 itertools = { workspace = true }
+portpicker = "0.1.1" # TODO: optional?
+tempfile = "3.9.0" # TODO: optional?
 
 jf-primitives = { workspace = true }
 jf-utils = { workspace = true } # TODO temporary: used only for test_rng()

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -81,8 +81,8 @@ impl<N: network::Type> StateSignatureDataSource<N> for State<N> {
     }
 }
 
-#[cfg(test)]
-mod test_helpers {
+#[cfg(any(test, feature = "testing"))]
+pub mod test_helpers {
     use super::*;
     use crate::{
         api::endpoints::{AccountQueryData, BlocksFrontier},

--- a/sequencer/src/bin/test-node.rs
+++ b/sequencer/src/bin/test-node.rs
@@ -1,0 +1,59 @@
+use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
+use clap::Parser;
+use futures::StreamExt as _;
+use sequencer::{
+    api::{options, test_helpers::TestNetwork, Options},
+    catchup::mock::MockStateCatchup,
+    persistence::no_storage::NoStorage,
+    testing::TestConfig,
+    ValidatedState,
+};
+
+#[derive(Debug, Clone, Parser)]
+struct Args {
+    /// Port the API will server will listen on.
+    #[clap(
+        short,
+        long,
+        env = "ESPRESSO_SEQUENCER_API_PORT",
+        default_value_t = 33000
+    )]
+    port: u16,
+}
+
+#[async_std::main]
+async fn main() {
+    setup_logging();
+    setup_backtrace();
+
+    let args = Args::parse();
+    let state = ValidatedState::default();
+    // Prefund an arbitrary builder account.
+    // TODO: why does it work without prefunding
+    // state.prefund_account(Default::default(), 1000.into());
+    let states = std::array::from_fn(|_| state.clone());
+
+    // A temporary directory to store the state.
+    let path = tempfile::tempdir().unwrap().path().into();
+    // Start a sequencer network, using the query service for catchup.
+    tracing::info!("Creating test network");
+    let api_options = Options::from(options::Http { port: args.port })
+        .status(Default::default())
+        .state(Default::default())
+        .submit(Default::default())
+        .query_fs(
+            Default::default(),
+            sequencer::persistence::fs::Options { path },
+        );
+    let with_state = TestNetwork::with_state(
+        api_options,
+        states,
+        [NoStorage; TestConfig::NUM_NODES],
+        std::array::from_fn(|_| MockStateCatchup::default()),
+    );
+    let network = with_state.await;
+    let mut events = network.server.get_event_stream();
+    while let Some(event) = events.next().await {
+        tracing::info!("Event: {:?}", event);
+    }
+}


### PR DESCRIPTION
This is a proof of concept for a sequencer test node binary. I think it would make our lives much easier for testing integrations because we will no longer have to maintain a separate docker compose project that goes out of date all the time. I expect it would also be helpful for other parties who would like to build on top of our sequencer.

Not sure if it makes sense to hide it behind the testing feature. Currently it uses some code that is only intended for tests.

To try:

    cargo run --release --features testing --bin test-node

Submit some transactions

    cargo run --release --bin submit-transactions -- http://localhost:33000