### PR TITLE
CI: checkout recursively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -120,6 +120,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download executables AMD
         uses: actions/download-artifact@v3

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -91,6 +91,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download executables AMD
         uses: actions/download-artifact@v3
@@ -200,7 +202,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.state-relay-server.outputs.tags }}
           labels: ${{ steps.state-relay-server.outputs.labels }}
-      
+
       - name: Build and push prover-service docker
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Currently the prover image is not working in demo mode where it needs the submodules to build the smart contracts.