### PR TITLE
update hotshot tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,27 @@ dependencies = [
  "async-std",
  "async-trait",
  "color-eyre",
- "console-subscriber",
+ "console-subscriber 0.1.10",
+ "flume 0.11.0",
+ "futures",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "async-compatibility-layer"
+version = "1.0.0"
+source = "git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2#482cece7d27f20d5a543e209a5d88b1837778b4c"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-lock 2.8.0",
+ "async-std",
+ "async-trait",
+ "color-eyre",
+ "console-subscriber 0.2.0",
  "flume 0.11.0",
  "futures",
  "tokio",
@@ -902,6 +922,28 @@ dependencies = [
  "hickory-resolver",
  "pin-utils",
  "socket2 0.5.5",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite 0.2.13",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1639,9 +1681,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "tonic 0.9.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-api"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
+dependencies = [
+ "futures-core",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "tonic 0.10.2",
  "tracing-core",
 ]
 
@@ -1651,19 +1706,43 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
 dependencies = [
- "console-api",
+ "console-api 0.5.0",
  "crossbeam-channel",
  "crossbeam-utils",
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.11.9",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
+dependencies = [
+ "console-api 0.6.0",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost-types 0.12.3",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.10.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.18",
@@ -1885,6 +1964,27 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
  "serdect",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3601,10 +3701,10 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "async-broadcast",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "async-trait",
@@ -3616,8 +3716,8 @@ dependencies = [
  "derive_more",
  "either",
  "embed-doc-image",
+ "ethereum-types",
  "futures",
- "hotshot-constants",
  "hotshot-orchestrator",
  "hotshot-task",
  "hotshot-task-impls",
@@ -3635,14 +3735,6 @@ dependencies = [
  "time 0.3.34",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "hotshot-constants"
-version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3671,10 +3763,10 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "async-broadcast",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "bincode",
@@ -3684,7 +3776,6 @@ dependencies = [
  "ethereum-types",
  "futures",
  "hotshot",
- "hotshot-constants",
  "hotshot-orchestrator",
  "hotshot-task",
  "hotshot-task-impls",
@@ -3703,15 +3794,17 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "blake3",
  "clap",
+ "csv",
  "futures",
  "hotshot-types",
+ "hotshot-utils",
  "libp2p",
  "serde",
  "serde-inline-default",
@@ -3726,11 +3819,11 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.0.9"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.0.15#4020da2031c04cadade2331b5e78f6f8a1cc4c22"
+version = "0.0.16"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.0.16#8e2427eb99e1367bb76585fd7e37ee8f0c51136f"
 dependencies = [
  "anyhow",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.4.1)",
  "async-std",
  "async-trait",
  "atomic_store",
@@ -3776,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -3804,7 +3897,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-srs",
  "ark-std 0.4.0",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.4.1)",
  "async-std",
  "async-trait",
  "blake3",
@@ -3841,10 +3934,10 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "async-broadcast",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-std",
  "futures",
  "tokio",
@@ -3854,10 +3947,10 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "async-broadcast",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "async-trait",
@@ -3867,7 +3960,6 @@ dependencies = [
  "commit",
  "either",
  "futures",
- "hotshot-constants",
  "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
@@ -3882,10 +3974,10 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "async-broadcast",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "bincode",
@@ -3895,7 +3987,6 @@ dependencies = [
  "ethereum-types",
  "futures",
  "hotshot",
- "hotshot-constants",
  "hotshot-example-types",
  "hotshot-orchestrator",
  "hotshot-task",
@@ -3915,15 +4006,16 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.1#4e6f836468c8e236f5f5711e941d4d0a5745433a"
 dependencies = [
  "ark-bls12-381",
+ "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
  "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.4.1)",
  "async-lock 2.8.0",
  "async-std",
  "async-trait",
@@ -3939,14 +4031,12 @@ dependencies = [
  "either",
  "espresso-systems-common 0.4.1",
  "ethereum-types",
+ "futures",
  "generic-array",
- "hotshot-constants",
- "hotshot-utils",
  "jf-plonk",
  "jf-primitives",
  "jf-utils",
  "lazy_static",
- "libp2p-networking",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3962,18 +4052,18 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
  "bincode",
- "hotshot-constants",
+ "hotshot-types",
 ]
 
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "clap",
@@ -5000,9 +5090,9 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.23#b414fa1bafddbc49961c98e60f97191ccaa65a6a"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.24#cb418bd07f183be6d0938fe6bba544f6b33d3225"
 dependencies = [
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.4.2)",
  "async-lock 2.8.0",
  "async-std",
  "async-trait",
@@ -5013,7 +5103,7 @@ dependencies = [
  "derive_builder",
  "either",
  "futures",
- "hotshot-constants",
+ "hotshot-types",
  "hotshot-utils",
  "lazy_static",
  "libp2p",
@@ -5021,6 +5111,7 @@ dependencies = [
  "libp2p-swarm-derive",
  "rand 0.8.5",
  "serde",
+ "serde_bytes",
  "serde_json",
  "snafu",
  "tokio",
@@ -6595,7 +6686,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.5.0",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes 1.5.0",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -6612,12 +6713,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -7454,7 +7577,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "async-compatibility-layer",
+ "async-compatibility-layer 1.0.0 (git+https://github.com/EspressoSystems/async-compatibility-layer?tag=1.4.1)",
  "async-std",
  "async-trait",
  "base64 0.22.0",
@@ -7543,6 +7666,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8832,7 +8964,34 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes 1.5.0",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.3",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,15 +38,15 @@ cld = "0.5"
 derive_more = "0.99.17"
 ethers = { version = "2.0" }
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.23" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.1" }
+hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }
 
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.0.15" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.0.16" }
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.1", features = [
   "test-apis",
   "test-srs",

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -101,7 +101,10 @@ mod test_helpers {
         stream::StreamExt,
     };
     use hotshot::types::{Event, EventType};
-    use hotshot_types::traits::{metrics::NoMetrics, node_implementation::ConsensusTime};
+    use hotshot_types::{
+        event::LeafInfo,
+        traits::{metrics::NoMetrics, node_implementation::ConsensusTime},
+    };
     use itertools::izip;
     use jf_primitives::merkle_tree::{MerkleCommitment, MerkleTreeScheme};
     use portpicker::pick_unused_port;
@@ -321,7 +324,7 @@ mod test_helpers {
             {
                 if leaf_chain
                     .iter()
-                    .any(|(leaf, _)| leaf.block_header.height > 2)
+                    .any(|LeafInfo { leaf, .. }| leaf.block_header.height > 2)
                 {
                     break;
                 }
@@ -687,7 +690,7 @@ mod test {
     use ethers::prelude::Signer;
     use futures::stream::StreamExt;
     use hotshot::types::EventType;
-    use hotshot_types::traits::block_contents::BlockHeader;
+    use hotshot_types::{event::LeafInfo, traits::block_contents::BlockHeader};
     use jf_primitives::merkle_tree::AppendableMerkleTreeScheme;
     use portpicker::pick_unused_port;
     use surf_disco::Client;
@@ -782,7 +785,7 @@ mod test {
             let EventType::Decide { leaf_chain, .. } = event.event else {
                 continue;
             };
-            for (leaf, _) in leaf_chain.iter().rev() {
+            for LeafInfo { leaf, .. } in leaf_chain.iter().rev() {
                 let height = leaf.block_header.height;
                 let leaf_builder = leaf.block_header.fee_info.account();
                 tracing::info!(

--- a/sequencer/src/bin/orchestrator.rs
+++ b/sequencer/src/bin/orchestrator.rs
@@ -190,8 +190,10 @@ async fn main() {
         start_delay_seconds: args.start_delay.as_secs(),
         ..Default::default()
     };
-    config.config.total_nodes = args.num_nodes;
+    config.config.num_nodes_with_stake = args.num_nodes;
+    config.config.num_nodes_without_stake = 0;
     config.config.known_nodes_with_stake = vec![Default::default(); args.num_nodes.get()];
+    config.config.known_nodes_without_stake = vec![];
     config.config.max_transactions = args.max_transactions;
     config.config.next_view_timeout = args.next_view_timeout.as_millis() as u64;
     config.config.timeout_ratio = args.timeout_ratio.into();
@@ -199,7 +201,8 @@ async fn main() {
     config.config.start_delay = args.start_delay.as_millis() as u64;
     config.config.propose_min_round_time = args.min_propose_time;
     config.config.propose_max_round_time = args.max_propose_time;
-    config.config.da_committee_size = args.num_nodes.get();
+    config.config.da_staked_committee_size = args.num_nodes.get();
+    config.config.da_non_staked_committee_size = 0;
     config.config.min_transactions = args.min_transactions;
 
     run_orchestrator(

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -81,6 +81,10 @@ impl BlockPayload for Payload<TxTableEntryWord> {
     fn builder_commitment(&self, _metadata: &Self::Metadata) -> BuilderCommitment {
         unimplemented!("TODO builder_commitment");
     }
+
+    fn get_transactions(&self, metadata: &Self::Metadata) -> &Vec<Self::Transaction> {
+        unimplemented!("TODO get_transactions");
+    }
 }
 
 #[cfg(test)]

--- a/sequencer/src/block.rs
+++ b/sequencer/src/block.rs
@@ -82,7 +82,7 @@ impl BlockPayload for Payload<TxTableEntryWord> {
         unimplemented!("TODO builder_commitment");
     }
 
-    fn get_transactions(&self, metadata: &Self::Metadata) -> &Vec<Self::Transaction> {
+    fn get_transactions(&self, _metadata: &Self::Metadata) -> &Vec<Self::Transaction> {
         unimplemented!("TODO get_transactions");
     }
 }

--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -70,7 +70,8 @@ impl<N: network::Type> SequencerContext<N> {
         let initializer = persistence.load_consensus_state(instance_state).await?;
 
         let election_config = GeneralStaticCommittee::<SeqTypes, PubKey>::default_election_config(
-            config.total_nodes.get() as u64,
+            config.num_nodes_with_stake.get() as u64,
+            0,
         );
         let membership = GeneralStaticCommittee::create_election(
             config.known_nodes_with_stake.clone(),

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -323,7 +323,7 @@ impl BlockHeader<SeqTypes> for Header {
         let ValidatedState {
             fee_merkle_tree,
             block_merkle_tree,
-        } = ValidatedState::genesis(instance_state);
+        } = ValidatedState::genesis(instance_state).0;
         let block_merkle_tree_root = block_merkle_tree.commitment();
         let fee_merkle_tree_root = fee_merkle_tree.commitment();
 
@@ -409,7 +409,7 @@ mod test_headers {
     impl Default for GenesisForTest {
         fn default() -> Self {
             let instance_state = NodeState::mock();
-            let validated_state = ValidatedState::genesis(&instance_state);
+            let validated_state = ValidatedState::genesis(&instance_state).0;
             let leaf = Leaf::genesis(&instance_state);
             let header = leaf.get_block_header().clone();
             let ns_table = leaf.get_block_payload().unwrap().get_ns_table().clone();

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -68,11 +68,11 @@ use persistence::SequencerPersistence;
 pub use block::payload::Payload;
 pub use chain_variables::ChainVariables;
 pub use header::Header;
+use hotshot_types::traits::states::StateDelta;
 pub use l1_client::L1BlockInfo;
 pub use options::Options;
 pub use state::ValidatedState;
 pub use transaction::{NamespaceId, Transaction};
-
 pub mod network {
     use hotshot_types::message::Message;
 
@@ -139,6 +139,11 @@ impl<N: network::Type> NodeImplementation<SeqTypes> for Node<N> {
     type QuorumNetwork = N::QuorumChannel;
     type CommitteeNetwork = N::DAChannel;
 }
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Delta {}
+
+impl StateDelta for Delta {}
 
 #[derive(Debug, Clone)]
 pub struct NodeState {

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -18,7 +18,7 @@ use hotshot::{
     types::{Event, EventType},
     HotShotInitializer,
 };
-use hotshot_types::traits::node_implementation::ConsensusTime;
+use hotshot_types::{event::LeafInfo, traits::node_implementation::ConsensusTime};
 use std::cmp::max;
 
 pub mod fs;
@@ -134,7 +134,7 @@ pub trait SequencerPersistence: Send + Sync + 'static {
     async fn handle_event(&mut self, event: &Event<SeqTypes>) {
         match &event.event {
             EventType::Decide { leaf_chain, .. } => {
-                if let Some((leaf, _)) = leaf_chain.first() {
+                if let Some(LeafInfo { leaf, .. }) = leaf_chain.first() {
                     if let Err(err) = self.save_anchor_leaf(leaf).await {
                         tracing::error!(
                             ?leaf,

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -110,7 +110,7 @@ pub trait SequencerPersistence: Send + Sync + 'static {
                 tracing::info!("no saved leaf, starting from genesis leaf");
                 (
                     Leaf::genesis(&state),
-                    Some(Arc::new(ValidatedState::genesis(&state))),
+                    Some(Arc::new(ValidatedState::genesis(&state).0)),
                 )
             }
         };

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -280,6 +280,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
 
     type Time = ViewNumber;
 
+    type Delta = ;
     fn on_commit(&self) {}
     /// Validate parent against known values (from state) and validate
     /// proposal descends from parent. Returns updated `ValidatedState`.

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{Header, Leaf, NodeState, SeqTypes};
+use crate::{Delta, Header, Leaf, NodeState, SeqTypes};
 use anyhow::{bail, ensure, Context};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
@@ -280,7 +280,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
 
     type Time = ViewNumber;
 
-    type Delta = ;
+    type Delta = Delta;
     fn on_commit(&self) {}
     /// Validate parent against known values (from state) and validate
     /// proposal descends from parent. Returns updated `ValidatedState`.
@@ -293,7 +293,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
         instance: &Self::Instance,
         parent_leaf: &Leaf,
         proposed_header: &Header,
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<(Self, Self::Delta), Self::Error> {
         // Clone state to avoid mutation. Consumer can take update
         // through returned value.
         let mut validated_state = self.clone();
@@ -367,7 +367,7 @@ impl HotShotState<SeqTypes> for ValidatedState {
             l1_deposits,
         )?;
 
-        Ok(validated_state)
+        Ok((validated_state, Delta {}))
     }
     /// Construct the state with the given block header.
     ///
@@ -382,8 +382,8 @@ impl HotShotState<SeqTypes> for ValidatedState {
     }
     /// Construct a genesis validated state.
     #[must_use]
-    fn genesis(instance: &Self::Instance) -> Self {
-        instance.genesis_state.clone()
+    fn genesis(instance: &Self::Instance) -> (Self, Self::Delta) {
+        (instance.genesis_state.clone(), Delta {})
     }
 }
 

--- a/sequencer/src/state_signature.rs
+++ b/sequencer/src/state_signature.rs
@@ -10,6 +10,7 @@ use hotshot_types::light_client::{
     CircuitField, LightClientState, StateSignatureRequestBody, StateVerKey,
 };
 use hotshot_types::{
+    event::LeafInfo,
     light_client::{StateSignature, StateSignatureScheme},
     signature_key::BLSPubKey,
     traits::{
@@ -69,7 +70,7 @@ impl StateSigner {
         let EventType::Decide { leaf_chain, .. } = &event.event else {
             return;
         };
-        let Some((leaf, _)) = leaf_chain.first() else {
+        let Some(LeafInfo { leaf, .. }) = leaf_chain.first() else {
             return;
         };
         match form_light_client_state(leaf, &self.stake_table_comm) {


### PR DESCRIPTION
It accommodates changes recently introuduced to Hotshot, especially `HotshotConfig`. Moreover, It makes `hotshot-types` points to its own repo, instead of hotshot crate.