### PR TITLE
CI: coverage: ignore dirs

### DIFF
--- a/.github/grcov.yml
+++ b/.github/grcov.yml
@@ -1,1 +1,4 @@
 output-type: lcov
+ignore:
+  - contract-bindings/*
+  - contracts/*


### PR DESCRIPTION
If I understand correctly this yaml file is only used by the github action but not something grcov understands. So we have to duplicate the ignore in the justfile and the config file here.