### PR TITLE
Make keygen tool friendlier to node operators, and slightly safer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
             target/release/submit-transactions
             target/release/reset-storage
             target/release/deploy
+            target/release/keygen
 
   build-arm:
     runs-on: [self-hosted, ARM64]
@@ -107,6 +108,7 @@ jobs:
             target/release/submit-transactions
             target/release/reset-storage
             target/release/deploy
+            target/release/keygen
 
   build-dockers:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -85,6 +85,7 @@ jobs:
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/submit-transactions
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/reset-storage
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/deploy
+            ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/keygen
 
   static-dockers:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7601,6 +7607,7 @@ dependencies = [
  "contract-bindings",
  "derivative",
  "derive_more",
+ "dotenvy",
  "espresso-macros",
  "ethers",
  "ethers-contract-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ base64-bytes = "0.1"
 clap = { version = "4.4", features = ["derive", "env", "string"] }
 cld = "0.5"
 derive_more = "0.99.17"
+dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.24" }

--- a/docker/sequencer.Dockerfile
+++ b/docker/sequencer.Dockerfile
@@ -13,6 +13,9 @@ RUN chmod +x /bin/sequencer
 COPY target/$TARGETARCH/release/reset-storage /bin/reset-storage
 RUN chmod +x /bin/reset-storage
 
+COPY target/$TARGETARCH/release/keygen /bin/keygen
+RUN chmod +x /bin/keygen
+
 # Set a path to save the consensus config on startup.
 #
 # Upon restart, the config will be loaded from this file and the node will be able to resume

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -32,7 +32,7 @@ for ARCH in "amd64" "arm64"; do
       ;;
   esac
   mkdir -p ${WORKDIR}/target/$ARCH/release
-  for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage" "state-relay-server" "state-prover" "deploy"; do
+  for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage" "state-relay-server" "state-prover" "deploy" "keygen"; do
     cp -v "${CARGO_TARGET_DIR}/${TARGET}/release/$binary" ${WORKDIR}/target/$ARCH/release
   done
 done

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -72,7 +72,7 @@ cleanup(){
 }
 
 mkdir -p ${WORKDIR}/target/$ARCH/release
-for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage" "state-relay-server" "state-prover" "deploy"; do
+for binary in "orchestrator" "web-server" "sequencer" "commitment-task" "submit-transactions" "reset-storage" "state-relay-server" "state-prover" "deploy" "keygen"; do
   cp -v "${CARGO_TARGET_DIR}/release/$binary" ${WORKDIR}/target/$ARCH/release
   # Patch the interpreter for running without nix inside the ubuntu based docker image.
   if [ $KERNEL == "linux" ]; then

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -36,6 +36,7 @@ commit = { git = "https://github.com/EspressoSystems/commit" }
 contract-bindings = { path = "../contract-bindings" }
 derivative = "2.2"
 derive_more = { workspace = true }
+dotenvy = { workspace = true }
 ethers = { workspace = true }
 ethers-contract-derive = "2.0.10"
 futures = { workspace = true }

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -43,10 +43,10 @@ async fn init_with_storage<S>(
 where
     S: DataSourceOptions,
 {
+    let (private_staking_key, private_state_key) = opt.private_keys()?;
     let l1_params = L1Params {
         url: opt.l1_provider_url,
     };
-
     let builder_params = BuilderParams {
         mnemonic: opt.eth_mnemonic,
         prefunded_accounts: opt.prefunded_builder_accounts,
@@ -58,8 +58,8 @@ where
         orchestrator_url: opt.orchestrator_url,
         state_relay_server_url: opt.state_relay_server_url,
         webserver_poll_interval: opt.webserver_poll_interval,
-        private_staking_key: opt.private_staking_key,
-        private_state_key: opt.private_state_key,
+        private_staking_key,
+        private_state_key,
         state_peers: opt.state_peers,
     };
 


### PR DESCRIPTION
* By default, output a .env file in exactly the format needed to configure a sequencer node
* By default, generate one of each required key type
* Do not write private keys to stdout
* Copy binary into sequencer docker image so node operators can easily download and run it
* Allow sequencer to be configured with a key file instead of individual keys, so it can be pointed directly at the output of `keygen`