### PR TITLE
chore: add decoded contract revert

### DIFF
--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -7,7 +7,7 @@ use async_std::{
     sync::Arc,
     task::{sleep, spawn},
 };
-use contract_bindings::light_client::LightClient;
+use contract_bindings::light_client::{LightClient, LightClientErrors};
 use displaydoc::Display;
 use ethers::{
     core::k256::ecdsa::SigningKey,
@@ -256,7 +256,7 @@ pub async fn submit_state_and_proof(
     let tx = contract.new_finalized_state(new_state.into(), proof.into());
 
     // send the tx
-    let (receipt, included_block) = sequencer_utils::contract_send(&tx)
+    let (receipt, included_block) = sequencer_utils::contract_send::<_, _, LightClientErrors>(&tx)
         .await
         .map_err(ProverError::ContractError)?;
 

--- a/sequencer/src/hotshot_commitment.rs
+++ b/sequencer/src/hotshot_commitment.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use async_std::{sync::Arc, task::sleep};
 use async_trait::async_trait;
-use contract_bindings::hot_shot::{HotShot, Qc};
+use contract_bindings::hot_shot::{HotShot, HotShotErrors, Qc};
 use ethers::prelude::*;
 use futures::{
     future,
@@ -249,7 +249,7 @@ async fn sync_with_l1(
     // error. We will retry, and may end up changing the transaction we send if the contract state
     // has changed, which is one possible cause of the transaction failure. This can happen, for
     // example, if there are multiple commitment tasks racing.
-    contract_send(&txn)
+    contract_send::<_, _, HotShotErrors>(&txn)
         .await
         .map_err(|e| SyncError::TransactionFailed { err: e, num_leaves })?;
 


### PR DESCRIPTION
Closes: #1156 

Results:

```
// prev:
Error: Error when communicating with the smart contract: error sending transaction: Contract call reverted with data: 0x09bde339

// now:
  2024-04-02T04:00:10.947239Z  INFO hotshot_state_prover::service::test: Successfully generated proof for new state.
    at hotshot-state-prover/src/service.rs:682

  2024-04-02T04:00:10.958064Z ERROR sequencer_utils: contract revert: InvalidProof(InvalidProof)
    at utils/src/lib.rs:363

Error: Error when communicating with the smart contract: error sending transaction: InvalidProof(InvalidProof)
```

I have also tested for both error with arguments and empty tuple:
```solidity
    error Foo();
    error Bar(uint256 ctr);
```
you will get:
```
got err: Bar(Bar { ctr: 4 })
got err: Foo(Foo)
test tests::decode_err_code ... ok
```