### PR TITLE
chore: update ark-srs dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ node_modules/
 
 # solidity files cache
 cache
+
+**/*.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,8 +493,9 @@ dependencies = [
 
 [[package]]
 name = "ark-srs"
-version = "0.1.0"
-source = "git+https://github.com/alxiong/ark-srs?tag=v0.1.0#610ee9948116fcb4426944141b8f03086dc1b758"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9d2dbff870743404933d3ef8a3be3adc3d1926f205e5aec2e43d3ee6885431"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -503,6 +504,8 @@ dependencies = [
  "ark-poly-commit",
  "ark-serialize",
  "ark-std",
+ "hex-literal",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3842,6 +3845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,7 +4562,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.13",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ark-ed-on-bn254 = "0.4"
 ark-ff = "0.4"
 ark-poly = "0.4"
 ark-serialize = "0.4"
+ark-srs = "0.2.0"
 async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer", tag = "1.4.1", features = [
   "logging-utils",
 ] }
@@ -61,11 +62,9 @@ cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", default-fea
 
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2", features = [
   "test-apis",
-  "test-srs",
 ] }
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2", features = [
   "std",
-  "test-srs",
 ] }
 jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.2", features = [
   "std",

--- a/contracts/rust/diff-test/Cargo.toml
+++ b/contracts/rust/diff-test/Cargo.toml
@@ -12,7 +12,7 @@ ark-ec = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-poly = { workspace = true }
-ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
+ark-srs = { workspace = true }
 ark-std = { workspace = true }
 clap = { version = "^4.4", features = ["derive"] }
 diff-test-bn254 = { git = "https://github.com/EspressoSystems/solidity-bn254.git" }

--- a/contracts/rust/gen-vk-contract/Cargo.toml
+++ b/contracts/rust/gen-vk-contract/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
+ark-srs = { workspace = true }
 hotshot-contract-adapter = { path = "../adapter" }
 hotshot-stake-table = { workspace = true }
 hotshot-state-prover = { path = "../../../hotshot-state-prover" }

--- a/contracts/rust/gen-vk-contract/src/main.rs
+++ b/contracts/rust/gen-vk-contract/src/main.rs
@@ -14,7 +14,7 @@ use jf_primitives::pcs::prelude::UnivariateUniversalParams;
 fn main() {
     let srs = {
         // load SRS from Aztec's ceremony
-        let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(20) as usize + 2)
+        let srs = ark_srs::kzg10::aztec20::setup(2u64.pow(20) as usize + 2)
             .expect("Aztec SRS fail to load");
         // convert to Jellyfish type
         // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440

--- a/flake.nix
+++ b/flake.nix
@@ -203,6 +203,7 @@
             nixpkgs-fmt
             entr
             process-compose
+            gh
             # `postgresql` defaults to an older version (15), so we select the latest version (16)
             # explicitly.
             postgresql_16
@@ -228,6 +229,9 @@
             # with rustup installations.
             export CARGO_HOME=$HOME/.cargo-nix
             export PATH="$PWD/$CARGO_TARGET_DIR/release:$PATH"
+            export ROOT_DIR=$(dirname "$(realpath ./flake.nix)")
+            export AZTEC_SRS_PATH="$ROOT_DIR/data/aztec20/kzg10-aztec20-srs-1048584.bin"
+            ./scripts/download_srs_aztec.sh
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -12,7 +12,7 @@ ark-ec = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
-ark-srs = { git = "https://github.com/alxiong/ark-srs", tag = "v0.1.0" }
+ark-srs = { workspace = true }
 ark-std = { workspace = true }
 async-compatibility-layer = { workspace = true }
 async-std = { workspace = true }

--- a/hotshot-state-prover/src/mock_ledger.rs
+++ b/hotshot-state-prover/src/mock_ledger.rs
@@ -243,7 +243,7 @@ impl MockLedger {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::kzg10::aztec20::setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440
@@ -301,7 +301,7 @@ impl MockLedger {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::kzg10::aztec20::setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440
@@ -430,7 +430,7 @@ pub fn gen_plonk_proof_for_test(
     // 1. Simulate universal setup
     let rng = &mut jf_utils::test_rng();
     let srs = {
-        let aztec_srs = ark_srs::aztec20::kzg10_setup(1024).expect("Aztec SRS fail to load");
+        let aztec_srs = ark_srs::kzg10::aztec20::setup(1024).expect("Aztec SRS fail to load");
 
         UnivariateUniversalParams {
             powers_of_g: aztec_srs.powers_of_g,

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -178,7 +178,7 @@ pub fn load_proving_key() -> ProvingKey {
 
         std::println!("Loading SRS from Aztec's ceremony...");
         let srs_timer = Instant::now();
-        let srs = ark_srs::aztec20::kzg10_setup(num_gates + 2).expect("Aztec SRS fail to load");
+        let srs = ark_srs::kzg10::aztec20::setup(num_gates + 2).expect("Aztec SRS fail to load");
         let srs_elapsed = srs_timer.elapsed();
         std::println!("Done in {srs_elapsed:.3}");
 
@@ -540,7 +540,7 @@ mod test {
 
         let srs = {
             // load SRS from Aztec's ceremony
-            let srs = ark_srs::aztec20::kzg10_setup(2u64.pow(16) as usize + 2)
+            let srs = ark_srs::kzg10::aztec20::setup(2u64.pow(16) as usize + 2)
                 .expect("Aztec SRS fail to load");
             // convert to Jellyfish type
             // TODO: (alex) use constructor instead https://github.com/EspressoSystems/jellyfish/issues/440

--- a/scripts/download_srs_aztec.sh
+++ b/scripts/download_srs_aztec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -f "$AZTEC_SRS_PATH" ]; then
+    echo "SRS file $AZTEC_SRS_PATH exists"
+else
+    echo "SRS file $AZTEC_SRS_PATH does not exist, downloading ..."
+    gh release download --repo alxiong/ark-srs v0.2.0 -p "$(basename $AZTEC_SRS_PATH)" -O "$AZTEC_SRS_PATH" --skip-existing
+fi


### PR DESCRIPTION
Pointing `ark-srs` to `0.2.0` on crates-io instead of to git repo, after updates in https://github.com/alxiong/ark-srs/pull/7. This is synced with https://github.com/EspressoSystems/HotShot/pull/2854