### PR TITLE
Feature flag Libp2p

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 
+[features]
+libp2p = ["sequencer/libp2p"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-broadcast = "0.7.0"

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -137,7 +137,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     channel_capacity: NonZeroUsize,
     bind_version: Ver,
     persistence: P,
-) -> anyhow::Result<BuilderContext<network::Combined, P, Ver>> {
+) -> anyhow::Result<BuilderContext<network::Networks, P, Ver>> {
     // Orchestrator client
     let validator_args = ValidatorArgs {
         url: network_params.orchestrator_url,
@@ -190,7 +190,8 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     .await
     .with_context(|| "Failed to create CDN network")?;
 
-    // Initialize the Libp2p network
+    // Initialize the Libp2p network (if enabled)
+    #[cfg(feature = "libp2p")]
     let p2p_network = Libp2pNetwork::from_config::<SeqTypes>(
         config.clone(),
         network_params.libp2p_bind_address,
@@ -202,17 +203,25 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     .await
     .with_context(|| "Failed to create libp2p network")?;
 
-    // Combine the two communication channels
-    let da_network = Arc::from(CombinedNetworks::new(
-        cdn_network.clone(),
-        p2p_network.clone(),
-        Duration::from_secs(1),
-    ));
-    let quorum_network = Arc::from(CombinedNetworks::new(
-        cdn_network,
-        p2p_network,
-        Duration::from_secs(1),
-    ));
+    // Combine the communication channels
+    #[cfg(feature = "libp2p")]
+    let (da_network, quorum_network) = {
+        (
+            Arc::from(CombinedNetworks::new(
+                cdn_network.clone(),
+                p2p_network.clone(),
+                Duration::from_secs(1),
+            )),
+            Arc::from(CombinedNetworks::new(
+                cdn_network,
+                p2p_network,
+                Duration::from_secs(1),
+            )),
+        )
+    };
+
+    #[cfg(not(feature = "libp2p"))]
+    let (da_network, quorum_network) = { (Arc::from(cdn_network.clone()), Arc::from(cdn_network)) };
 
     // Convert to the sequencer-compatible type
     let networks = Networks {

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -137,7 +137,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     channel_capacity: NonZeroUsize,
     bind_version: Ver,
     persistence: P,
-) -> anyhow::Result<BuilderContext<network::Networks, P, Ver>> {
+) -> anyhow::Result<BuilderContext<network::Production, P, Ver>> {
     // Orchestrator client
     let validator_args = ValidatorArgs {
         url: network_params.orchestrator_url,

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [features]
 testing = ["hotshot-testing"]
+libp2p = []
 
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -95,16 +95,16 @@ pub mod network {
     }
 
     #[derive(Clone, Copy, Default)]
-    pub struct Networks;
+    pub struct Production;
 
     #[cfg(feature = "libp2p")]
-    impl Type for Networks {
+    impl Type for Production {
         type DAChannel = CombinedNetworks<SeqTypes>;
         type QuorumChannel = CombinedNetworks<SeqTypes>;
     }
 
     #[cfg(not(feature = "libp2p"))]
-    impl Type for Networks {
+    impl Type for Production {
         type DAChannel = PushCdnNetwork<SeqTypes>;
         type QuorumChannel = PushCdnNetwork<SeqTypes>;
     }
@@ -311,7 +311,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     builder_params: BuilderParams,
     l1_params: L1Params,
     bind_version: Ver,
-) -> anyhow::Result<SequencerContext<network::Networks, P, Ver>> {
+) -> anyhow::Result<SequencerContext<network::Production, P, Ver>> {
     // Orchestrator client
     let validator_args = ValidatorArgs {
         url: network_params.orchestrator_url,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -36,8 +36,8 @@ use hotshot::{
     traits::{
         election::static_committee::{GeneralStaticCommittee, StaticElectionConfig},
         implementations::{
-            derive_libp2p_peer_id, CombinedNetworks, KeyPair, Libp2pNetwork, MemoryNetwork,
-            NetworkingMetricsValue, PushCdnNetwork, WrappedSignatureKey,
+            derive_libp2p_peer_id, KeyPair, MemoryNetwork, NetworkingMetricsValue, PushCdnNetwork,
+            WrappedSignatureKey,
         },
     },
     types::SignatureKey,
@@ -68,11 +68,14 @@ use hotshot_types::{
 use persistence::SequencerPersistence;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::{
-    collections::BTreeMap, fmt::Debug, marker::PhantomData, net::SocketAddr, sync::Arc,
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt::Debug, marker::PhantomData, net::SocketAddr, sync::Arc};
 use versioned_binary_serialization::version::StaticVersionType;
+
+#[cfg(feature = "libp2p")]
+use {
+    hotshot::traits::implementations::{CombinedNetworks, Libp2pNetwork},
+    std::time::Duration,
+};
 
 pub use block::payload::Payload;
 pub use chain_variables::ChainVariables;
@@ -82,7 +85,6 @@ pub use options::Options;
 pub use state::ValidatedState;
 pub use transaction::{NamespaceId, Transaction};
 pub mod network {
-    use hotshot::traits::implementations::CombinedNetworks;
     use hotshot_types::message::Message;
 
     use super::*;
@@ -93,11 +95,18 @@ pub mod network {
     }
 
     #[derive(Clone, Copy, Default)]
-    pub struct Combined;
+    pub struct Networks;
 
-    impl Type for Combined {
+    #[cfg(feature = "libp2p")]
+    impl Type for Networks {
         type DAChannel = CombinedNetworks<SeqTypes>;
         type QuorumChannel = CombinedNetworks<SeqTypes>;
+    }
+
+    #[cfg(not(feature = "libp2p"))]
+    impl Type for Networks {
+        type DAChannel = PushCdnNetwork<SeqTypes>;
+        type QuorumChannel = PushCdnNetwork<SeqTypes>;
     }
 
     #[derive(Clone, Copy, Debug, Default)]
@@ -302,7 +311,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     builder_params: BuilderParams,
     l1_params: L1Params,
     bind_version: Ver,
-) -> anyhow::Result<SequencerContext<network::Combined, P, Ver>> {
+) -> anyhow::Result<SequencerContext<network::Networks, P, Ver>> {
     // Orchestrator client
     let validator_args = ValidatorArgs {
         url: network_params.orchestrator_url,
@@ -364,7 +373,8 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     .await
     .with_context(|| "Failed to create CDN network")?;
 
-    // Initialize the Libp2p network
+    // Initialize the Libp2p network (if enabled)
+    #[cfg(feature = "libp2p")]
     let p2p_network = Libp2pNetwork::from_config::<SeqTypes>(
         config.clone(),
         network_params.libp2p_bind_address,
@@ -376,17 +386,25 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     .await
     .with_context(|| "Failed to create libp2p network")?;
 
-    // Combine the two communication channels
-    let da_network = Arc::from(CombinedNetworks::new(
-        cdn_network.clone(),
-        p2p_network.clone(),
-        Duration::from_secs(1),
-    ));
-    let quorum_network = Arc::from(CombinedNetworks::new(
-        cdn_network,
-        p2p_network,
-        Duration::from_secs(1),
-    ));
+    // Combine the communication channels
+    #[cfg(feature = "libp2p")]
+    let (da_network, quorum_network) = {
+        (
+            Arc::from(CombinedNetworks::new(
+                cdn_network.clone(),
+                p2p_network.clone(),
+                Duration::from_secs(1),
+            )),
+            Arc::from(CombinedNetworks::new(
+                cdn_network,
+                p2p_network,
+                Duration::from_secs(1),
+            )),
+        )
+    };
+
+    #[cfg(not(feature = "libp2p"))]
+    let (da_network, quorum_network) = { (Arc::from(cdn_network.clone()), Arc::from(cdn_network)) };
 
     // Convert to the sequencer-compatible type
     let networks = Networks {


### PR DESCRIPTION
Adds a feature flag `libp2p` that enables Libp2p. Without it, only the CDN is used.