### PR TITLE
update hotshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ dependencies = [
  "hotshot-stake-table",
  "hotshot-state-prover",
  "hotshot-types",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
  "portpicker",
  "rand 0.8.5",
  "sequencer",
@@ -2519,9 +2519,9 @@ dependencies = [
  "hotshot-types",
  "itertools 0.12.1",
  "jf-plonk",
- "jf-primitives 0.4.3",
- "jf-relation 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-relation 0.4.4",
+ "jf-utils 0.4.4",
  "sha3",
 ]
 
@@ -3592,7 +3592,7 @@ dependencies = [
  "hotshot-contract-adapter",
  "hotshot-stake-table",
  "hotshot-state-prover",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
 ]
 
 [[package]]
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4000,7 +4000,7 @@ dependencies = [
  "hotshot-task-impls",
  "hotshot-types",
  "hotshot-web-server",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
  "libp2p-identity",
  "libp2p-networking",
  "lru 0.12.3",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "async-trait",
  "clap",
@@ -4037,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.9"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.9#fbe38808f8a97f968abce839cc1a4afaab29b067"
+version = "0.1.10"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.10#83fc2024a674e1263406f179748348183b3613d0"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4079,16 +4079,16 @@ dependencies = [
  "ethers",
  "hotshot-types",
  "jf-plonk",
- "jf-primitives 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-utils 0.4.4",
  "num-bigint",
  "num-traits",
 ]
 
 [[package]]
 name = "hotshot-events-service"
-version = "0.1.9"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.10#ecd750f36c8955871def4dfb66785585f59f1898"
+version = "0.1.11"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.11#7d13c5e7b296b718ed3d4c2c1b7d16ae17b14400"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4113,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4182,8 +4182,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.1.9"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.10#2eb1faa7f9a200a0dbb5635be79971bda110c5fc"
+version = "0.1.10"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.11#2287f11d89aa959c3c7d6636a1ae2a9442f4790b"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4209,7 +4209,7 @@ dependencies = [
  "hotshot-types",
  "include_dir",
  "itertools 0.12.1",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
  "native-tls",
  "portpicker",
  "postgres-native-tls",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4247,8 +4247,8 @@ dependencies = [
  "digest 0.10.7",
  "ethereum-types",
  "hotshot-types",
- "jf-primitives 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-utils 0.4.4",
  "serde",
  "tagged-base64 0.4.0",
 ]
@@ -4284,9 +4284,9 @@ dependencies = [
  "hotshot-types",
  "itertools 0.12.1",
  "jf-plonk",
- "jf-primitives 0.4.3",
- "jf-relation 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-relation 0.4.4",
+ "jf-utils 0.4.4",
  "rand_chacha 0.3.1",
  "sequencer-utils",
  "serde",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4334,7 +4334,7 @@ dependencies = [
  "hotshot-builder-api",
  "hotshot-task",
  "hotshot-types",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4371,7 +4371,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",
- "jf-primitives 0.4.3",
+ "jf-primitives 0.4.4",
  "lru 0.12.3",
  "portpicker",
  "rand 0.8.5",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -4419,8 +4419,8 @@ dependencies = [
  "futures",
  "generic-array",
  "jf-plonk",
- "jf-primitives 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-utils 0.4.4",
  "lazy_static",
  "memoize",
  "rand 0.8.5",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4984,8 +4984,8 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jf-plonk"
-version = "0.4.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.3#4a2e7b7c3f8f10b352262869133a17e30ae94981"
+version = "0.4.4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.4#8f48813ca52d964090dbf0de62f07f5e0c7e22c6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4999,9 +4999,9 @@ dependencies = [
  "espresso-systems-common 0.4.0",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
- "jf-primitives 0.4.3",
- "jf-relation 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-relation 0.4.4",
+ "jf-utils 0.4.4",
  "merlin",
  "num-bigint",
  "rand_chacha 0.3.1",
@@ -5057,8 +5057,8 @@ dependencies = [
 
 [[package]]
 name = "jf-primitives"
-version = "0.4.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.3#4a2e7b7c3f8f10b352262869133a17e30ae94981"
+version = "0.4.4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.4#8f48813ca52d964090dbf0de62f07f5e0c7e22c6"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -5085,8 +5085,8 @@ dependencies = [
  "generic-array",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
- "jf-relation 0.4.3",
- "jf-utils 0.4.3",
+ "jf-relation 0.4.4",
+ "jf-utils 0.4.4",
  "merlin",
  "num-bigint",
  "num-traits",
@@ -5126,8 +5126,8 @@ dependencies = [
 
 [[package]]
 name = "jf-relation"
-version = "0.4.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.3#4a2e7b7c3f8f10b352262869133a17e30ae94981"
+version = "0.4.4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.4#8f48813ca52d964090dbf0de62f07f5e0c7e22c6"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -5144,7 +5144,7 @@ dependencies = [
  "dyn-clone 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
- "jf-utils 0.4.3",
+ "jf-utils 0.4.4",
  "num-bigint",
  "rand_chacha 0.3.1",
  "rayon",
@@ -5167,8 +5167,8 @@ dependencies = [
 
 [[package]]
 name = "jf-utils"
-version = "0.4.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.3#4a2e7b7c3f8f10b352262869133a17e30ae94981"
+version = "0.4.4"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.4#8f48813ca52d964090dbf0de62f07f5e0c7e22c6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -5636,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.40"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.41#4f9c275421936c65c6943a305406aa4280f35a1c"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.42#98874b2369dcf26acc6c887368a63efb5bfaf2d7"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -8516,8 +8516,8 @@ dependencies = [
  "hotshot-web-server",
  "include_dir",
  "itertools 0.12.1",
- "jf-primitives 0.4.3",
- "jf-utils 0.4.3",
+ "jf-primitives 0.4.4",
+ "jf-utils 0.4.4",
  "lazy_static",
  "num-traits",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,18 +47,18 @@ ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
 # Hotshot imports
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.41" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.9" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.10" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.42" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.10" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.11" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.41" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.10" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.42" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.11" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
@@ -70,16 +70,16 @@ cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", features = 
   "global-permits",
 ], tag = "0.2.1", package = "cdn-marshal" }
 
-jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.3", features = [
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.4", features = [
   "test-apis",
 ] }
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.3", features = [
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.4", features = [
   "std",
 ] }
-jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.3", features = [
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.4", features = [
   "std",
 ] }
-jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.3" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.4" }
 snafu = "0.8"
 strum = { version = "0.26", features = ["derive"] }
 surf-disco = "0.6"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -727,8 +727,7 @@ mod test {
                 // TODO we should not need to collect payload bytes just to compute vid_commitment
                 let payload_bytes = genesis_payload
                     .encode()
-                    .expect("unable to encode genesis payload")
-                    .collect();
+                    .expect("unable to encode genesis payload");
                 vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
             };
             let genesis_state = NodeState::mock();

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -116,8 +116,7 @@ impl BuilderConfig {
             // TODO we should not need to collect payload bytes just to compute vid_commitment
             let payload_bytes = genesis_payload
                 .encode()
-                .expect("unable to encode genesis payload")
-                .collect();
+                .expect("unable to encode genesis payload");
             vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
         };
 
@@ -324,7 +323,7 @@ mod test {
         let (hotshot_client_pub_key, hotshot_client_private_key) =
             BLSPubKey::generated_from_seed_indexed(seed, 2011_u64);
 
-        let parent_commitment = vid_commitment(&vec![], GENESIS_VID_NUM_STORAGE_NODES);
+        let parent_commitment = vid_commitment(&[], GENESIS_VID_NUM_STORAGE_NODES);
 
         // sign the parent_commitment using the client_private_key
         let encoded_signature = <SeqTypes as NodeType>::SignatureKey::sign(

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -411,8 +411,7 @@ impl<N: network::Type, P: SequencerPersistence, Ver: StaticVersionType + 'static
             // TODO we should not need to collect payload bytes just to compute vid_commitment
             let payload_bytes = genesis_payload
                 .encode()
-                .expect("unable to encode genesis payload")
-                .collect();
+                .expect("unable to encode genesis payload");
             vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
         };
 
@@ -594,7 +593,7 @@ mod test {
         let (hotshot_client_pub_key, hotshot_client_private_key) =
             BLSPubKey::generated_from_seed_indexed(seed, 2011_u64);
 
-        let parent_commitment = vid_commitment(&vec![], GENESIS_VID_NUM_STORAGE_NODES);
+        let parent_commitment = vid_commitment(&[], GENESIS_VID_NUM_STORAGE_NODES);
 
         // sign the parent_commitment using the client_private_key
         let encoded_signature = <SeqTypes as NodeType>::SignatureKey::sign(

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -683,10 +683,7 @@ mod test {
             );
 
             // TODO don't initialize Payload with empty namespace table
-            let block = Payload::from_bytes(
-                test_case.payload.iter().cloned(),
-                &NameSpaceTable::default(),
-            );
+            let block = Payload::from_bytes(&test_case.payload, &NameSpaceTable::default());
             // assert_eq!(block.len(), test_case.num_txs);
             assert_eq!(block.raw_payload.len(), payload_byte_len);
 
@@ -729,10 +726,7 @@ mod test {
         let test_case = TestCase::<TableWord>::from_tx_table_len_unchecked(1, 3, &mut rng); // 3-byte payload too small to store tx table len
 
         // TODO don't initialize Payload with empty namespace table
-        let block = Payload::from_bytes(
-            test_case.payload.iter().cloned(),
-            &NameSpaceTable::default(),
-        );
+        let block = Payload::from_bytes(&test_case.payload, &NameSpaceTable::default());
         assert_eq!(block.raw_payload.len(), test_case.payload.len());
         // assert_eq!(block.len(), test_case.num_txs);
 
@@ -836,7 +830,7 @@ mod test {
             let actual_payload_bytes = &test_case[1];
 
             let block = Payload::from_bytes(
-                actual_payload_bytes.iter().cloned(),
+                actual_payload_bytes,
                 &NameSpaceTable::from_bytes(actual_ns_table_bytes.to_vec()),
             );
             let disperse_data = vid.disperse(&block.raw_payload).unwrap();
@@ -980,7 +974,7 @@ mod test {
             let actual_payload_bytes = &test_case[1];
 
             let block = Payload::from_bytes(
-                actual_payload_bytes.iter().cloned(),
+                actual_payload_bytes,
                 &NameSpaceTable::from_bytes(actual_ns_table_bytes.to_vec()),
             );
             let ns_table = block.get_ns_table();

--- a/sequencer/src/block/tables.rs
+++ b/sequencer/src/block/tables.rs
@@ -48,8 +48,7 @@ pub struct NameSpaceTable<TableWord: TableWordTraits> {
 
 impl<TableWord: TableWordTraits> EncodeBytes for NameSpaceTable<TableWord> {
     fn encode(&self) -> std::sync::Arc<[u8]> {
-        let boxed_slice: Box<[u8]> = self.bytes.clone().into_boxed_slice();
-        Arc::from(boxed_slice)
+        Arc::from(self.bytes.clone())
     }
 }
 

--- a/sequencer/src/block/tables.rs
+++ b/sequencer/src/block/tables.rs
@@ -2,11 +2,13 @@ use crate::block::entry::TxTableEntry;
 use crate::block::payload::TableWordTraits;
 use crate::{BlockBuildingSnafu, Error, NamespaceId};
 use derivative::Derivative;
+use hotshot_types::traits::EncodeBytes;
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
+use std::sync::Arc;
 
 pub trait Table<TableWord: TableWordTraits> {
     // Read TxTableEntry::byte_len() bytes from `table_bytes` starting at `offset`.
@@ -42,6 +44,13 @@ pub struct NameSpaceTable<TableWord: TableWordTraits> {
     pub(super) bytes: Vec<u8>,
     #[serde(skip)]
     pub(super) phantom: PhantomData<TableWord>,
+}
+
+impl<TableWord: TableWordTraits> EncodeBytes for NameSpaceTable<TableWord> {
+    fn encode(&self) -> std::sync::Arc<[u8]> {
+        let boxed_slice: Box<[u8]> = self.bytes.clone().into_boxed_slice();
+        Arc::from(boxed_slice)
+    }
 }
 
 impl<TableWord: TableWordTraits> NameSpaceTable<TableWord> {

--- a/sequencer/src/hotshot_commitment.rs
+++ b/sequencer/src/hotshot_commitment.rs
@@ -329,7 +329,7 @@ mod test {
 
     fn mock_leaf(height: u64, node_state: &NodeState) -> LeafQueryData<SeqTypes> {
         let mut leaf = Leaf::genesis(node_state);
-        let mut qc = QuorumCertificate::genesis();
+        let mut qc = QuorumCertificate::genesis(node_state);
         leaf.get_block_header_mut().height = height;
         qc.data.leaf_commit = leaf.commit();
         LeafQueryData::new(leaf, qc).unwrap()

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -784,8 +784,7 @@ mod test {
                 // TODO we should not need to collect payload bytes just to compute vid_commitment
                 let payload_bytes = genesis_payload
                     .encode()
-                    .expect("unable to encode genesis payload")
-                    .collect();
+                    .expect("unable to encode genesis payload");
                 vid_commitment(&payload_bytes, GENESIS_VID_NUM_STORAGE_NODES)
             };
             let genesis_state = NodeState::mock();


### PR DESCRIPTION
This PR updates HotShot to the latest version which includes, among other things, significant changes to the interfaces for encoding and handling of bytes (essentially removes all the copying that existed before). It also includes a slew of updates for the trait updates Artemii made. Lastly, it implements `EncodeBytes` for the NamespaeTable.

The principal change, however, was a bugfix within `HotShot` which fixed an issue where `instance_state` would get passed to sequencer via a lock on the `consensus` state object. As a result, if sequencer got stuck in a loop while it held the lock, it'd lock consensus from writing and neither would proceed, even when messages that would ordinarily break the loop arrived.