### PR TITLE
Enforce max_block_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "arbitrary"
@@ -2752,9 +2752,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-trait",
  "clap",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-core"
 version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?branch=instance_state_by_ref#2eae8a50274ef01114c9452d40b564601e2692ac"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?branch=instance_state_by_ref#9e4fe648baefdd673975d1d5fddd41ca5e11448a"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.18"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=tbro/update-hotshot#dbd3931a17e2aa9b1c9c3b24e5131eb84050704f"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=tbro/update-hotshot#370f1b46ffcc49c991abb8aa1e03957875c8af1c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=update-hotshot#a3d4ca328954cc0ea477c4a17cedc93f43373a02"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=update-hotshot#a1f9c7abf9d595c9c9448cd5379d3c383326973e"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnpc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ba30e0f08582d53c2f3710cf4bb65ff562614b1ba86906d7391adffe189ec"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,7 +1524,31 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "clap",
+ "console-subscriber",
+ "dashmap",
+ "derivative",
+ "jf-primitives 0.4.0-pre.0",
+ "lazy_static",
+ "local-ip-address",
+ "parking_lot",
+ "portpicker",
+ "prometheus",
+ "rand 0.8.5",
+ "rkyv",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "cdn-broker"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+dependencies = [
+ "async-std",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "clap",
  "console-subscriber",
  "dashmap",
@@ -1536,10 +1569,10 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "rand 0.8.5",
@@ -1554,7 +1587,21 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "clap",
+ "jf-primitives 0.4.0-pre.0",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "cdn-marshal"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+dependencies = [
+ "async-std",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "tokio",
@@ -1571,6 +1618,38 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "capnp",
+ "derivative",
+ "jf-primitives 0.4.0-pre.0",
+ "kanal",
+ "lazy_static",
+ "mnemonic",
+ "mockall",
+ "pem 3.0.4",
+ "prometheus",
+ "quinn",
+ "rand 0.8.5",
+ "rcgen 0.12.1",
+ "redis",
+ "rkyv",
+ "rustls 0.21.12",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "warp",
+]
+
+[[package]]
+name = "cdn-proto"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
+dependencies = [
+ "anyhow",
+ "ark-serialize",
+ "async-trait",
+ "capnp",
+ "capnpc",
  "derivative",
  "jf-primitives 0.4.0-pre.0",
  "kanal",
@@ -3975,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3986,9 +4065,9 @@ dependencies = [
  "bimap",
  "bincode",
  "blake3",
- "cdn-broker",
+ "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "cdn-client",
- "cdn-marshal",
+ "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "committable",
  "custom_debug 0.5.1",
  "dashmap",
@@ -4019,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "async-trait",
  "clap",
@@ -4037,9 +4116,10 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?branch=instance_state_by_ref#9e4fe648baefdd673975d1d5fddd41ca5e11448a"
+version = "0.1.18"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.18#4f3f9169e709a74ae657e5425729ba19ed4aaecb"
 dependencies = [
+ "anyhow",
  "async-broadcast",
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4088,8 +4168,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-events-service"
-version = "0.1.18"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=tbro/update-hotshot#370f1b46ffcc49c991abb8aa1e03957875c8af1c"
+version = "0.1.19"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.19#b6b6ac5aa27742539bbc19eebe2e6a90b03a660c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4114,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4144,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4155,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4183,8 +4263,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=update-hotshot#a1f9c7abf9d595c9c9448cd5379d3c383326973e"
+version = "0.1.17"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.17#bce8fe56ba45e1dadd95a538b06a0b833042290b"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4238,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4304,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4317,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4350,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4389,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -4407,7 +4487,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake3",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
  "committable",
  "custom_debug 0.5.1",
  "derivative",
@@ -5624,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.49#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.50#6facd5bb4c5800486dd427c84b5de607f17b4224"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -7416,7 +7496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -8488,8 +8568,8 @@ dependencies = [
  "bincode",
  "blake3",
  "bytesize",
- "cdn-broker",
- "cdn-marshal",
+ "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
  "clap",
  "cld",
  "committable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -134,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -172,47 +172,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -1061,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "automod"
@@ -1162,9 +1163,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-bytes"
@@ -1172,7 +1173,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce54e4e485fa0eed9c3aa5348162be09168f75bb5be7bc6587bcf2a65ee1386"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -1499,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
@@ -1511,32 +1512,10 @@ dependencies = [
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
-dependencies = [
- "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
- "clap",
- "dashmap",
- "derivative",
- "jf-primitives 0.4.0-pre.0",
- "lazy_static",
- "local-ip-address",
- "parking_lot",
- "prometheus",
- "rand 0.8.5",
- "rkyv",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-broker"
-version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "cdn-proto",
  "clap",
  "console-subscriber",
  "dashmap",
@@ -1557,27 +1536,13 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
+ "cdn-proto",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "rand 0.8.5",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-marshal"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
-dependencies = [
- "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
- "clap",
- "jf-primitives 0.4.0-pre.0",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -1589,44 +1554,12 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "cdn-proto",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-proto"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
-dependencies = [
- "anyhow",
- "ark-serialize",
- "async-trait",
- "capnp",
- "derivative",
- "jf-primitives 0.4.0-pre.0",
- "kanal",
- "lazy_static",
- "mnemonic",
- "mockall",
- "parking_lot",
- "pem 3.0.4",
- "prometheus",
- "quinn",
- "rand 0.8.5",
- "rcgen 0.12.1",
- "redis",
- "rkyv",
- "rustls 0.21.12",
- "sqlx",
- "thiserror",
- "tokio",
- "tracing",
- "url",
- "warp",
 ]
 
 [[package]]
@@ -1852,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -1988,7 +1921,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2102,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "crc-any"
-version = "2.4.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
 
 [[package]]
 name = "crc-catalog"
@@ -3688,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4042,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4053,9 +3986,9 @@ dependencies = [
  "bimap",
  "bincode",
  "blake3",
- "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
+ "cdn-broker",
  "cdn-client",
- "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
+ "cdn-marshal",
  "committable",
  "custom_debug 0.5.1",
  "dashmap",
@@ -4067,7 +4000,6 @@ dependencies = [
  "hotshot-task",
  "hotshot-task-impls",
  "hotshot-types",
- "hotshot-web-server",
  "jf-primitives 0.4.4",
  "libp2p-identity",
  "libp2p-networking",
@@ -4087,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-trait",
  "clap",
@@ -4105,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.17"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.17#e661421e5ef51d5a4c75ddce2b889b83bea45b0e"
+version = "0.1.16"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?branch=instance_state_by_ref#2eae8a50274ef01114c9452d40b564601e2692ac"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4157,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.18"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.18#fb32c7c0f12e571436ec462c48ad2938017f9f8b"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=tbro/update-hotshot#dbd3931a17e2aa9b1c9c3b24e5131eb84050704f"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4182,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4212,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4223,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4252,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.16#cbdfa40278fb98c283e220264a0b563f3bb8fd41"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=update-hotshot#a3d4ca328954cc0ea477c4a17cedc93f43373a02"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4306,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4372,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4385,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4418,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4457,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -4475,7 +4407,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake3",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5)",
+ "cdn-proto",
  "committable",
  "custom_debug 0.5.1",
  "derivative",
@@ -4503,25 +4435,6 @@ dependencies = [
  "tracing",
  "typenum",
  "url",
- "vbs",
-]
-
-[[package]]
-name = "hotshot-web-server"
-version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
-dependencies = [
- "async-compatibility-layer",
- "async-lock 2.8.0",
- "async-std",
- "clap",
- "futures",
- "hotshot-types",
- "rand 0.8.5",
- "tide-disco",
- "tokio",
- "toml",
- "tracing",
  "vbs",
 ]
 
@@ -4752,7 +4665,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -4985,6 +4898,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "isahc"
@@ -5376,9 +5295,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -5406,7 +5325,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-autonat",
@@ -5567,7 +5486,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-ticker",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "hex_fmt",
  "instant",
  "libp2p-core",
@@ -5587,9 +5506,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20499a945d2f0221fdc6269b3848892c0f370d2ee3e19c7f65a29d8f860f6126"
+checksum = "b5d635ebea5ca0c3c3e77d414ae9b67eccf2a822be06091b9c1a0d13029a1e2f"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -5705,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.48#136dd95096528dfdaf3672b17e2d7bfcb6a581d7"
+source = "git+https://github.com/EspressoSystems/hotshot?rev=6d293ae9b#6d293ae9b71c0b2433704f97c15c4bb77135e9b6"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -5762,9 +5681,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.44.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b94ee41bd8c294194fe608851e45eb98de26fe79bc7913838cbffbfe8c7ce2"
+checksum = "a1de5a6cf64fba7f7e8f2102711c9c6c043a8e56b86db8cd306492c517da3fb3"
 dependencies = [
  "either",
  "futures",
@@ -5835,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aadb213ffc8e1a6f2b9c48dcf0fc07bf370f2ea4db7981813d45e50671c8d9d"
+checksum = "4d1c667cfabf3dd675c8e3cea63b7b98434ecf51721b7894cbb01d29983a6a9b"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes 1.6.0",
@@ -5845,7 +5764,6 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
@@ -5856,6 +5774,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "void",
+ "web-time",
 ]
 
 [[package]]
@@ -5884,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12823250fe0c45bdddea6eefa2be9a609aff1283ff4e1d8a294fdbb89572f6f"
+checksum = "6946e5456240b3173187cc37a17cb40c3cd1f7138c76e2c773e0d792a42a8de1"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -5906,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92532fc3c4fb292ae30c371815c9b10103718777726ea5497abc268a4761866"
+checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
 dependencies = [
  "async-std",
  "either",
@@ -5919,6 +5838,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
+ "lru 0.12.3",
  "multistream-select",
  "once_cell",
  "rand 0.8.5",
@@ -5930,11 +5850,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644268b4acfdaa6a6100b31226ee7a36d96ab4c43287d113bfd2308607d8b6f"
+checksum = "5daceb9dd908417b6dfcfe8e94098bc4aac54500c282e78120b885dadc09b999"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -5990,9 +5910,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49cc89949bf0e06869297cd4fe2c132358c23fe93e76ad43950453df4da3d35"
+checksum = "cccf04b0e3ff3de52d07d5fd6c3b061d0e7f908ffc683c32d9638caedce86fc8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6036,7 +5956,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.1",
+ "yamux 0.13.2",
 ]
 
 [[package]]
@@ -6438,7 +6358,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -6650,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -6661,9 +6581,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -6948,7 +6868,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -6969,9 +6889,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6980,9 +6900,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6990,9 +6910,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -7003,9 +6923,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -7427,9 +7347,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -7702,7 +7622,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -7824,7 +7744,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -7974,7 +7894,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes 1.6.0",
  "encoding_rs",
  "futures-core",
@@ -8053,7 +7973,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -8320,7 +8240,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -8491,11 +8411,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -8504,9 +8424,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8563,13 +8483,13 @@ dependencies = [
  "async-once-cell",
  "async-std",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "base64-bytes",
  "bincode",
  "blake3",
  "bytesize",
- "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
- "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "cdn-broker",
+ "cdn-marshal",
  "clap",
  "cld",
  "committable",
@@ -8591,7 +8511,6 @@ dependencies = [
  "hotshot-task",
  "hotshot-testing",
  "hotshot-types",
- "hotshot-web-server",
  "include_dir",
  "itertools 0.12.1",
  "jf-primitives 0.4.4",
@@ -8648,9 +8567,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -8677,9 +8596,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8744,7 +8663,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9504,7 +9423,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "futures-util",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "http-client",
  "http-types",
  "log",
@@ -9728,7 +9647,7 @@ checksum = "7b74bbf1db405a3fd2c6f8cd403bfa14727faa145925efe3012fa270b61551f1"
 dependencies = [
  "ark-serialize",
  "ark-std",
- "base64 0.22.0",
+ "base64 0.22.1",
  "crc-any",
  "serde",
  "snafu 0.8.2",
@@ -10140,16 +10059,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes 1.6.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.14",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -10216,7 +10134,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.7",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -10595,7 +10513,7 @@ version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -10642,7 +10560,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -10660,9 +10578,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -10670,9 +10588,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc35703541cbccb5278ef7b589d79439fc808ff0b5867195a3230f9a47421d39"
+checksum = "ccacf50c5cb077a9abb723c5bcb5e0754c1a433f1e1de89edc328e2760b6328b"
 dependencies = [
  "erased-serde",
  "serde",
@@ -10681,9 +10599,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285b43c29d0b4c0e65aad24561baee67a1b69dc9be9375d4a85138cbf556f7f8"
+checksum = "1785bae486022dfb9703915d42287dcb284c1ee37bd1080eeba78cc04721285b"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -10874,6 +10792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10961,7 +10889,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core",
+ "windows-core 0.51.1",
  "windows-targets 0.48.5",
 ]
 
@@ -10972,6 +10900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -11124,9 +11061,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -11250,9 +11187,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1d0148b89300047e72994bee99ecdabd15a9166a7b70c8b8c37c314dcc9002"
+checksum = "5f97202f6b125031b95d83e01dc57292b529384f80bfae4677e4bbc10178cf72"
 dependencies = [
  "futures",
  "instant",
@@ -11281,18 +11218,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,34 +1521,10 @@ dependencies = [
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
-dependencies = [
- "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
- "clap",
- "console-subscriber",
- "dashmap",
- "derivative",
- "jf-primitives 0.4.0-pre.0",
- "lazy_static",
- "local-ip-address",
- "parking_lot",
- "portpicker",
- "prometheus",
- "rand 0.8.5",
- "rkyv",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-broker"
-version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-proto",
  "clap",
  "console-subscriber",
  "dashmap",
@@ -1572,24 +1548,10 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-proto",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "rand 0.8.5",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-marshal"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
-dependencies = [
- "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
- "clap",
- "jf-primitives 0.4.0-pre.0",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -1601,43 +1563,12 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2#c41604361b634830b5ba874e06b997993055c25c"
 dependencies = [
  "async-std",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-proto",
  "clap",
  "jf-primitives 0.4.0-pre.0",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "cdn-proto"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3#bde96dbc21f4c9fde116606cb580db0ab759f44f"
-dependencies = [
- "anyhow",
- "ark-serialize",
- "async-trait",
- "capnp",
- "derivative",
- "jf-primitives 0.4.0-pre.0",
- "kanal",
- "lazy_static",
- "mnemonic",
- "mockall",
- "pem 3.0.4",
- "prometheus",
- "quinn",
- "rand 0.8.5",
- "rcgen 0.12.1",
- "redis",
- "rkyv",
- "rustls 0.21.12",
- "sqlx",
- "thiserror",
- "tokio",
- "tracing",
- "url",
- "warp",
 ]
 
 [[package]]
@@ -4065,9 +3996,9 @@ dependencies = [
  "bimap",
  "bincode",
  "blake3",
- "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-broker",
  "cdn-client",
- "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-marshal",
  "committable",
  "custom_debug 0.5.1",
  "dashmap",
@@ -4487,7 +4418,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake3",
- "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.2)",
+ "cdn-proto",
  "committable",
  "custom_debug 0.5.1",
  "derivative",
@@ -8568,8 +8499,8 @@ dependencies = [
  "bincode",
  "blake3",
  "bytesize",
- "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
- "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3)",
+ "cdn-broker",
+ "cdn-marshal",
  "clap",
  "cld",
  "committable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,19 @@ dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
+
 # Hotshot imports
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.49" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", branch = "instance_state_by_ref" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "tbro/update-hotshot" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", branch = "update-hotshot" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.50" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.18" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.19" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.17" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.50" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,18 @@ dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
 # Hotshot imports
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "6d293ae9b" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.49" }
 hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", branch = "instance_state_by_ref" }
 hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "tbro/update-hotshot" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
 hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", branch = "update-hotshot" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.49" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
   "runtime-async-std",
   "global-permits",
-], tag = "0.3", package = "cdn-broker" }
+], tag = "0.3.2", package = "cdn-broker" }
 cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
   "runtime-async-std",
   "global-permits",
-], tag = "0.3", package = "cdn-marshal" }
+], tag = "0.3.2", package = "cdn-marshal" }
 
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.4", features = [
   "test-apis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,19 +46,18 @@ dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
 # Hotshot imports
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.48" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.17" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.18" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.16" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "6d293ae9b" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", branch = "instance_state_by_ref" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "tbro/update-hotshot" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", branch = "update-hotshot" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
-hotshot-web-server = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", rev = "6d293ae9b" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -10,8 +10,7 @@ use futures::{
 };
 use hotshot::{
     traits::{
-        election::static_committee::GeneralStaticCommittee,
-        implementations::{NetworkingMetricsValue, WebServerNetwork},
+        election::static_committee::GeneralStaticCommittee, implementations::NetworkingMetricsValue,
     },
     types::{SignatureKey, SystemContextHandle},
     HotShotInitializer, Memberships, Networks, SystemContext,
@@ -706,7 +705,7 @@ mod test {
         let mut parent = {
             // TODO refactor repeated code from other tests
             let (genesis_payload, genesis_ns_table) =
-                Payload::from_transactions([], Arc::new(genesis_state.clone()))
+                Payload::from_transactions([], &genesis_state)
                     .expect("unable to create genesis payload");
             let builder_commitment = genesis_payload.builder_commitment(&genesis_ns_table);
             let genesis_commitment = {

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -101,9 +101,8 @@ impl BuilderConfig {
         // builder api request channel
         let (req_sender, req_receiver) = broadcast::<MessageType<SeqTypes>>(channel_capacity.get());
 
-        let (genesis_payload, genesis_ns_table) =
-            Payload::from_transactions([], Arc::new(instance_state.clone()))
-                .expect("genesis payload construction failed");
+        let (genesis_payload, genesis_ns_table) = Payload::from_transactions([], &instance_state)
+            .expect("genesis payload construction failed");
 
         let builder_commitment = genesis_payload.builder_commitment(&genesis_ns_table);
 

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -164,37 +164,21 @@ impl BuilderConfig {
         // start the hotshot api service
         run_builder_api_service(hotshot_builder_apis_url.clone(), proxy_global_state);
 
-        // create a client for it
-        // Start Client for the event streaming api
-        tracing::info!(
-            "Builder client connecting to hotshot events API at {}",
-            hotshot_events_api_url.to_string()
-        );
-        let client = Client::<EventStreamApiError, Version01>::new(hotshot_events_api_url.clone());
-
-        assert!(client.connect(None).await);
-
-        tracing::info!("Builder client connected to the hotshot events api");
-
-        // client subscrive to hotshot events
-        let subscribed_events = client
-            .socket("hotshot-events/events")
-            .subscribe::<BuilderEvent<SeqTypes>>()
-            .await
-            .unwrap();
-
-        tracing::info!("Builder client subscribed to hotshot events");
-
         // spawn the builder service
+        let events_url = hotshot_events_api_url
+            .clone()
+            .join("hotshot-events/events")
+            .unwrap();
         async_spawn(async move {
-            run_non_permissioned_standalone_builder_service(
+            let res = run_non_permissioned_standalone_builder_service(
                 tx_sender,
                 da_sender,
                 qc_sender,
                 decide_sender,
-                subscribed_events,
+                events_url,
             )
             .await;
+            tracing::error!(?res, "builder service exited")
         });
 
         tracing::info!("Builder init finished");

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -13,7 +13,7 @@ use hotshot::{
         election::static_committee::GeneralStaticCommittee,
         implementations::{
             derive_libp2p_peer_id, CombinedNetworks, KeyPair, Libp2pNetwork,
-            NetworkingMetricsValue, PushCdnNetwork, WebServerNetwork, WrappedSignatureKey,
+            NetworkingMetricsValue, PushCdnNetwork, WrappedSignatureKey,
         },
     },
     types::{SignatureKey, SystemContextHandle},

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -400,9 +400,8 @@ impl<N: network::Type, P: SequencerPersistence, Ver: StaticVersionType + 'static
         // builder api request channel
         let (req_sender, req_receiver) = broadcast::<MessageType<SeqTypes>>(channel_capacity.get());
 
-        let (genesis_payload, genesis_ns_table) =
-            Payload::from_transactions([], Arc::new(instance_state.clone()))
-                .expect("genesis payload construction failed");
+        let (genesis_payload, genesis_ns_table) = Payload::from_transactions([], &instance_state)
+            .expect("genesis payload construction failed");
 
         let builder_commitment = genesis_payload.builder_commitment(&genesis_ns_table);
 

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -13,7 +13,7 @@ use hotshot::{
         election::static_committee::GeneralStaticCommittee,
         implementations::{
             derive_libp2p_peer_id, CombinedNetworks, KeyPair, Libp2pNetwork,
-            NetworkingMetricsValue, PushCdnNetwork, WrappedSignatureKey,
+            NetworkingMetricsValue, PushCdnNetwork, Topic, WrappedSignatureKey,
         },
     },
     types::{SignatureKey, SystemContextHandle},
@@ -188,7 +188,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     // Initialize the push CDN network (and perform the initial connection)
     let cdn_network = PushCdnNetwork::new(
         network_params.cdn_endpoint,
-        vec!["Global".into(), "DA".into()],
+        vec![Topic::Global, Topic::DA],
         KeyPair {
             public_key: WrappedSignatureKey(my_config.public_key),
             private_key: my_config.private_key.clone(),

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -60,7 +60,6 @@ hotshot-task = { workspace = true }
 # Dependencies for feature `testing`
 hotshot-testing = { workspace = true, optional = true }
 hotshot-types = { workspace = true }
-hotshot-web-server = { workspace = true }
 include_dir = "0.7"
 itertools = { workspace = true }
 

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -367,18 +367,17 @@ mod test {
             payload_size.try_into().unwrap(),
         ));
 
-        // The final 2 txns will be ommitted
+        // The final 2 txns will be omitted
         let payload = Payload::<TxTableEntryWord>::from_txs(txs.clone(), &chain_config).unwrap();
         assert_eq!(payload.txn_count(), txs.len() as u64 - 2u64);
 
-        // The final txn will be ommitted
+        // The final txn will be omitted
         txs.pop();
         let payload = Payload::<TxTableEntryWord>::from_txs(txs.clone(), &chain_config).unwrap();
         assert_eq!(payload.txn_count(), txs.len() as u64 - 1u64);
 
         // All txns will be included.
         txs.pop();
-        dbg!(txs.len());
         let payload = Payload::<TxTableEntryWord>::from_txs(txs.clone(), &chain_config).unwrap();
 
         assert_eq!(payload.txn_count(), txs.len() as u64);

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -166,7 +166,7 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
             block_size += (tx.payload().len() + size_of::<TxTableEntry>()) as u64;
 
             // block_size is updated when we encounter a new namespace
-            if namespaces.contains_key(&tx.namespace()) {
+            if !namespaces.contains_key(&tx.namespace()) {
                 block_size += size_of::<TxTableEntry>() as u64;
             }
 

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -171,7 +171,6 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
             }
 
             if block_size > chain_config.max_block_size() {
-                dbg!(block_size);
                 break;
             }
 
@@ -369,21 +368,19 @@ mod test {
         let payload_size = 6;
         // `tx_size` is payload + table entry size
         let tx_size = (payload_size + size_of::<TxTableEntry>()) as u64;
+        // check our sanity
         assert_eq!(tx_size, 10);
 
         let n_txs = target_payload_total as u64 / tx_size;
-        dbg!(n_txs);
         let chain_config = ChainConfig::new(1, max_block_size, 1);
 
-        dbg!(size_of::<TxTableEntry>());
-
         let mut txs = (0..n_txs)
-            .map(|_| Transaction::of_size(payload_size.try_into().unwrap()))
+            .map(|_| Transaction::of_size(payload_size.unwrap()))
             .collect::<Vec<Transaction>>();
 
         assert_eq!(txs.len(), 100);
 
-        txs.push(Transaction::of_size(payload_size.try_into().unwrap()));
+        txs.push(Transaction::of_size(payload_size.unwrap()));
 
         // The final txn will be omitted
         let payload = Payload::<TxTableEntryWord>::from_txs(txs.clone(), &chain_config).unwrap();
@@ -391,8 +388,6 @@ mod test {
             .iter()
             .map(|tx| tx.payload().len() + size_of::<TxTableEntry>())
             .sum();
-        dbg!(txs_len + size_of::<TxTableEntry>());
-        dbg!(payload.txn_count() * tx_size);
         assert_eq!(payload.txn_count(), txs.len() as u64 - 1u64);
 
         txs.pop();

--- a/sequencer/src/block/payload.rs
+++ b/sequencer/src/block/payload.rs
@@ -166,7 +166,7 @@ impl<TableWord: TableWordTraits> Payload<TableWord> {
             block_size += (tx.payload().len() + size_of::<TxTableEntry>()) as u64;
 
             // block_size is updated when we encounter a new namespace
-            if namespaces.get(&tx.namespace()).is_none() {
+            if namespaces.contains_key(&tx.namespace()) {
                 block_size += size_of::<TxTableEntry>() as u64;
             }
 
@@ -375,19 +375,15 @@ mod test {
         let chain_config = ChainConfig::new(1, max_block_size, 1);
 
         let mut txs = (0..n_txs)
-            .map(|_| Transaction::of_size(payload_size.unwrap()))
+            .map(|_| Transaction::of_size(payload_size))
             .collect::<Vec<Transaction>>();
 
         assert_eq!(txs.len(), 100);
 
-        txs.push(Transaction::of_size(payload_size.unwrap()));
+        txs.push(Transaction::of_size(payload_size));
 
         // The final txn will be omitted
         let payload = Payload::<TxTableEntryWord>::from_txs(txs.clone(), &chain_config).unwrap();
-        let txs_len: usize = txs
-            .iter()
-            .map(|tx| tx.payload().len() + size_of::<TxTableEntry>())
-            .sum();
         assert_eq!(payload.txn_count(), txs.len() as u64 - 1u64);
 
         txs.pop();

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -17,7 +17,7 @@ use hotshot_types::{
         EncodeBytes, ValidatedState as HotShotState,
     },
     utils::BuilderCommitment,
-    vid::VidCommitment,
+    vid::{VidCommitment, VidCommon},
 };
 use jf_primitives::merkle_tree::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -245,7 +245,7 @@ impl Header {
 }
 
 #[derive(Debug, Snafu)]
-#[snafu(display("Invalid Block Headre {msg}"))]
+#[snafu(display("Invalid Block Header {msg}"))]
 pub struct InvalidBlockHeader {
     msg: String,
 }
@@ -254,8 +254,16 @@ impl InvalidBlockHeader {
         Self { msg }
     }
 }
+
+impl From<anyhow::Error> for InvalidBlockHeader {
+    fn from(err: anyhow::Error) -> Self {
+        Self::new(format!("{err:#}"))
+    }
+}
+
 impl BlockHeader<SeqTypes> for Header {
     type Error = InvalidBlockHeader;
+
     #[tracing::instrument(
         skip_all,
         fields(
@@ -273,6 +281,7 @@ impl BlockHeader<SeqTypes> for Header {
         builder_commitment: BuilderCommitment,
         metadata: <<SeqTypes as NodeType>::BlockPayload as BlockPayload>::Metadata,
         builder_fee: BuilderFee<SeqTypes>,
+        _vid_common: VidCommon,
     ) -> Result<Self, Self::Error> {
         let height = parent_leaf.get_height();
         let view = parent_leaf.get_view_number();
@@ -286,7 +295,7 @@ impl BlockHeader<SeqTypes> for Header {
             builder_fee
                 .fee_signature
                 .recover(fee_msg)
-                .expect("invalid builder signature"),
+                .context("invalid builder signature")?,
         );
 
         // Figure out which accounts we need to fetch, in case we are missing some state needed to
@@ -322,7 +331,6 @@ impl BlockHeader<SeqTypes> for Header {
             );
 
             // Fetch missing fee state entries
-            // Unwrapping here is okay as we retry until we get the accounts or until the task is canceled.
             let missing_account_proofs = instance_state
                 .peers
                 .as_ref()
@@ -332,15 +340,14 @@ impl BlockHeader<SeqTypes> for Header {
                     parent_state.fee_merkle_tree.commitment(),
                     missing_accounts,
                 )
-                .await
-                .unwrap();
+                .await?;
 
             // Insert missing fee state entries
             for account in missing_account_proofs.iter() {
                 account
                     .proof
                     .remember(&mut validated_state.fee_merkle_tree)
-                    .expect("proof previously verified");
+                    .context("remembering fee account")?;
             }
         }
 
@@ -352,10 +359,10 @@ impl BlockHeader<SeqTypes> for Header {
                 .as_ref()
                 .remember_blocks_merkle_tree(height, view, &mut validated_state.block_merkle_tree)
                 .await
-                .expect("failed to remember proof");
+                .context("remembering block proof")?;
         }
 
-        Self::from_info(
+        Ok(Self::from_info(
             payload_commitment,
             builder_commitment,
             metadata,
@@ -367,8 +374,7 @@ impl BlockHeader<SeqTypes> for Header {
             OffsetDateTime::now_utc().unix_timestamp() as u64,
             validated_state,
             instance_state.chain_config,
-        )
-        .map_err(|e| InvalidBlockHeader::new(format!("{e:#}")))
+        )?)
     }
 
     fn genesis(
@@ -458,7 +464,8 @@ mod test_headers {
         types::{Address, U256},
         utils::Anvil,
     };
-    use hotshot_types::traits::signature_key::BuilderSignatureKey;
+    use hotshot_types::{traits::signature_key::BuilderSignatureKey, vid::vid_scheme};
+    use jf_primitives::vid::VidScheme;
 
     #[derive(Debug, Default)]
     #[must_use]
@@ -733,6 +740,7 @@ mod test_headers {
     #[test]
     fn test_validate_proposal_error_cases() {
         let genesis = GenesisForTest::default();
+        let vid_common = vid_scheme(1).disperse([]).unwrap().common;
 
         let mut validated_state = ValidatedState::default();
         let mut block_merkle_tree = validated_state.block_merkle_tree.clone();
@@ -757,6 +765,7 @@ mod test_headers {
             ChainConfig::new(U256::zero(), 0u64, U256::zero()),
             &parent_leaf,
             &proposal,
+            &vid_common,
         )
         .unwrap_err();
 
@@ -770,6 +779,7 @@ mod test_headers {
             genesis.instance_state.chain_config,
             &parent_leaf,
             &proposal,
+            &vid_common,
         )
         .unwrap_err();
         assert_eq!(
@@ -787,6 +797,7 @@ mod test_headers {
             genesis.instance_state.chain_config,
             &parent_leaf,
             &proposal,
+            &vid_common,
         )
         .unwrap_err();
         // Fails b/c `proposal` has not advanced from `parent`
@@ -805,6 +816,7 @@ mod test_headers {
         ));
 
         let genesis = GenesisForTest::default();
+        let vid_common = vid_scheme(1).disperse([]).unwrap().common;
 
         let mut parent_state = genesis.validated_state.clone();
 
@@ -844,6 +856,7 @@ mod test_headers {
             FeeAccount::sign_fee(&key_pair, fee_amount, &ns_table, &payload_commitment).unwrap();
         let builder_fee = BuilderFee {
             fee_amount,
+            fee_account: key_pair.fee_account(),
             fee_signature,
         };
         let proposal = Header::new(
@@ -854,6 +867,7 @@ mod test_headers {
             builder_commitment,
             ns_table,
             builder_fee,
+            vid_common.clone(),
         )
         .await
         .unwrap();
@@ -880,6 +894,7 @@ mod test_headers {
             genesis.instance_state.chain_config,
             &parent_leaf,
             &proposal.clone(),
+            &vid_common,
         )
         .unwrap();
 

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -368,7 +368,7 @@ impl BlockHeader<SeqTypes> for Header {
             validated_state,
             instance_state.chain_config,
         )
-        .map_err(|e| InvalidBlockHeader::new(e.to_string()))
+        .map_err(|e| InvalidBlockHeader::new(format!("{e:#}")))
     }
 
     fn genesis(

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -35,7 +35,7 @@ use hotshot::{
         election::static_committee::GeneralStaticCommittee,
         implementations::{
             derive_libp2p_peer_id, KeyPair, MemoryNetwork, NetworkingMetricsValue, PushCdnNetwork,
-            WrappedSignatureKey,
+            Topic, WrappedSignatureKey,
         },
     },
     types::SignatureKey,
@@ -348,9 +348,9 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
 
     // If we are a DA node, we need to subscribe to the DA topic
     let topics = {
-        let mut topics = vec!["Global".into()];
+        let mut topics = vec![Topic::Global];
         if is_da {
-            topics.push("DA".into());
+            topics.push(Topic::DA);
         }
         topics
     };

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -806,7 +806,7 @@ mod test {
         let mut parent = {
             // TODO refactor repeated code from other tests
             let (genesis_payload, genesis_ns_table) =
-                Payload::from_transactions([], Arc::new(NodeState::mock())).unwrap();
+                Payload::from_transactions([], &NodeState::mock()).unwrap();
             let genesis_commitment = {
                 // TODO we should not need to collect payload bytes just to compute vid_commitment
                 let payload_bytes = genesis_payload

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -202,6 +202,20 @@ impl NodeState {
     }
 }
 
+// This allows us to turn on `Default` on InstanceState trait
+// which is used in `HotShot` by `TestBuilderImplementation`.
+#[cfg(any(test, feature = "testing"))]
+impl Default for NodeState {
+    fn default() -> Self {
+        Self::new(
+            1u64,
+            ChainConfig::default(),
+            L1Client::new("http://localhost:3331".parse().unwrap(), Address::default()),
+            catchup::mock::MockStateCatchup::default(),
+        )
+    }
+}
+
 impl InstanceState for NodeState {}
 
 impl NodeType for SeqTypes {

--- a/sequencer/src/transaction.rs
+++ b/sequencer/src/transaction.rs
@@ -77,10 +77,9 @@ impl Transaction {
     }
     #[cfg(any(test, feature = "testing"))]
     /// Useful for when we want to test size of transaction(s)
-    pub fn of_size(rng: &mut dyn rand::RngCore, len: usize) -> Self {
-        use rand::Rng;
+    pub fn of_size(len: usize) -> Self {
         Self::new(
-            NamespaceId(rng.gen_range(0..10)),
+            NamespaceId(0),
             (0..len).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
         )
     }

--- a/sequencer/src/transaction.rs
+++ b/sequencer/src/transaction.rs
@@ -75,6 +75,15 @@ impl Transaction {
             (0..len).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
         )
     }
+    #[cfg(any(test, feature = "testing"))]
+    /// Useful for when we want to test size of transaction(s)
+    pub fn of_size(rng: &mut dyn rand::RngCore, len: usize) -> Self {
+        use rand::Rng;
+        Self::new(
+            NamespaceId(rng.gen_range(0..10)),
+            (0..len).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+        )
+    }
 }
 
 impl HotShotTransaction for Transaction {}


### PR DESCRIPTION
Omit transactions that exceed max_block_size from payload. Use mocked `max_block_size` for now. 

Depends on:  https://github.com/EspressoSystems/HotShot/pull/3096
Related to: https://github.com/EspressoSystems/hotshot-builder-core/pull/122