### PR TITLE
Demote logs for fetching missing state from WARN to INFO

### DIFF
--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -67,6 +67,7 @@ impl<Ver: StaticVersionType> StatePeers<Ver> {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     async fn fetch_account(
         &self,
         view: ViewNumber,
@@ -107,7 +108,6 @@ impl<Ver: StaticVersionType> StatePeers<Ver> {
 
 #[async_trait]
 impl<Ver: StaticVersionType> StateCatchup for StatePeers<Ver> {
-    #[tracing::instrument(skip(self))]
     async fn fetch_accounts(
         &self,
         view: ViewNumber,

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -632,7 +632,7 @@ impl ValidatedState {
 
         // Ensure merkle tree has frontier
         if self.need_to_fetch_blocks_mt_frontier() {
-            tracing::warn!("fetching block frontier for view {view:?} from peers");
+            tracing::info!("fetching block frontier for view {view:?} from peers");
 
             instance
                 .peers
@@ -643,7 +643,7 @@ impl ValidatedState {
 
         // Fetch missing fee state entries
         if !missing_accounts.is_empty() {
-            tracing::warn!("fetching missing accounts {missing_accounts:?} from peers");
+            tracing::info!("fetching missing accounts {missing_accounts:?} from peers");
 
             let missing_account_proofs = instance
                 .peers


### PR DESCRIPTION
This happens routinely, particular with the merklized state storage, so it's too noisy at WARN level. We mainly only care when there is a problem fetching the state, which will be logged at WARN level with context from tracing spans.
