### PR TITLE
Set working RUSTFLAGS in .cargo/config.toml

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[net]
-git-fetch-with-cli = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[net]
+git-fetch-with-cli = true
+
+[build]
+rustflags =  ['--cfg', 'async_executor_impl="async-std"', '--cfg', 'async_channel_impl="async-std"']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: "--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\""
   RUST_LOG: info,libp2p=off
 
 jobs:

--- a/.github/workflows/test-demo-native.yml
+++ b/.github/workflows/test-demo-native.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
+  # Build test binary with `testing` feature, which requires `hotshot_example` config
+  RUSTFLAGS: --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg hotshot_example
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:
@@ -48,9 +49,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Test
-        # Build test binary with `testing` feature, which requires `hotshot_example` config
         run: |
-          export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
           cargo build --locked --bin diff-test --release
           cargo test --locked --release --workspace --all-features --no-run

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -4,9 +4,6 @@ on:
 
 name: udeps
 
-env:
-  RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
-
 jobs:
   check:
     name: Rust project
@@ -22,7 +19,7 @@ jobs:
       - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
         with:

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,6 +1,5 @@
 {
     "rust-analyzer.server.extraEnv": {
-        "CARGO_TARGET_DIR": "target/vscode_rust_analyzer",
-        "RUSTFLAGS": " --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\""
+        "CARGO_TARGET_DIR": "target/vscode_rust_analyzer"
     },
 }

--- a/cross-shell.nix
+++ b/cross-shell.nix
@@ -1,6 +1,6 @@
 # A simplest nix shell file with the project dependencies and
 # a cross-compilation support.
-{ pkgs, RUSTFLAGS, RUST_LOG, RUST_BACKTRACE, CARGO_TARGET_DIR }:
+{ pkgs, RUST_LOG, RUST_BACKTRACE, CARGO_TARGET_DIR }:
 pkgs.mkShell {
   # Native project dependencies like build utilities and additional routines
   # like container building, linters, etc.
@@ -25,5 +25,5 @@ pkgs.mkShell {
     rustCrossHook
   ];
 
-  inherit RUSTFLAGS RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
+  inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
 }

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -40,7 +40,6 @@ Just is not available in the official ubuntu repos.
 
 To run the SQL tests docker needs to be installed and running.
 
-    export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
     export "PATH=$PWD/target/release:$PATH"
     cargo build --release --bin diff-test
     cargo test --release --all-features -- --skip sql

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,6 @@
       # node=error: disable noisy anvil output
       RUST_LOG = "info,libp2p=off,isahc=error,surf=error,node=error";
       RUST_BACKTRACE = 1;
-      RUSTFLAGS =
-        " --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\" --cfg hotshot_example";
       # Use a distinct target dir for builds from within nix shells.
       CARGO_TARGET_DIR = "target/nix";
 
@@ -92,7 +90,7 @@
         in
         import ./cross-shell.nix {
           inherit pkgs;
-          inherit RUST_LOG RUST_BACKTRACE RUSTFLAGS CARGO_TARGET_DIR;
+          inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
         };
     in
     with pkgs; {
@@ -231,7 +229,7 @@
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";
-          inherit RUST_LOG RUST_BACKTRACE RUSTFLAGS CARGO_TARGET_DIR;
+          inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
         };
       devShells.crossShell =
         crossShell { config = "x86_64-unknown-linux-musl"; };
@@ -252,7 +250,7 @@
             protobuf # to compile libp2p-autonat
             toolchain
           ];
-          inherit RUST_LOG RUST_BACKTRACE RUSTFLAGS CARGO_TARGET_DIR;
+          inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
         };
       devShells.coverage =
         let
@@ -268,7 +266,7 @@
             toolchain
             grcov
           ];
-          inherit RUST_LOG RUST_BACKTRACE RUSTFLAGS CARGO_TARGET_DIR;
+          inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
           CARGO_INCREMENTAL = "0";
           shellHook = ''
             RUSTFLAGS="$RUSTFLAGS -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Cdebuginfo=2"
@@ -291,7 +289,7 @@
             protobuf # to compile libp2p-autonat
             stableToolchain
           ];
-          inherit RUST_LOG RUST_BACKTRACE RUSTFLAGS CARGO_TARGET_DIR;
+          inherit RUST_LOG RUST_BACKTRACE CARGO_TARGET_DIR;
         };
     });
 }

--- a/justfile
+++ b/justfile
@@ -26,9 +26,9 @@ docker-stop-rm:
 anvil *args:
     docker run -p 127.0.0.1:8545:8545 ghcr.io/foundry-rs/foundry:latest "anvil {{args}}"
 
-test:
+test *args:
     cargo build --bin diff-test --release
-    cargo test --release --all-features
+    cargo test --release --all-features {{args}}
 
 # Helpful shortcuts for local development
 dev-orchestrator:

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -56,14 +56,12 @@ case $KERNEL in
   CARGO_TARGET_DIR=target/docker
 
   # Build in docker container:
-  #   - RUSTFLAGS is needed for compilation.
   #   - CARGO_TARGET_DIR is set to point to the location where the hosts
   #     CARGO_TARGET_DIR is mounted.
   #   - PWD is mounted to /work.
   #   - Cargo registry and git directory are mounted to avoid re-downloading
   #     dependencies.
   docker run \
-    -e RUSTFLAGS \
     -e CARGO_TARGET_DIR=/work/target/docker \
     -v "$(pwd):/work" \
     -v "$CARGO_HOME/registry:/usr/local/cargo/registry" \


### PR DESCRIPTION
Closes #845

### This PR:
Avoids developers running into compilation errors due to RUSTFLAGS.

The RUSTFLAGS in `.cargo/config.toml` will be used for all rustc invocations unless the RUSTFLAGS env var is set. In that case the env var will override the value in the config file.

Removes setting of `--cfg hotshot_example` (except for on the CI). This does lead to some warnings when compiling the tests with `--release` but requires less configuration. I think the main problem here is that we need to run tests with `--release` and we should instead fix that by for example enabling optimization of dependencies and leave the warning there until we fix it.

### This PR does not:
Fix issues with compilation with tokio. Tracked in #1401

### Key places to review:
It would be good if a vscode user could test if the changes to the settings are okay. cc @ImJeremyHe 