### PR TITLE
Prevent possible race condition in state persistence/resetartability

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -392,6 +392,7 @@ pub mod testing {
             };
 
             let node_state = NodeState::new(
+                i as u64,
                 ChainConfig::default(),
                 L1Client::new(self.anvil.endpoint().parse().unwrap(), Address::default()),
                 MockStateCatchup::default(),
@@ -529,6 +530,7 @@ pub mod testing {
         ) -> Self {
             // setup the instance state
             let node_state = NodeState::new(
+                u64::MAX,
                 ChainConfig::default(),
                 L1Client::new(
                     hotshot_test_config.get_anvil().endpoint().parse().unwrap(),
@@ -590,6 +592,7 @@ pub mod testing {
         ) -> Self {
             // setup the instance state
             let node_state = NodeState::new(
+                node_id,
                 ChainConfig::default(),
                 L1Client::new(
                     hotshot_test_config.get_anvil().endpoint().parse().unwrap(),

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -63,6 +63,7 @@ pub fn build_instance_state<Ver: StaticVersionType + 'static>(
 ) -> anyhow::Result<NodeState> {
     let l1_client = L1Client::new(l1_params.url, Address::default());
     let instance_state = NodeState::new(
+        u64::MAX, // dummy node ID, only used for debugging
         ChainConfig::default(),
         l1_client,
         Arc::new(StatePeers::<Ver>::from_urls(state_peers)),

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -253,6 +253,7 @@ pub async fn init_node<P: SequencerPersistence, Ver: StaticVersionType + 'static
     let l1_client = L1Client::new(l1_params.url, Address::default());
 
     let instance_state = NodeState::new(
+        node_index,
         ChainConfig::default(),
         l1_client,
         Arc::new(StatePeers::<Ver>::from_urls(network_params.state_peers)),

--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1713838472,
-        "narHash": "sha256-lCdDz6/YgyXdFRHall3P+dCETRpfz3Pi9eREnA9RX6k=",
+        "lastModified": 1714616033,
+        "narHash": "sha256-JcWAjIDl3h0bE/pII0emeHwokTeBl+SWrzwrjoRu7a0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "28a9436d356181603fb0d333565431c3d952f299",
+        "rev": "3e416d5067ba31ff8ac31eeb763e4388bdf45089",
         "type": "github"
       },
       "original": {

--- a/sequencer/api/catchup.toml
+++ b/sequencer/api/catchup.toml
@@ -1,18 +1,23 @@
 [route.account]
-PATH = ["/:view/account/:address", "/account/:address"]
+PATH = ["/:height/:view/account/:address"]
+":height" = "Integer"
 ":view" = "Integer"
 ":address" = "Literal"
 DOC = """
 Get the fee account balance for `address`.
 
 This endpoint can be used to catch up to the current state from a recent state by fetching the
-balance (with proof) at the given `:view` number. It can also be used to query the latest finalized
-state.
+balance (with proof) at the given block `:height` and `:view` number. `:height` and `:view` _must_
+correspond! `:height` is provided to simplify lookups for backends where data is not indexed by
+view.
 
-Returns the account balance and a Merkle proof relative to the fee state root at the requested view.
-If there is no entry for this account in the requested fee state (note: this is distinct from the
-server _not knowing_ the entry for this account), the returned balance is 0 and the proof is a
-Merkle _non-membership_ proof.
+This endpoint is intended to be used for catchup, so `:view` should be no older than the last
+decided view.
+
+Returns the account balance and a Merkle proof relative to the fee state root at the requested
+height and view. If there is no entry for this account in the requested fee state (note: this is
+distinct from the server _not knowing_ the entry for this account), the returned balance is 0 and
+the proof is a Merkle _non-membership_ proof.
 
 ```
 {
@@ -23,14 +28,19 @@ Merkle _non-membership_ proof.
 """
 
 [route.blocks]
-PATH = ["/:view/blocks", "/blocks"]
+PATH = ["/:height/:view/blocks"]
+":height" = "Integer"
 ":view" = "Integer"
 DOC = """
 Get the blocks Merkle tree frontier.
 
 This endpoint can be used to catch up to the current state from a recent state by fetching the
-frontier at the given `:view` number. It can also be used to query the latest finalized state.
+frontier at the given block `:height` and `:view` number. `:height` and `:view` _must_ correspond!
+`:height` is provided to simplify lookups for backends where data is not indexed by view.
+
+This endpoint is intended to be used for catchup, so `:view` should be no older than the last
+decided view.
 
 Returns the blocks Merkle tree frontier -- the path to the most recently appended leaf, relative to
-root node at the requested view.
+root node at the requested block height and view.
 """

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1092,19 +1092,6 @@ mod test {
         let state = network.server.consensus().get_decided_state().await;
         tracing::info!(?decided_view, ?state, "consensus state");
 
-        // Wait for merklized state storage to update.
-        while let Err(err) = client
-            .get::<()>(&format!("block-state/{}/{}", height - 1, height - 2))
-            .send()
-            .await
-        {
-            tracing::info!(
-                height,
-                "waiting for merklized state to become available ({err:#})"
-            );
-            sleep(Duration::from_secs(1)).await;
-        }
-
         // Fully shut down the API servers.
         drop(network);
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1,13 +1,18 @@
 use self::data_source::StateSignatureDataSource;
 use crate::{
-    network, persistence::SequencerPersistence, state::ValidatedState,
-    state_signature::StateSigner, Node, NodeState, SeqTypes, SequencerContext, Transaction,
+    network,
+    persistence::SequencerPersistence,
+    state::{BlockMerkleTree, FeeAccountProof},
+    state_signature::StateSigner,
+    Node, NodeState, SeqTypes, SequencerContext, Transaction,
 };
+use anyhow::Context;
 use async_once_cell::Lazy;
 use async_std::sync::{Arc, RwLock};
 use async_trait::async_trait;
-use data_source::{StateDataSource, SubmitDataSource};
+use data_source::{CatchupDataSource, SubmitDataSource};
 use derivative::Derivative;
+use ethers::prelude::{Address, U256};
 use futures::{
     future::{BoxFuture, Future, FutureExt},
     stream::{BoxStream, Stream},
@@ -16,6 +21,8 @@ use hotshot::types::{Event, SystemContextHandle};
 use hotshot_events_service::events_source::{BuilderEvent, EventsSource, EventsStreamer};
 use hotshot_query_service::data_source::ExtensibleDataSource;
 use hotshot_types::{data::ViewNumber, light_client::StateSignatureRequestBody};
+use jf_primitives::merkle_tree::MerkleTreeScheme;
+use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use vbs::version::StaticVersionType;
 
@@ -27,6 +34,20 @@ pub mod sql;
 mod update;
 
 pub use options::Options;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AccountQueryData {
+    pub balance: U256,
+    pub proof: FeeAccountProof,
+}
+
+impl From<(FeeAccountProof, U256)> for AccountQueryData {
+    fn from((proof, balance): (FeeAccountProof, U256)) -> Self {
+        Self { balance, proof }
+    }
+}
+
+pub type BlocksFrontier = <BlockMerkleTree as MerkleTreeScheme>::MembershipProof;
 
 type BoxLazy<T> = Pin<Arc<Lazy<T, BoxFuture<'static, T>>>>;
 
@@ -139,29 +160,82 @@ impl<N: network::Type, Ver: StaticVersionType + 'static, P: SequencerPersistence
 
 impl<
         N: network::Type,
-        D: Send + Sync,
         Ver: StaticVersionType + 'static,
         P: SequencerPersistence,
-    > StateDataSource for StorageState<N, P, D, Ver>
+        D: CatchupDataSource + Send + Sync,
+    > CatchupDataSource for StorageState<N, P, D, Ver>
 {
-    async fn get_decided_state(&self) -> Arc<ValidatedState> {
-        self.as_ref().get_decided_state().await
+    #[tracing::instrument(skip(self))]
+    async fn get_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        account: Address,
+    ) -> anyhow::Result<AccountQueryData> {
+        // Check if we have the desired state in memory.
+        match self.as_ref().get_account(height, view, account).await {
+            Ok(account) => return Ok(account),
+            Err(err) => {
+                tracing::info!("account is not in memory, trying storage: {err:#}");
+            }
+        }
+
+        // Try storage.
+        self.inner().get_account(height, view, account).await
     }
 
-    async fn get_undecided_state(&self, view: ViewNumber) -> Option<Arc<ValidatedState>> {
-        self.as_ref().get_undecided_state(view).await
+    #[tracing::instrument(skip(self))]
+    async fn get_frontier(&self, height: u64, view: ViewNumber) -> anyhow::Result<BlocksFrontier> {
+        // Check if we have the desired state in memory.
+        match self.as_ref().get_frontier(height, view).await {
+            Ok(frontier) => return Ok(frontier),
+            Err(err) => {
+                tracing::info!("frontier is not in memory, trying storage: {err:#}");
+            }
+        }
+
+        // Try storage.
+        self.inner().get_frontier(height, view).await
     }
 }
 
-impl<N: network::Type, Ver: StaticVersionType + 'static, P: SequencerPersistence> StateDataSource
+impl<N: network::Type, Ver: StaticVersionType + 'static, P: SequencerPersistence> CatchupDataSource
     for ApiState<N, P, Ver>
 {
-    async fn get_decided_state(&self) -> Arc<ValidatedState> {
-        self.consensus().await.get_decided_state().await
+    #[tracing::instrument(skip(self))]
+    async fn get_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        account: Address,
+    ) -> anyhow::Result<AccountQueryData> {
+        let state = self
+            .consensus()
+            .await
+            .get_state(view)
+            .await
+            .context(format!(
+                "state not available for height {height}, view {view:?}"
+            ))?;
+        let (proof, balance) = FeeAccountProof::prove(&state.fee_merkle_tree, account).context(
+            format!("account {account} not available for height {height}, view {view:?}"),
+        )?;
+        Ok(AccountQueryData { balance, proof })
     }
 
-    async fn get_undecided_state(&self, view: ViewNumber) -> Option<Arc<ValidatedState>> {
-        self.consensus().await.get_state(view).await
+    #[tracing::instrument(skip(self))]
+    async fn get_frontier(&self, height: u64, view: ViewNumber) -> anyhow::Result<BlocksFrontier> {
+        let state = self
+            .consensus()
+            .await
+            .get_state(view)
+            .await
+            .context(format!(
+                "state not available for height {height}, view {view:?}"
+            ))?;
+        let tree = &state.block_merkle_tree;
+        let frontier = tree.lookup(tree.num_leaves() - 1).expect_ok()?.1;
+        Ok(frontier)
     }
 }
 
@@ -187,10 +261,9 @@ impl<N: network::Type, Ver: StaticVersionType + 'static, P: SequencerPersistence
 mod test_helpers {
     use super::*;
     use crate::{
-        api::endpoints::{AccountQueryData, BlocksFrontier},
         catchup::{mock::MockStateCatchup, StateCatchup},
         persistence::{no_storage, PersistenceOptions, SequencerPersistence},
-        state::BlockMerkleTree,
+        state::{BlockMerkleTree, ValidatedState},
         testing::{run_test_builder, wait_for_decide_on_handle, TestConfig},
     };
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
@@ -437,14 +510,14 @@ mod test_helpers {
             .unwrap();
     }
 
-    /// Test the state API with custom options.
+    /// Test the catchup API with custom options.
     ///
     /// The `opt` function can be used to modify the [`Options`] which are used to start the server.
     /// By default, the options are the minimal required to run this test (configuring a port and
-    /// enabling the state API). `opt` may add additional functionality (e.g. adding a query module
+    /// enabling the catchup API). `opt` may add additional functionality (e.g. adding a query module
     /// to test a different initialization path) but should not remove or modify the existing
-    /// functionality (e.g. removing the state module or changing the port).
-    pub async fn state_test_helper(opt: impl FnOnce(Options) -> Options) {
+    /// functionality (e.g. removing the catchup module or changing the port).
+    pub async fn catchup_test_helper(opt: impl FnOnce(Options) -> Options) {
         setup_logging();
         setup_backtrace();
 
@@ -477,34 +550,13 @@ mod test_helpers {
         // Stop consensus running on the node so we freeze the decided and undecided states.
         network.server.consensus_mut().shut_down().await;
 
-        // Decided fee state: absent account.
-        let res = client
-            .get::<AccountQueryData>(&format!("catchup/account/{:x}", Address::default()))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(res.balance, 0.into());
-        assert_eq!(
-            res.proof
-                .verify(
-                    &network
-                        .server
-                        .consensus()
-                        .get_decided_state()
-                        .await
-                        .fee_merkle_tree
-                        .commitment()
-                )
-                .unwrap(),
-            0.into()
-        );
-
         // Undecided fee state: absent account.
         let leaf = network.server.consensus().get_decided_leaf().await;
+        let height = leaf.get_height() + 1;
         let view = leaf.get_view_number() + 1;
         let res = client
             .get::<AccountQueryData>(&format!(
-                "catchup/{}/account/{:x}",
+                "catchup/{height}/{}/account/{:x}",
                 view.get_u64(),
                 Address::default()
             ))
@@ -528,26 +580,9 @@ mod test_helpers {
             0.into()
         );
 
-        // Decided block state.
-        let res = client
-            .get::<BlocksFrontier>("catchup/blocks")
-            .send()
-            .await
-            .unwrap();
-        let root = &network
-            .server
-            .consensus()
-            .get_decided_state()
-            .await
-            .block_merkle_tree
-            .commitment();
-        BlockMerkleTree::verify(root.digest(), root.size() - 1, res)
-            .unwrap()
-            .unwrap();
-
         // Undecided block state.
         let res = client
-            .get::<BlocksFrontier>(&format!("catchup/{}/blocks", view.get_u64()))
+            .get::<BlocksFrontier>(&format!("catchup/{height}/{}/blocks", view.get_u64()))
             .send()
             .await
             .unwrap();
@@ -587,7 +622,7 @@ mod api_tests {
     use portpicker::pick_unused_port;
     use surf_disco::Client;
     use test_helpers::{
-        state_signature_test_helper, state_test_helper, status_test_helper, submit_test_helper,
+        catchup_test_helper, state_signature_test_helper, status_test_helper, submit_test_helper,
         TestNetwork,
     };
     use tide_disco::error::ServerError;
@@ -688,9 +723,9 @@ mod api_tests {
     }
 
     #[async_std::test]
-    pub(crate) async fn state_test_with_query_module<D: TestableSequencerDataSource>() {
+    pub(crate) async fn catchup_test_with_query_module<D: TestableSequencerDataSource>() {
         let storage = D::create_storage().await;
-        state_test_helper(|opt| D::options(&storage, opt)).await
+        catchup_test_helper(|opt| D::options(&storage, opt)).await
     }
 
     #[async_std::test]
@@ -759,7 +794,7 @@ mod test {
     use crate::{
         catchup::{mock::MockStateCatchup, StatePeers},
         persistence::no_storage,
-        state::{FeeAccount, FeeAmount},
+        state::{FeeAccount, FeeAmount, ValidatedState},
         testing::TestConfig,
         Header,
     };
@@ -785,7 +820,7 @@ mod test {
     use std::time::Duration;
     use surf_disco::Client;
     use test_helpers::{
-        state_signature_test_helper, state_test_helper, status_test_helper, submit_test_helper,
+        catchup_test_helper, state_signature_test_helper, status_test_helper, submit_test_helper,
         TestNetwork,
     };
     use tide_disco::{app::AppHealth, error::ServerError, healthcheck::HealthStatus};
@@ -823,8 +858,8 @@ mod test {
     }
 
     #[async_std::test]
-    async fn state_test_without_query_module() {
-        state_test_helper(|opt| opt).await
+    async fn catchup_test_without_query_module() {
+        catchup_test_helper(|opt| opt).await
     }
 
     #[async_std::test]

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -1,20 +1,20 @@
 use super::{
     fs,
     options::{Options, Query},
-    sql,
+    sql, AccountQueryData, BlocksFrontier,
 };
 use crate::{
     network,
     persistence::{self, SequencerPersistence},
-    state::ValidatedState,
     SeqTypes, Transaction,
 };
-use async_std::sync::Arc;
+use anyhow::bail;
 use async_trait::async_trait;
+use ethers::prelude::Address;
 use futures::future::Future;
 use hotshot_query_service::{
     availability::AvailabilityDataSource,
-    data_source::{UpdateDataSource, VersionedDataSource},
+    data_source::{MetricsDataSource, UpdateDataSource, VersionedDataSource},
     fetching::provider::{AnyProvider, QueryServiceProvider},
     node::NodeDataSource,
     status::StatusDataSource,
@@ -89,13 +89,50 @@ pub(crate) trait StateSignatureDataSource<N: network::Type> {
     async fn get_state_signature(&self, height: u64) -> Option<StateSignatureRequestBody>;
 }
 
-pub(crate) trait StateDataSource {
-    fn get_decided_state(&self) -> impl Send + Future<Output = Arc<ValidatedState>>;
-    fn get_undecided_state(
+pub(crate) trait CatchupDataSource {
+    /// Get the state of the requested `account`.
+    ///
+    /// The state is fetched from a snapshot at the given height and view, which _must_ correspond!
+    /// `height` is provided to simplify lookups for backends where data is not indexed by view.
+    /// This function is intended to be used for catchup, so `view` should be no older than the last
+    /// decided view.
+    fn get_account(
         &self,
-        view: ViewNumber,
-    ) -> impl Send + Future<Output = Option<Arc<ValidatedState>>>;
+        _height: u64,
+        _view: ViewNumber,
+        _account: Address,
+    ) -> impl Send + Future<Output = anyhow::Result<AccountQueryData>> {
+        // Merklized state catchup is only supported by persistence backends that provide merklized
+        // state storage. This default implementation is overridden for those that do. Otherwise,
+        // catchup can still be provided by fetching undecided merklized state from consensus
+        // memory.
+        async {
+            bail!("merklized state catchup is not supported for this data source");
+        }
+    }
+
+    /// Get the blocks Merkle tree frontier.
+    ///
+    /// The state is fetched from a snapshot at the given height and view, which _must_ correspond!
+    /// `height` is provided to simplify lookups for backends where data is not indexed by view.
+    /// This function is intended to be used for catchup, so `view` should be no older than the last
+    /// decided view.
+    fn get_frontier(
+        &self,
+        _height: u64,
+        _view: ViewNumber,
+    ) -> impl Send + Future<Output = anyhow::Result<BlocksFrontier>> {
+        // Merklized state catchup is only supported by persistence backends that provide merklized
+        // state storage. This default implementation is overridden for those that do. Otherwise,
+        // catchup can still be provided by fetching undecided merklized state from consensus
+        // memory.
+        async {
+            bail!("merklized state catchup is not supported for this data source");
+        }
+    }
 }
+
+impl CatchupDataSource for MetricsDataSource {}
 
 #[cfg(test)]
 pub(crate) mod testing {

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -101,16 +101,20 @@ pub(crate) trait StateDataSource {
 pub(crate) mod testing {
     use super::super::Options;
     use super::*;
-    use crate::persistence::SequencerPersistence;
-    use std::fmt::Debug;
+    use crate::persistence::PersistenceOptions;
 
     #[async_trait]
     pub(crate) trait TestableSequencerDataSource: SequencerDataSource {
-        type Storage;
-        type Persistence: Debug + SequencerPersistence;
+        type Storage: Sync;
 
         async fn create_storage() -> Self::Storage;
-        async fn connect(storage: &Self::Storage) -> Self::Persistence;
+        fn persistence_options(storage: &Self::Storage) -> Self::Options;
         fn options(storage: &Self::Storage, opt: Options) -> Options;
+
+        async fn connect(
+            storage: &Self::Storage,
+        ) -> <Self::Options as PersistenceOptions>::Persistence {
+            Self::persistence_options(storage).create().await.unwrap()
+        }
     }
 }

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -138,7 +138,6 @@ impl CatchupDataSource for MetricsDataSource {}
 pub(crate) mod testing {
     use super::super::Options;
     use super::*;
-    use crate::persistence::PersistenceOptions;
 
     #[async_trait]
     pub(crate) trait TestableSequencerDataSource: SequencerDataSource {
@@ -147,11 +146,5 @@ pub(crate) mod testing {
         async fn create_storage() -> Self::Storage;
         fn persistence_options(storage: &Self::Storage) -> Self::Options;
         fn options(storage: &Self::Storage, opt: Options) -> Options;
-
-        async fn connect(
-            storage: &Self::Storage,
-        ) -> <Self::Options as PersistenceOptions>::Persistence {
-            Self::persistence_options(storage).create().await.unwrap()
-        }
     }
 }

--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -27,28 +27,21 @@ impl SequencerDataSource for DataSource {
 #[cfg(test)]
 mod impl_testable_data_source {
     use super::*;
-    use crate::{
-        api::{self, data_source::testing::TestableSequencerDataSource},
-        persistence::{fs, PersistenceOptions},
-    };
+    use crate::api::{self, data_source::testing::TestableSequencerDataSource};
     use tempfile::TempDir;
 
     #[async_trait]
     impl TestableSequencerDataSource for DataSource {
         type Storage = TempDir;
-        type Persistence = fs::Persistence;
 
         async fn create_storage() -> Self::Storage {
             TempDir::new().unwrap()
         }
 
-        async fn connect(storage: &Self::Storage) -> Self::Persistence {
+        fn persistence_options(storage: &Self::Storage) -> Self::Options {
             Options {
                 path: storage.path().into(),
             }
-            .create()
-            .await
-            .unwrap()
         }
 
         fn options(storage: &Self::Storage, opt: api::Options) -> api::Options {

--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -1,4 +1,4 @@
-use super::data_source::{Provider, SequencerDataSource};
+use super::data_source::{CatchupDataSource, Provider, SequencerDataSource};
 use crate::{persistence::fs::Options, SeqTypes};
 use async_trait::async_trait;
 use hotshot_query_service::data_source::FileSystemDataSource;
@@ -23,6 +23,8 @@ impl SequencerDataSource for DataSource {
         Ok(data_source)
     }
 }
+
+impl CatchupDataSource for DataSource {}
 
 #[cfg(test)]
 mod impl_testable_data_source {

--- a/sequencer/src/api/sql.rs
+++ b/sequencer/src/api/sql.rs
@@ -22,11 +22,8 @@ impl SequencerDataSource for DataSource {
 #[cfg(test)]
 mod impl_testable_data_source {
     use super::*;
-    use crate::{
-        api::{self, data_source::testing::TestableSequencerDataSource},
-        persistence::PersistenceOptions,
-    };
-    use hotshot_query_service::data_source::storage::sql::{testing::TmpDb, SqlStorage};
+    use crate::api::{self, data_source::testing::TestableSequencerDataSource};
+    use hotshot_query_service::data_source::storage::sql::testing::TmpDb;
 
     fn tmp_options(db: &TmpDb) -> Options {
         Options {
@@ -41,14 +38,13 @@ mod impl_testable_data_source {
     #[async_trait]
     impl TestableSequencerDataSource for DataSource {
         type Storage = TmpDb;
-        type Persistence = SqlStorage;
 
         async fn create_storage() -> Self::Storage {
             TmpDb::init().await
         }
 
-        async fn connect(storage: &Self::Storage) -> Self::Persistence {
-            tmp_options(storage).create().await.unwrap()
+        fn persistence_options(storage: &Self::Storage) -> Self::Options {
+            tmp_options(storage)
         }
 
         fn options(storage: &Self::Storage, opt: api::Options) -> api::Options {

--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -1,12 +1,20 @@
 use crate::{
     api::endpoints::{AccountQueryData, BlocksFrontier},
-    state::{BlockMerkleTree, FeeAccount, FeeMerkleCommitment},
+    persistence::PersistenceOptions,
+    state::{BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment, FeeMerkleTree},
+    SeqTypes,
 };
+use anyhow::{bail, Context};
+use async_std::sync::RwLock;
 use async_trait::async_trait;
+use derive_more::From;
+use hotshot_query_service::merklized_state::{MerklizedStateDataSource, Snapshot};
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime as _};
-use jf_primitives::merkle_tree::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
+use jf_primitives::merkle_tree::{
+    prelude::MerkleNode, ForgetableMerkleTreeScheme, MerkleTreeScheme,
+};
 use serde::de::DeserializeOwned;
-use std::{sync::Arc, time::Duration};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use surf_disco::Request;
 use tide_disco::error::ServerError;
 use url::Url;
@@ -35,18 +43,89 @@ impl<Ver: StaticVersionType> Client<ServerError, Ver> {
 
 #[async_trait]
 pub trait StateCatchup: Send + Sync + std::fmt::Debug {
+    /// Try to fetch the given account state, failing without retrying if unable.
+    async fn try_fetch_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        fee_merkle_tree_root: FeeMerkleCommitment,
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData>;
+
+    /// Fetch the given list of accounts, retrying on transient errors.
     async fn fetch_accounts(
         &self,
+        height: u64,
         view: ViewNumber,
         fee_merkle_tree_root: FeeMerkleCommitment,
         accounts: Vec<FeeAccount>,
-    ) -> anyhow::Result<Vec<AccountQueryData>>;
+    ) -> anyhow::Result<Vec<AccountQueryData>> {
+        let mut ret = vec![];
+        for account in accounts {
+            // Retry until we succeed.
+            let account = loop {
+                match self
+                    .try_fetch_account(height, view, fee_merkle_tree_root, account)
+                    .await
+                {
+                    Ok(account) => break account,
+                    Err(err) => {
+                        tracing::warn!(%account, "Could not fetch account, retrying: {err:#}");
+                        async_std::task::sleep(self.retry_interval()).await;
+                    }
+                }
+            };
+            ret.push(account);
+        }
+        Ok(ret)
+    }
 
-    async fn remember_blocks_merkle_tree(
+    /// Try to fetch and remember the blocks frontier, failing without retrying if unable.
+    async fn try_remember_blocks_merkle_tree(
         &self,
+        height: u64,
         view: ViewNumber,
         mt: &mut BlockMerkleTree,
     ) -> anyhow::Result<()>;
+
+    /// Fetch and remember the blocks frontier, retrying on transient errors.
+    async fn remember_blocks_merkle_tree(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        mt: &mut BlockMerkleTree,
+    ) -> anyhow::Result<()> {
+        loop {
+            match self.try_remember_blocks_merkle_tree(height, view, mt).await {
+                Ok(()) => break,
+                Err(err) => {
+                    tracing::warn!("Could not fetch frontier from any peer, retrying: {err:#}");
+                    async_std::task::sleep(self.retry_interval()).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn retry_interval(&self) -> Duration {
+        Duration::from_millis(100)
+    }
+}
+
+/// A catchup implementation that falls back to a remote provider, but prefers a local provider when
+/// supported.
+pub(crate) async fn local_and_remote(
+    local_opt: impl PersistenceOptions,
+    remote: impl StateCatchup + 'static,
+) -> Arc<dyn StateCatchup> {
+    match local_opt.create_catchup_provider().await {
+        Ok(local) => Arc::new(vec![local, Arc::new(remote)]),
+        Err(err) => {
+            tracing::warn!("not using local catchup: {err:#}");
+            Arc::new(remote)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -66,147 +145,303 @@ impl<Ver: StaticVersionType> StatePeers<Ver> {
             interval: Duration::from_secs(1),
         }
     }
-
-    #[tracing::instrument(skip(self))]
-    async fn fetch_account(
-        &self,
-        view: ViewNumber,
-        fee_merkle_tree_root: FeeMerkleCommitment,
-        account: FeeAccount,
-    ) -> AccountQueryData {
-        if self.clients.is_empty() {
-            panic!("No peers to fetch account from");
-        }
-        loop {
-            for client in self.clients.iter() {
-                tracing::info!(
-                    "Fetching account {account:?} for view {view:?} from {}",
-                    client.url
-                );
-                match client
-                    .get::<AccountQueryData>(&format!(
-                        "catchup/{}/account/{account}",
-                        view.get_u64(),
-                    ))
-                    .send()
-                    .await
-                {
-                    Ok(res) => match res.proof.verify(&fee_merkle_tree_root) {
-                        Ok(_) => return res,
-                        Err(err) => tracing::warn!("Error verifying account proof: {}", err),
-                    },
-                    Err(err) => {
-                        tracing::warn!("Error fetching account from peer: {}", err);
-                    }
-                }
-            }
-            tracing::warn!("Could not fetch account from any peer, retrying");
-            async_std::task::sleep(self.interval).await;
-        }
-    }
 }
 
 #[async_trait]
 impl<Ver: StaticVersionType> StateCatchup for StatePeers<Ver> {
-    async fn fetch_accounts(
+    #[tracing::instrument(skip(self))]
+    async fn try_fetch_account(
         &self,
+        _height: u64,
         view: ViewNumber,
         fee_merkle_tree_root: FeeMerkleCommitment,
-        accounts: Vec<FeeAccount>,
-    ) -> anyhow::Result<Vec<AccountQueryData>> {
-        let mut ret = vec![];
-        for account in accounts {
-            tracing::info!("Fetching account {account:?} for view {view:?}");
-            ret.push(
-                self.fetch_account(view, fee_merkle_tree_root, account)
-                    .await,
-            )
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData> {
+        for client in self.clients.iter() {
+            tracing::info!("Fetching account {account:?} from {}", client.url);
+            match client
+                .get::<AccountQueryData>(&format!("catchup/{}/account/{account}", view.get_u64(),))
+                .send()
+                .await
+            {
+                Ok(res) => match res.proof.verify(&fee_merkle_tree_root) {
+                    Ok(_) => return Ok(res),
+                    Err(err) => tracing::warn!("Error verifying account proof: {}", err),
+                },
+                Err(err) => {
+                    tracing::warn!("Error fetching account from peer: {}", err);
+                }
+            }
         }
-        Ok(ret)
+        bail!("Could not fetch account from any peer");
     }
 
     #[tracing::instrument(skip(self, mt), height = mt.num_leaves())]
-    async fn remember_blocks_merkle_tree(
+    async fn try_remember_blocks_merkle_tree(
         &self,
+        _height: u64,
         view: ViewNumber,
         mt: &mut BlockMerkleTree,
     ) -> anyhow::Result<()> {
-        if self.clients.is_empty() {
-            panic!("No peers to fetch frontier from");
-        }
-        loop {
-            for client in self.clients.iter() {
-                tracing::info!("Fetching frontier from {}", client.url);
-                match client
-                    .get::<BlocksFrontier>(&format!("catchup/{}/blocks", view.get_u64()))
-                    .send()
-                    .await
-                {
-                    Ok(frontier) => {
-                        let Some(elem) = frontier.elem() else {
-                            tracing::warn!("Provided frontier is missing leaf element");
+        for client in self.clients.iter() {
+            tracing::info!("Fetching frontier from {}", client.url);
+            match client
+                .get::<BlocksFrontier>(&format!("catchup/{}/blocks", view.get_u64()))
+                .send()
+                .await
+            {
+                Ok(frontier) => {
+                    let Some(elem) = frontier.elem() else {
+                        tracing::warn!("Provided frontier is missing leaf element");
+                        continue;
+                    };
+                    match mt.remember(mt.num_leaves() - 1, *elem, &frontier) {
+                        Ok(_) => return Ok(()),
+                        Err(err) => {
+                            tracing::warn!("Error verifying block proof: {}", err);
                             continue;
-                        };
-                        match mt.remember(mt.num_leaves() - 1, *elem, &frontier) {
-                            Ok(_) => return Ok(()),
-                            Err(err) => {
-                                tracing::warn!("Error verifying block proof: {}", err);
-                                continue;
-                            }
                         }
                     }
-                    Err(err) => {
-                        tracing::warn!("Error fetching blocks from peer: {}", err);
-                    }
+                }
+                Err(err) => {
+                    tracing::warn!("Error fetching blocks from peer: {}", err);
                 }
             }
-            tracing::warn!("Could not fetch frontier from any peer, retrying");
-            async_std::task::sleep(self.interval).await;
+        }
+        bail!("Could not fetch frontier from any peer");
+    }
+
+    fn retry_interval(&self) -> Duration {
+        self.interval
+    }
+}
+
+#[derive(Debug, From)]
+pub(crate) struct SqlStateCatchup<T> {
+    db: Arc<RwLock<T>>,
+}
+
+#[async_trait]
+impl<T> StateCatchup for SqlStateCatchup<T>
+where
+    T: MerklizedStateDataSource<SeqTypes, FeeMerkleTree, { FeeMerkleTree::ARITY }>
+        + MerklizedStateDataSource<SeqTypes, BlockMerkleTree, { BlockMerkleTree::ARITY }>
+        + Debug
+        + Send
+        + Sync,
+{
+    #[tracing::instrument(skip(self))]
+    async fn try_fetch_account(
+        &self,
+        block_height: u64,
+        _view: ViewNumber,
+        _fee_merkle_tree_root: FeeMerkleCommitment,
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData> {
+        let proof = self
+            .db
+            .read()
+            .await
+            .get_path(
+                Snapshot::<SeqTypes, FeeMerkleTree, { FeeMerkleTree::ARITY }>::Index(block_height),
+                account,
+            )
+            .await
+            .context(format!("fetching account {account}; height {block_height}"))?;
+
+        match proof.proof.first().context(format!(
+            "empty proof for account {account}; height {block_height}"
+        ))? {
+            MerkleNode::Leaf { pos, elem, .. } => Ok(AccountQueryData {
+                balance: (*elem).into(),
+                proof: FeeAccountProof::presence(*pos, proof),
+            }),
+
+            MerkleNode::Empty => Ok(AccountQueryData {
+                balance: 0_u64.into(),
+                proof: FeeAccountProof::absence(account, proof),
+            }),
+            _ => {
+                bail!("Invalid proof");
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn try_remember_blocks_merkle_tree(
+        &self,
+        bh: u64,
+        _view: ViewNumber,
+        mt: &mut BlockMerkleTree,
+    ) -> anyhow::Result<()> {
+        if bh == 0 {
+            return Ok(());
+        }
+
+        let proof = self
+            .db
+            .read()
+            .await
+            .get_path(
+                Snapshot::<SeqTypes, BlockMerkleTree, { BlockMerkleTree::ARITY }>::Index(bh),
+                bh - 1,
+            )
+            .await
+            .context(format!("fetching frontier at height {bh}"))?;
+
+        match proof
+            .proof
+            .first()
+            .context(format!("empty proof for frontier at height {bh}"))?
+        {
+            MerkleNode::Leaf { pos, elem, .. } => mt
+                .remember(pos, elem, proof.clone())
+                .context("failed to remember proof"),
+            _ => bail!("invalid proof"),
         }
     }
 }
 
 #[async_trait]
 impl<T: StateCatchup + ?Sized> StateCatchup for Box<T> {
+    async fn try_fetch_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        fee_merkle_tree_root: FeeMerkleCommitment,
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData> {
+        (**self)
+            .try_fetch_account(height, view, fee_merkle_tree_root, account)
+            .await
+    }
+
     async fn fetch_accounts(
         &self,
+        height: u64,
         view: ViewNumber,
         fee_merkle_tree_root: FeeMerkleCommitment,
         accounts: Vec<FeeAccount>,
     ) -> anyhow::Result<Vec<AccountQueryData>> {
         (**self)
-            .fetch_accounts(view, fee_merkle_tree_root, accounts)
+            .fetch_accounts(height, view, fee_merkle_tree_root, accounts)
+            .await
+    }
+
+    async fn try_remember_blocks_merkle_tree(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        mt: &mut BlockMerkleTree,
+    ) -> anyhow::Result<()> {
+        (**self)
+            .try_remember_blocks_merkle_tree(height, view, mt)
             .await
     }
 
     async fn remember_blocks_merkle_tree(
         &self,
+        height: u64,
         view: ViewNumber,
         mt: &mut BlockMerkleTree,
     ) -> anyhow::Result<()> {
-        (**self).remember_blocks_merkle_tree(view, mt).await
+        (**self).remember_blocks_merkle_tree(height, view, mt).await
     }
 }
 
 #[async_trait]
 impl<T: StateCatchup + ?Sized> StateCatchup for Arc<T> {
+    async fn try_fetch_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        fee_merkle_tree_root: FeeMerkleCommitment,
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData> {
+        (**self)
+            .try_fetch_account(height, view, fee_merkle_tree_root, account)
+            .await
+    }
+
     async fn fetch_accounts(
         &self,
+        height: u64,
         view: ViewNumber,
         fee_merkle_tree_root: FeeMerkleCommitment,
         accounts: Vec<FeeAccount>,
     ) -> anyhow::Result<Vec<AccountQueryData>> {
         (**self)
-            .fetch_accounts(view, fee_merkle_tree_root, accounts)
+            .fetch_accounts(height, view, fee_merkle_tree_root, accounts)
+            .await
+    }
+
+    async fn try_remember_blocks_merkle_tree(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        mt: &mut BlockMerkleTree,
+    ) -> anyhow::Result<()> {
+        (**self)
+            .try_remember_blocks_merkle_tree(height, view, mt)
             .await
     }
 
     async fn remember_blocks_merkle_tree(
         &self,
+        height: u64,
         view: ViewNumber,
         mt: &mut BlockMerkleTree,
     ) -> anyhow::Result<()> {
-        (**self).remember_blocks_merkle_tree(view, mt).await
+        (**self).remember_blocks_merkle_tree(height, view, mt).await
+    }
+}
+
+/// Catchup from multiple providers tries each provider in a round robin fashion until it succeeds.
+#[async_trait]
+impl<T: StateCatchup> StateCatchup for Vec<T> {
+    #[tracing::instrument(skip(self))]
+    async fn try_fetch_account(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        fee_merkle_tree_root: FeeMerkleCommitment,
+        account: FeeAccount,
+    ) -> anyhow::Result<AccountQueryData> {
+        for provider in self {
+            match provider
+                .try_fetch_account(height, view, fee_merkle_tree_root, account)
+                .await
+            {
+                Ok(account) => return Ok(account),
+                Err(err) => {
+                    tracing::warn!(%account, ?provider, "failed to fetch account: {err:#}");
+                }
+            }
+        }
+
+        bail!("could not fetch account from any provider");
+    }
+
+    #[tracing::instrument(skip(self, mt))]
+    async fn try_remember_blocks_merkle_tree(
+        &self,
+        height: u64,
+        view: ViewNumber,
+        mt: &mut BlockMerkleTree,
+    ) -> anyhow::Result<()> {
+        for provider in self {
+            match provider
+                .try_remember_blocks_merkle_tree(height, view, mt)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    tracing::warn!(?provider, "failed to fetch frontier: {err:#}");
+                }
+            }
+        }
+
+        bail!("could not fetch account from any provider");
     }
 }
 
@@ -232,29 +467,25 @@ pub mod mock {
 
     #[async_trait]
     impl StateCatchup for MockStateCatchup {
-        async fn fetch_accounts(
+        async fn try_fetch_account(
             &self,
+            _height: u64,
             view: ViewNumber,
             fee_merkle_tree_root: FeeMerkleCommitment,
-            accounts: Vec<FeeAccount>,
-        ) -> anyhow::Result<Vec<AccountQueryData>> {
-            tracing::info!("catchup: fetching account data for view {view:?}");
+            account: FeeAccount,
+        ) -> anyhow::Result<AccountQueryData> {
             let src = &self.state[&view].fee_merkle_tree;
             assert_eq!(src.commitment(), fee_merkle_tree_root);
 
-            accounts
-                .into_iter()
-                .map(|account| {
-                    tracing::info!("catchup: fetching account {account:?} for view {view:?}");
-                    Ok(FeeAccountProof::prove(src, account.into())
-                        .unwrap_or_else(|| panic!("Account {account:?} not in memory"))
-                        .into())
-                })
-                .collect::<anyhow::Result<_>>()
+            tracing::info!("catchup: fetching account {account:?} for view {view:?}");
+            Ok(FeeAccountProof::prove(src, account.into())
+                .unwrap_or_else(|| panic!("Account {account:?} not in memory"))
+                .into())
         }
 
-        async fn remember_blocks_merkle_tree(
+        async fn try_remember_blocks_merkle_tree(
             &self,
+            _height: u64,
             view: ViewNumber,
             mt: &mut BlockMerkleTree,
         ) -> anyhow::Result<()> {

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -18,10 +18,10 @@ async fn main() -> anyhow::Result<()> {
     setup_logging();
     setup_backtrace();
 
-    tracing::info!("sequencer starting up");
+    tracing::warn!("sequencer starting up");
     let opt = Options::parse();
-    tracing::warn!("options: {:?}", opt);
     let mut modules = opt.modules();
+    tracing::warn!("modules: {:?}", modules);
 
     if let Some(storage) = modules.storage_fs.take() {
         init_with_storage(modules, opt, storage, SEQUENCER_VERSION).await
@@ -111,7 +111,6 @@ where
                 http_opt = http_opt.hotshot_events(hotshot_events);
             }
 
-            let storage = storage_opt.create().await?;
             http_opt
                 .serve(
                     move |metrics| {
@@ -119,7 +118,7 @@ where
                             init_node(
                                 network_params,
                                 &*metrics,
-                                storage,
+                                storage_opt,
                                 builder_params,
                                 l1_params,
                                 stake_table_capacity,
@@ -140,7 +139,7 @@ where
             init_node(
                 network_params,
                 &NoMetrics,
-                storage_opt.create().await?,
+                storage_opt,
                 builder_params,
                 l1_params,
                 stake_table_capacity,

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -8,8 +8,8 @@
 //! an extension that node operators can opt into. This module defines the minimum level of
 //! persistence which is _required_ to run a node.
 
-use crate::{Header, Leaf, NodeState, PubKey, SeqTypes, ValidatedState, ViewNumber};
-use anyhow::{ensure, Context};
+use crate::{Leaf, NodeState, PubKey, SeqTypes, StateCatchup, ValidatedState, ViewNumber};
+use anyhow::{bail, ensure, Context};
 use async_std::sync::Arc;
 use async_trait::async_trait;
 use committable::Committable;
@@ -34,15 +34,24 @@ pub mod sql;
 pub type NetworkConfig = hotshot_orchestrator::config::NetworkConfig<PubKey>;
 
 #[async_trait]
-pub trait PersistenceOptions: Clone {
+pub trait PersistenceOptions: Clone + Send + Sync + 'static {
     type Persistence: SequencerPersistence;
 
     async fn create(self) -> anyhow::Result<Self::Persistence>;
     async fn reset(self) -> anyhow::Result<()>;
+
+    async fn create_catchup_provider(self) -> anyhow::Result<Arc<dyn StateCatchup>> {
+        self.create().await?.into_catchup_provider()
+    }
 }
 
 #[async_trait]
-pub trait SequencerPersistence: Send + Sync + 'static {
+pub trait SequencerPersistence: Sized + Send + Sync + 'static {
+    /// Use this storage as a state catchup backend, if supported.
+    fn into_catchup_provider(self) -> anyhow::Result<Arc<dyn StateCatchup>> {
+        bail!("state catchup is not implemented for this persistence type");
+    }
+
     /// Load the orchestrator config from storage.
     ///
     /// Returns `None` if no config exists (we are joining a network for the first time). Fails with
@@ -80,9 +89,6 @@ pub trait SequencerPersistence: Send + Sync + 'static {
         view: ViewNumber,
     ) -> anyhow::Result<Option<Proposal<SeqTypes, DAProposal<SeqTypes>>>>;
 
-    /// Load the validated state after `header`, if available.
-    async fn load_validated_state(&self, header: &Header) -> anyhow::Result<ValidatedState>;
-
     /// Load the latest known consensus state.
     ///
     /// Returns an initializer to resume HotShot from the latest saved state (or start from genesis,
@@ -105,7 +111,7 @@ pub trait SequencerPersistence: Send + Sync + 'static {
                 ViewNumber::genesis()
             }
         };
-        let (leaf, high_qc, validated_state) = match self
+        let (leaf, high_qc) = match self
             .load_anchor_leaf()
             .await
             .context("loading anchor leaf")?
@@ -120,29 +126,14 @@ pub trait SequencerPersistence: Send + Sync + 'static {
                         high_qc.view_number
                     )
                 );
-
-                let validated_state = match self.load_validated_state(leaf.get_block_header()).await
-                {
-                    Ok(validated_state) => Some(Arc::new(validated_state)),
-                    Err(err) => {
-                        tracing::error!(
-                            "unable to load validated state, will need to catchup: {err:#}"
-                        );
-                        None
-                    }
-                };
-
-                (leaf, high_qc, validated_state)
+                (leaf, high_qc)
             }
             None => {
                 tracing::info!("no saved leaf, starting from genesis leaf");
-                (
-                    Leaf::genesis(&state),
-                    QuorumCertificate::genesis(&state),
-                    Some(Arc::new(ValidatedState::genesis(&state).0)),
-                )
+                (Leaf::genesis(&state), QuorumCertificate::genesis(&state))
             }
         };
+        let validated_state = Some(Arc::new(ValidatedState::genesis(&state).0));
 
         // We start from the view following the maximum view between `highest_voted_view` and
         // `leaf.view_number`. This prevents double votes from starting in a view in which we had

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1,6 +1,6 @@
 use super::{NetworkConfig, PersistenceOptions, SequencerPersistence};
-use crate::{Header, Leaf, SeqTypes, ValidatedState, ViewNumber};
-use anyhow::{anyhow, bail, Context};
+use crate::{Leaf, SeqTypes, ViewNumber};
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use clap::Parser;
 
@@ -348,10 +348,6 @@ impl SequencerPersistence for Persistence {
                 Ok(())
             },
         )
-    }
-
-    async fn load_validated_state(&self, _header: &Header) -> anyhow::Result<ValidatedState> {
-        bail!("state persistence not implemented");
     }
 }
 

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -2,8 +2,7 @@
 #![cfg(any(test, feature = "testing"))]
 
 use super::{NetworkConfig, PersistenceOptions, SequencerPersistence};
-use crate::{Header, Leaf, SeqTypes, ValidatedState, ViewNumber};
-use anyhow::bail;
+use crate::{Leaf, SeqTypes, ViewNumber};
 use async_trait::async_trait;
 use hotshot_types::{
     data::{DAProposal, VidDisperseShare},
@@ -95,9 +94,5 @@ impl SequencerPersistence for NoStorage {
         _action: HotShotAction,
     ) -> anyhow::Result<()> {
         Ok(())
-    }
-
-    async fn load_validated_state(&self, _header: &Header) -> anyhow::Result<ValidatedState> {
-        bail!("state persistence not implemented");
     }
 }


### PR DESCRIPTION
### This PR:

Prevents a race condition where a node is shut down after saving a decided leaf but before saving the corresponding validated state. If this happens to all nodes, then there is no node able to serve catchup queries, and the system stalls.

We want to keep the asynchronous state catchup, because it is extremely simple and resilient to all kinds of failures in the underlying event processing, and because it's auxiliary in a sense: as long as we have the block data, we have all the information we need to reconstruct the state at any time, and so it makes no sense to make the state computation blocking.

In light of this, one potential solution would just make the state loading at startup wait/retry until the state reconstruction loop has reconstructed the desired state. However, a better, more generalized solution is to incorporate the state storage into the normal catchup flow, which already has a retry loop. This removes the need to load entire state snapshots into memory at all, which is very nice: it is a step towards having the in-memory `ValidatedState` being just a cache for the full persisted state. This also further unifies the restart procedure with the normal catchup procedure. In other words, it is as if a node that has restarted has merely been offline for some amount of time.

This PR has a lot of changes, but a fair bit of it is just moving things around and implementing some boilerplate traits for wrapper types. The primary semantic changes of this PR:
1. Catchup is able to fetch missing state both from peers and from the local database (if supported)
    * Most importantly, this means we don't rely on having the entire state saved the moment we start up anymore
    * This can also make catchup more efficient: previously, archival nodes that had all the information they needed locally would still reach out to other nodes during catchup
2. Serving catchup queries for other nodes can also utilize persisted state, an important bit of symmetry with (1)
3. We no longer even try to load a validated state snapshot on startup. Technically, we could still do this, and it might prevent the catchup flow from being triggered in some cases. However, it is lighter weight to load only the state we need on demand, plus by forcing everything through the same code path of catchup we can have more confidence that this code path is correct, and that we are not relying on having the full state loaded at startup more than we should be.
4. Catchup API queries no longer return the decided state if no view number is specified. This was not being used anyways.


### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
* Fetching state for catchup is implemented in `api/sql.rs`
* New catchup client logic in `catchup.rs`
  - Pulled the body of each retry loop out into its own function, which makes it easier to write catchup wrappers/adaptors
  - Added a new catchup implementation for `Vec<T> where T: StateCatchup`, which lets us try to catchup from multiple sources (e.g. peers and local database)
  - Moved `SqlStateCatchup` here from `state.rs`
* New catchup server in `catchup.toml`, `api/endpoints.rs`

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

### Things tested

Removed a loop in `test_restart` after stopping consensus but before shutting down the nodes which waited for merklized state to be persisted. This loop was intended to subvert exactly the race condition described above. Previously, it was needed for the test to pass consistently, but now the test passes without it, which is good confirmation that the change is working as intended. See [6cacced](https://github.com/EspressoSystems/espresso-sequencer/pull/1417/commits/6cacceda6c69c5c93bfaa7b459f1f27857531d4f).

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
