### PR TITLE
Updated builder core for logging (and not hitting `panic!()`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,8 +4105,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.16"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.16#5c529bb32f980377ec1b6d7fb1947380d566cc42"
+version = "0.1.17"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.17#e661421e5ef51d5a4c75ddce2b889b83bea45b0e"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ futures = "0.3"
 hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
 # Hotshot imports
 hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.48" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.16" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.17" }
 hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.18" }
 hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.48" }
 hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.16" }


### PR DESCRIPTION
Cleanup of hotshot-builder-core dependency for diagnostic purposes.

### This PR:
Updates hotshot-builder-core to 0.1.17

### This PR does not:
Do anything else

Hopefully, rerunning with this will provide more info if the builder falls down.