### PR TITLE
Store undecided consensus state and load it on restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,7 +3952,6 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3975,7 +3974,7 @@ dependencies = [
  "futures",
  "hotshot-orchestrator",
  "hotshot-task",
- "hotshot-task-impls",
+ "hotshot-task-impls 0.5.43",
  "hotshot-types",
  "jf-signature",
  "libp2p-identity",
@@ -3997,7 +3996,6 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "async-trait",
  "clap",
@@ -4093,6 +4091,35 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
+dependencies = [
+ "anyhow",
+ "async-broadcast",
+ "async-compatibility-layer",
+ "async-lock 2.8.0",
+ "async-std",
+ "async-trait",
+ "bitvec",
+ "committable",
+ "either",
+ "ethereum-types",
+ "futures",
+ "hotshot",
+ "hotshot-task",
+ "hotshot-task-impls 0.5.43",
+ "hotshot-types",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "snafu 0.8.2",
+ "time 0.3.36",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hotshot-example-types"
+version = "0.5.43"
 source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "anyhow",
@@ -4108,7 +4135,7 @@ dependencies = [
  "futures",
  "hotshot",
  "hotshot-task",
- "hotshot-task-impls",
+ "hotshot-task-impls 0.5.43 (git+https://github.com/EspressoSystems/hotshot?tag=0.5.51)",
  "hotshot-types",
  "rand 0.8.5",
  "serde",
@@ -4123,7 +4150,6 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4134,7 +4160,6 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4182,7 +4207,7 @@ dependencies = [
  "espresso-macros",
  "futures",
  "hotshot",
- "hotshot-example-types",
+ "hotshot-example-types 0.5.43 (git+https://github.com/EspressoSystems/hotshot?tag=0.5.51)",
  "hotshot-testing",
  "hotshot-types",
  "include_dir",
@@ -4216,7 +4241,6 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4287,7 +4311,6 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4295,6 +4318,40 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hotshot-task-impls"
+version = "0.5.43"
+dependencies = [
+ "anyhow",
+ "async-broadcast",
+ "async-compatibility-layer",
+ "async-lock 2.8.0",
+ "async-std",
+ "async-trait",
+ "bincode",
+ "bitvec",
+ "cdn-proto",
+ "chrono",
+ "committable",
+ "either",
+ "futures",
+ "hotshot-builder-api",
+ "hotshot-task",
+ "hotshot-types",
+ "jf-signature",
+ "jf-vid",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.8",
+ "snafu 0.8.2",
+ "surf-disco",
+ "tagged-base64",
+ "time 0.3.36",
+ "tokio",
+ "tracing",
+ "vbs",
 ]
 
 [[package]]
@@ -4335,7 +4392,6 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4350,11 +4406,11 @@ dependencies = [
  "futures",
  "hotshot",
  "hotshot-builder-api",
- "hotshot-example-types",
+ "hotshot-example-types 0.5.43",
  "hotshot-macros",
  "hotshot-orchestrator",
  "hotshot-task",
- "hotshot-task-impls",
+ "hotshot-task-impls 0.5.43",
  "hotshot-types",
  "jf-signature",
  "jf-vid",
@@ -4375,7 +4431,6 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -5638,7 +5693,6 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3974,7 +3975,7 @@ dependencies = [
  "futures",
  "hotshot-orchestrator",
  "hotshot-task",
- "hotshot-task-impls 0.5.43",
+ "hotshot-task-impls",
  "hotshot-types",
  "jf-signature",
  "libp2p-identity",
@@ -3996,6 +3997,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "async-trait",
  "clap",
@@ -4013,8 +4015,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.18"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.19#18a5ddec1a68ce7229113c26cedc753ef0d08285"
+version = "0.1.20"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.20#9ce5d19c43121ac3410940d3995b4bc20c5fa94a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4065,8 +4067,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-events-service"
-version = "0.1.19"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.20#f5f5ea98e438d8ee0f77c3d30b8fb6f362d8c818"
+version = "0.1.21"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.21#ae2e647b69351e06b8f59b19eee59ad54f56f837"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4091,6 +4093,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4105,37 +4108,7 @@ dependencies = [
  "futures",
  "hotshot",
  "hotshot-task",
- "hotshot-task-impls 0.5.43",
- "hotshot-types",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.8",
- "sha3",
- "snafu 0.8.2",
- "time 0.3.36",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hotshot-example-types"
-version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
-dependencies = [
- "anyhow",
- "async-broadcast",
- "async-compatibility-layer",
- "async-lock 2.8.0",
- "async-std",
- "async-trait",
- "bitvec",
- "committable",
- "either",
- "ethereum-types",
- "futures",
- "hotshot",
- "hotshot-task",
- "hotshot-task-impls 0.5.43 (git+https://github.com/EspressoSystems/hotshot?tag=0.5.51)",
+ "hotshot-task-impls",
  "hotshot-types",
  "rand 0.8.5",
  "serde",
@@ -4150,6 +4123,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4160,6 +4134,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4187,8 +4162,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.1.19"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.20#900e6e356945365ff3c6e9a2631b490c51f82db9"
+version = "0.1.21"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.21#ee7554cb8b5a301b6971079edb52568c37eec7dc"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4207,7 +4182,7 @@ dependencies = [
  "espresso-macros",
  "futures",
  "hotshot",
- "hotshot-example-types 0.5.43 (git+https://github.com/EspressoSystems/hotshot?tag=0.5.51)",
+ "hotshot-example-types",
  "hotshot-testing",
  "hotshot-types",
  "include_dir",
@@ -4241,6 +4216,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4311,6 +4287,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4323,41 +4300,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
-dependencies = [
- "anyhow",
- "async-broadcast",
- "async-compatibility-layer",
- "async-lock 2.8.0",
- "async-std",
- "async-trait",
- "bincode",
- "bitvec",
- "cdn-proto",
- "chrono",
- "committable",
- "either",
- "futures",
- "hotshot-builder-api",
- "hotshot-task",
- "hotshot-types",
- "jf-signature",
- "jf-vid",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.8",
- "snafu 0.8.2",
- "surf-disco",
- "tagged-base64",
- "time 0.3.36",
- "tokio",
- "tracing",
- "vbs",
-]
-
-[[package]]
-name = "hotshot-task-impls"
-version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.51#0b6aa78b9e81d5f8875ebd9f1bb6a6a531297891"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4392,6 +4335,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4406,11 +4350,11 @@ dependencies = [
  "futures",
  "hotshot",
  "hotshot-builder-api",
- "hotshot-example-types 0.5.43",
+ "hotshot-example-types",
  "hotshot-macros",
  "hotshot-orchestrator",
  "hotshot-task",
- "hotshot-task-impls 0.5.43",
+ "hotshot-task-impls",
  "hotshot-types",
  "jf-signature",
  "jf-vid",
@@ -4431,6 +4375,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -5693,6 +5638,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,18 @@ dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
 # Hotshot imports
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.51" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.19" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.20" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.20" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.53" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.20" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.21" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.21" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.51" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
@@ -111,12 +111,3 @@ vergen = { version = "8.3", features = ["git", "gitcl"] }
 zeroize = "1.7"
 committable = "0.2"
 portpicker = "0.1.1"
-
-[patch."https://github.com/EspressoSystems/HotShot.git"]
-hotshot = { path = "../HotShot/crates/hotshot" }
-hotshot-builder-api = { path = "../HotShot/crates/builder-api" }
-hotshot-orchestrator = { path = "../HotShot/crates/orchestrator" }
-hotshot-stake-table = { path = "../HotShot/crates/hotshot-stake-table" }
-hotshot-task = { path = "../HotShot/crates/task" }
-hotshot-testing = { path = "../HotShot/crates/testing" }
-hotshot-types = { path = "../HotShot/crates/types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,12 @@ vergen = { version = "8.3", features = ["git", "gitcl"] }
 zeroize = "1.7"
 committable = "0.2"
 portpicker = "0.1.1"
+
+[patch."https://github.com/EspressoSystems/HotShot.git"]
+hotshot = { path = "../HotShot/crates/hotshot" }
+hotshot-builder-api = { path = "../HotShot/crates/builder-api" }
+hotshot-orchestrator = { path = "../HotShot/crates/orchestrator" }
+hotshot-stake-table = { path = "../HotShot/crates/hotshot-stake-table" }
+hotshot-task = { path = "../HotShot/crates/task" }
+hotshot-testing = { path = "../HotShot/crates/testing" }
+hotshot-types = { path = "../HotShot/crates/types" }

--- a/sequencer/api/migrations/V15__undecided_state.sql
+++ b/sequencer/api/migrations/V15__undecided_state.sql
@@ -1,0 +1,8 @@
+CREATE TABLE undecided_state (
+    -- The ID is always set to 0. Setting it explicitly allows us to enforce with every insert or
+    -- update that there is only a single entry in this table: the latest known state.
+    id INT PRIMARY KEY,
+
+    leaves BYTEA NOT NULL,
+    state  BYTEA NOT NULL
+);

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -145,10 +145,13 @@ impl<P: SequencerPersistence> Storage<SeqTypes> for Arc<RwLock<P>> {
 
     async fn update_undecided_state(
         &self,
-        _leaves: CommitmentMap<Leaf>,
-        _state: BTreeMap<ViewNumber, View<SeqTypes>>,
+        leaves: CommitmentMap<Leaf>,
+        state: BTreeMap<ViewNumber, View<SeqTypes>>,
     ) -> anyhow::Result<()> {
-        Ok(())
+        self.write()
+            .await
+            .update_undecided_state(leaves, state)
+            .await
     }
 }
 

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -5,11 +5,14 @@ use super::{NetworkConfig, PersistenceOptions, SequencerPersistence};
 use crate::{Leaf, SeqTypes, ViewNumber};
 use async_trait::async_trait;
 use hotshot_types::{
+    consensus::CommitmentMap,
     data::{DAProposal, VidDisperseShare},
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
+    utils::View,
 };
+use std::collections::BTreeMap;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Options;
@@ -62,6 +65,12 @@ impl SequencerPersistence for NoStorage {
         Ok(None)
     }
 
+    async fn load_undecided_state(
+        &self,
+    ) -> anyhow::Result<Option<(CommitmentMap<Leaf>, BTreeMap<ViewNumber, View<SeqTypes>>)>> {
+        Ok(None)
+    }
+
     async fn load_da_proposal(
         &self,
         _view: ViewNumber,
@@ -92,6 +101,13 @@ impl SequencerPersistence for NoStorage {
         &mut self,
         _view: ViewNumber,
         _action: HotShotAction,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn update_undecided_state(
+        &mut self,
+        _leaves: CommitmentMap<Leaf>,
+        _state: BTreeMap<ViewNumber, View<SeqTypes>>,
     ) -> anyhow::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Depends on https://github.com/EspressoSystems/HotShot/pull/3147

### This PR:

* Implements the `update_undecided_state` storage method so that we have persistence for undecided consensus state
* Uses this state on restart. Hopefully this will make it easier for nodes that have restarted to catch up with consensus.

### This PR does not:

Add a restart test that works with the undecided state persistence and fails without it. I think it's a bit hard to write such a test in a unit test way, because it requires actually shutting down a certain subset of the nodes and wiping their in-memory state, but keeping other nodes running. I think we can test in staging: in theory this change should allow us to shut down and restart half the nodes, and for the network to then resume consensus.
