### PR TITLE
Add logging information in the prover service.

### DIFF
--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -281,6 +281,7 @@ pub async fn sync_state<Ver: StaticVersionType>(
     tracing::info!("Start syncing light client state.");
 
     let bundle = fetch_latest_state(relay_server_client).await?;
+    tracing::info!("Bundle accumulated: {}", bundle.accumulated_weight);
     tracing::info!("Latest HotShot block height: {}", bundle.state.block_height);
     let old_state = read_contract_state(config).await?;
     tracing::info!(
@@ -321,12 +322,6 @@ pub async fn sync_state<Ver: StaticVersionType>(
             "The signers' total weight doesn't reach the threshold.".to_string(),
         ));
     }
-
-    // TODO this assert fails. See https://github.com/EspressoSystems/espresso-sequencer/issues/1161
-    // assert_eq!(
-    //     bundle.state.stake_table_comm,
-    //     st.commitment(SnapshotVersion::LastEpochStart).unwrap()
-    // );
 
     tracing::info!("Collected latest state and signatures. Start generating SNARK proof.");
     let proof_gen_start = Instant::now();

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -281,7 +281,7 @@ pub async fn sync_state<Ver: StaticVersionType>(
     tracing::info!("Start syncing light client state.");
 
     let bundle = fetch_latest_state(relay_server_client).await?;
-    tracing::info!("Bundle accumulated: {}", bundle.accumulated_weight);
+    tracing::info!("Bundle accumulated weight: {}", bundle.accumulated_weight);
     tracing::info!("Latest HotShot block height: {}", bundle.state.block_height);
     let old_state = read_contract_state(config).await?;
     tracing::info!(


### PR DESCRIPTION
Adding some logging message in order to debug some issue in [staging](https://app.datadoghq.com/logs?query=source%3Acloudwatch%20host%3A%2Asepolia%2A%20%40aws.awslogs.logStream%3A%22ecs%2Fprover%2F9f4874a6d3cd4bf0ba93a39bc02ac775%22&agg_m=count&agg_m_source=base&agg_t=count&cols=%40logger.name&event=AgAAAY9yynADdp3iZgAAAAAAAAAYAAAAAEFZOXl5bmdrQUFCV2ZRemQ1VjVwMkFBRgAAACQAAAAAMDE4ZjcyY2YtODllYS00ZjQ1LWIxMjUtZmFmZGEwYjNkZTNi&fromUser=false&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1715464998574&to_ts=1715468598574&live=true) environment.

### This PR:
Add some logging message displaying the size of a signatures bundle received from the state relay server.
The goal is to check if it is equal to the threshold the prover has before generating a proof for the light client.

Also deletes some redundant comment.

