### PR TITLE
Decrease relative proportion of open stream actions in nasty-client

### DIFF
--- a/sequencer/src/bin/nasty-client.rs
+++ b/sequencer/src/bin/nasty-client.rs
@@ -149,7 +149,7 @@ struct ClientConfig {
 #[derive(Clone, Debug, Parser)]
 struct ActionDistribution {
     /// The weight of query actions in the random distribution.
-    #[clap(long, env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY", default_value = "5")]
+    #[clap(long, env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY", default_value = "20")]
     weight_query: u8,
 
     /// The weight of "open stream" actions in the random distribution.
@@ -172,7 +172,7 @@ struct ActionDistribution {
     #[clap(
         long,
         env = "ESPRESSO_NASTY_CLIENT_WEIGHT_POLL_STREAM",
-        default_value = "5"
+        default_value = "10"
     )]
     weight_poll_stream: u8,
 
@@ -180,7 +180,7 @@ struct ActionDistribution {
     #[clap(
         long,
         env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY_WINDOW",
-        default_value = "3"
+        default_value = "15"
     )]
     weight_query_window: u8,
 
@@ -188,7 +188,7 @@ struct ActionDistribution {
     #[clap(
         long,
         env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY_NAMESPACE",
-        default_value = "3"
+        default_value = "15"
     )]
     weight_query_namespace: u8,
 
@@ -196,7 +196,7 @@ struct ActionDistribution {
     #[clap(
         long,
         env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY_BLOCK_STATE",
-        default_value = "3"
+        default_value = "15"
     )]
     weight_query_block_state: u8,
 
@@ -204,7 +204,7 @@ struct ActionDistribution {
     #[clap(
         long,
         env = "ESPRESSO_NASTY_CLIENT_WEIGHT_QUERY_FEE_STATE",
-        default_value = "3"
+        default_value = "15"
     )]
     weight_query_fee_state: u8,
 }


### PR DESCRIPTION
### This PR:

Decreases the relative frequency of opening new streams in the nasty client, compared to other actions like polling streams and querying regular endpoints.

As discussed in [incident 8](https://www.notion.so/espressosys/High-CPU-usage-in-staging-4f32cee6c27d4e9e9eb09e96d1923ded), opening a new stream, particularly for an old block, will cause the query server to use all spare CPU it has available. This is not a bad thing, as it won't steal CPU from other tasks and doesn't interfere with other queries. But it has a "false positive" effect when looking at metrics in Datadog: this benign elevated CPU usage can hide or disguise other problems that also manifest as elevated CPU. Since this pattern is not even a realistic usage, it is better to avoid it in stress testing.
