### PR TITLE
Make text metrics parseable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "async-trait",
  "clap",
@@ -4015,8 +4015,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.20"
-source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.20#9ce5d19c43121ac3410940d3995b4bc20c5fa94a"
+version = "0.1.21"
+source = "git+https://github.com/EspressoSystems/hotshot-builder-core?tag=0.1.21#ebbf1c887ea80217b492853c573506bf6972fd3a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4067,8 +4067,8 @@ dependencies = [
 
 [[package]]
 name = "hotshot-events-service"
-version = "0.1.21"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.21#ae2e647b69351e06b8f59b19eee59ad54f56f837"
+version = "0.1.22"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.22#0986778c44d729b94b88b3e80db58d82de7dae9e"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.23"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.23#bb81c2cb281ced831ea85015fc16379e89cb48cb"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.24#d81e21183efcc83273595ea21a2ac37831d7bd8a"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -5638,7 +5638,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
-source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.53#9fbb21fe45ee1dbf63c136e850cda7a520d24a39"
+source = "git+https://github.com/EspressoSystems/hotshot?tag=0.5.54#af6e40d6157e335a7ed71c956ef37d8e820635c5"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -8495,6 +8495,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
+ "reqwest 0.12.4",
  "sequencer-utils",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,18 @@ dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"
 
-hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
 # Hotshot imports
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.53" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.20" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.21" }
-hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.23" }
-hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.54" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/hotshot-builder-core", tag = "0.1.21" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.22" }
+hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/hotshot-query-service", tag = "0.1.24" }
+hotshot-stake-table = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
 hotshot-state-prover = { version = "0.1.0", path = "hotshot-state-prover" }
-hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.53" }
+hotshot-task = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.54" }
 
 # Push CDN imports
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
@@ -103,6 +103,7 @@ bytesize = "1.3"
 itertools = "0.12"
 rand_chacha = "0.3"
 rand_distr = "0.4"
+reqwest = "0.12"
 serde = { version = "1.0.195", features = ["derive"] }
 toml = "0.8"
 url = "2.3"

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -13,6 +13,7 @@ libp2p = []
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 hotshot-query-service = { workspace = true, features = ["testing"] }
 rand = "0.8.5"
+reqwest = { workspace = true }
 tempfile = "3.9.0"
 
 [build-dependencies]

--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -78,11 +78,7 @@ impl<N: network::Type, P: SequencerPersistence, Ver: StaticVersionType + 'static
         let pub_key = config.my_own_validator_config.public_key;
         tracing::info!(%pub_key, "initializing consensus");
 
-        // Stick our public key and node ID in `metrics` so it is easily accessible via the status
-        // API.
-        metrics
-            .create_label("pub_key".into())
-            .set(pub_key.to_string());
+        // Stick our node ID in `metrics` so it is easily accessible via the status API.
         metrics
             .create_gauge("node_index".into(), None)
             .set(instance_state.node_id as usize);

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -47,7 +47,7 @@ use hotshot_orchestrator::{
 };
 use hotshot_types::{
     consensus::CommitmentMap,
-    data::{DAProposal, VidDisperseShare, ViewNumber},
+    data::{DaProposal, VidDisperseShare, ViewNumber},
     event::HotShotAction,
     light_client::{StateKeyPair, StateSignKey},
     message::Proposal,
@@ -117,7 +117,7 @@ pub type PrivKey = <PubKey as SignatureKey>::PrivateKey;
 
 impl<N: network::Type, P: SequencerPersistence> NodeImplementation<SeqTypes> for Node<N, P> {
     type QuorumNetwork = N::QuorumChannel;
-    type CommitteeNetwork = N::DAChannel;
+    type DaNetwork = N::DAChannel;
     type Storage = Arc<RwLock<P>>;
 }
 
@@ -132,7 +132,7 @@ impl<P: SequencerPersistence> Storage<SeqTypes> for Arc<RwLock<P>> {
 
     async fn append_da(
         &self,
-        proposal: &Proposal<SeqTypes, DAProposal<SeqTypes>>,
+        proposal: &Proposal<SeqTypes, DaProposal<SeqTypes>>,
     ) -> anyhow::Result<()> {
         self.write().await.append_da(proposal).await
     }
@@ -309,14 +309,21 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
 ) -> anyhow::Result<SequencerContext<network::Production, P::Persistence, Ver>> {
     // Expose git information via status API.
     metrics
-        .create_label("git_rev".into())
-        .set(env!("VERGEN_GIT_SHA").into());
+        .text_family(
+            "version".into(),
+            vec!["rev".into(), "desc".into(), "timestamp".into()],
+        )
+        .create(vec![
+            env!("VERGEN_GIT_SHA").into(),
+            env!("VERGEN_GIT_DESCRIBE").into(),
+            env!("VERGEN_GIT_COMMIT_TIMESTAMP").into(),
+        ]);
+
+    // Stick our public key in `metrics` so it is easily accessible via the status API.
+    let pub_key = BLSPubKey::from_private(&network_params.private_staking_key);
     metrics
-        .create_label("git_desc".into())
-        .set(env!("VERGEN_GIT_DESCRIBE").into());
-    metrics
-        .create_label("git_timestamp".into())
-        .set(env!("VERGEN_GIT_COMMIT_TIMESTAMP").into());
+        .text_family("node".into(), vec!["key".into()])
+        .create(vec![pub_key.to_string()]);
 
     // Orchestrator client
     let validator_args = ValidatorArgs {
@@ -327,7 +334,7 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
     let orchestrator_client = OrchestratorClient::new(validator_args);
     let state_key_pair = StateKeyPair::from_sign_key(network_params.private_state_key);
     let my_config = ValidatorConfig {
-        public_key: BLSPubKey::from_private(&network_params.private_staking_key),
+        public_key: pub_key,
         private_key: network_params.private_staking_key,
         stake_value: 1,
         state_key_pair,

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -161,3 +161,98 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use async_std::task::spawn;
+    use es_version::SequencerVersion;
+    use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey};
+    use portpicker::pick_unused_port;
+    use sequencer::{
+        api::options::{Http, Status},
+        persistence::fs,
+        PubKey,
+    };
+    use std::time::Duration;
+    use surf_disco::{error::ClientError, Client, Url};
+    use tempfile::TempDir;
+
+    #[async_std::test]
+    async fn test_startup_before_orchestrator() {
+        setup_logging();
+        setup_backtrace();
+
+        let (pub_key, priv_key) = PubKey::generated_from_seed_indexed([0; 32], 0);
+        let state_key = StateKeyPair::generate_from_seed_indexed([0; 32], 0);
+
+        let port = pick_unused_port().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let modules = Modules {
+            http: Some(Http { port }),
+            status: Some(Status),
+            ..Default::default()
+        };
+        let opt = Options::parse_from([
+            "sequencer",
+            "--private-staking-key",
+            &priv_key.to_string(),
+            "--private-state-key",
+            &state_key.sign_key_ref().to_string(),
+        ]);
+
+        // Start the sequencer in a background task. This process will not complete, because it will
+        // be waiting for the orchestrator, but it should at least start up the API server and
+        // populate some metrics.
+        tracing::info!(port, "starting sequencer");
+        let task = spawn(async move {
+            if let Err(err) = init_with_storage(
+                modules,
+                opt,
+                fs::Options {
+                    path: tmp.path().into(),
+                },
+                SEQUENCER_VERSION,
+            )
+            .await
+            {
+                tracing::error!("failed to start sequencer: {err:#}");
+            }
+        });
+
+        // The healthcheck should eventually come up even though the node is waiting for the
+        // orchestrator.
+        tracing::info!("waiting for API to start");
+        let url: Url = format!("http://localhost:{port}").parse().unwrap();
+        let client = Client::<ClientError, SequencerVersion>::new(url.clone());
+        assert!(client.connect(Some(Duration::from_secs(60))).await);
+        client.get::<()>("healthcheck").send().await.unwrap();
+
+        // The metrics should include information about the node and software version. surf-disco
+        // doesn't currently support fetching a plaintext file, so we use a raw reqwest client.
+        let res = reqwest::get(url.join("/status/metrics").unwrap())
+            .await
+            .unwrap();
+        assert!(res.status().is_success(), "{}", res.status());
+        let metrics = res.text().await.unwrap();
+        let lines = metrics.lines().collect::<Vec<_>>();
+        assert!(
+            lines.contains(&format!("consensus_node{{key=\"{pub_key}\"}} 1").as_str()),
+            "{lines:#?}"
+        );
+        assert!(
+            lines.contains(
+                &format!(
+                    "consensus_version{{desc=\"{}\",rev=\"{}\",timestamp=\"{}\"}} 1",
+                    env!("VERGEN_GIT_DESCRIBE"),
+                    env!("VERGEN_GIT_SHA"),
+                    env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
+                )
+                .as_str()
+            ),
+            "{lines:#?}"
+        );
+
+        task.cancel().await;
+    }
+}

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -148,7 +148,11 @@ pub struct Options {
     pub prefunded_builder_accounts: Vec<Address>,
 
     /// Url we will use for RPC communication with L1.
-    #[clap(long, env = "ESPRESSO_SEQUENCER_L1_PROVIDER")]
+    #[clap(
+        long,
+        env = "ESPRESSO_SEQUENCER_L1_PROVIDER",
+        default_value = "http://localhost:8545"
+    )]
     #[derivative(Debug(format_with = "Display::fmt"))]
     pub l1_provider_url: Url,
 

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -20,7 +20,7 @@ use hotshot::{
 };
 use hotshot_types::{
     consensus::CommitmentMap,
-    data::{DAProposal, VidDisperseShare},
+    data::{DaProposal, VidDisperseShare},
     event::{HotShotAction, LeafInfo},
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -94,7 +94,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + 'static {
     async fn load_da_proposal(
         &self,
         view: ViewNumber,
-    ) -> anyhow::Result<Option<Proposal<SeqTypes, DAProposal<SeqTypes>>>>;
+    ) -> anyhow::Result<Option<Proposal<SeqTypes, DaProposal<SeqTypes>>>>;
 
     /// Load the latest known consensus state.
     ///
@@ -209,7 +209,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + 'static {
     ) -> anyhow::Result<()>;
     async fn append_da(
         &mut self,
-        proposal: &Proposal<SeqTypes, DAProposal<SeqTypes>>,
+        proposal: &Proposal<SeqTypes, DaProposal<SeqTypes>>,
     ) -> anyhow::Result<()>;
     async fn record_action(
         &mut self,
@@ -401,7 +401,7 @@ mod persistence_tests {
         let block_payload_signature =
             BLSPubKey::sign(&privkey, &tx_hash).expect("Failed to sign tx hash");
 
-        let da_proposal_inner = DAProposal::<SeqTypes> {
+        let da_proposal_inner = DaProposal::<SeqTypes> {
             encoded_transactions: Arc::from(tx_hash),
             metadata: Default::default(),
             view_number: ViewNumber::new(1),

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use hotshot_types::{
     consensus::CommitmentMap,
-    data::{DAProposal, VidDisperseShare},
+    data::{DaProposal, VidDisperseShare},
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -255,7 +255,7 @@ impl SequencerPersistence for Persistence {
     async fn load_da_proposal(
         &self,
         view: ViewNumber,
-    ) -> anyhow::Result<Option<Proposal<SeqTypes, DAProposal<SeqTypes>>>> {
+    ) -> anyhow::Result<Option<Proposal<SeqTypes, DaProposal<SeqTypes>>>> {
         let dir_path = self.da_dir_path();
 
         let file_path = dir_path
@@ -268,7 +268,7 @@ impl SequencerPersistence for Persistence {
 
         let da_bytes = fs::read(file_path)?;
 
-        let da_proposal: Proposal<SeqTypes, DAProposal<SeqTypes>> =
+        let da_proposal: Proposal<SeqTypes, DaProposal<SeqTypes>> =
             bincode::deserialize(&da_bytes)?;
         Ok(Some(da_proposal))
     }
@@ -320,7 +320,7 @@ impl SequencerPersistence for Persistence {
     }
     async fn append_da(
         &mut self,
-        proposal: &Proposal<SeqTypes, DAProposal<SeqTypes>>,
+        proposal: &Proposal<SeqTypes, DaProposal<SeqTypes>>,
     ) -> anyhow::Result<()> {
         let view_number = proposal.data.get_view_number().get_u64();
         let dir_path = self.da_dir_path();

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -6,7 +6,7 @@ use crate::{Leaf, SeqTypes, ViewNumber};
 use async_trait::async_trait;
 use hotshot_types::{
     consensus::CommitmentMap,
-    data::{DAProposal, VidDisperseShare},
+    data::{DaProposal, VidDisperseShare},
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -74,7 +74,7 @@ impl SequencerPersistence for NoStorage {
     async fn load_da_proposal(
         &self,
         _view: ViewNumber,
-    ) -> anyhow::Result<Option<Proposal<SeqTypes, DAProposal<SeqTypes>>>> {
+    ) -> anyhow::Result<Option<Proposal<SeqTypes, DaProposal<SeqTypes>>>> {
         Ok(None)
     }
 
@@ -93,7 +93,7 @@ impl SequencerPersistence for NoStorage {
     }
     async fn append_da(
         &mut self,
-        _proposal: &Proposal<SeqTypes, DAProposal<SeqTypes>>,
+        _proposal: &Proposal<SeqTypes, DaProposal<SeqTypes>>,
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -19,7 +19,7 @@ use hotshot_query_service::data_source::{
 };
 use hotshot_types::{
     consensus::CommitmentMap,
-    data::{DAProposal, VidDisperseShare},
+    data::{DaProposal, VidDisperseShare},
     event::HotShotAction,
     message::Proposal,
     simple_certificate::QuorumCertificate,
@@ -388,7 +388,7 @@ impl SequencerPersistence for Persistence {
     async fn load_da_proposal(
         &self,
         view: ViewNumber,
-    ) -> anyhow::Result<Option<Proposal<SeqTypes, DAProposal<SeqTypes>>>> {
+    ) -> anyhow::Result<Option<Proposal<SeqTypes, DaProposal<SeqTypes>>>> {
         let result = self
             .query_opt(
                 "SELECT data FROM da_proposal where view = $1",
@@ -448,7 +448,7 @@ impl SequencerPersistence for Persistence {
     }
     async fn append_da(
         &mut self,
-        proposal: &Proposal<SeqTypes, DAProposal<SeqTypes>>,
+        proposal: &Proposal<SeqTypes, DaProposal<SeqTypes>>,
     ) -> anyhow::Result<()> {
         let data = &proposal.data;
         let view = data.get_view_number().get_u64();


### PR DESCRIPTION
Uses the new labels functionality of the metrics trait to make parseable the version information and public key. Also adds a test that these metrics are correct and available before the orchestrator starts.
