### PR TITLE
Allow undecided state storage to be selectively turned out

### DIFF
--- a/sequencer/src/api/fs.rs
+++ b/sequencer/src/api/fs.rs
@@ -11,7 +11,7 @@ impl SequencerDataSource for DataSource {
     type Options = Options;
 
     async fn create(opt: Self::Options, provider: Provider, reset: bool) -> anyhow::Result<Self> {
-        let path = Path::new(&opt.path);
+        let path = Path::new(opt.path());
         let data_source = {
             if reset {
                 FileSystemDataSource::create(path, provider).await?
@@ -41,18 +41,11 @@ mod impl_testable_data_source {
         }
 
         fn persistence_options(storage: &Self::Storage) -> Self::Options {
-            Options {
-                path: storage.path().into(),
-            }
+            Options::new(storage.path().into())
         }
 
         fn options(storage: &Self::Storage, opt: api::Options) -> api::Options {
-            opt.query_fs(
-                Default::default(),
-                Options {
-                    path: storage.path().into(),
-                },
-            )
+            opt.query_fs(Default::default(), Options::new(storage.path().into()))
         }
     }
 }

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -209,9 +209,7 @@ mod test {
             if let Err(err) = init_with_storage(
                 modules,
                 opt,
-                fs::Options {
-                    path: tmp.path().into(),
-                },
+                fs::Options::new(tmp.path().into()),
                 SEQUENCER_VERSION,
             )
             .await


### PR DESCRIPTION
Intended to mitigate [incident 13](https://www.notion.so/espressosys/Unit-410-Lagging-DA-Node-783dc4aa86d84708a6bfca6a253df475) while still retaining the ability to store undecided state in case we need to restart a bunch of nodes at once.