### PR TITLE
prepend target directory to PATH

### DIFF
--- a/scripts/demo-native
+++ b/scripts/demo-native
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH=$PATH:./target/release
+export PATH=./target/release:$PATH
 
 ESPRESSO_BASE_STORAGE_PATH=$(mktemp -d -t espresso-XXXXXXXX)
 export ESPRESSO_BASE_STORAGE_PATH


### PR DESCRIPTION
Prepend the target directory containing Espresso binaries to PATH environment variable 
to ensure the Espresso binary is always run when there are multiple binaries with the same name.