### PR TITLE
Add Libp2p peerID derivation to public key binary

### DIFF
--- a/sequencer/src/bin/pub-key.rs
+++ b/sequencer/src/bin/pub-key.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use clap::Parser;
+use hotshot::{traits::implementations::derive_libp2p_peer_id, types::BLSPubKey};
 use hotshot_types::{
     light_client::{StateKeyPair, StateSignKey},
     traits::signature_key::SignatureKey,
@@ -30,13 +31,33 @@ impl FromStr for PrivateKey {
 /// Get the public key corresponding to a private key.
 #[derive(Clone, Debug, Parser)]
 struct Options {
+    /// The private key to get the public key for.
     key: PrivateKey,
+
+    // Whether or not to derive the libp2p peer ID from the private key.
+    #[clap(long, short)]
+    libp2p: bool,
 }
 
 fn main() {
     let opt = Options::parse();
-    match opt.key {
-        PrivateKey::Bls(key) => println!("{}", PubKey::from_private(&key)),
-        PrivateKey::Schnorr(key) => println!("{}", StateKeyPair::from_sign_key(key).ver_key()),
+
+    match (opt.libp2p, opt.key) {
+        // Non-libp2p
+        (false, PrivateKey::Bls(key)) => println!("{}", PubKey::from_private(&key)),
+        (false, PrivateKey::Schnorr(key)) => {
+            println!("{}", StateKeyPair::from_sign_key(key).ver_key())
+        }
+
+        // Libp2p
+        (true, PrivateKey::Bls(key)) => {
+            println!(
+                "{}",
+                derive_libp2p_peer_id::<BLSPubKey>(&key).expect("Failed to derive libp2p peer ID")
+            );
+        }
+        (true, _) => {
+            eprintln!("Key type unsupported for libp2p peer ID derivation");
+        }
     }
 }


### PR DESCRIPTION
No linked issue.

Adds the ability to derive a Libp2p peerID (public key) to the public key binary. This will make an upgrade to Libp2p easier as the keys need to be known to bootstrap into the network