### PR TITLE
Avoid always using binaries in target/release

### DIFF
--- a/scripts/demo-native
+++ b/scripts/demo-native
@@ -10,8 +10,6 @@ if [ -z "${IN_NIX_SHELL-}" ]; then
     export "PATH=${TARGET_DIR}/release:$PATH"
 fi
 
-export PATH=./target/release:$PATH
-
 ESPRESSO_BASE_STORAGE_PATH=$(mktemp -d -t espresso-XXXXXXXX)
 export ESPRESSO_BASE_STORAGE_PATH
 echo "Using sequencer storage path: $ESPRESSO_BASE_STORAGE_PATH"

--- a/scripts/demo-native
+++ b/scripts/demo-native
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # If we aren't in a nix shell (where this handled in flake.nix) add the target
-# directory to the path so that the process-compose binary can be found.
+# directory to the path so that the binaries are found by process-compose.
 if [ -z "${IN_NIX_SHELL-}" ]; then
     REPO_ROOT="$(dirname "$(dirname "$(readlink -fm "$0")")")"
     # Default to CARGO_TARGET_DIR if set, otherwise use the default target directory.

--- a/scripts/demo-native
+++ b/scripts/demo-native
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# If we aren't in a nix shell (where this handled in flake.nix) add the target
+# directory to the path so that the process-compose binary can be found.
+if [ -z "${IN_NIX_SHELL-}" ]; then
+    REPO_ROOT="$(dirname "$(dirname "$(readlink -fm "$0")")")"
+    # Default to CARGO_TARGET_DIR if set, otherwise use the default target directory.
+    TARGET_DIR="${CARGO_TARGET_DIR:-${REPO_ROOT}/target}"
+    export "PATH=${TARGET_DIR}/release:$PATH"
+fi
+
 export PATH=./target/release:$PATH
 
 ESPRESSO_BASE_STORAGE_PATH=$(mktemp -d -t espresso-XXXXXXXX)


### PR DESCRIPTION
If one previously ran `cargo build` without nix and then switches to nix, the demo script uses the old binaries and things don't work.