### PR TITLE
reject txn with namespace > u32::max

### DIFF
--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -177,6 +177,17 @@ where
             let tx = req
                 .body_auto::<Transaction, Ver>(Ver::instance())
                 .map_err(Error::from_request_error)?;
+
+            // Transactions with namespaces that do not fit in the u32
+            // cannot be included in the block.
+            // TODO: This issue will be addressed in the next release.
+            if tx.namespace() > NamespaceId::from(u32::MAX as u64) {
+                return Err(Error::Custom {
+                    message: "Transaction namespace > u32::MAX".to_string(),
+                    status: StatusCode::BadRequest,
+                });
+            }
+
             let hash = tx.commit();
             state
                 .submit(tx)


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1503

Currently, there is a bug in the Cappuccino namespace table where transactions with namespace > u32::max can not be included in the block. We are going to reject those transactions for now.