### PR TITLE
Longer delay time for fee bridge

### DIFF
--- a/sequencer/src/bin/bridge.rs
+++ b/sequencer/src/bin/bridge.rs
@@ -318,7 +318,7 @@ async fn get_espresso_balance(
                 if retry == max_retries {
                     return Err(err).context("getting account balance");
                 } else {
-                    sleep(Duration::from_secs(1)).await;
+                    sleep(Duration::from_secs(5)).await;
                 }
             }
         }


### PR DESCRIPTION
### This PR:
Adds a longer delay time when fetching the espresso balance because we are consistently hitting the timeout in the docker demo. 
