### PR TITLE
Remove unnecessary write lock for submit endpoint

### DIFF
--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -172,7 +172,7 @@ where
     let toml = toml::from_str::<toml::Value>(include_str!("../../api/submit.toml"))?;
     let mut api = Api::<S, Error, Ver>::new(toml)?;
 
-    api.post("submit", |req, state| {
+    api.at("submit", |req, state| {
         async move {
             let tx = req
                 .body_auto::<Transaction, Ver>(Ver::instance())
@@ -190,7 +190,7 @@ where
 
             let hash = tx.commit();
             state
-                .submit(tx)
+                .read(|state| state.submit(tx).boxed())
                 .await
                 .map_err(|err| Error::internal(err.to_string()))?;
             Ok(hash)


### PR DESCRIPTION
The submit endpoint took a write lock on the state by default, since it is a POST endpoint. However, this lock is unnecessary, because internally all we do is send an event, we don't mutate any state. By using `at` instead of `post`, we can manually control the locking, and take just a read lock. This should help significantly in avoiding queues on the API state lock when many transactions are being submitted.

### This PR:
* Changes the lock acquired by the `submit` endpoint from exclusive to shared
