### PR TITLE
Add `Option<builder_port>` param to dev-node

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -345,10 +345,11 @@ pub mod test_helpers {
             persistence: [impl PersistenceOptions<Persistence = P>; TestConfig::NUM_NODES],
             catchup: [impl StateCatchup + 'static; TestConfig::NUM_NODES],
             l1: Url,
+            builder_port: Option<u16>,
         ) -> Self {
             let mut cfg = TestConfig::default_with_l1(l1);
 
-            let (builder_task, builder_url) = run_test_builder().await;
+            let (builder_task, builder_url) = run_test_builder(builder_port).await;
 
             cfg.set_builder_url(builder_url);
 
@@ -417,6 +418,7 @@ pub mod test_helpers {
             opt: Options,
             persistence: [impl PersistenceOptions<Persistence = P>; TestConfig::NUM_NODES],
             l1: Url,
+            builder_port: Option<u16>,
         ) -> Self {
             Self::with_state(
                 opt,
@@ -424,6 +426,7 @@ pub mod test_helpers {
                 persistence,
                 std::array::from_fn(|_| MockStateCatchup::default()),
                 l1,
+                builder_port,
             )
             .await
         }
@@ -460,8 +463,13 @@ pub mod test_helpers {
         let options = opt(Options::from(options::Http { port }).status(Default::default()));
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let _network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let _network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
         client.connect(None).await;
 
         // The status API is well tested in the query service repo. Here we are just smoke testing
@@ -509,8 +517,13 @@ pub mod test_helpers {
         let options = opt(Options::from(options::Http { port }).submit(Default::default()));
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
         let mut events = network.server.event_stream().await;
 
         client.connect(None).await;
@@ -541,8 +554,13 @@ pub mod test_helpers {
         let options = opt(Options::from(options::Http { port }));
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
 
         let mut height: u64;
         // Wait for block >=2 appears
@@ -580,8 +598,13 @@ pub mod test_helpers {
         let options = opt(Options::from(options::Http { port }).catchup(Default::default()));
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
         client.connect(None).await;
 
         // Wait for a few blocks to be decided.
@@ -941,8 +964,13 @@ mod test {
 
         let anvil: ethers::utils::AnvilInstance = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let mut network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let mut network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
         let url = format!("http://localhost:{port}").parse().unwrap();
         let client: Client<ServerError, SequencerVersion> = Client::new(url);
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -741,6 +741,7 @@ mod api_tests {
             D::options(&storage, options::Http { port }.into()).submit(Default::default()),
             [no_storage::Options; TestConfig::NUM_NODES],
             l1,
+            None,
         )
         .await;
         let mut events = network.server.event_stream().await;
@@ -840,8 +841,13 @@ mod api_tests {
 
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let _network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let _network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
 
         let mut subscribed_events = client
             .socket("hotshot-events/events")
@@ -919,8 +925,13 @@ mod test {
         let options = Options::from(options::Http { port });
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
-        let _network =
-            TestNetwork::new(options, [no_storage::Options; TestConfig::NUM_NODES], l1).await;
+        let _network = TestNetwork::new(
+            options,
+            [no_storage::Options; TestConfig::NUM_NODES],
+            l1,
+            None,
+        )
+        .await;
 
         client.connect(None).await;
         let health = client.get::<AppHealth>("healthcheck").send().await.unwrap();
@@ -1041,6 +1052,7 @@ mod test {
                     .unwrap()])
             }),
             l1,
+            None,
         )
         .await;
 
@@ -1142,6 +1154,7 @@ mod test {
             persistence,
             std::array::from_fn(|_| MockStateCatchup::default()),
             l1,
+            None,
         )
         .await;
 
@@ -1217,6 +1230,7 @@ mod test {
                     .unwrap()])
             }),
             l1,
+            None,
         )
         .await;
         let client: Client<ServerError, SequencerVersion> =

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -526,10 +526,17 @@ pub mod testing {
 
     const STAKE_TABLE_CAPACITY_FOR_TEST: u64 = 10;
 
-    pub async fn run_test_builder() -> (Option<Box<dyn BuilderTask<SeqTypes>>>, Url) {
+    pub async fn run_test_builder(
+        port: Option<u16>,
+    ) -> (Option<Box<dyn BuilderTask<SeqTypes>>>, Url) {
+        let builder_config = if let Some(port) = port {
+            SimpleBuilderConfig { port }
+        } else {
+            SimpleBuilderConfig::default()
+        };
         <SimpleBuilderImplementation as TestBuilderImplementation<SeqTypes>>::start(
             TestConfig::NUM_NODES,
-            SimpleBuilderConfig::default(),
+            builder_config,
         )
         .await
     }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -811,7 +811,7 @@ mod test {
         let url = anvil.url();
         let mut config = TestConfig::default_with_l1(url);
 
-        let (builder_task, builder_url) = run_test_builder().await;
+        let (builder_task, builder_url) = run_test_builder(None).await;
 
         config.set_builder_url(builder_url);
 
@@ -853,7 +853,7 @@ mod test {
         let url = anvil.url();
         let mut config = TestConfig::default_with_l1(url);
 
-        let (builder_task, builder_url) = run_test_builder().await;
+        let (builder_task, builder_url) = run_test_builder(None).await;
 
         config.set_builder_url(builder_url);
         let handles = config.init_nodes(ver).await;


### PR DESCRIPTION
This PR add `Option<builder_port>` param in order to supply known port to `SimpleBuilder`. This is needed in integration testing scenarios where we multiple services need to know where to reach the builder. As a consequence, `TestNetwork::new()` now requires a `builder_port` param as well. 

In addition to the above, some variable names were updated for clarity.

Closes #1522 

### Key places to review:
Please check that:

  * we agree on variable name changes
  * changes to `TestNetwork` are ok (I think it is okay to be flexible with `TestNetwork` since it is a testing utility (not production code))

### How to test this PR:
We should probably go ahead and use this in integration testing scenarios to ensure everything is working as expected.