### PR TITLE
Remove the commitment task in dev node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
         id: espresso-dev-node
         with:
           images: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node
+
       - name: Generate bridge metadata
         uses: docker/metadata-action@v5
         id: bridge
@@ -386,7 +387,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./
-          file: ./docker/nasty-client.Dockerfile
+          file: ./docker/espresso-dev-node.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.espresso-dev-node.outputs.tags }}

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -90,6 +90,7 @@ jobs:
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/keygen
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/pub-key
             ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/espresso-bridge
+            ${{ env.CARGO_TARGET_DIR }}/${{ env.TARGET_TRIPLET }}/release/espresso-dev-node
 
   static-dockers:
     runs-on: ubuntu-latest
@@ -191,6 +192,13 @@ jobs:
         id: deploy
         with:
           images: ghcr.io/espressosystems/espresso-sequencer/deploy
+          flavor: suffix=musl
+
+      - name: Generate espresso-dev-node metadata
+        uses: docker/metadata-action@v5
+        id: espresso-dev-node
+        with:
+          images: ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node
           flavor: suffix=musl
 
       - name: Generate bridge metadata
@@ -299,6 +307,16 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.deploy.outputs.tags }}
           labels: ${{ steps.deploy.outputs.labels }}
+
+      - name: Build and push dev node docker
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          file: ./docker/espresso-dev-node.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.espresso-dev-node.outputs.tags }}
+          labels: ${{ steps.espresso-dev-node.outputs.labels }}
 
       - name: Build and push bridge docker
         uses: docker/build-push-action@v5

--- a/docker/espresso-dev-node.Dockerfile
+++ b/docker/espresso-dev-node.Dockerfile
@@ -14,12 +14,6 @@ RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0
 COPY target/$TARGETARCH/release/espresso-dev-node /bin/espresso-dev-node
 RUN chmod +x /bin/espresso-dev-node
 
-COPY target/$TARGETARCH/release/anvil /bin/anvil
-RUN chmod +x /bin/anvil
-
-COPY launch-dev-node-with-postgres /bin/launch-dev-node-with-postgres
-RUN chmod +x /bin/launch-dev-node-with-postgres
-
 # When running as a Docker service, we always want a healthcheck endpoint, so set a default for the
 # port that the HTTP server will run on. This can be overridden in any given deployment environment.
 ENV ESPRESSO_SEQUENCER_API_PORT=8770
@@ -29,4 +23,4 @@ EXPOSE 8770
 EXPOSE 8771
 EXPOSE 8772
 
-CMD [ "/bin/launch-dev-node-with-postgres"]
+CMD [ "/bin/espresso-dev-node"]

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -1,25 +1,15 @@
-use std::{io, time::Duration};
+use std::time::Duration;
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
-use async_std::task::spawn;
+use async_std::task::sleep;
 use clap::Parser;
-use es_version::SEQUENCER_VERSION;
-use ethers::types::Address;
 use futures::FutureExt;
-use sequencer::{
-    api::options,
-    api::test_helpers::TestNetwork,
-    hotshot_commitment::{run_hotshot_commitment_task, CommitmentTaskOptions},
-    persistence,
-    testing::TestConfig,
-};
+use sequencer::{api::options, api::test_helpers::TestNetwork, persistence, testing::TestConfig};
 use sequencer_utils::{
-    deployer::{deploy, Contract, Contracts},
+    deployer::{deploy, Contracts},
     AnvilOptions,
 };
-use tide_disco::{error::ServerError, Api};
 use url::Url;
-use vbs::version::StaticVersionType;
 
 #[derive(Clone, Debug, Parser)]
 struct Args {
@@ -54,12 +44,6 @@ struct Args {
     /// Maximum concurrent connections allowed by the HTTP API server.
     #[clap(long, env = "ESPRESSO_SEQUENCER_MAX_CONNECTIONS")]
     sequencer_api_max_connections: Option<usize>,
-
-    /// If provided, the service will run a basic HTTP server on the given port.
-    ///
-    /// The server provides healthcheck and version endpoints.
-    #[clap(short, long, env = "ESPRESSO_COMMITMENT_TASK_PORT")]
-    commitment_task_port: u16,
 
     /// Port for connecting to the builder.
     #[clap(short, long, env = "ESPRESSO_BUILDER_PORT")]
@@ -111,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
 
     let light_client_genesis = network.light_client_genesis();
 
-    let contracts = deploy(
+    let _contracts = deploy(
         url.clone(),
         cli_params.mnemonic.clone(),
         cli_params.account_index,
@@ -122,62 +106,9 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let hotshot_address = contracts
-        .get_contract_address(Contract::HotShot)
-        .expect("Cannot get the hotshot contract address");
-    tracing::info!("hotshot address: {}", hotshot_address);
-
-    tracing::info!("starting the commitment server");
-    start_commitment_server(
-        cli_params.commitment_task_port,
-        hotshot_address,
-        SEQUENCER_VERSION,
-    )
-    .unwrap();
-
-    let sequencer_url =
-        Url::parse(format!("http://localhost:{}", cli_params.sequencer_api_port).as_str()).unwrap();
-    let commitment_task_options = CommitmentTaskOptions {
-        l1_provider: url,
-        l1_chain_id: None,
-        hotshot_address,
-        sequencer_mnemonic: cli_params.mnemonic,
-        sequencer_account_index: cli_params.account_index,
-        query_service_url: Some(sequencer_url),
-        request_timeout: Duration::from_secs(5),
-        delay: None,
-    };
-
-    tracing::info!("starting hotshot commitment task");
-    run_hotshot_commitment_task::<es_version::SequencerVersion>(&commitment_task_options).await;
-
-    Ok(())
-}
-
-// Copied from `commitment_task::start_http_server`.
-// TODO: Remove these redundant code
-fn start_commitment_server<Ver: StaticVersionType + 'static>(
-    port: u16,
-    hotshot_address: Address,
-    bind_version: Ver,
-) -> io::Result<()> {
-    let mut app = tide_disco::App::<(), ServerError>::with_state(());
-    let toml = toml::from_str::<toml::value::Value>(include_str!("../../api/commitment_task.toml"))
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-
-    let mut api = Api::<(), ServerError, Ver>::new(toml)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-
-    api.get("gethotshotcontract", move |_, _| {
-        async move { Ok(hotshot_address) }.boxed()
-    })
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-
-    app.register_module("api", api)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
-
-    spawn(app.serve(format!("localhost:{port}"), bind_version));
-    Ok(())
+    loop {
+        sleep(Duration::from_secs(3600)).await
+    }
 }
 
 #[cfg(test)]
@@ -221,7 +152,7 @@ mod tests {
         setup_logging();
         setup_backtrace();
 
-        let commitment_task_port = pick_unused_port().unwrap();
+        let builder_port = pick_unused_port().unwrap();
 
         let api_port = pick_unused_port().unwrap();
 
@@ -235,10 +166,7 @@ mod tests {
             .run()
             .unwrap()
             .command()
-            .env(
-                "ESPRESSO_COMMITMENT_TASK_PORT",
-                commitment_task_port.to_string(),
-            )
+            .env("ESPRESSO_BUILDER_PORT", builder_port.to_string())
             .env("ESPRESSO_SEQUENCER_API_PORT", api_port.to_string())
             .env("ESPRESSO_SEQUENCER_POSTGRES_HOST", "localhost")
             .env(
@@ -267,20 +195,17 @@ mod tests {
             .await
             .unwrap();
 
-        let commitment_api_client: Client<ServerError, SequencerVersion> = Client::new(
-            format!("http://localhost:{commitment_task_port}/api")
-                .parse()
-                .unwrap(),
-        );
-        commitment_api_client.connect(None).await;
+        let builder_api_client: Client<ServerError, SequencerVersion> =
+            Client::new(format!("http://localhost:{builder_port}").parse().unwrap());
+        builder_api_client.connect(None).await;
 
-        let hotshot_contract = commitment_api_client
-            .get::<String>("hotshot_contract")
+        let builder_address = builder_api_client
+            .get::<String>("block_info/builderaddress")
             .send()
             .await
             .unwrap();
 
-        assert!(!hotshot_contract.is_empty());
+        assert!(!builder_address.is_empty());
 
         let tx = Transaction::new(100.into(), vec![1, 2, 3]);
 


### PR DESCRIPTION
### This PR:
- Remove the commitment task in the dev node and this will make the dev-node a better performance
- Fix the building image of dev-node

### This PR does not:
Change any other logic

### Key places to review:
Although the dev node test passes, but I am not sure about these things:
- do we need to do the `fund-builder` in the dev-node?
- is it okay to remove the `commitment-task`
