### PR TITLE
Update the CDN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "color-eyre",
- "console-subscriber",
+ "console-subscriber 0.2.0",
  "flume 0.11.0",
  "futures",
  "tokio",
@@ -1548,12 +1548,36 @@ dependencies = [
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11#f25e6a33ae79c1d3c066f76cf7fbe541ee0d5963"
+dependencies = [
+ "async-std",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11)",
+ "clap",
+ "console-subscriber 0.3.0",
+ "dashmap",
+ "derivative",
+ "jf-signature",
+ "lazy_static",
+ "local-ip-address",
+ "parking_lot",
+ "portpicker",
+ "prometheus",
+ "rand 0.8.5",
+ "rkyv",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "cdn-broker"
+version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6#569d6a6ec3ccbbd41c041a4c80bd260bc5c928ff"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "clap",
- "console-subscriber",
+ "console-subscriber 0.2.0",
  "dashmap",
  "derivative",
  "jf-signature",
@@ -1575,7 +1599,7 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6#569d6a6ec3ccbbd41c041a4c80bd260bc5c928ff"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "clap",
  "jf-signature",
  "rand 0.8.5",
@@ -1587,15 +1611,63 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6#569d6a6ec3ccbbd41c041a4c80bd260bc5c928ff"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11#f25e6a33ae79c1d3c066f76cf7fbe541ee0d5963"
 dependencies = [
  "async-std",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11)",
  "clap",
  "jf-signature",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "cdn-marshal"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6#569d6a6ec3ccbbd41c041a4c80bd260bc5c928ff"
+dependencies = [
+ "async-std",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
+ "clap",
+ "jf-signature",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "cdn-proto"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11#f25e6a33ae79c1d3c066f76cf7fbe541ee0d5963"
+dependencies = [
+ "anyhow",
+ "ark-serialize",
+ "async-trait",
+ "capnp",
+ "capnpc",
+ "derivative",
+ "jf-signature",
+ "kanal",
+ "lazy_static",
+ "mnemonic",
+ "num_enum",
+ "pem 3.0.4",
+ "prometheus",
+ "quinn 0.11.1",
+ "rand 0.8.5",
+ "rcgen 0.13.1",
+ "redis 0.25.4",
+ "rkyv",
+ "rustls 0.23.9",
+ "rustls-pki-types",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tracing",
+ "url",
+ "warp",
 ]
 
 [[package]]
@@ -1619,7 +1691,7 @@ dependencies = [
  "quinn 0.10.2",
  "rand 0.8.5",
  "rcgen 0.12.1",
- "redis",
+ "redis 0.24.0",
  "rkyv",
  "rustls 0.21.12",
  "sqlx",
@@ -1896,7 +1968,20 @@ dependencies = [
  "futures-core",
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.10.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257c22cd7e487dd4a13d413beabc512c5052f0bc048db0da6a84c3d8a6142fd"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic 0.11.0",
  "tracing-core",
 ]
 
@@ -1906,7 +1991,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
 dependencies = [
- "console-api",
+ "console-api 0.6.0",
  "crossbeam-channel",
  "crossbeam-utils",
  "futures-task",
@@ -1918,7 +2003,32 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.10.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c4cc54bae66f7d9188996404abdf7fdfa23034ef8e43478c8810828abad758"
+dependencies = [
+ "console-api 0.7.0",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.11.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.18",
@@ -4017,9 +4127,9 @@ dependencies = [
  "bimap",
  "bincode",
  "blake3",
- "cdn-broker",
+ "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "cdn-client",
- "cdn-marshal",
+ "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "chrono",
  "committable",
  "custom_debug 0.5.1",
@@ -4370,7 +4480,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bitvec",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "chrono",
  "committable",
  "either",
@@ -4454,7 +4564,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake3",
- "cdn-proto",
+ "cdn-proto 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.6)",
  "committable",
  "custom_debug 0.5.1",
  "derivative",
@@ -4651,7 +4761,7 @@ dependencies = [
  "hyper 0.14.29",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -7764,10 +7874,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem 3.0.4",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "time 0.3.36",
+ "x509-parser 0.16.0",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes 1.6.0",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite 0.2.14",
+ "ryu",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7943,7 +8089,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8567,8 +8713,8 @@ dependencies = [
  "bincode",
  "blake3",
  "bytesize",
- "cdn-broker",
- "cdn-marshal",
+ "cdn-broker 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11)",
+ "cdn-marshal 0.1.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.3.11)",
  "clap",
  "cld",
  "committable",
@@ -8602,6 +8748,7 @@ dependencies = [
  "jf-vid",
  "libp2p",
  "num-traits",
+ "num_enum",
  "portpicker",
  "pretty_assertions",
  "rand 0.8.5",
@@ -8613,6 +8760,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "snafu 0.8.3",
+ "static_assertions",
  "strum",
  "surf-disco",
  "tagged-base64",
@@ -10078,6 +10226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.9",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10098,7 +10257,7 @@ dependencies = [
  "log",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
 ]
@@ -10166,6 +10325,33 @@ name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes 1.6.0",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -11206,6 +11392,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry 0.7.0",
+ "ring 0.17.8",
  "rusticata-macros",
  "thiserror",
  "time 0.3.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,11 @@ hotshot-contract-adapter = { version = "0.1.0", path = "contracts/rust/adapter" 
 cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
   "runtime-async-std",
   "global-permits",
-], tag = "0.3.6", package = "cdn-broker" }
+], tag = "0.3.11", package = "cdn-broker" }
 cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", features = [
   "runtime-async-std",
   "global-permits",
-], tag = "0.3.6", package = "cdn-marshal" }
+], tag = "0.3.11", package = "cdn-marshal" }
 
 jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", features = [
   "test-apis",

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -84,6 +84,7 @@ jf-utils = { workspace = true } # TODO temporary: used only for test_rng()
 jf-vid = { workspace = true }
 libp2p = { version = "0.53", default-features = false } 
 num-traits = "0.2.18"
+num_enum = "0.7"
 portpicker = { workspace = true }
 rand = "0.8.5"
 rand_chacha = { workspace = true }
@@ -93,6 +94,7 @@ serde = { workspace = true }
 serde_json = "^1.0.113"
 sha2 = "0.10" # TODO temporary, used only for VID, should be set in hotshot
 snafu = { workspace = true }
+static_assertions = "1"
 strum = { workspace = true }
 surf-disco = { workspace = true }
 tagged-base64 = { workspace = true }

--- a/sequencer/src/bin/cdn-broker.rs
+++ b/sequencer/src/bin/cdn-broker.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::traits::signature_key::SignatureKey;
 use sequencer::network::cdn::{ProductionDef, WrappedSignatureKey};
+use sequencer::options::parse_size;
 use sequencer::SeqTypes;
 use sha2::Digest;
 use tracing_subscriber::EnvFilter;
@@ -72,6 +73,17 @@ struct Args {
     /// The seed for broker key generation
     #[arg(short, long, default_value_t = 0, env = "ESPRESSO_CDN_BROKER_KEY_SEED")]
     key_seed: u64,
+
+    /// The size of the global memory pool. This is the maximum number of bytes that
+    /// can be allocated at once for all connections. A connection will block if it
+    /// tries to allocate more than this amount until some memory is freed.
+    #[arg(
+        long,
+        default_value = "1GB",
+        value_parser = parse_size,
+        env = "ESPRESSO_CDN_BROKER_GLOBAL_MEMORY_POOL_SIZE"
+    )]
+    global_memory_pool_size: usize,
 }
 #[async_std::main]
 async fn main() -> Result<()> {
@@ -111,6 +123,7 @@ async fn main() -> Result<()> {
         public_advertise_endpoint: args.public_advertise_endpoint,
         private_bind_endpoint: args.private_bind_endpoint,
         private_advertise_endpoint: args.private_advertise_endpoint,
+        global_memory_pool_size: Some(args.global_memory_pool_size),
     };
 
     // Create new `Broker`

--- a/sequencer/src/bin/cdn-marshal.rs
+++ b/sequencer/src/bin/cdn-marshal.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use cdn_marshal::{Config, Marshal};
 use clap::Parser;
-use sequencer::{network::cdn::ProductionDef, SeqTypes};
+use sequencer::{network::cdn::ProductionDef, options::parse_size, SeqTypes};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
@@ -38,6 +38,17 @@ struct Args {
     /// If not provided, a local, pinned CA is used
     #[arg(long, env = "ESPRESSO_CDN_MARSHAL_CA_KEY_PATH")]
     ca_key_path: Option<String>,
+
+    /// The size of the global memory pool. This is the maximum number of bytes that
+    /// can be allocated at once for all connections. A connection will block if it
+    /// tries to allocate more than this amount until some memory is freed.
+    #[arg(
+        long,
+        default_value = "1GB",
+        value_parser = parse_size,
+        env = "ESPRESSO_CDN_MARSHAL_GLOBAL_MEMORY_POOL_SIZE"
+    )]
+    global_memory_pool_size: usize,
 }
 
 #[async_std::main]
@@ -64,6 +75,7 @@ async fn main() -> Result<()> {
         metrics_bind_endpoint: args.metrics_bind_endpoint,
         ca_cert_path: args.ca_cert_path,
         ca_key_path: args.ca_key_path,
+        global_memory_pool_size: Some(args.global_memory_pool_size),
     };
 
     // Create new `Marshal` from the config

--- a/sequencer/src/bin/dev-cdn.rs
+++ b/sequencer/src/bin/dev-cdn.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<()> {
 
         ca_cert_path: None,
         ca_key_path: None,
+        global_memory_pool_size: Some(1024 * 1024 * 1024),
     };
 
     // Configure the marshal
@@ -84,6 +85,7 @@ async fn main() -> Result<()> {
         discovery_endpoint: discovery_endpoint.clone(),
         ca_cert_path: None,
         ca_key_path: None,
+        global_memory_pool_size: Some(1024 * 1024 * 1024),
     };
 
     // Create a new `Broker`


### PR DESCRIPTION
- Improves throughput ~4x for larger (1000 node) runs by reducing contention
- Better logging
- Moves allocation pool (limiter for the the amount of total outstanding bytes not processed) to be definable during runtime
- Adds TCP+TLS support. On my local machine it's much faster (10x??) than QUIC for the scenario I tested, we may want to use it in the future. But it may be from lack of GSO support on MacOS 
- Adds latency buckets for tail latency of message received -> sent to everyone
  - Adds 30s sliding window tail latency metric

Unrelated changes:
- `Topics` didn't like being updated out of band with HotShot, so I pulled them and and added static assertions that they are equal