### PR TITLE
[Prover] Sequencer node stake table initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4339,6 +4339,7 @@ dependencies = [
  "jf-signature",
  "jf-utils",
  "rand_chacha 0.3.1",
+ "reqwest 0.12.4",
  "sequencer-utils",
  "serde",
  "snafu 0.8.3",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
     environment:
       - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
       - ESPRESSO_SEQUENCER_L1_PROVIDER
+      - ESPRESSO_SEQUENCER_URL
       - ESPRESSO_SEQUENCER_STAKE_TABLE_CAPACITY
       - ESPRESSO_DEPLOYER_ACCOUNT_INDEX
       - RUST_LOG
@@ -42,7 +43,7 @@ services:
     depends_on:
       demo-l1-network:
         condition: service_healthy
-      orchestrator:
+      sequencer0:
         condition: service_healthy
       # Make sure this doesn't start until the other contracts have been deployed, since we use the same mnemonic.
       deploy-sequencer-contracts:
@@ -185,7 +186,7 @@ services:
     environment:
       - ESPRESSO_PROVER_SERVICE_PORT
       - ESPRESSO_STATE_RELAY_SERVER_URL
-      - ESPRESSO_SEQUENCER_ORCHESTRATOR_URL
+      - ESPRESSO_SEQUENCER_URL
       - ESPRESSO_STATE_PROVER_UPDATE_INTERVAL
       - ESPRESSO_SEQUENCER_L1_PROVIDER
       - ESPRESSO_SEQUENCER_ETH_MNEMONIC
@@ -199,7 +200,7 @@ services:
       - ASYNC_STD_THREAD_COUNT
       - RAYON_NUM_THREADS
     depends_on:
-      orchestrator:
+      sequencer0:
         condition: service_healthy
       state-relay-server:
         condition: service_healthy

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
@@ -39,6 +39,7 @@ jf-rescue = { workspace = true, features = ["gadgets"] }
 jf-signature = { workspace = true, features = ["schnorr", "bls", "gadgets"] }
 jf-utils = { workspace = true }
 rand_chacha = { workspace = true }
+reqwest = { workspace = true }
 sequencer-utils = { path = "../utils" }
 serde = { workspace = true }
 snafu = { workspace = true }

--- a/hotshot-state-prover/src/bin/state-prover.rs
+++ b/hotshot-state-prover/src/bin/state-prover.rs
@@ -122,12 +122,12 @@ async fn main() {
 
     if args.daemon {
         // Launching the prover service daemon
-        if let Err(err) = run_prover_service(config, SEQUENCER_VERSION).await{
+        if let Err(err) = run_prover_service(config, SEQUENCER_VERSION).await {
             tracing::error!("Error running prover service: {:?}", err);
         };
     } else {
         // Run light client state update once
-        if let Err(err) = run_prover_once(config, SEQUENCER_VERSION).await{
+        if let Err(err) = run_prover_once(config, SEQUENCER_VERSION).await {
             tracing::error!("Error running prover once: {:?}", err);
         };
     }

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -39,7 +39,7 @@ processes:
     depends_on:
       demo-l1-network:
         condition: process_healthy
-      orchestrator:
+      sequencer0:
         condition: process_healthy
       # Make sure this doesn't start until the other contracts have been deployed, since we use the same mnemonic.
       deploy-sequencer-contracts:
@@ -92,7 +92,7 @@ processes:
       - MNEMONIC=$ESPRESSO_SEQUENCER_ETH_MNEMONIC
       - RAYON_NUM_THREADS=$PROVER_RAYON_NUM_THREADS
     depends_on:
-      orchestrator:
+      sequencer0:
         condition: process_healthy
       state-relay-server:
         condition: process_healthy

--- a/sequencer/src/bin/deploy.rs
+++ b/sequencer/src/bin/deploy.rs
@@ -34,15 +34,14 @@ struct Options {
     )]
     rpc_url: Url,
 
-    /// URL of the HotShot orchestrator.
-    ///
-    /// This is used to get the stake table for initializing the light client contract.
+    /// URL of a sequencer node that is currently providing the HotShot config.
+    /// This is used to initialize the stake table.
     #[clap(
         long,
-        env = "ESPRESSO_SEQUENCER_ORCHESTRATOR_URL",
-        default_value = "http://localhost:40001"
+        env = "ESPRESSO_SEQUENCER_URL",
+        default_value = "http://localhost:24000"
     )]
-    orchestrator_url: Url,
+    pub sequencer_url: Url,
 
     /// Mnemonic for an L1 wallet.
     ///
@@ -94,9 +93,9 @@ async fn main() -> anyhow::Result<()> {
     let opt = Options::parse();
     let contracts = Contracts::from(opt.contracts);
 
-    let orchestrator_url = opt.orchestrator_url.clone();
+    let sequencer_url = opt.sequencer_url.clone();
 
-    let genesis = light_client_genesis(&orchestrator_url, opt.stake_table_capacity).boxed();
+    let genesis = light_client_genesis(&sequencer_url, opt.stake_table_capacity).boxed();
 
     let contracts = deploy(
         opt.rpc_url,


### PR DESCRIPTION
Allows the prover to pull in the stake table from sequencer nodes running with `--` `config`. 

This makes it so that a transient failure of both the prover and orchestrator does not cause the prover to lose the stake table permanently. This would cause it to stop working entirely