### PR TITLE
[Libp2p] Bootstrap from env variable instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "hotshot-types",
  "jf-merkle-tree",
  "jf-signature",
+ "libp2p",
  "portpicker",
  "rand 0.8.5",
  "sequencer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4
   "std",
 ] }
 jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
+libp2p = { version = "0.53", default-features = false } 
 snafu = "0.8"
 strum = { version = "0.26", features = ["derive"] }
 surf-disco = "0.8"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -32,6 +32,7 @@ hotshot-state-prover = { path = "../hotshot-state-prover" }
 hotshot-types = { workspace = true }
 jf-merkle-tree = { workspace = true }
 jf-signature = { workspace = true, features = ["bls"] }
+libp2p = { workspace = true }
 portpicker = { workspace = true }
 rand = "0.8.5"
 sequencer = { path = "../sequencer", features = ["testing"] }

--- a/builder/src/bin/permissioned-builder.rs
+++ b/builder/src/bin/permissioned-builder.rs
@@ -10,6 +10,7 @@ use hotshot_types::light_client::StateSignKey;
 use hotshot_types::signature_key::BLSPrivKey;
 use hotshot_types::traits::metrics::NoMetrics;
 use hotshot_types::traits::node_implementation::ConsensusTime;
+use libp2p::Multiaddr;
 use sequencer::persistence::no_storage::NoStorage;
 use sequencer::{eth_signature_key::EthKeyPair, Genesis};
 use sequencer::{L1Params, NetworkParams};
@@ -56,6 +57,18 @@ pub struct PermissionedBuilderOptions {
         default_value = "localhost:1769"
     )]
     pub libp2p_advertise_address: String,
+
+    /// A comma-separated list of Libp2p multiaddresses to use as bootstrap
+    /// nodes.
+    ///
+    /// Overrides those loaded from the `HotShot` config.
+    #[clap(
+        long,
+        env = "ESPRESSO_SEQUENCER_LIBP2P_BOOTSTRAP_NODES",
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    pub libp2p_bootstrap_nodes: Option<Vec<Multiaddr>>,
 
     /// URL of the Light Client State Relay Server
     #[clap(
@@ -243,6 +256,7 @@ async fn main() -> anyhow::Result<()> {
         cdn_endpoint: opt.cdn_endpoint,
         libp2p_advertise_address,
         libp2p_bind_address,
+        libp2p_bootstrap_nodes: opt.libp2p_bootstrap_nodes,
         orchestrator_url: opt.orchestrator_url,
         state_relay_server_url: opt.state_relay_server_url,
         private_staking_key: private_staking_key.clone(),

--- a/data/genesis/cappuccino.toml
+++ b/data/genesis/cappuccino.toml
@@ -9,12 +9,3 @@ fee_recipient = '0x0000000000000000000000000000000000000000'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
-
-[network]
-# bootstrap_nodes = [
-#     "/ip4/127.0.0.1/udp/7003/quic-v1/p2p/12D3KooWFLKhKr61FhtdcMNR2wV4XHnceJQRFo6KKwQvwvRCRvy6",
-#     "/ip4/127.0.0.1/udp/7001/quic-v1/p2p/12D3KooWR9caJf3eqwyB3rZQX7DFUYTjM1jvXZJJxYbwhkAnPf4w",
-#     "/ip4/127.0.0.1/udp/7002/quic-v1/p2p/12D3KooWGbEJ2VsfX8KdUZgVaLYFndAxmtdScC91EritK57FbE2N",
-#     "/ip4/127.0.0.1/udp/7000/quic-v1/p2p/12D3KooWDtGECieXrqKoVxfDhU7afYnS6toj1GqWXuEDfcaGPDxa",
-#     "/ip4/127.0.0.1/udp/1769/quic-v1/p2p/12D3KooWCzRqAGWkUib7EqHgaWsJsGvKnujXSLsm4xf8u36nJKhH"
-# ]

--- a/data/genesis/demo.toml
+++ b/data/genesis/demo.toml
@@ -10,12 +10,3 @@ fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
-
-[network]
-# bootstrap_nodes = [
-#     "/ip4/127.0.0.1/udp/7003/quic-v1/p2p/12D3KooWFLKhKr61FhtdcMNR2wV4XHnceJQRFo6KKwQvwvRCRvy6",
-#     "/ip4/127.0.0.1/udp/7001/quic-v1/p2p/12D3KooWR9caJf3eqwyB3rZQX7DFUYTjM1jvXZJJxYbwhkAnPf4w",
-#     "/ip4/127.0.0.1/udp/7002/quic-v1/p2p/12D3KooWGbEJ2VsfX8KdUZgVaLYFndAxmtdScC91EritK57FbE2N",
-#     "/ip4/127.0.0.1/udp/7000/quic-v1/p2p/12D3KooWDtGECieXrqKoVxfDhU7afYnS6toj1GqWXuEDfcaGPDxa",
-#     "/ip4/127.0.0.1/udp/1769/quic-v1/p2p/12D3KooWCzRqAGWkUib7EqHgaWsJsGvKnujXSLsm4xf8u36nJKhH"
-# ]

--- a/data/genesis/staging.toml
+++ b/data/genesis/staging.toml
@@ -9,12 +9,3 @@ fee_recipient = '0x0000000000000000000000000000000000000000'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
-
-[network]
-# bootstrap_nodes = [
-#     "/ip4/127.0.0.1/udp/7003/quic-v1/p2p/12D3KooWFLKhKr61FhtdcMNR2wV4XHnceJQRFo6KKwQvwvRCRvy6",
-#     "/ip4/127.0.0.1/udp/7001/quic-v1/p2p/12D3KooWR9caJf3eqwyB3rZQX7DFUYTjM1jvXZJJxYbwhkAnPf4w",
-#     "/ip4/127.0.0.1/udp/7002/quic-v1/p2p/12D3KooWGbEJ2VsfX8KdUZgVaLYFndAxmtdScC91EritK57FbE2N",
-#     "/ip4/127.0.0.1/udp/7000/quic-v1/p2p/12D3KooWDtGECieXrqKoVxfDhU7afYnS6toj1GqWXuEDfcaGPDxa",
-#     "/ip4/127.0.0.1/udp/1769/quic-v1/p2p/12D3KooWCzRqAGWkUib7EqHgaWsJsGvKnujXSLsm4xf8u36nJKhH"
-# ]

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -84,7 +84,7 @@ jf-rescue = { workspace = true }
 jf-signature = { workspace = true, features = ["bls", "schnorr"] }
 jf-utils = { workspace = true } # TODO temporary: used only for test_rng()
 jf-vid = { workspace = true }
-libp2p = { version = "0.53", default-features = false } 
+libp2p = { workspace = true } 
 num-traits = "0.2.18"
 portpicker = { workspace = true }
 rand = "0.8.5"

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -1,6 +1,5 @@
 use crate::{
     l1_client::L1BlockInfo,
-    network::GenesisNetworkConfig,
     state::{FeeAccount, FeeAmount},
     ChainConfig,
 };
@@ -99,7 +98,6 @@ pub struct Genesis {
     pub accounts: HashMap<FeeAccount, FeeAmount>,
     pub l1_finalized: Option<L1Finalized>,
     pub header: GenesisHeader,
-    pub network: Option<GenesisNetworkConfig>,
 }
 
 impl Genesis {

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -77,6 +77,7 @@ where
         cdn_endpoint: opt.cdn_endpoint,
         libp2p_advertise_address,
         libp2p_bind_address,
+        libp2p_bootstrap_nodes: opt.libp2p_bootstrap_nodes,
         orchestrator_url: opt.orchestrator_url,
         state_relay_server_url: opt.state_relay_server_url,
         private_staking_key,
@@ -194,7 +195,6 @@ mod test {
             accounts: Default::default(),
             l1_finalized: Default::default(),
             header: Default::default(),
-            network: Default::default(),
         };
         genesis.to_file(&genesis_file).unwrap();
 

--- a/sequencer/src/network/libp2p.rs
+++ b/sequencer/src/network/libp2p.rs
@@ -1,38 +1,14 @@
 use anyhow::Result;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
-use serde::{Deserialize, Serialize};
 
-/// A bootstrap node. Contains the multiaddress and peer ID
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(try_from = "Multiaddr", into = "Multiaddr")]
-pub struct BootstrapNode {
-    pub address: Multiaddr,
-    pub peer_id: PeerId,
-}
+/// Split off the peer ID from a multiaddress, returning the shortened address and the peer ID.
+///
+/// # Errors
+/// - If the last protocol in the address is not a peer ID.
+pub fn split_off_peer_id(mut address: Multiaddr) -> Result<(PeerId, Multiaddr)> {
+    let Some(Protocol::P2p(peer_id)) = address.pop() else {
+        return Err(anyhow::anyhow!("Failed to parse peer ID from address"));
+    };
 
-impl From<BootstrapNode> for Multiaddr {
-    fn from(node: BootstrapNode) -> Self {
-        let mut address = node.address;
-
-        // The standard is to have the peer ID as the last part of the address
-        address.push(Protocol::P2p(node.peer_id));
-
-        address
-    }
-}
-
-impl TryFrom<Multiaddr> for BootstrapNode {
-    type Error = anyhow::Error;
-
-    fn try_from(address: Multiaddr) -> Result<Self> {
-        // Clone the address so we can pop the peer ID off the end
-        let mut address = address.clone();
-
-        // The standard is to have the peer ID as the last part of the address
-        let Some(Protocol::P2p(peer_id)) = address.pop() else {
-            return Err(anyhow::anyhow!("Failed to parse peer ID from address"));
-        };
-
-        Ok(BootstrapNode { address, peer_id })
-    }
+    Ok((peer_id, address))
 }

--- a/sequencer/src/network/mod.rs
+++ b/sequencer/src/network/mod.rs
@@ -1,46 +1,9 @@
-use anyhow::Result;
 use hotshot_types::message::Message;
-use libp2p::BootstrapNode;
-use persistence::NetworkConfig;
 
 use super::*;
 
 pub mod cdn;
 pub mod libp2p;
-
-/// The genesis network configuration. Overrides what is received from the orchestrator
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GenesisNetworkConfig {
-    /// An optional list of bootstrap nodes (multiaddress and peer ID) to connect to
-    pub bootstrap_nodes: Option<Vec<BootstrapNode>>,
-}
-
-impl GenesisNetworkConfig {
-    /// Update the HotShot config with the genesis network config
-    pub fn populate_config(&self, config: &mut NetworkConfig) -> Result<()> {
-        // Attempt to populate the bootstrap nodes if present
-        if let Some(bootstrap_nodes) = &self.bootstrap_nodes {
-            // Make sure Libp2p is configured if we have supplied bootstrap nodes
-            let Some(ref mut libp2p_config) = config.libp2p_config else {
-                return Err(anyhow::anyhow!(
-                    "Bootstrap nodes supplied but no libp2p configuration found"
-                ));
-            };
-
-            // Replace the bootstrap nodes with the ones from the file
-            libp2p_config.bootstrap_nodes = bootstrap_nodes
-                .iter()
-                .cloned()
-                .map(|node| {
-                    let BootstrapNode { address, peer_id } = node;
-                    (peer_id, address)
-                })
-                .collect();
-        }
-
-        Ok(())
-    }
-}
 
 pub trait Type: 'static {
     type DAChannel: ConnectedNetwork<Message<SeqTypes>, PubKey>;

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -8,6 +8,7 @@ use derivative::Derivative;
 use derive_more::From;
 use hotshot_types::light_client::StateSignKey;
 use hotshot_types::signature_key::BLSPrivKey;
+use libp2p::Multiaddr;
 use snafu::Snafu;
 use std::{
     collections::{HashMap, HashSet},
@@ -77,6 +78,18 @@ pub struct Options {
         default_value = "localhost:1769"
     )]
     pub libp2p_advertise_address: String,
+
+    /// A comma-separated list of Libp2p multiaddresses to use as bootstrap
+    /// nodes.
+    ///
+    /// Overrides those loaded from the `HotShot` config.
+    #[clap(
+        long,
+        env = "ESPRESSO_SEQUENCER_LIBP2P_BOOTSTRAP_NODES",
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    pub libp2p_bootstrap_nodes: Option<Vec<Multiaddr>>,
 
     /// URL of the Light Client State Relay Server
     #[clap(


### PR DESCRIPTION
No linked issue.

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
- Removes the ability to load bootstrap nodes from a genesis (`.toml`) file
- Adds the ability to load bootstrap nodes from an env variable/command line argument. Requires a comma separated list of multiaddresses

### Things tested:
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->
- [x] Able to parse DNS multiaddress
- [x] Is not able to bootstrap Libp2p when an unroutable multiaddress is supplied
- [x] Does not start when any invalid addresses are supplied 
- [x] Demo runs with a nonzero amount of correct, routable addresses