### PR TITLE
Implement BidTx

### DIFF
--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -146,9 +146,6 @@ impl Committable for BidTxBody {
 
 impl Default for BidTxBody {
     fn default() -> Self {
-        let message = ";)";
-        let mut commitment = [0u8; 32];
-        commitment[..message.len()].copy_from_slice(message.as_bytes());
         let key = FeeAccount::test_key_pair();
         let nsid = NamespaceId::from(999);
         Self {
@@ -166,7 +163,7 @@ impl Default for BidTx {
     fn default() -> Self {
         let body = BidTxBody::default();
         let commitment = body.commit();
-        let (account, key) = FeeAccount::generated_from_seed_indexed([0; 32], 0);
+        let key = FeeAccount::test_key_pair();
         let signature = FeeAccount::sign_builder_message(&key, commitment.as_ref()).unwrap();
         Self { signature, body }
     }
@@ -205,7 +202,7 @@ impl BidTx {
         Ok(())
     }
     // fn charge(&self) {}
-    /// Verify signature
+    /// Cryptographic signature verification
     fn verify(&self) -> Result<(), ExecutionError> {
         if !self
             .body
@@ -249,7 +246,7 @@ mod test {
     use super::*;
 
     impl BidTx {
-        fn mock(account: FeeAccount, key: EthKeyPair) -> Self {
+        fn mock(key: EthKeyPair) -> Self {
             let body = BidTxBody::default();
             let commitment = body.commit();
             let signature = FeeAccount::sign_builder_message(&key, commitment.as_ref()).unwrap();
@@ -259,13 +256,9 @@ mod test {
 
     #[test]
     fn test_default_bidtx_body() {
-        let a = FeeAccount::default();
-
         let message = ";)";
         let mut commitment = [0u8; 32];
         commitment[..message.len()].copy_from_slice(message.as_bytes());
-        let key = FeeAccount::generated_from_seed_indexed([0; 32], 0).1;
-        let signature = FeeAccount::sign_builder_message(&key, &commitment).unwrap();
         let bid = BidTxBody::default();
         dbg!(&bid);
     }
@@ -277,8 +270,7 @@ mod test {
     #[test]
     fn test_sign_and_verify_mock_bid() {
         let key = FeeAccount::test_key_pair();
-        let account = key.fee_account();
-        let bidtx = BidTx::mock(account, key);
+        let bidtx = BidTx::mock(key);
         bidtx.verify().unwrap();
     }
 }

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -200,7 +200,7 @@ impl BidTx {
         self.verify()
             .map_err(|e| (e, FullNetworkTx::Bid(self.clone())))?;
 
-        // self.charge().map_err;
+        // TODO do we still do this in JIT auction?
         store_in_marketplace_state();
 
         // TODO what do we return in good result?
@@ -221,21 +221,13 @@ impl BidTx {
     }
 }
 
+// TODO I'm not sure how phases will work in JIT
 pub fn get_phase() -> AuctionPhaseKind {
     AuctionPhaseKind::Bid
 }
 
 fn store_in_marketplace_state() {
     unimplemented!();
-}
-
-// Seems like sequencer could just check for refund flags on events so
-// we probably don't need an explicit transaction type.
-struct BidRefundTx {
-    nonce: Nonce,
-    // I don't think we need the list b/c we have them in state
-    // txns_to_refund: Vec<BidTx>,
-    signature: Signature,
 }
 
 /// Nonce for special (auction) transactions

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 use url::Url;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+// This is here to fill in for something I don't understand yet.
 struct SequencerKey;
 
 // for MVP-0(-1) (JIT)
@@ -104,7 +105,7 @@ pub struct BidTxBody {
     /// The bid amount designated in Wei.  This is different than
     /// the sequencing fee (gas price) for this transaction
     bid_amount: FeeAmount,
-    // TODO What is the correct type?
+    // TODO What is the correct type? What do we use this for?
     /// The public key of this sequencer
     public_key: SequencerKey,
     /// The URL the HotShot leader will use to request a bundle
@@ -139,7 +140,7 @@ impl BidTxBody {
     pub fn sign(&self, key: &EthKeyPair) -> Result<Signature, SigningError> {
         FeeAccount::sign_builder_message(key, self.commit().as_ref())
     }
-    /// Get account responsible for bid
+    /// Get account submitting the bid
     pub fn account(&self) -> FeeAccount {
         self.account
     }
@@ -167,9 +168,8 @@ impl Default for BidTxBody {
 impl Default for BidTx {
     fn default() -> Self {
         let body = BidTxBody::default();
-        let commitment = body.commit();
         let key = FeeAccount::test_key_pair();
-        let signature = FeeAccount::sign_builder_message(&key, commitment.as_ref()).unwrap();
+        let signature = FeeAccount::sign_builder_message(&key, body.commit().as_ref()).unwrap();
         Self { signature, body }
     }
 }

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -129,11 +129,7 @@ impl Committable for BidTxBody {
             .fixed_size_field("bid_amount", &self.bid_amount.to_fixed_bytes())
             .var_size_field("url", self.url.as_str().as_ref())
             .u64_field("slot", self.slot.0)
-            .var_size_field(
-                "bundle",
-                // TODO what is the correct way to serialize `Vec<NamespaceId>`
-                &bincode::serialize(&self.bundle.as_slice()).unwrap(),
-            );
+            .var_size_field("bundle", &bincode::serialize(&self.bundle).unwrap());
         comm.finalize()
     }
 }

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -230,23 +230,6 @@ fn store_in_marketplace_state() {
     unimplemented!();
 }
 
-enum ExecutionResult<T, E, K> {
-    Ok(T),
-    Err(E, K),
-}
-
-// enum ExecutionResult {
-//     Bid(String),
-// }
-
-/// A solution to one auction of sequencing rights for namespaces
-struct AuctionResultTx {
-    auction: AuctionId,
-    nonce: Nonce,
-    winners: Vec<BidTx>,
-    signature: Signature,
-}
-
 // Seems like sequencer could just check for refund flags on events so
 // we probably don't need an explicit transaction type.
 struct BidRefundTx {

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -149,11 +149,11 @@ impl Default for BidTxBody {
         let message = ";)";
         let mut commitment = [0u8; 32];
         commitment[..message.len()].copy_from_slice(message.as_bytes());
-        let (account, key) = FeeAccount::generated_from_seed_indexed([0; 32], 0);
+        let key = FeeAccount::test_key_pair();
         let nsid = NamespaceId::from(999);
         Self {
             url: Url::from_str("htts://sequencer:3939/request_budle").unwrap(),
-            account,
+            account: key.fee_account(),
             public_key: SequencerKey,
             gas_price: FeeAmount::default(),
             bid_amount: FeeAmount::default(),
@@ -276,8 +276,8 @@ mod test {
     }
     #[test]
     fn test_sign_and_verify_mock_bid() {
-        let account = FeeAccount::default();
-        let key = FeeAccount::generated_from_seed_indexed([0; 32], 0).1;
+        let key = FeeAccount::test_key_pair();
+        let account = key.fee_account();
         let bidtx = BidTx::mock(account, key);
         bidtx.verify().unwrap();
     }

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -14,8 +14,6 @@ use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Hash)]
-pub struct Slot(u64);
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
 /// Wrapper enum for Full Network Transactions. Each transaction type
 /// will be a variant of this enum.

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -7,7 +7,10 @@ use committable::{Commitment, Committable};
 use ethers::types::Signature;
 use hotshot_types::{
     data::ViewNumber,
-    traits::{node_implementation::ConsensusTime, signature_key::BuilderSignatureKey},
+    traits::{
+        auction_results_provider::HasUrl, node_implementation::ConsensusTime,
+        signature_key::BuilderSignatureKey,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -120,10 +123,6 @@ impl BidTxBody {
     /// Update `url` field on a previously instantiated `BidTxBody`.
     pub fn with_url(self, url: Url) -> Self {
         Self { url, ..self }
-    }
-    /// Get the `url` field.
-    pub fn url(&self) -> Url {
-        self.url.clone()
     }
 }
 
@@ -238,10 +237,6 @@ impl BidTx {
         let body = self.body.with_url(url);
         Self { body, ..self }
     }
-    /// Get the `url` field from the body
-    pub fn url(&self) -> Url {
-        self.body.url()
-    }
     /// get gas price
     pub fn gas_price(&self) -> FeeAmount {
         self.body.gas_price
@@ -253,6 +248,20 @@ impl BidTx {
     /// get bid amount
     pub fn account(&self) -> FeeAccount {
         self.body.account
+    }
+}
+
+impl HasUrl for BidTx {
+    /// Get the `url` field from the body.
+    fn url(&self) -> Url {
+        self.body.url()
+    }
+}
+
+impl HasUrl for BidTxBody {
+    /// Get the cloned `url` field.
+    fn url(&self) -> Url {
+        self.url.clone()
     }
 }
 

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -92,6 +92,14 @@ impl BidTxBody {
     pub fn amount(&self) -> FeeAmount {
         self.bid_amount
     }
+    /// Update `url` field on a previously instantiated `BidTxBody`.
+    pub fn with_url(self, url: Url) -> Self {
+        Self { url, ..self }
+    }
+    /// Get the `url` field.
+    pub fn url(&self) -> Url {
+        self.url.clone()
+    }
 }
 
 impl Default for BidTxBody {
@@ -128,7 +136,7 @@ pub enum ExecutionError {
     InvalidPhase,
     #[error("FeeError: {0}")]
     FeeError(FeeError),
-    #[error("Could not resolve ChainConfig")]
+    #[error("Could not resolve `ChainConfig`")]
     UnresolvableChainConfig,
 }
 
@@ -189,6 +197,15 @@ impl BidTx {
     /// Return the body of the transaction
     pub fn body(self) -> BidTxBody {
         self.body
+    }
+    /// Update `url` field on a previously instantiated `BidTxBody`.
+    pub fn with_url(self, url: Url) -> Self {
+        let body = self.body.with_url(url);
+        Self { body, ..self }
+    }
+    /// Get the `url` field from the body
+    pub fn url(&self) -> Url {
+        self.body.url()
     }
 }
 

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -1,6 +1,42 @@
-use crate::{state::FeeAmount, NamespaceId};
-use hotshot_types::data::ViewNumber;
-use std::num::NonZeroU64;
+use crate::{
+    eth_signature_key::EthKeyPair,
+    state::{FeeAccount, FeeAmount},
+    NamespaceId, Transaction, ValidatedState,
+};
+use ark_serialize::CanonicalSerialize;
+use committable::{Commitment, Committable};
+use derivative::Derivative;
+use ethers::types::Signature;
+use hotshot::types::SignatureKey;
+use hotshot_types::{data::ViewNumber, traits::signature_key::BuilderSignatureKey};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroU64,
+    str::FromStr,
+};
+use url::Url;
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+struct SequencerKey;
+
+// for MVP-0(-1) (JIT)
+// Sum of all sequencing fee match current check
+// builder signature no longer includes payload
+// new fee info flag (fee or bid)
+
+pub struct MarketplaceResults {
+    /// Slot these results are for
+    slot: Slot,
+    /// Bids that did not win, intially all bids are added to this,
+    /// and then the winning bids are removed
+    pending_bids: Vec<BidTx>,
+    /// Map of winning sequencer public keys to the bundle of namespaces they bid for
+    winner_map: HashMap<SequencerKey, HashSet<NamespaceId>>,
+    /// Whether refunds have been processed for this slot
+    refunds_processed: bool,
+}
 
 // - needs to be configured in genesis block
 // - needs to be updatable
@@ -12,12 +48,15 @@ struct AuctionConfig {
 }
 
 /// Uniquely identifies an auction for sequencing rights of namespaces in the network
+#[derive(Clone, Copy)]
 struct AuctionId(u64);
 
 /// Uniquely identifies one auction phase for a specific auction
+#[derive(Clone, Copy)]
 struct AuctionPhaseId(AuctionId, AuctionPhaseKind);
 
 /// Describes one auction phase for a specific auction
+#[derive(Clone, Copy)]
 struct AuctionPhase {
     id: AuctionPhaseId,
     kind: AuctionPhaseKind,
@@ -26,22 +65,179 @@ struct AuctionPhase {
 }
 
 /// Describes the 3 kinds of phases an active auction can be in
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum AuctionPhaseKind {
     Bid,
     Assign,
     Sequence,
 }
 
-struct Signature;
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Hash)]
+pub struct Slot(u64);
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+pub enum FullNetworkTx {
+    Bid(BidTx),
+}
 
-/// A transaction to bid for the sequencing rights of a namespace
+impl FullNetworkTx {
+    pub fn execute(&self, state: &ValidatedState) -> Result<(), (ExecutionError, FullNetworkTx)> {
+        dbg!("execute");
+        match self {
+            Self::Bid(bid) => bid.execute(state),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
 struct BidTx {
-    auction: AuctionId,
-    amount: FeeAmount,
-    namespace: NamespaceId,
-    nonce: Nonce,
+    body: BidTxBody,
     signature: Signature,
 }
+
+/// A transaction to bid for the sequencing rights of a namespace
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+struct BidTxBody {
+    /// Account responsible for the signature
+    account: FeeAccount,
+    /// Fee to be sequenced in the network.  Different than the bid_amount fee
+    // FULL_NETWORK_GAS * MINIMUM_GAS_PRICE
+    gas_price: FeeAmount,
+    /// The bid amount designated in Wei.  This is different than
+    /// the sequencing fee (gas price) for this transaction
+    bid_amount: FeeAmount,
+    // TODO What is the correct type?
+    /// The public key of this sequencer
+    public_key: SequencerKey,
+    /// The URL the HotShot leader will use to request a bundle
+    /// from this sequencer if they win the auction
+    url: Url,
+    /// The slot this bid is for
+    slot: Slot,
+    /// The set of namespace ids the sequencer is bidding for
+    bundle: Vec<NamespaceId>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+struct ShortBidTx {
+    signature: Signature,
+    /// Account responsible for the signature
+    account: FeeAccount,
+    url: Url,
+}
+
+// TODO consider a committable derive macro
+impl Committable for BidTxBody {
+    fn tag() -> String {
+        "BID_TX".to_string()
+    }
+
+    fn commit(&self) -> Commitment<Self> {
+        let comm = committable::RawCommitmentBuilder::new(&Self::tag())
+            .fixed_size_field("account", &self.account.to_fixed_bytes())
+            .fixed_size_field("gas_price", &self.gas_price.to_fixed_bytes())
+            .fixed_size_field("bid_amount", &self.bid_amount.to_fixed_bytes())
+            .var_size_field("url", self.url.as_str().as_ref())
+            .u64_field("slot", self.slot.0)
+            .var_size_field(
+                "bundle",
+                // TODO what is the correct way to serialize `Vec<NamespaceId>`
+                &bincode::serialize(&self.bundle.as_slice()).unwrap(),
+            );
+        comm.finalize()
+    }
+}
+
+impl Default for BidTxBody {
+    fn default() -> Self {
+        let message = ";)";
+        let mut commitment = [0u8; 32];
+        commitment[..message.len()].copy_from_slice(message.as_bytes());
+        let (account, key) = FeeAccount::generated_from_seed_indexed([0; 32], 0);
+        let nsid = NamespaceId::from(999);
+        Self {
+            url: Url::from_str("htts://sequencer:3939/request_budle").unwrap(),
+            account,
+            public_key: SequencerKey,
+            gas_price: FeeAmount::default(),
+            bid_amount: FeeAmount::default(),
+            slot: Slot::default(),
+            bundle: vec![nsid],
+        }
+    }
+}
+impl Default for BidTx {
+    fn default() -> Self {
+        let body = BidTxBody::default();
+        let commitment = body.commit();
+        let (account, key) = FeeAccount::generated_from_seed_indexed([0; 32], 0);
+        let signature = FeeAccount::sign_builder_message(&key, &commitment.as_ref()).unwrap();
+        Self { signature, body }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+pub enum ExecutionError {
+    InvalidSignature,
+    InvalidPhase,
+}
+
+// TODO consider moving common functionality to trait.
+impl BidTx {
+    /// Executes `BidTx`.
+    /// * verify signature
+    /// * charge fee
+    /// * store state
+    // The rational behind the `Err` is to provide not only what
+    // failed, but for which varient. The entire Tx is probably
+    // overkill, but we can narrow down how much we want to know about
+    // Failed Tx in the future. Maybe we just want its name.
+    pub fn execute(&self, state: &ValidatedState) -> Result<(), (ExecutionError, FullNetworkTx)> {
+        if get_phase() != AuctionPhaseKind::Bid {
+            return Err((
+                ExecutionError::InvalidPhase,
+                FullNetworkTx::Bid(self.clone()),
+            ));
+        }
+        self.verify()
+            .map_err(|e| (e, FullNetworkTx::Bid(self.clone())))?;
+
+        // self.charge().map_err;
+        store_in_marketplace_state();
+
+        // TODO what do we return in good result?
+        Ok(())
+    }
+    // fn charge(&self) {}
+    /// Verify signature
+    fn verify(&self) -> Result<(), ExecutionError> {
+        if !self
+            .body
+            .account
+            .validate_builder_signature(&self.signature, self.body.commit().as_ref())
+        {
+            return Err(ExecutionError::InvalidSignature);
+        };
+
+        Ok(())
+    }
+}
+
+pub fn get_phase() -> AuctionPhaseKind {
+    AuctionPhaseKind::Bid
+}
+
+fn store_in_marketplace_state() {
+    unimplemented!();
+}
+
+enum ExecutionResult<T, E, K> {
+    Ok(T),
+    Err(E, K),
+}
+
+// enum ExecutionResult {
+//     Bid(String),
+// }
 
 /// A solution to one auction of sequencing rights for namespaces
 struct AuctionResultTx {
@@ -51,12 +247,58 @@ struct AuctionResultTx {
     signature: Signature,
 }
 
-// Not sure if needed
+// Seems like sequencer could just check for refund flags on events so
+// we probably don't need an explicit transaction type.
 struct BidRefundTx {
     nonce: Nonce,
-    txns_to_refund: Vec<BidTx>,
+    // I don't think we need the list b/c we have them in state
+    // txns_to_refund: Vec<BidTx>,
     signature: Signature,
 }
 
 /// Nonce for special (auction) transactions
 struct Nonce(u64);
+
+pub fn mock_full_network_txs() -> Vec<FullNetworkTx> {
+    let x = FullNetworkTx::Bid(BidTx::default());
+    dbg!(&x);
+    vec![x]
+}
+
+mod test {
+    use super::*;
+
+    impl BidTx {
+        fn mock(account: FeeAccount, key: EthKeyPair) -> Self {
+            let body = BidTxBody::default();
+            let commitment = body.commit();
+            let signature = FeeAccount::sign_builder_message(&key, commitment.as_ref()).unwrap();
+            Self { signature, body }
+        }
+    }
+
+    #[test]
+    fn test_default_bidtx_body() {
+        let a = FeeAccount::default();
+
+        let message = ";)";
+        let mut commitment = [0u8; 32];
+        commitment[..message.len()].copy_from_slice(message.as_bytes());
+        let key = FeeAccount::generated_from_seed_indexed([0; 32], 0).1;
+        let signature = FeeAccount::sign_builder_message(&key, &commitment).unwrap();
+        let bid = BidTxBody::default();
+        dbg!(&bid);
+    }
+    #[test]
+    fn test_mock_full_network_txs() {
+        let x = mock_full_network_txs();
+        dbg!(&x);
+    }
+    #[test]
+    fn test_sign_and_verify_mock_bid() {
+        let account = FeeAccount::default();
+        let key = FeeAccount::generated_from_seed_indexed([0; 32], 0).1;
+        let bidtx = BidTx::mock(account, key);
+        bidtx.verify().unwrap();
+    }
+}

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -1,15 +1,12 @@
 use crate::{
     eth_signature_key::EthKeyPair,
     state::{FeeAccount, FeeAmount},
-    NamespaceId, Transaction, ValidatedState,
+    NamespaceId, ValidatedState,
 };
-use ark_serialize::CanonicalSerialize;
 use committable::{Commitment, Committable};
-use derivative::Derivative;
 use ethers::types::Signature;
 use hotshot::types::SignatureKey;
 use hotshot_types::{data::ViewNumber, traits::signature_key::BuilderSignatureKey};
-use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -170,7 +167,7 @@ impl Default for BidTx {
         let body = BidTxBody::default();
         let commitment = body.commit();
         let (account, key) = FeeAccount::generated_from_seed_indexed([0; 32], 0);
-        let signature = FeeAccount::sign_builder_message(&key, &commitment.as_ref()).unwrap();
+        let signature = FeeAccount::sign_builder_message(&key, commitment.as_ref()).unwrap();
         Self { signature, body }
     }
 }

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -264,10 +264,6 @@ pub fn mock_full_network_txs(key: Option<EthKeyPair>) -> Vec<FullNetworkTx> {
 }
 
 mod test {
-    use ethers::core::k256::ecdsa::SigningKey;
-
-    use crate::genesis;
-
     use super::*;
 
     impl BidTx {

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -27,7 +27,7 @@ struct SequencerKey;
 pub struct MarketplaceResults {
     /// Slot these results are for
     slot: Slot,
-    /// Bids that did not win, intially all bids are added to this,
+    /// Bids that did not win, initially all bids are added to this,
     /// and then the winning bids are removed
     pending_bids: Vec<BidTx>,
     /// Map of winning sequencer public keys to the bundle of namespaces they bid for
@@ -73,6 +73,8 @@ enum AuctionPhaseKind {
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Hash)]
 pub struct Slot(u64);
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, Hash)]
+/// Wrapper enum for Full Network Transactions. Each transaction type
+/// will be a variant of this enum.
 pub enum FullNetworkTx {
     Bid(BidTx),
 }
@@ -200,7 +202,7 @@ impl BidTx {
     /// * charge fee
     /// * store state (maybe not for JIT)
     // The rational behind the `Err` is to provide not only what
-    // failed, but for which varient. The entire Tx is probably
+    // failed, but for which variant. The entire Tx is probably
     // overkill, but we can narrow down how much we want to know about
     // Failed Tx in the future. Maybe we just want its name.
     pub fn execute(
@@ -230,7 +232,7 @@ impl BidTx {
     /// Charge Bid. Only winning bids are charged in JIT (I think).
     fn charge(&self, state: &mut ValidatedState) -> Result<(), ExecutionError> {
         // As the code is currently organized, I think chain_config
-        // will always be resolved here. But lets guard against the
+        // will always be resolved here. But let's guard against the
         // error in case code is shifted around in the future.
         if let Some(chain_config) = state.chain_config.resolve() {
             let recipient = chain_config.bid_recipient;

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -1,0 +1,62 @@
+use crate::{state::FeeAmount, NamespaceId};
+use hotshot_types::data::ViewNumber;
+use std::num::NonZeroU64;
+
+// - needs to be configured in genesis block
+// - needs to be updatable
+/// Configuration for the auction system
+struct AuctionConfig {
+    bid_phase_num_views: NonZeroU64,
+    auction_phase_num_views: NonZeroU64,
+    sequencing_phase_num_views: NonZeroU64,
+}
+
+/// Uniquely identifies an auction for sequencing rights of namespaces in the network
+struct AuctionId(u64);
+
+/// Uniquely identifies one auction phase for a specific auction
+struct AuctionPhaseId(AuctionId, AuctionPhaseKind);
+
+/// Describes one auction phase for a specific auction
+struct AuctionPhase {
+    id: AuctionPhaseId,
+    kind: AuctionPhaseKind,
+    start: ViewNumber,
+    end: ViewNumber,
+}
+
+/// Describes the 3 kinds of phases an active auction can be in
+enum AuctionPhaseKind {
+    Bid,
+    Assign,
+    Sequence,
+}
+
+struct Signature;
+
+/// A transaction to bid for the sequencing rights of a namespace
+struct BidTx {
+    auction: AuctionId,
+    amount: FeeAmount,
+    namespace: NamespaceId,
+    nonce: Nonce,
+    signature: Signature,
+}
+
+/// A solution to one auction of sequencing rights for namespaces
+struct AuctionResultTx {
+    auction: AuctionId,
+    nonce: Nonce,
+    winners: Vec<BidTx>,
+    signature: Signature,
+}
+
+// Not sure if needed
+struct BidRefundTx {
+    nonce: Nonce,
+    txns_to_refund: Vec<BidTx>,
+    signature: Signature,
+}
+
+/// Nonce for special (auction) transactions
+struct Nonce(u64);

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -224,7 +224,7 @@ impl BidTx {
             .map_err(|e| (e, FullNetworkTx::Bid(self.clone())))?;
 
         // TODO do we still do this in JIT auction?
-        store_in_marketplace_state();
+        // store_in_marketplace_state();
 
         // TODO what do we return in good result?
         Ok(())
@@ -269,33 +269,22 @@ fn store_in_marketplace_state() {
 /// Nonce for special (auction) transactions
 struct Nonce(u64);
 
-pub fn mock_full_network_txs() -> Vec<FullNetworkTx> {
-    let x = FullNetworkTx::Bid(BidTx::default());
-    dbg!(&x);
-    vec![x]
+pub fn mock_full_network_txs(key: Option<EthKeyPair>) -> Vec<FullNetworkTx> {
+    // if no key is supplied, use `test_key_pair`. Since default `BidTxBody` is
+    // signed with `test_key_pair`, it will verify successfully
+    let key = key.unwrap_or_else(FeeAccount::test_key_pair);
+    vec![FullNetworkTx::Bid(BidTx::mock(key))]
 }
 
 mod test {
     use super::*;
 
     impl BidTx {
-        fn mock(key: EthKeyPair) -> Self {
+        pub fn mock(key: EthKeyPair) -> Self {
             let body = BidTxBody::default();
             let signature = body.sign(&key).unwrap();
             Self { signature, body }
         }
-    }
-
-    #[test]
-    fn test_default_bidtx_body() {
-        let bid = BidTxBody::default();
-        dbg!(&bid);
-    }
-
-    #[test]
-    fn test_mock_full_network_txs() {
-        let x = mock_full_network_txs();
-        dbg!(&x);
     }
 
     #[test]

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -252,7 +252,7 @@ impl BidTx {
     }
     /// get bid amount
     pub fn account(&self) -> FeeAccount {
-        self.body.account()
+        self.body.account
     }
 }
 

--- a/sequencer/src/auction.rs
+++ b/sequencer/src/auction.rs
@@ -10,11 +10,7 @@ use hotshot_types::{
     traits::{node_implementation::ConsensusTime, signature_key::BuilderSignatureKey},
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    num::NonZeroU64,
-    str::FromStr,
-};
+use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
 
@@ -79,7 +75,7 @@ impl Committable for BidTxBody {
             .fixed_size_field("gas_price", &self.gas_price.to_fixed_bytes())
             .fixed_size_field("bid_amount", &self.bid_amount.to_fixed_bytes())
             .var_size_field("url", self.url.as_str().as_ref())
-            .u64_field("slot", self.slot.0)
+            .u64_field("view", self.view.u64())
             .var_size_field("bundle", &bincode::serialize(&self.bundle).unwrap());
         comm.finalize()
     }

--- a/sequencer/src/chain_config.rs
+++ b/sequencer/src/chain_config.rs
@@ -110,6 +110,9 @@ pub struct ChainConfig {
     /// regardless of whether or not their is a `fee_contract` deployed. Once deployed, the fee
     /// contract can decide what to do with tokens locked in this account in Espresso.
     pub fee_recipient: FeeAccount,
+
+    /// Account that receives sequencing bids.
+    pub bid_recipient: FeeAccount,
 }
 
 impl Default for ChainConfig {
@@ -120,6 +123,7 @@ impl Default for ChainConfig {
             base_fee: 0.into(),
             fee_contract: None,
             fee_recipient: Default::default(),
+            bid_recipient: Default::default(),
         }
     }
 }

--- a/sequencer/src/eth_signature_key.rs
+++ b/sequencer/src/eth_signature_key.rs
@@ -47,6 +47,9 @@ impl EthKeyPair {
         let signing_key: &SigningKey = derived_priv_key.as_ref();
         Ok(signing_key.clone().into())
     }
+    pub fn random() -> EthKeyPair {
+        SigningKey::random(&mut rand::thread_rng()).into()
+    }
 
     pub fn fee_account(&self) -> FeeAccount {
         self.fee_account

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -276,6 +276,7 @@ mod test {
                 max_block_size: 30000.into(),
                 base_fee: 1.into(),
                 fee_recipient: FeeAccount::default(),
+                bid_recipient: FeeAccount::default(),
                 fee_contract: Some(Address::default())
             }
         );
@@ -340,6 +341,7 @@ mod test {
                 max_block_size: 30000.into(),
                 base_fee: 1.into(),
                 fee_recipient: FeeAccount::default(),
+                bid_recipient: FeeAccount::default(),
                 fee_contract: None,
             }
         );

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    auction::{mock_full_network_txs, FullNetworkTx, Slot},
+    auction::{mock_full_network_txs, FullNetworkTx},
     block::NsTable,
     chain_config::ResolvableChainConfig,
     eth_signature_key::BuilderSignature,
@@ -144,9 +144,6 @@ impl Header {
     pub fn get_full_network_txs(&self) -> Vec<FullNetworkTx> {
         // TODO unmock
         mock_full_network_txs(None)
-    }
-    pub fn get_refund_bids(&self) -> HashSet<Slot> {
-        unimplemented!();
     }
     #[allow(clippy::too_many_arguments)]
     fn from_info(

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -144,7 +144,7 @@ impl Header {
     // TODO move to BlockHeader
     pub fn get_full_network_txs(&self) -> Vec<FullNetworkTx> {
         // TODO unmock
-        mock_full_network_txs()
+        mock_full_network_txs(None)
     }
     pub fn get_refund_bids(&self) -> HashSet<Slot> {
         unimplemented!();

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -102,7 +102,6 @@ pub struct Header {
     // /// refund flag set at the beginning of new slots
     // /// In extreme cases, more than one slot may need to be refunded,
     // /// hence this data structure
-    // pub refund_bids: HashSet<Slot>,
 }
 
 impl Committable for Header {

--- a/sequencer/src/header.rs
+++ b/sequencer/src/header.rs
@@ -1,4 +1,7 @@
+use std::collections::HashSet;
+
 use crate::{
+    auction::{mock_full_network_txs, FullNetworkTx, Slot},
     block::NsTable,
     chain_config::ResolvableChainConfig,
     eth_signature_key::BuilderSignature,
@@ -95,6 +98,11 @@ pub struct Header {
     /// that `fee_info` is correct without relying on the signature. Thus, this signature is not
     /// included in the header commitment.
     pub builder_signature: Option<BuilderSignature>,
+    // pub full_network_txs: Vec<FullNetworkTx>,
+    // /// refund flag set at the beginning of new slots
+    // /// In extreme cases, more than one slot may need to be refunded,
+    // /// hence this data structure
+    // pub refund_bids: HashSet<Slot>,
 }
 
 impl Committable for Header {
@@ -133,6 +141,14 @@ impl Committable for Header {
 }
 
 impl Header {
+    // TODO move to BlockHeader
+    pub fn get_full_network_txs(&self) -> Vec<FullNetworkTx> {
+        // TODO unmock
+        mock_full_network_txs()
+    }
+    pub fn get_refund_bids(&self) -> HashSet<Slot> {
+        unimplemented!();
+    }
     #[allow(clippy::too_many_arguments)]
     fn from_info(
         payload_commitment: VidCommitment,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod auction;
 pub mod block;
 pub mod catchup;
 mod chain_config;

--- a/sequencer/src/reference_tests.rs
+++ b/sequencer/src/reference_tests.rs
@@ -90,6 +90,7 @@ fn reference_chain_config() -> ChainConfig {
         base_fee: 0.into(),
         fee_contract: Some(Default::default()),
         fee_recipient: Default::default(),
+        bid_recipient: Default::default(),
     }
 }
 

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -82,9 +82,6 @@ pub struct ValidatedState {
     /// Fee Merkle Tree
     pub fee_merkle_tree: FeeMerkleTree,
     pub chain_config: ResolvableChainConfig,
-    // TODO
-    // /// Map of Marketplace Results.
-    // slot_map: HashMap<Slot, MarketplaceResults>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -1672,8 +1672,14 @@ mod test {
     #[test]
     fn test_apply_full_tx() {
         let mut state = ValidatedState::default();
-        let txs = mock_full_network_txs();
-        let (err, bid) = apply_full_transactions(&mut state, txs).unwrap_err();
+        let txs = mock_full_network_txs(None);
+        // default key can be verified. The same signed by mock tx
+        apply_full_transactions(&mut state, txs).unwrap();
+
+        // should be a different key than that generated in the mock
+        let key = FeeAccount::generated_from_seed_indexed([1; 32], 0).1;
+        let invalid = mock_full_network_txs(Some(key));
+        let (err, _) = apply_full_transactions(&mut state, invalid).unwrap_err();
         assert_eq!(ExecutionError::InvalidSignature, err);
     }
 

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::data_source::CatchupDataSource,
     block::{NsTableValidationError, PayloadByteLen},
-    auction::{ExecutionError, FullNetworkTx, MarketplaceResults, Slot},
+    auction::{ExecutionError, FullNetworkTx},
     catchup::SqlStateCatchup,
     chain_config::BlockSize,
     chain_config::ResolvableChainConfig,
@@ -59,7 +59,7 @@ use sequencer_utils::{
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use std::{collections::HashMap, sync::Arc};
+use std::{sync::Arc};
 use std::{collections::HashSet, ops::Add, str::FromStr};
 use thiserror::Error;
 use vbs::version::Version;

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -1673,10 +1673,11 @@ mod test {
     fn test_apply_full_tx() {
         let mut state = ValidatedState::default();
         let txs = mock_full_network_txs(None);
-        // default key can be verified. The same signed by mock tx
+        // Default key can be verified b/c it is the same that signs the mock tx
         apply_full_transactions(&mut state, txs).unwrap();
 
-        // should be a different key than that generated in the mock
+        // Tx will be invalid if it is signed by a different key than
+        // set in `account` field.
         let key = FeeAccount::generated_from_seed_indexed([1; 32], 0).1;
         let invalid = mock_full_network_txs(Some(key));
         let (err, _) = apply_full_transactions(&mut state, invalid).unwrap_err();


### PR DESCRIPTION
### This PR:
This PR itroduces `FullNetworkTx` by way of a single enum variant, `BidTx`. To meet upcoming goals we only need `BidTx` but having it nested in long term structure may be helpful. There is a tiny bit of test coverage to ensure a moderate degree of santity.

This is a DRAFT and exists for collaboration and to gather feedback.

### Key places to review:
 Most of the juicy bits are in `auction.rs`. `Header` in `header.rs` has been given some useful methods (mocks for now) and validation logic in `state.rs` has been updated to execute the transaction. None of the logic is complete or refined, but it more or less covers the *breadth* of requirements for the first iteration of `BidTx`. 

### How to test this PR: 
Tests are currently testing, you can run `cargo test` if you like.

### Things tested
There is currently a test for verifying signature of a mock `BidTx`.
