### PR TITLE
Resolves Docker Compose Warning

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 networks:
   default:
     name: espresso-sequencer
@@ -81,11 +79,11 @@ services:
       - RUST_LOG_FORMAT
       - ASYNC_STD_THREAD_COUNT
 
-  # We use KeyDB (a Redis variant) to maintain consistency between 
+  # We use KeyDB (a Redis variant) to maintain consistency between
   # different parts of the CDN
   keydb:
     image: docker.io/eqalpha/keydb:latest
-    command: [ "--requirepass", "changemeplease!!" ]
+    command: ["--requirepass", "changemeplease!!"]
     healthcheck:
       # Attempt to PING the database
       test: keydb-cli --pass changemeplease!! --raw incr PING


### PR DESCRIPTION
### This PR:
Resolves the following warning thrown by `docker-compose`: WARN[0000] docker-compose.yml: `version` is obsolete. See warning details [here](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md)

### This PR does not:
Does not change dockerfile functionality

### Key places to review:
docker-compose.yaml

<!-- Complete the following items before creating this PR -->
<!-- [x] Issue linked or PR description mentions why this change is necessary. -->
<!-- [x] PR description is clear enough for reviewers. -->
<!-- [x] Documentation for changes (additions) has been updated (added).  -->
<!-- [x] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
