### PR TITLE
Add anvil and postgres to dev-node image

### DIFF
--- a/docker/espresso-dev-node.Dockerfile
+++ b/docker/espresso-dev-node.Dockerfile
@@ -14,6 +14,12 @@ RUN curl -LO https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0
 COPY target/$TARGETARCH/release/espresso-dev-node /bin/espresso-dev-node
 RUN chmod +x /bin/espresso-dev-node
 
+# Download the anvil binary
+RUN curl -L https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_${TARGETARCH}.tar.gz --output -| tar -xzvf - -C /bin/ anvil
+
+COPY scripts/launch-dev-node-with-postgres /bin/launch-dev-node-with-postgres
+RUN chmod +x /bin/launch-dev-node-with-postgres
+
 # When running as a Docker service, we always want a healthcheck endpoint, so set a default for the
 # port that the HTTP server will run on. This can be overridden in any given deployment environment.
 ENV ESPRESSO_SEQUENCER_API_PORT=8770
@@ -23,4 +29,4 @@ EXPOSE 8770
 EXPOSE 8771
 EXPOSE 8772
 
-CMD [ "/bin/espresso-dev-node"]
+CMD [ "/bin/launch-dev-node-with-postgres"]

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -40,6 +40,9 @@ for ARCH in "amd64" "arm64"; do
   done
 done
 
+mkdir -p ${WORKDIR}/docker/scripts
+cp -v docker/scripts/sequencer-awssecretsmanager.sh ${WORKDIR}/docker/scripts
+
 # Copy the dev-node launch script
 mkdir -p ${WORKDIR}/scripts
 cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}/scripts

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -38,14 +38,11 @@ for ARCH in "amd64" "arm64"; do
   for binary in "orchestrator" "cdn-broker" "cdn-marshal" "cdn-whitelist" "sequencer" "commitment-task" "submit-transactions" "reset-storage" "state-relay-server" "state-prover" "deploy" "keygen" "permissionless-builder" "nasty-client" "pub-key" "espresso-bridge" "espresso-dev-node"; do
     cp -v "${CARGO_TARGET_DIR}/${TARGET}/release/$binary" ${WORKDIR}/target/$ARCH/release
   done
-
-  # Download the latest foundry binary and extract anvil for the dev-node docker image.
-  curl -L https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_${ARCH}.tar.gz -o ${WORKDIR}/foundry.tar.gz
-  tar -xzvf ${WORKDIR}/foundry.tar.gz -C ${WORKDIR}/target/$ARCH/release anvil
 done
 
 # Copy the dev-node launch script
-cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}
+mkdir -p ${WORKDIR}/scripts
+cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}/scripts
 
 export DOCKER_BUILDKIT=1
 docker build -t ghcr.io/espressosystems/espresso-sequencer/orchestrator:main -f docker/orchestrator.Dockerfile ${WORKDIR}

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -95,6 +95,9 @@ for binary in "orchestrator" "cdn-broker" "cdn-marshal" "cdn-whitelist" "sequenc
   fi
 done
 
+mkdir -p ${WORKDIR}/docker/scripts
+cp -v docker/scripts/sequencer-awssecretsmanager.sh ${WORKDIR}/docker/scripts
+
 # Copy the dev-node launch script
 mkdir -p ${WORKDIR}/scripts
 cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}/scripts

--- a/scripts/build-docker-images-native
+++ b/scripts/build-docker-images-native
@@ -96,12 +96,8 @@ for binary in "orchestrator" "cdn-broker" "cdn-marshal" "cdn-whitelist" "sequenc
 done
 
 # Copy the dev-node launch script
-cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}
-
-# Download the latest foundry binary and extract anvil for the dev-node docker image.
-curl -L https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_${ARCH}.tar.gz -o ${WORKDIR}/foundry.tar.gz
-tar -xzvf ${WORKDIR}/foundry.tar.gz -C ${WORKDIR}/target/$ARCH/release anvil
-
+mkdir -p ${WORKDIR}/scripts
+cp -v scripts/launch-dev-node-with-postgres ${WORKDIR}/scripts
 
 export DOCKER_BUILDKIT=1
 docker build --platform $PLATFORM -t ghcr.io/espressosystems/espresso-sequencer/orchestrator:main -f docker/orchestrator.Dockerfile ${WORKDIR}


### PR DESCRIPTION
Closes #1616 

### This PR:
- Download the anvil binary in the `espresso-dev-node.Dockerfile`. It is more convenient based on that we hardly need a pinned `anvil`.
- Use the existing script to run the `postgres`
- Fix the `build-docker-images-native.sh`

### How to test this PR:
Run this command locally
```cmd
./scritps/build-docker-images-native
```
And in this action https://github.com/EspressoSystems/espresso-sequencer/actions/runs/9935660410,
this docker image can be run without setting L1 url and postgres options
