### PR TITLE
Add the espresso-dev-node server

### DIFF
--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -409,7 +409,14 @@ pub async fn run_prover_service<Ver: StaticVersionType + 'static>(
             .await
             .with_context(|| "Failed to initialize stake table")?,
     );
+    run_prover_service_with_stake_table(config, bind_version, st).await
+}
 
+pub async fn run_prover_service_with_stake_table<Ver: StaticVersionType + 'static>(
+    config: StateProverConfig,
+    bind_version: Ver,
+    st: Arc<StakeTable<BLSPubKey, StateVerKey, CircuitField>>,
+) -> Result<()> {
     tracing::info!("Light client address: {:?}", config.light_client_address);
     let relay_server_client =
         Arc::new(Client::<ServerError, Ver>::new(config.relay_server.clone()));
@@ -422,7 +429,7 @@ pub async fn run_prover_service<Ver: StaticVersionType + 'static>(
     }
 
     let proving_key =
-        spawn_blocking(move || Arc::new(load_proving_key(stake_table_capacity))).await;
+        spawn_blocking(move || Arc::new(load_proving_key(config.stake_table_capacity))).await;
 
     let update_interval = config.update_interval;
     let retry_interval = config.retry_interval;

--- a/sequencer/api/espresso_dev_node.toml
+++ b/sequencer/api/espresso_dev_node.toml
@@ -1,0 +1,29 @@
+[meta]
+NAME = "espresso_dev_node_server"
+DESCRIPTION = "A server for debugging and developing with the espresso dev node"
+FORMAT_VERSION = "0.1.0"
+
+[route.devinfo]
+PATH = ["/dev-info"]
+DOC = """
+Get the debug info
+"""
+
+[route.freeze]
+PATH = ["mock-contract/freeze/:height"]
+":height" = "Integer"
+DOC = """
+Freeze the L1 height in the light client contract.
+
+By doing this, the L1 height in the light contract will be frozen and rollups will detect
+the HotShot failure. This is intended to be used when testing the rollups' functionalities.
+"""
+
+[route.unfreeze]
+PATH = ["mock-contract/unfreeze"]
+DOC = """
+Unfreeze the L1 height in the light client contract.
+
+This is intended to be used when `freeze` has been called previously. By unfreezing the L1 height,
+rollups will detect the reactivity of HotShot.
+"""

--- a/sequencer/api/espresso_dev_node.toml
+++ b/sequencer/api/espresso_dev_node.toml
@@ -7,22 +7,39 @@ FORMAT_VERSION = "0.1.0"
 PATH = ["/dev-info"]
 DOC = """
 Get the debug info
+
+Returns
+```
+{
+    "builder_url": string,
+    "prover_port": integer,
+    "l1_url": string,
+    "light_client_address:" address,
+}
+```
 """
 
-[route.freeze]
-PATH = ["mock-contract/freeze/:height"]
-":height" = "Integer"
+[route.sethotshotdown]
+PATH = ["set-hotshot-down"]
+METHOD = "POST"
 DOC = """
-Freeze the L1 height in the light client contract.
+Set the hotshot down since the given L1 height.
 
+Body:
+```
+{
+    "height": integer,
+}
+```
 By doing this, the L1 height in the light contract will be frozen and rollups will detect
 the HotShot failure. This is intended to be used when testing the rollups' functionalities.
 """
 
-[route.unfreeze]
-PATH = ["mock-contract/unfreeze"]
+[route.sethotshotup]
+PATH = ["set-hotshot-up"]
+METHOD = "POST"
 DOC = """
-Unfreeze the L1 height in the light client contract.
+Set the hotshot up in the light client contract.
 
 This is intended to be used when `freeze` has been called previously. By unfreezing the L1 height,
 rollups will detect the reactivity of HotShot.

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -1,16 +1,19 @@
-use std::{sync::Arc, time::Duration};
+use std::{io, sync::Arc, time::Duration};
 
 use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
-use async_std::task::{sleep, spawn, spawn_blocking};
+use async_std::task::spawn;
 use clap::Parser;
-use es_version::{SequencerVersion, SEQUENCER_VERSION};
+use contract_bindings::light_client_mock::LightClientMock;
+use es_version::SEQUENCER_VERSION;
 use ethers::{
+    middleware::{MiddlewareBuilder, SignerMiddleware},
     providers::{Http, Middleware, Provider},
     signers::{coins_bip39::English, MnemonicBuilder, Signer},
+    types::{Address, U256},
 };
 use futures::FutureExt;
 use hotshot_state_prover::service::{
-    load_proving_key, one_honest_threshold, sync_state, StateProverConfig,
+    one_honest_threshold, run_prover_service_with_stake_table, StateProverConfig,
 };
 use hotshot_types::traits::stake_table::{SnapshotVersion, StakeTableScheme};
 use portpicker::pick_unused_port;
@@ -27,9 +30,10 @@ use sequencer_utils::{
     deployer::{deploy, Contract, Contracts},
     AnvilOptions,
 };
-use surf_disco::Client;
-use tide_disco::error::ServerError;
+use serde::{Deserialize, Serialize};
+use tide_disco::{error::ServerError, Api, Error as _, StatusCode};
 use url::Url;
+use vbs::version::StaticVersionType;
 
 #[derive(Clone, Debug, Parser)]
 struct Args {
@@ -68,6 +72,16 @@ struct Args {
     /// Port for connecting to the builder.
     #[clap(short, long, env = "ESPRESSO_BUILDER_PORT")]
     builder_port: Option<u16>,
+
+    /// Port for connecting to the prover.
+    #[clap(short, long, env = "ESPRESSO_PROVER_PORT")]
+    prover_port: Option<u16>,
+
+    /// Port for the dev node.
+    ///
+    /// This is used to provide tools and information to facilitate developers debugging.
+    #[clap(short, long, env = "ESPRESSO_DEV_NODE_PORT", default_value = "20000")]
+    dev_node_port: u16,
 
     #[clap(flatten)]
     sql: persistence::sql::Options,
@@ -148,52 +162,130 @@ async fn main() -> anyhow::Result<()> {
         SEQUENCER_VERSION,
     ));
 
-    // Run the prover service. These code are basically from `hotshot-state-prover`. The difference
-    // is that here we don't need to fetch the `stake table` from other entities.
-    // TODO: Remove the redundant code.
-    let proving_key =
-        spawn_blocking(move || Arc::new(load_proving_key(STAKE_TABLE_CAPACITY_FOR_TEST as usize)))
-            .await;
-    let relay_server_client =
-        Client::<ServerError, SequencerVersion>::new(relay_server_url.clone());
-
-    let provider = Provider::<Http>::try_from(url.to_string()).unwrap();
+    let provider = Provider::<Http>::try_from(url.as_str()).unwrap();
     let chain_id = provider.get_chainid().await.unwrap().as_u64();
+
+    let wallet = MnemonicBuilder::<English>::default()
+        .phrase(cli_params.mnemonic.as_str())
+        .index(cli_params.account_index)
+        .expect("error building wallet")
+        .build()
+        .expect("error opening wallet")
+        .with_chain_id(chain_id);
 
     let update_interval = Duration::from_secs(20);
     let retry_interval = Duration::from_secs(2);
+    let prover_port = cli_params
+        .prover_port
+        .unwrap_or(pick_unused_port().unwrap());
+    let light_client_address = contracts
+        .get_contract_address(Contract::LightClientProxy)
+        .unwrap();
     let config = StateProverConfig {
         relay_server: relay_server_url,
         update_interval,
         retry_interval,
-        l1_provider: url,
-        light_client_address: contracts
-            .get_contract_address(Contract::LightClientProxy)
-            .unwrap(),
-        eth_signing_key: MnemonicBuilder::<English>::default()
-            .phrase(cli_params.mnemonic.as_str())
-            .index(cli_params.account_index)
-            .expect("error building wallet")
-            .build()
-            .expect("error opening wallet")
-            .with_chain_id(chain_id)
-            .signer()
-            .clone(),
+        l1_provider: url.clone(),
+        light_client_address,
+        eth_signing_key: wallet.signer().clone(),
         sequencer_url: "http://localhost".parse().unwrap(), // This should not be used in dev-node
-        port: None,
+        port: Some(prover_port),
         stake_table_capacity: STAKE_TABLE_CAPACITY_FOR_TEST as usize,
     };
 
-    loop {
-        if let Err(err) = sync_state(&st, proving_key.clone(), &relay_server_client, &config).await
-        {
-            tracing::error!("Cannot sync the light client state, will retry: {}", err);
-            sleep(retry_interval).await;
-        } else {
-            tracing::info!("Sleeping for {:?}", update_interval);
-            sleep(update_interval).await;
+    spawn(run_prover_service_with_stake_table(
+        config,
+        SEQUENCER_VERSION,
+        Arc::new(st),
+    ));
+
+    let dev_info = DevInfo {
+        builder_url: network.cfg.hotshot_config().builder_urls[0].clone(),
+        prover_port,
+        l1_url: url,
+        light_client_address,
+    };
+
+    let mock_contract =
+        LightClientMock::new(light_client_address, Arc::new(provider.with_signer(wallet)));
+
+    run_dev_node_server(
+        cli_params.dev_node_port,
+        mock_contract,
+        dev_info,
+        SEQUENCER_VERSION,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn run_dev_node_server<Ver: StaticVersionType + 'static, S: Signer + Clone + 'static>(
+    port: u16,
+    mock_contract: LightClientMock<SignerMiddleware<Provider<Http>, S>>,
+    dev_info: DevInfo,
+    bind_version: Ver,
+) -> anyhow::Result<()> {
+    let mut app = tide_disco::App::<(), ServerError>::with_state(());
+    let toml =
+        toml::from_str::<toml::value::Value>(include_str!("../../api/espresso_dev_node.toml"))
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    let mut api = Api::<(), ServerError, Ver>::new(toml)
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    api.get("devinfo", move |_, _| {
+        let info = dev_info.clone();
+        async move { Ok(info.clone()) }.boxed()
+    })
+    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    let contract = mock_contract.clone();
+    api.get("freeze", move |req, _| {
+        let contract = contract.clone();
+        async move {
+            let height: u64 = req
+                .integer_param("height")
+                .map_err(ServerError::from_request_error)?;
+            contract
+                .set_hot_shot_down_since(U256::from(height))
+                .send()
+                .await
+                .map_err(|err| ServerError::catch_all(StatusCode::FORBIDDEN, err.to_string()))?;
+            Ok(())
         }
-    }
+        .boxed()
+    })
+    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    api.get("unfreeze", move |_, _| {
+        let contract = mock_contract.clone();
+        async move {
+            contract
+                .set_hot_shot_up()
+                .send()
+                .await
+                .map_err(|err| ServerError::catch_all(StatusCode::FORBIDDEN, err.to_string()))?;
+            Ok(())
+        }
+        .boxed()
+    })
+    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    app.register_module("api", api)
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+    app.serve(format!("0.0.0.0:{port}"), bind_version).await?;
+
+    Ok(())
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct DevInfo {
+    pub builder_url: Url,
+    pub prover_port: u16,
+    pub l1_url: Url,
+    pub light_client_address: Address,
 }
 
 #[cfg(test)]
@@ -220,6 +312,8 @@ mod tests {
     use surf_disco::Client;
     use tide_disco::error::ServerError;
 
+    use crate::DevInfo;
+
     const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
 
     pub struct BackgroundProcess(Child);
@@ -244,6 +338,8 @@ mod tests {
 
         let api_port = pick_unused_port().unwrap();
 
+        let dev_node_port = pick_unused_port().unwrap();
+
         let instance = AnvilOptions::default().spawn().await;
         let l1_url = instance.url();
 
@@ -263,6 +359,7 @@ mod tests {
             .env("ESPRESSO_SEQUENCER_POSTGRES_HOST", "localhost")
             .env("ESPRESSO_SEQUENCER_ETH_MNEMONIC", TEST_MNEMONIC)
             .env("ESPRESSO_DEPLOYER_ACCOUNT_INDEX", "0")
+            .env("ESPRESSO_DEV_NODE_PORT", dev_node_port.to_string())
             .env(
                 "ESPRESSO_SEQUENCER_POSTGRES_PORT",
                 postgres_port.to_string(),
@@ -393,6 +490,31 @@ mod tests {
             {
                 sleep(Duration::from_secs(3)).await;
             }
+        }
+
+        let dev_node_client: Client<ServerError, SequencerVersion> =
+            Client::new(format!("http://localhost:{dev_node_port}").parse().unwrap());
+        dev_node_client.connect(None).await;
+
+        // Check the dev node api
+        {
+            dev_node_client
+                .get::<DevInfo>("api/dev-info")
+                .send()
+                .await
+                .unwrap();
+
+            dev_node_client
+                .get::<()>("api/mock-contract/freeze/3")
+                .send()
+                .await
+                .unwrap();
+
+            dev_node_client
+                .get::<()>("api/mock-contract/unfreeze")
+                .send()
+                .await
+                .unwrap();
         }
 
         drop(db);


### PR DESCRIPTION
Closes #1679 

### This PR:
- Expose the prover port
- Run a server for
    - returning debug information to users
    - providing endpoints for users setting the hotshot up/down

This would be helpful in these cases:
- Sometimes users run the `dev-node` without specifying the ports or urls. `/api/dev-info` shows the urls or ports that are being used. That will be helpful when they are going to debug or report the bugs to us
- Easily setting the hotshot is down/up without constructing transactions.

### Key places to review:
`espresso-dev-node.rs` and the toml file.