### PR TITLE
Allow nodes to fetch network config from peers

### DIFF
--- a/builder/src/bin/permissioned-builder.rs
+++ b/builder/src/bin/permissioned-builder.rs
@@ -255,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
         private_staking_key: private_staking_key.clone(),
         private_state_key,
         state_peers: opt.state_peers,
+        config_peers: None,
         catchup_backoff: Default::default(),
     };
 

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1699,6 +1699,7 @@ mod test {
         let mut config = peers.fetch_config(validator.clone()).await;
 
         // Check the node-specific information in the recovered config is correct.
+        assert_eq!(config.node_index, 1);
         assert_eq!(
             config.config.my_own_validator_config.public_key,
             validator.public_key

--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -20,13 +20,12 @@ use hotshot::{
 };
 use hotshot_events_service::events_source::{EventConsumer, EventsStreamer};
 use hotshot_example_types::auction_results_provider_types::TestAuctionResultsProvider;
-use hotshot_orchestrator::client::OrchestratorClient;
+use hotshot_orchestrator::{client::OrchestratorClient, config::NetworkConfig};
 use hotshot_query_service::Leaf;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
     data::ViewNumber,
     traits::{election::Membership, metrics::Metrics, network::ConnectedNetwork},
-    HotShotConfig,
 };
 use url::Url;
 use vbs::version::StaticVersionType;
@@ -63,6 +62,8 @@ pub struct SequencerContext<
     detached: bool,
 
     node_state: NodeState,
+
+    config: NetworkConfig<PubKey>,
 }
 
 impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionType + 'static>
@@ -71,7 +72,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
     #[tracing::instrument(skip_all, fields(node_id = instance_state.node_id))]
     #[allow(clippy::too_many_arguments)]
     pub async fn init(
-        config: HotShotConfig<PubKey>,
+        network_config: NetworkConfig<PubKey>,
         instance_state: NodeState,
         persistence: P,
         network: Arc<N>,
@@ -80,6 +81,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
         stake_table_capacity: u64,
         _: Ver,
     ) -> anyhow::Result<Self> {
+        let config = &network_config.config;
         let pub_key = config.my_own_validator_config.public_key;
         tracing::info!(%pub_key, "initializing consensus");
 
@@ -131,7 +133,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
             config.my_own_validator_config.public_key,
             config.my_own_validator_config.private_key.clone(),
             instance_state.node_id,
-            config,
+            config.clone(),
             memberships,
             network,
             initializer,
@@ -153,6 +155,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
             state_signer,
             event_streamer,
             instance_state,
+            network_config,
         ))
     }
 
@@ -163,6 +166,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
         state_signer: StateSigner<Ver>,
         event_streamer: Arc<RwLock<EventsStreamer<SeqTypes>>>,
         node_state: NodeState,
+        config: NetworkConfig<PubKey>,
     ) -> Self {
         let events = handle.event_stream();
 
@@ -174,6 +178,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
             wait_for_orchestrator: None,
             events_streamer: event_streamer.clone(),
             node_state,
+            config,
         };
         ctx.spawn(
             "main event handler",
@@ -284,6 +289,10 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, Ver: StaticVersionTyp
     pub fn detach(&mut self) {
         // Set `detached` so the drop handler doesn't call `shut_down`.
         self.detached = true;
+    }
+
+    pub fn config(&self) -> NetworkConfig<PubKey> {
+        self.config.clone()
     }
 }
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -182,6 +182,13 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
             tracing::info!(?peers, "loading network config from peers");
             let peers = StatePeers::<Ver>::from_urls(peers, network_params.catchup_backoff);
             let config = peers.fetch_config(my_config.clone()).await;
+
+            tracing::info!(
+                node_id = config.node_index,
+                stake_table = ?config.config.known_nodes_with_stake,
+                "loaded config",
+            );
+            persistence.save_config(&config).await?;
             (config, false)
         }
         // Otherwise, this is a fresh network; load from the orchestrator.

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -328,7 +328,7 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
     };
 
     let mut ctx = SequencerContext::init(
-        config.config,
+        config,
         instance_state,
         persistence,
         network,
@@ -659,7 +659,12 @@ pub mod testing {
                 "starting node",
             );
             SequencerContext::init(
-                config,
+                NetworkConfig {
+                    config,
+                    // For testing, we use a fake network, so the rest of the network config beyond
+                    // the base consensus config does not matter.
+                    ..Default::default()
+                },
                 node_state,
                 persistence_opt.create().await.unwrap(),
                 network,

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -102,6 +102,7 @@ pub struct NetworkParams {
     pub private_staking_key: BLSPrivKey,
     pub private_state_key: StateSignKey,
     pub state_peers: Vec<Url>,
+    pub config_peers: Option<Vec<Url>>,
     pub catchup_backoff: BackoffParams,
 
     /// The address to send to other Libp2p nodes to contact us
@@ -168,12 +169,23 @@ pub async fn init_node<P: PersistenceOptions, Ver: StaticVersionType + 'static>(
             .with_context(|| "Failed to derive Libp2p peer ID")?;
 
     let mut persistence = persistence_opt.clone().create().await?;
-    let (mut config, wait_for_orchestrator) = match persistence.load_config().await? {
-        Some(config) => {
+    let (mut config, wait_for_orchestrator) = match (
+        persistence.load_config().await?,
+        network_params.config_peers,
+    ) {
+        (Some(config), _) => {
             tracing::info!("loaded network config from storage, rejoining existing network");
             (config, false)
         }
-        None => {
+        // If we were told to fetch the config from an already-started peer, do so.
+        (None, Some(peers)) => {
+            tracing::info!(?peers, "loading network config from peers");
+            let peers = StatePeers::<Ver>::from_urls(peers, network_params.catchup_backoff);
+            let config = peers.fetch_config(my_config.clone()).await;
+            (config, false)
+        }
+        // Otherwise, this is a fresh network; load from the orchestrator.
+        (None, None) => {
             tracing::info!("loading network config from orchestrator");
             tracing::error!(
                 "waiting for other nodes to connect, DO NOT RESTART until fully connected"

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -83,6 +83,7 @@ where
         private_staking_key,
         private_state_key,
         state_peers: opt.state_peers,
+        config_peers: opt.config_peers,
         catchup_backoff: opt.catchup_backoff,
     };
 

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -188,6 +188,16 @@ pub struct Options {
     #[derivative(Debug(format_with = "fmt_urls"))]
     pub state_peers: Vec<Url>,
 
+    /// Peer nodes use to fetch missing config
+    ///
+    /// Typically, the network-wide config is fetched from the orchestrator on startup and then
+    /// persisted and loaded from local storage each time the node restarts. However, if the
+    /// persisted config is missing when the node restarts (for example, the node is being migrated
+    /// to new persistent storage), it can instead be fetched directly from a peer.
+    #[clap(long, env = "ESPRESSO_SEQUENCER_CONFIG_PEERS", value_delimiter = ',')]
+    #[derivative(Debug(format_with = "fmt_opt_urls"))]
+    pub config_peers: Option<Vec<Url>>,
+
     /// Exponential backoff for fetching missing state from peers.
     #[clap(flatten)]
     pub catchup_backoff: BackoffParams,
@@ -228,6 +238,23 @@ fn fmt_urls(v: &[Url], fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Er
         "{:?}",
         v.iter().map(|i| i.to_string()).collect::<Vec<_>>()
     )
+}
+
+fn fmt_opt_urls(
+    v: &Option<Vec<Url>>,
+    fmt: &mut std::fmt::Formatter,
+) -> Result<(), std::fmt::Error> {
+    match v {
+        Some(urls) => {
+            write!(fmt, "Some(")?;
+            fmt_urls(urls, fmt)?;
+            write!(fmt, ")")?;
+        }
+        None => {
+            write!(fmt, "None")?;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, Snafu)]


### PR DESCRIPTION
This allows nodes to fetch the network config from the `config` API of another node, instead of/in addition to local storage and the orchestrator. This could be useful when a node in an existing network is migrating to new storage, or when storage has been lost. In particular, Kudasai is currently not running their Cappuccino nodes because (for reasons still unknown) they lost their persisted network config, and now have no way of getting it back since the orchestrator is already shut down.

### This PR:
* Adds a `PublicNetworkConfig` which wraps a `PublicHotShotConfig`
* Has the `config/hotshot` endpoint return the network config instead of just the HotShot config, which is strictly more information
* Adds functions to convert a `PublicNetworkConfig` to a proper `NetworkConfig` based on a given set of private keys
* Adds configuration logic to fetch the network config from a peer on startup

### This PR does not:
* Fix any issues with the network config being lost from persistent storage

### Key places to review:
* New config serialization in `api/data_source.rs`
* Configuration logic in `lib.rs`
