### PR TITLE
use max base fee in builder

### DIFF
--- a/builder/src/bin/permissionless-builder.rs
+++ b/builder/src/bin/permissionless-builder.rs
@@ -4,13 +4,14 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use builder::non_permissioned::{build_instance_state, BuilderConfig};
 use clap::Parser;
 use cld::ClDuration;
-use es_version::SEQUENCER_VERSION;
-use espresso_types::eth_signature_key::EthKeyPair;
+use espresso_types::{eth_signature_key::EthKeyPair, SeqTypes};
 use hotshot::traits::ValidatedState;
+use hotshot_builder_core::testing::basic_test::NodeType;
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 use sequencer::{Genesis, L1Params};
 use snafu::Snafu;
 use url::Url;
+use vbs::version::StaticVersionType;
 
 #[derive(Parser, Clone, Debug)]
 struct NonPermissionedBuilderOptions {
@@ -106,8 +107,6 @@ async fn main() -> anyhow::Result<()> {
     let opt = NonPermissionedBuilderOptions::parse();
     let genesis = Genesis::from_file(&opt.genesis_file)?;
 
-    let sequencer_version = SEQUENCER_VERSION;
-
     let l1_params = L1Params {
         url: opt.l1_provider_url,
         events_max_block_range: 10000,
@@ -122,9 +121,11 @@ async fn main() -> anyhow::Result<()> {
         genesis.chain_config,
         l1_params,
         opt.state_peers,
-        sequencer_version,
+        <SeqTypes as NodeType>::Base::instance(),
     )
     .unwrap();
+
+    let base_fee = genesis.max_base_fee();
 
     let validated_state = ValidatedState::genesis(&instance_state).0;
 
@@ -148,6 +149,7 @@ async fn main() -> anyhow::Result<()> {
         api_response_timeout_duration,
         buffer_view_num_count,
         txn_timeout_duration,
+        base_fee,
     )
     .await;
 

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -574,6 +574,7 @@ pub mod testing {
                 Duration::from_millis(2000),
                 15,
                 Duration::from_millis(500),
+                ChainConfig::default().base_fee,
             )
             .await
             .unwrap();
@@ -640,6 +641,7 @@ pub mod testing {
                 Duration::from_millis(2000),
                 15,
                 Duration::from_millis(500),
+                ChainConfig::default().base_fee,
             )
             .await
             .unwrap();

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -10,7 +10,7 @@ use async_compatibility_layer::{
 };
 use async_std::sync::{Arc, RwLock};
 use espresso_types::{
-    eth_signature_key::EthKeyPair, ChainConfig, L1Client, NodeState, Payload, SeqTypes,
+    eth_signature_key::EthKeyPair, ChainConfig, FeeAmount, L1Client, NodeState, Payload, SeqTypes,
     ValidatedState,
 };
 use ethers::{
@@ -94,6 +94,7 @@ impl BuilderConfig {
         max_api_timeout_duration: Duration,
         buffered_view_num_count: usize,
         maximize_txns_count_timeout_duration: Duration,
+        base_fee: FeeAmount,
     ) -> anyhow::Result<Self> {
         tracing::info!(
             address = %builder_key_pair.fee_account(),
@@ -168,9 +169,7 @@ impl BuilderConfig {
             global_state_clone,
             node_count,
             maximize_txns_count_timeout_duration,
-            instance_state
-                .chain_config
-                .base_fee
+            base_fee
                 .as_u64()
                 .context("the base fee exceeds the maximum amount that a builder can pay (defined by u64::MAX)")?,
             Arc::new(instance_state),

--- a/data/genesis/demo.toml
+++ b/data/genesis/demo.toml
@@ -3,7 +3,7 @@ capacity = 10
 
 [chain_config]
 chain_id = 999999999
-base_fee = '1 wei'
+base_fee = '0 wei'
 max_block_size = '1mb'
 fee_recipient = '0x0000000000000000000000000000000000000000'
 fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'
@@ -18,7 +18,7 @@ stop_proposing_view = 15
 
 [upgrade.chain_config]
 chain_id = 999999999
-base_fee = '2 wei'
+base_fee = '1 wei'
 max_block_size = '1mb'
 fee_recipient = '0x0000000000000000000000000000000000000000'
 fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'


### PR DESCRIPTION
The builder does not have know about upgrades and uses the base fee from the default chain  in the Genesis file. To support chain config upgrades, the builder should use the highest base fees from the list of chain config upgrades and the default chain config.