### PR TITLE
Remove es_version crate and use SeqTypes::Base version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,6 @@ dependencies = [
  "cld",
  "committable",
  "dotenvy",
- "es-version",
  "espresso-types 0.1.0",
  "ethers",
  "futures",
@@ -2020,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "contract-bindings"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#6d52a7e331a5517d9c19ea459ee18947f6c567cc"
+source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#ac42ca041b6ab41f12417fa8e3d8cd9f1b7e22b8"
 dependencies = [
  "ethers",
  "serde",
@@ -2928,7 +2927,6 @@ dependencies = [
  "committable",
  "contract-bindings 0.1.0",
  "derive_more",
- "es-version",
  "ethers",
  "fluent-asserter",
  "futures",
@@ -2964,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "espresso-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#6d52a7e331a5517d9c19ea459ee18947f6c567cc"
+source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#ac42ca041b6ab41f12417fa8e3d8cd9f1b7e22b8"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4226,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "hotshot-contract-adapter"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#6d52a7e331a5517d9c19ea459ee18947f6c567cc"
+source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#ac42ca041b6ab41f12417fa8e3d8cd9f1b7e22b8"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4457,7 +4455,7 @@ dependencies = [
  "cld",
  "contract-bindings 0.1.0",
  "displaydoc",
- "es-version",
+ "espresso-types 0.1.0",
  "ethers",
  "futures",
  "hotshot-contract-adapter 0.1.0",
@@ -8504,7 +8502,6 @@ dependencies = [
  "derivative",
  "derive_more",
  "dotenvy",
- "es-version",
  "escargot",
  "espresso-macros",
  "espresso-types 0.1.0",
@@ -8586,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "sequencer-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#6d52a7e331a5517d9c19ea459ee18947f6c567cc"
+source = "git+https://github.com/EspressoSystems/espresso-sequencer.git?branch=main#ac42ca041b6ab41f12417fa8e3d8cd9f1b7e22b8"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ blake3 = "1.5"
 clap = { version = "4.4", features = ["derive", "env", "string"] }
 cld = "0.5"
 derive_more = "0.99.17"
-es-version = { git = "https://github.com/EspressoSystems/es-version.git", branch = "main" }
 dotenvy = "0.15"
 ethers = { version = "2.0", features = ["solc"] }
 futures = "0.3"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -20,7 +20,6 @@ clap = { workspace = true }
 cld = { workspace = true }
 committable = { workspace = true }
 dotenvy = { workspace = true }
-es-version = { workspace = true }
 espresso-types = { path = "../types", features = ["testing"] }
 ethers = { workspace = true }
 futures = { workspace = true }

--- a/builder/src/bin/permissioned-builder.rs
+++ b/builder/src/bin/permissioned-builder.rs
@@ -5,7 +5,6 @@ use std::{
 use anyhow::{bail, Context};
 use builder::permissioned::init_node;
 use clap::Parser;
-use es_version::SEQUENCER_VERSION;
 use espresso_types::eth_signature_key::EthKeyPair;
 use ethers::types::Address;
 use hotshot_types::{
@@ -20,6 +19,7 @@ use sequencer::{
 };
 use sequencer_utils::logging;
 use url::Url;
+use vbs::version::{StaticVersion, StaticVersionType};
 
 #[derive(Parser, Clone, Debug)]
 pub struct PermissionedBuilderOptions {
@@ -260,7 +260,7 @@ async fn main() -> anyhow::Result<()> {
         catchup_backoff: Default::default(),
     };
 
-    let sequencer_version = SEQUENCER_VERSION;
+    let sequencer_version = StaticVersion::<0, 1>::instance();
 
     let builder_server_url: Url = format!("http://0.0.0.0:{}", opt.port).parse().unwrap();
 

--- a/builder/src/bin/permissionless-builder.rs
+++ b/builder/src/bin/permissionless-builder.rs
@@ -3,15 +3,14 @@ use std::{num::NonZeroUsize, path::PathBuf, str::FromStr, time::Duration};
 use builder::non_permissioned::{build_instance_state, BuilderConfig};
 use clap::Parser;
 use cld::ClDuration;
-use espresso_types::{eth_signature_key::EthKeyPair, SeqTypes};
+use espresso_types::eth_signature_key::EthKeyPair;
 use hotshot::traits::ValidatedState;
-use hotshot_builder_core::testing::basic_test::NodeType;
 use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
 use sequencer::{Genesis, L1Params};
 use sequencer_utils::logging;
 use snafu::Snafu;
 use url::Url;
-use vbs::version::StaticVersionType;
+use vbs::version::{StaticVersion, StaticVersionType};
 
 #[derive(Parser, Clone, Debug)]
 struct NonPermissionedBuilderOptions {
@@ -123,7 +122,7 @@ async fn main() -> anyhow::Result<()> {
         genesis.chain_config,
         l1_params,
         opt.state_peers,
-        <SeqTypes as NodeType>::Base::instance(),
+        StaticVersion::<0, 1>::instance(),
     )
     .unwrap();
 

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -229,7 +229,6 @@ mod test {
     };
     use async_lock::RwLock;
     use async_std::task;
-    use es_version::SequencerVersion;
     use espresso_types::{FeeAccount, NamespaceId, Transaction};
     use hotshot_builder_api::v0_1::{
         block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
@@ -257,6 +256,7 @@ mod test {
     use sequencer::persistence::no_storage::{self, NoStorage};
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
+    use vbs::version::StaticVersion;
 
     use super::*;
     use crate::testing::{
@@ -270,7 +270,7 @@ mod test {
     async fn test_non_permissioned_builder() {
         setup_test();
 
-        let ver = SequencerVersion::instance();
+        let ver = StaticVersion::<0, 1>::instance();
         // Hotshot Test Config
         let hotshot_config = HotShotTestConfig::default();
 
@@ -316,10 +316,10 @@ mod test {
         let builder_pub_key = builder_config.fee_account;
 
         // Start a builder api client
-        let builder_client = Client::<
-            hotshot_builder_api::v0_1::builder::Error,
-            <SeqTypes as NodeType>::Base,
-        >::new(hotshot_builder_api_url.clone());
+        let builder_client =
+            Client::<hotshot_builder_api::v0_1::builder::Error, StaticVersion<0, 1>>::new(
+                hotshot_builder_api_url.clone(),
+            );
         assert!(builder_client.connect(Some(Duration::from_secs(60))).await);
 
         let seed = [207_u8; 32];

--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -553,7 +553,7 @@ mod test {
     use async_compatibility_layer::art::{async_sleep, async_spawn};
     use async_lock::RwLock;
     use async_std::task;
-    use es_version::SequencerVersion;
+
     use espresso_types::{FeeAccount, NamespaceId, Transaction};
     use hotshot_builder_api::v0_1::{
         block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
@@ -581,6 +581,7 @@ mod test {
     use sequencer::persistence::no_storage::{self, NoStorage};
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
+    use vbs::version::StaticVersion;
 
     use super::*;
     use crate::{
@@ -595,7 +596,7 @@ mod test {
     async fn test_permissioned_builder() {
         setup_test();
 
-        let ver = SequencerVersion::instance();
+        let ver = StaticVersion::<0, 1>::instance();
 
         // Hotshot Test Config
         let hotshot_config = HotShotTestConfig::default();
@@ -629,10 +630,10 @@ mod test {
         let builder_pub_key = builder_config.fee_account;
 
         // Start a builder api client
-        let builder_client = Client::<
-            hotshot_builder_api::v0_1::builder::Error,
-            <SeqTypes as NodeType>::Base,
-        >::new(hotshot_builder_api_url.clone());
+        let builder_client =
+            Client::<hotshot_builder_api::v0_1::builder::Error, StaticVersion<0, 1>>::new(
+                hotshot_builder_api_url.clone(),
+            );
         assert!(builder_client.connect(Some(Duration::from_secs(60))).await);
 
         let seed = [207_u8; 32];

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -19,7 +19,7 @@ clap = { workspace = true }
 cld = { workspace = true }
 contract-bindings = { path = "../contract-bindings" }
 displaydoc = { version = "0.2.3", default-features = false }
-es-version = { workspace = true }
+espresso-types = { path = "../types", features = ["testing"] }
 ethers = { workspace = true }
 futures = { workspace = true }
 hotshot-contract-adapter = { workspace = true }

--- a/hotshot-state-prover/src/bin/state-prover.rs
+++ b/hotshot-state-prover/src/bin/state-prover.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr as _, time::Duration};
 
 use clap::Parser;
 use cld::ClDuration;
-use es_version::SEQUENCER_VERSION;
+use espresso_types::SeqTypes;
 use ethers::{
     providers::{Http, Middleware, Provider},
     signers::{coins_bip39::English, MnemonicBuilder, Signer},
@@ -10,9 +10,11 @@ use ethers::{
 };
 use hotshot_stake_table::config::STAKE_TABLE_CAPACITY;
 use hotshot_state_prover::service::{run_prover_once, run_prover_service, StateProverConfig};
+use hotshot_types::traits::node_implementation::NodeType;
 use sequencer_utils::logging;
 use snafu::Snafu;
 use url::Url;
+use vbs::version::StaticVersionType;
 
 #[derive(Parser)]
 struct Args {
@@ -126,12 +128,13 @@ async fn main() {
 
     if args.daemon {
         // Launching the prover service daemon
-        if let Err(err) = run_prover_service(config, SEQUENCER_VERSION).await {
+        if let Err(err) = run_prover_service(config, <SeqTypes as NodeType>::Base::instance()).await
+        {
             tracing::error!("Error running prover service: {:?}", err);
         };
     } else {
         // Run light client state update once
-        if let Err(err) = run_prover_once(config, SEQUENCER_VERSION).await {
+        if let Err(err) = run_prover_once(config, <SeqTypes as NodeType>::Base::instance()).await {
             tracing::error!("Error running prover once: {:?}", err);
         };
     }

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -52,7 +52,6 @@ csv = "1"
 derivative = "2.2"
 derive_more = { workspace = true }
 dotenvy = { workspace = true }
-es-version = { workspace = true }
 espresso-types = { path = "../types", features = ["testing"] }
 ethers = { workspace = true }
 futures = { workspace = true }

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -360,7 +360,7 @@ pub mod test_helpers {
 
     use async_std::task::sleep;
     use committable::Committable;
-    use es_version::{SequencerVersion, SEQUENCER_VERSION};
+
     use espresso_types::{
         mock::MockStateCatchup,
         v0::traits::{PersistenceOptions, StateCatchup},
@@ -373,6 +373,7 @@ pub mod test_helpers {
     };
     use hotshot::types::{Event, EventType};
     use hotshot_contract_adapter::light_client::ParsedLightClientState;
+    use hotshot_types::traits::node_implementation::NodeType;
     use hotshot_types::{
         event::LeafInfo,
         traits::{metrics::NoMetrics, node_implementation::ConsensusTime},
@@ -392,9 +393,13 @@ pub mod test_helpers {
 
     pub const STAKE_TABLE_CAPACITY_FOR_TEST: u64 = 10;
 
-    pub struct TestNetwork<P: PersistenceOptions, const NUM_NODES: usize> {
-        pub server: SequencerContext<network::Memory, P::Persistence, SequencerVersion>,
-        pub peers: Vec<SequencerContext<network::Memory, P::Persistence, SequencerVersion>>,
+    pub struct TestNetwork<
+        P: PersistenceOptions,
+        const NUM_NODES: usize,
+        Ver: StaticVersionType + 'static,
+    > {
+        pub server: SequencerContext<network::Memory, P::Persistence, Ver>,
+        pub peers: Vec<SequencerContext<network::Memory, P::Persistence, Ver>>,
         pub cfg: TestConfig<{ NUM_NODES }>,
     }
 
@@ -507,9 +512,12 @@ pub mod test_helpers {
         }
     }
 
-    impl<P: PersistenceOptions, const NUM_NODES: usize> TestNetwork<P, { NUM_NODES }> {
+    impl<P: PersistenceOptions, const NUM_NODES: usize, Ver: StaticVersionType + 'static>
+        TestNetwork<P, { NUM_NODES }, Ver>
+    {
         pub async fn new<C: StateCatchup + 'static>(
             cfg: TestNetworkConfig<{ NUM_NODES }, P, C>,
+            _bind_ver: Ver,
         ) -> Self {
             let mut cfg = cfg;
             let (builder_task, builder_url) =
@@ -538,14 +546,14 @@ pub mod test_helpers {
                                                 catchup,
                                                 &*metrics,
                                                 STAKE_TABLE_CAPACITY_FOR_TEST,
-                                                SEQUENCER_VERSION,
+                                                Ver::instance(),
                                                 upgrades_map,
                                             )
                                             .await
                                         }
                                         .boxed()
                                     },
-                                    SEQUENCER_VERSION,
+                                    Ver::instance(),
                                 )
                                 .await
                                 .unwrap()
@@ -557,7 +565,7 @@ pub mod test_helpers {
                                     catchup,
                                     &NoMetrics,
                                     STAKE_TABLE_CAPACITY_FOR_TEST,
-                                    SEQUENCER_VERSION,
+                                    Ver::instance(),
                                     upgrades_map,
                                 )
                                 .await
@@ -612,7 +620,7 @@ pub mod test_helpers {
 
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         let options = opt(Options::with_port(port).status(Default::default()));
         let anvil = Anvil::new().spawn();
@@ -622,7 +630,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let _network = TestNetwork::new(config).await;
+        let _network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         client.connect(None).await;
 
         // The status API is well tested in the query service repo. Here we are just smoke testing
@@ -664,7 +672,7 @@ pub mod test_helpers {
         let port = pick_unused_port().expect("No ports free");
 
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         let options = opt(Options::with_port(port).submit(Default::default()));
         let anvil = Anvil::new().spawn();
@@ -674,7 +682,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let network = TestNetwork::new(config).await;
+        let network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         let mut events = network.server.event_stream().await;
 
         client.connect(None).await;
@@ -699,7 +707,7 @@ pub mod test_helpers {
         let port = pick_unused_port().expect("No ports free");
 
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         let options = opt(Options::with_port(port));
         let anvil = Anvil::new().spawn();
@@ -709,7 +717,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let network = TestNetwork::new(config).await;
+        let network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         let mut height: u64;
         // Wait for block >=2 appears
@@ -741,7 +749,7 @@ pub mod test_helpers {
 
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         let options = opt(Options::with_port(port).catchup(Default::default()));
         let anvil = Anvil::new().spawn();
@@ -751,7 +759,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let network = TestNetwork::new(config).await;
+        let network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         client.connect(None).await;
 
         // Wait for a few blocks to be decided.
@@ -831,11 +839,12 @@ mod api_tests {
     use committable::Committable;
     use data_source::testing::TestableSequencerDataSource;
     use endpoints::NamespaceProofQueryData;
-    use es_version::SequencerVersion;
+
     use espresso_types::{Header, NamespaceId};
     use ethers::utils::Anvil;
     use futures::stream::StreamExt;
     use hotshot_query_service::availability::{LeafQueryData, VidCommonQueryData};
+    use hotshot_types::traits::node_implementation::NodeType;
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
@@ -885,11 +894,11 @@ mod api_tests {
             .api_config(D::options(&storage, Options::with_port(port)).submit(Default::default()))
             .network_config(network_config)
             .build();
-        let network = TestNetwork::new(config).await;
+        let network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         let mut events = network.server.event_stream().await;
 
         // Connect client.
-        let client: Client<ServerError, SequencerVersion> =
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> =
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         client.connect(None).await;
 
@@ -988,7 +997,7 @@ mod api_tests {
             events_service_port: hotshot_event_streaming_port,
         };
 
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         let options = Options::with_port(query_service_port).hotshot_events(hotshot_events);
 
@@ -999,7 +1008,7 @@ mod api_tests {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let _network = TestNetwork::new(config).await;
+        let _network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         let mut subscribed_events = client
             .socket("hotshot-events/events")
@@ -1032,7 +1041,7 @@ mod test {
 
     use async_std::task::sleep;
     use committable::{Commitment, Committable};
-    use es_version::{SequencerVersion, SEQUENCER_VERSION};
+
     use espresso_types::{
         mock::MockStateCatchup,
         v0_1::{UpgradeMode, ViewBasedUpgrade},
@@ -1065,7 +1074,6 @@ mod test {
         TestNetwork, TestNetworkConfigBuilder,
     };
     use tide_disco::{app::AppHealth, error::ServerError, healthcheck::HealthStatus};
-    use vbs::version::Version;
 
     use self::{
         data_source::{testing::TestableSequencerDataSource, PublicHotShotConfig},
@@ -1084,7 +1092,7 @@ mod test {
 
         let port = pick_unused_port().expect("No ports free");
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
         let options = Options::with_port(port);
         let anvil = Anvil::new().spawn();
         let l1 = anvil.endpoint().parse().unwrap();
@@ -1093,7 +1101,7 @@ mod test {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let _network = TestNetwork::new(config).await;
+        let _network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         client.connect(None).await;
         let health = client.get::<AppHealth>("healthcheck").send().await.unwrap();
@@ -1141,9 +1149,9 @@ mod test {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         let url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url);
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url);
 
         client.connect(None).await;
 
@@ -1206,13 +1214,13 @@ mod test {
             .api_config(Options::with_port(port).catchup(Default::default()))
             .network_config(TestConfigBuilder::default().l1_url(l1).build())
             .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 )
             }))
             .build();
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         // Wait for replica 0 to reach a (non-genesis) decide, before disconnecting it.
         let mut events = network.peers[0].event_stream().await;
@@ -1250,13 +1258,13 @@ mod test {
                 1,
                 ValidatedState::default(),
                 no_storage::Options,
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 ),
                 &NoMetrics,
                 test_helpers::STAKE_TABLE_CAPACITY_FOR_TEST,
-                SEQUENCER_VERSION,
+                <SeqTypes as NodeType>::Base::instance(),
                 Default::default(),
             )
             .await;
@@ -1313,7 +1321,7 @@ mod test {
             .api_config(Options::with_port(port).catchup(Default::default()))
             .states(states)
             .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 )
@@ -1321,7 +1329,7 @@ mod test {
             .network_config(TestConfigBuilder::default().l1_url(l1).build())
             .build();
 
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         // Wait for few blocks to be decided.
         network
@@ -1390,7 +1398,7 @@ mod test {
             )
             .states(states)
             .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 )
@@ -1398,7 +1406,7 @@ mod test {
             .network_config(TestConfigBuilder::default().l1_url(l1).build())
             .build();
 
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         // Wait for a few blocks to be decided.
         network
@@ -1463,7 +1471,7 @@ mod test {
                 .status(Default::default()),
             )
             .catchups(std::array::from_fn(|_| {
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 )
@@ -1476,7 +1484,7 @@ mod test {
             )
             .build();
 
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         let mut events = network.server.event_stream().await;
         loop {
@@ -1486,14 +1494,14 @@ mod test {
                 EventType::UpgradeProposal { proposal, .. } => {
                     let upgrade = proposal.data.upgrade_proposal;
                     let new_version = upgrade.new_version;
-                    assert_eq!(new_version, Version { major: 0, minor: 2 });
+                    assert_eq!(new_version, <SeqTypes as NodeType>::Upgrade::VERSION);
                     break;
                 }
                 _ => continue,
             }
         }
 
-        let client: Client<ServerError, SequencerVersion> =
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> =
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         client.connect(None).await;
         tracing::info!(port, "server running");
@@ -1551,10 +1559,10 @@ mod test {
             .persistences(persistence)
             .network_config(TestConfigBuilder::default().l1_url(l1).build())
             .build();
-        let mut network = TestNetwork::new(config).await;
+        let mut network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
 
         // Connect client.
-        let client: Client<ServerError, SequencerVersion> =
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> =
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         client.connect(None).await;
         tracing::info!(port, "server running");
@@ -1621,15 +1629,15 @@ mod test {
                 // Catchup using node 0 as a peer. Node 0 was running the archival state service
                 // before the restart, so it should be able to resume without catching up by loading
                 // state from storage.
-                StatePeers::<SequencerVersion>::from_urls(
+                StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
                     vec![format!("http://localhost:{port}").parse().unwrap()],
                     Default::default(),
                 )
             }))
             .network_config(TestConfigBuilder::default().l1_url(l1).build())
             .build();
-        let _network = TestNetwork::new(config).await;
-        let client: Client<ServerError, SequencerVersion> =
+        let _network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> =
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         client.connect(None).await;
         tracing::info!(port, "server running");
@@ -1670,7 +1678,7 @@ mod test {
 
         let port = pick_unused_port().expect("No ports free");
         let url: surf_disco::Url = format!("http://localhost:{port}").parse().unwrap();
-        let client: Client<ServerError, SequencerVersion> = Client::new(url.clone());
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> = Client::new(url.clone());
 
         let options = Options::with_port(port).config(Default::default());
         let anvil = Anvil::new().spawn();
@@ -1680,12 +1688,12 @@ mod test {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let network = TestNetwork::new(config).await;
+        let network = TestNetwork::new(config, <SeqTypes as NodeType>::Base::instance()).await;
         client.connect(None).await;
 
         // Fetch a network config from the API server. The first peer URL is bogus, to test the
         // failure/retry case.
-        let peers = StatePeers::<SequencerVersion>::from_urls(
+        let peers = StatePeers::<<SeqTypes as NodeType>::Base>::from_urls(
             vec!["https://notarealnode.network".parse().unwrap(), url],
             Default::default(),
         );

--- a/sequencer/src/bin/commitment-task.rs
+++ b/sequencer/src/bin/commitment-task.rs
@@ -2,9 +2,10 @@ use std::{io, time::Duration};
 
 use async_std::task::spawn;
 use clap::Parser;
-use es_version::SEQUENCER_VERSION;
+use espresso_types::SeqTypes;
 use ethers::prelude::*;
 use futures::FutureExt;
+use hotshot_types::traits::node_implementation::NodeType;
 use sequencer::{
     hotshot_commitment::{run_hotshot_commitment_task, CommitmentTaskOptions},
     options::parse_duration,
@@ -68,7 +69,12 @@ async fn main() {
     opt.logging.init();
 
     if let Some(port) = opt.port {
-        start_http_server(port, opt.hotshot_address, SEQUENCER_VERSION).unwrap();
+        start_http_server(
+            port,
+            opt.hotshot_address,
+            <SeqTypes as NodeType>::Base::instance(),
+        )
+        .unwrap();
     }
 
     let hotshot_contract_options = CommitmentTaskOptions {
@@ -82,7 +88,7 @@ async fn main() {
         query_service_url: Some(opt.sequencer_url),
     };
     tracing::info!("Launching HotShot commitment task..");
-    run_hotshot_commitment_task::<es_version::SequencerVersion>(&hotshot_contract_options).await;
+    run_hotshot_commitment_task::<<SeqTypes as NodeType>::Base>(&hotshot_contract_options).await;
 }
 
 fn start_http_server<Ver: StaticVersionType + 'static>(
@@ -111,10 +117,12 @@ fn start_http_server<Ver: StaticVersionType + 'static>(
 
 #[cfg(test)]
 mod test {
-    use es_version::{SequencerVersion, SEQUENCER_VERSION};
+    use espresso_types::SeqTypes;
+    use hotshot_types::traits::node_implementation::NodeType;
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::Client;
+    use vbs::version::StaticVersionType;
 
     use super::{start_http_server, Address, ServerError};
 
@@ -126,10 +134,14 @@ mod test {
         let expected_addr = "0xED15E1FE0789c524398137a066ceb2EF9884E5D8"
             .parse::<Address>()
             .unwrap();
-        start_http_server(port, expected_addr, SEQUENCER_VERSION)
-            .expect("Failed to start the server");
+        start_http_server(
+            port,
+            expected_addr,
+            <SeqTypes as NodeType>::Base::instance(),
+        )
+        .expect("Failed to start the server");
 
-        let client: Client<ServerError, SequencerVersion> =
+        let client: Client<ServerError, <SeqTypes as NodeType>::Base> =
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         client.connect(None).await;
 

--- a/sequencer/src/bin/espresso-bridge.rs
+++ b/sequencer/src/bin/espresso-bridge.rs
@@ -4,14 +4,16 @@ use anyhow::{bail, ensure, Context};
 use async_std::{sync::Arc, task::sleep};
 use clap::{Parser, Subcommand};
 use contract_bindings::fee_contract::FeeContract;
-use es_version::SequencerVersion;
-use espresso_types::{eth_signature_key::EthKeyPair, FeeAccount, FeeAmount, FeeMerkleTree, Header};
+use espresso_types::{
+    eth_signature_key::EthKeyPair, FeeAccount, FeeAmount, FeeMerkleTree, Header, SeqTypes,
+};
 use ethers::{
     middleware::{Middleware, SignerMiddleware},
     providers::Provider,
     types::{Address, BlockId, U256},
 };
 use futures::stream::StreamExt;
+use hotshot_types::traits::node_implementation::NodeType;
 use jf_merkle_tree::{
     prelude::{MerkleProof, Sha3Node},
     MerkleTreeScheme,
@@ -19,7 +21,7 @@ use jf_merkle_tree::{
 use sequencer_utils::logging;
 use surf_disco::{error::ClientError, Url};
 
-type EspressoClient = surf_disco::Client<ClientError, SequencerVersion>;
+type EspressoClient = surf_disco::Client<ClientError, <SeqTypes as NodeType>::Base>;
 
 type FeeMerkleProof = MerkleProof<FeeAmount, FeeAccount, Sha3Node, { FeeMerkleTree::ARITY }>;
 

--- a/sequencer/src/bin/state-relay-server.rs
+++ b/sequencer/src/bin/state-relay-server.rs
@@ -1,9 +1,11 @@
 use clap::Parser;
-use es_version::SEQUENCER_VERSION;
+use espresso_types::SeqTypes;
 use ethers::types::U256;
 use hotshot_state_prover::service::one_honest_threshold;
+use hotshot_types::traits::node_implementation::NodeType;
 use sequencer::state_signature::relay_server::run_relay_server;
 use sequencer_utils::logging;
+use vbs::version::StaticVersionType;
 
 #[derive(Parser)]
 struct Args {
@@ -45,7 +47,7 @@ async fn main() {
         None,
         threshold,
         format!("http://0.0.0.0:{}", args.port).parse().unwrap(),
-        SEQUENCER_VERSION,
+        <SeqTypes as NodeType>::Base::instance(),
     )
     .await
     .unwrap();

--- a/sequencer/src/bin/submit-transactions.rs
+++ b/sequencer/src/bin/submit-transactions.rs
@@ -8,7 +8,6 @@ use std::{
 use async_std::task::{sleep, spawn};
 use clap::Parser;
 use committable::{Commitment, Committable};
-use es_version::{SequencerVersion, SEQUENCER_VERSION};
 use espresso_types::{SeqTypes, Transaction};
 use futures::{
     channel::mpsc::{self, Sender},
@@ -16,6 +15,7 @@ use futures::{
     stream::StreamExt,
 };
 use hotshot_query_service::{availability::BlockQueryData, types::HeightIndexed, Error};
+use hotshot_types::traits::node_implementation::NodeType;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rand_distr::Distribution;
@@ -175,7 +175,7 @@ async fn main() {
     let mut rng = ChaChaRng::seed_from_u64(seed);
 
     // Subscribe to block stream so we can check that our transactions are getting sequenced.
-    let client = Client::<Error, SequencerVersion>::new(opt.url.clone());
+    let client = Client::<Error, <SeqTypes as NodeType>::Base>::new(opt.url.clone());
     let block_height: usize = client.get("status/block-height").send().await.unwrap();
     let mut blocks = client
         .socket(&format!("availability/stream/blocks/{}", block_height - 1))
@@ -190,13 +190,13 @@ async fn main() {
             opt.clone(),
             sender.clone(),
             ChaChaRng::from_rng(&mut rng).unwrap(),
-            SEQUENCER_VERSION,
+            <SeqTypes as NodeType>::Base::instance(),
         ));
     }
 
     // Start healthcheck endpoint once tasks are running.
     if let Some(port) = opt.port {
-        spawn(server(port, SEQUENCER_VERSION));
+        spawn(server(port, <SeqTypes as NodeType>::Base::instance()));
     }
 
     // Keep track of the results.

--- a/sequencer/src/bin/verify-headers.rs
+++ b/sequencer/src/bin/verify-headers.rs
@@ -4,9 +4,10 @@ use std::{cmp::max, process::exit, time::Duration};
 
 use async_std::{sync::Arc, task::sleep};
 use clap::Parser;
-use espresso_types::{Header, L1BlockInfo};
+use espresso_types::{Header, L1BlockInfo, SeqTypes};
 use ethers::prelude::*;
 use futures::future::join_all;
+use hotshot_types::traits::node_implementation::NodeType;
 use itertools::Itertools;
 use sequencer_utils::logging;
 use surf_disco::Url;
@@ -169,7 +170,7 @@ async fn main() {
     let opt = Arc::new(Options::parse());
     opt.logging.init();
 
-    let seq = Arc::new(SequencerClient::<es_version::SequencerVersion>::new(
+    let seq = Arc::new(SequencerClient::<<SeqTypes as NodeType>::Base>::new(
         opt.url.clone(),
     ));
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -678,6 +678,7 @@ pub mod testing {
                 L1Client::new(self.l1_url.clone(), 1000),
                 catchup::local_and_remote(persistence_opt.clone(), catchup).await,
             )
+            .with_current_version(Ver::version())
             .with_genesis(state)
             .with_upgrades(upgrades);
 
@@ -748,7 +749,7 @@ pub mod testing {
 
 #[cfg(test)]
 mod test {
-    use es_version::SequencerVersion;
+
     use espresso_types::{Header, NamespaceId, Payload, Transaction};
     use futures::StreamExt;
     use hotshot::types::EventType::Decide;
@@ -767,7 +768,7 @@ mod test {
     #[async_std::test]
     async fn test_skeleton_instantiation() {
         setup_test();
-        let ver = SequencerVersion::instance();
+        let ver = <SeqTypes as NodeType>::Base::instance();
         // Assign `config` so it isn't dropped early.
         let anvil = AnvilOptions::default().spawn().await;
         let url = anvil.url();
@@ -809,7 +810,7 @@ mod test {
         setup_test();
 
         let success_height = 30;
-        let ver = SequencerVersion::instance();
+        let ver = <SeqTypes as NodeType>::Base::instance();
         // Assign `config` so it isn't dropped early.
         let anvil = AnvilOptions::default().spawn().await;
         let url = anvil.url();

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -1,9 +1,9 @@
 use std::net::ToSocketAddrs;
 
 use clap::Parser;
-use es_version::SEQUENCER_VERSION;
+use espresso_types::SeqTypes;
 use futures::future::FutureExt;
-use hotshot_types::traits::metrics::NoMetrics;
+use hotshot_types::traits::{metrics::NoMetrics, node_implementation::NodeType};
 use sequencer::{
     api::{self, data_source::DataSourceOptions},
     init_node,
@@ -21,16 +21,28 @@ async fn main() -> anyhow::Result<()> {
     tracing::warn!(?modules, "sequencer starting up");
 
     if let Some(storage) = modules.storage_fs.take() {
-        init_with_storage(modules, opt, storage, SEQUENCER_VERSION).await
+        init_with_storage(
+            modules,
+            opt,
+            storage,
+            <SeqTypes as NodeType>::Base::instance(),
+        )
+        .await
     } else if let Some(storage) = modules.storage_sql.take() {
-        init_with_storage(modules, opt, storage, SEQUENCER_VERSION).await
+        init_with_storage(
+            modules,
+            opt,
+            storage,
+            <SeqTypes as NodeType>::Base::instance(),
+        )
+        .await
     } else {
         // Persistence is required. If none is provided, just use the local file system.
         init_with_storage(
             modules,
             opt,
             persistence::fs::Options::default(),
-            SEQUENCER_VERSION,
+            <SeqTypes as NodeType>::Base::instance(),
         )
         .await
     }
@@ -164,9 +176,12 @@ mod test {
     use std::time::Duration;
 
     use async_std::task::spawn;
-    use es_version::SequencerVersion;
-    use espresso_types::PubKey;
-    use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey};
+
+    use espresso_types::{PubKey, SeqTypes};
+    use hotshot_types::{
+        light_client::StateKeyPair,
+        traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    };
     use portpicker::pick_unused_port;
     use sequencer::{
         api::options::{Http, Status},
@@ -224,7 +239,7 @@ mod test {
                 modules,
                 opt,
                 fs::Options::new(tmp.path().into()),
-                SEQUENCER_VERSION,
+                <SeqTypes as NodeType>::Base::instance(),
             )
             .await
             {
@@ -236,7 +251,7 @@ mod test {
         // orchestrator.
         tracing::info!("waiting for API to start");
         let url: Url = format!("http://localhost:{port}").parse().unwrap();
-        let client = Client::<ClientError, SequencerVersion>::new(url.clone());
+        let client = Client::<ClientError, <SeqTypes as NodeType>::Base>::new(url.clone());
         assert!(client.connect(Some(Duration::from_secs(60))).await);
         client.get::<()>("healthcheck").send().await.unwrap();
 

--- a/sequencer/src/message_compat_tests.rs
+++ b/sequencer/src/message_compat_tests.rs
@@ -17,8 +17,7 @@
 use std::path::Path;
 
 use committable::Committable;
-use es_version::SequencerVersion;
-use espresso_types::{Leaf, NodeState, PubKey, ValidatedState};
+use espresso_types::{Leaf, NodeState, PubKey, SeqTypes, ValidatedState};
 use hotshot::traits::election::static_committee::GeneralStaticCommittee;
 use hotshot_types::{
     data::{
@@ -39,7 +38,9 @@ use hotshot_types::{
         ViewSyncFinalizeVote, ViewSyncPreCommitData, ViewSyncPreCommitVote,
     },
     traits::{
-        node_implementation::ConsensusTime, signature_key::SignatureKey, BlockPayload, EncodeBytes,
+        node_implementation::{ConsensusTime, NodeType},
+        signature_key::SignatureKey,
+        BlockPayload, EncodeBytes,
     },
     vid::vid_scheme,
 };
@@ -48,7 +49,7 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 use vbs::{version::Version, BinarySerializer};
 
-type Serializer = vbs::Serializer<SequencerVersion>;
+type Serializer = vbs::Serializer<<SeqTypes as NodeType>::Base>;
 
 #[async_std::test]
 #[cfg(feature = "testing")]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -23,7 +23,6 @@ cld = { workspace = true }
 committable = { workspace = true }
 contract-bindings = { path = "../contract-bindings" }
 derive_more = { workspace = true }
-es-version = { workspace = true }
 ethers = { workspace = true }
 fluent-asserter = "0.1.9"
 futures = { workspace = true }

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -1429,7 +1429,7 @@ mod test_headers {
         *parent_header.block_merkle_tree_root_mut() = block_merkle_tree_root;
         let mut proposal = parent_header.clone();
 
-        let ver = StaticVersion::<1, 0>::version();
+        let ver = StaticVersion::<0, 1>::version();
 
         // Pass a different chain config to trigger a chain config validation error.
         let state = validated_state
@@ -1508,8 +1508,9 @@ mod test_headers {
         setup_test();
 
         let anvil = Anvil::new().block_time(1u32).spawn();
-        let mut genesis_state =
-            NodeState::mock().with_l1(L1Client::new(anvil.endpoint().parse().unwrap(), 1));
+        let mut genesis_state = NodeState::mock()
+            .with_l1(L1Client::new(anvil.endpoint().parse().unwrap(), 1))
+            .with_current_version(StaticVersion::<0, 1>::version());
 
         let genesis = GenesisForTest::default().await;
         let vid_common = vid_scheme(1).disperse([]).unwrap().common;
@@ -1564,7 +1565,7 @@ mod test_headers {
             ns_table,
             builder_fee,
             vid_common.clone(),
-            <SeqTypes as NodeType>::Base::version(),
+            StaticVersion::<0, 1>::version(),
         )
         .await
         .unwrap();
@@ -1586,7 +1587,7 @@ mod test_headers {
                 &genesis_state,
                 &parent_leaf,
                 &proposal,
-                StaticVersion::<1, 0>::version(),
+                StaticVersion::<0, 1>::version(),
             )
             .await
             .unwrap()

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -92,6 +92,11 @@ impl NodeState {
         self.upgrades = upgrades;
         self
     }
+
+    pub fn with_current_version(mut self, ver: Version) -> Self {
+        self.current_version = ver;
+        self
+    }
 }
 
 // This allows us to turn on `Default` on InstanceState trait

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -10,6 +10,7 @@ use hotshot_types::{
     },
     vid::{VidCommon, VidSchemeType},
 };
+
 use itertools::Itertools;
 use jf_merkle_tree::{
     prelude::{MerkleProof, Sha3Digest, Sha3Node},
@@ -750,16 +751,15 @@ impl MerklizedState<SeqTypes, { Self::ARITY }> for FeeMerkleTree {
 mod test {
     use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
     use ethers::types::U256;
-    use hotshot_types::traits::{block_contents::BlockHeader, signature_key::BuilderSignatureKey};
-    use hotshot_types::vid::vid_scheme;
+    use hotshot_types::{traits::signature_key::BuilderSignatureKey, vid::vid_scheme};
     use jf_vid::VidScheme;
     use sequencer_utils::ser::FromStringOrInteger;
 
     use super::*;
     use crate::{
         eth_signature_key::{BuilderSignature, EthKeyPair},
-        v0_1,
-        v0_3::BidTx,
+        v0_1, v0_2,
+        v0_3::{self, BidTx},
         BlockSize, FeeAccountProof, FeeMerkleProof,
     };
 
@@ -1048,7 +1048,16 @@ mod test {
                 fee_info: FeeInfo::new(account, data),
                 ..header
             }),
-            _ => unimplemented!(),
+            Header::V2(header) => Header::V2(v0_2::Header {
+                builder_signature: Some(sig),
+                fee_info: FeeInfo::new(account, data),
+                ..header
+            }),
+            Header::V3(header) => Header::V3(v0_3::Header {
+                builder_signature: vec![sig],
+                fee_info: vec![FeeInfo::new(account, data)],
+                ..header
+            }),
         };
 
         validate_builder_fee(&header).unwrap();
@@ -1067,7 +1076,16 @@ mod test {
                 fee_info: FeeInfo::new(account, data),
                 ..header
             }),
-            _ => unimplemented!(),
+            Header::V2(header) => Header::V2(v0_2::Header {
+                builder_signature: Some(sig),
+                fee_info: FeeInfo::new(account, data),
+                ..header
+            }),
+            Header::V3(header) => Header::V3(v0_3::Header {
+                builder_signature: vec![sig],
+                fee_info: vec![FeeInfo::new(account, data)],
+                ..header
+            }),
         };
 
         let sig: Vec<BuilderSignature> = header.builder_signature();


### PR DESCRIPTION
We have consistencies where we use the es_version crate's SequencerVersion in most places, and also SeqTypes::Base version. This did not cause any issues as both versions were the same. However, updating the base version would cause some tests to fail.

This PR
- removes es_crate completely and use SeqTypes::Base version


future work:
- parameterize SeqTypes<Base, Upgrade> and then instantiate the sequencer at the top level with the appropriate Base and Upgrade version based on runtime configuration (e.g. genesis file) so that we are still able to run staging tests with 0.1 and 0.2 with the same binary
- add message compat tests for all versions as changing base version will break them