### PR TITLE
Fix comment in `_linearizationScalarsAndBases`

### DIFF
--- a/contracts/src/libraries/PlonkVerifier.sol
+++ b/contracts/src/libraries/PlonkVerifier.sol
@@ -766,7 +766,7 @@ library PlonkVerifier {
 
         // ============================================
         // Compute coefficient for the last wire sigma polynomial commitment.
-        // secondScalar = alpha * beta * z_w
+        // secondScalar = - alpha * beta * z_w
         //              * (wireEval0 + gamma + beta * sigmaEval0)
         //              * (wireEval1 + gamma + beta * sigmaEval1)
         //              * ...

--- a/contracts/src/libraries/PlonkVerifier.sol
+++ b/contracts/src/libraries/PlonkVerifier.sol
@@ -766,7 +766,7 @@ library PlonkVerifier {
 
         // ============================================
         // Compute coefficient for the last wire sigma polynomial commitment.
-        // secondScalar = alpha * beta * z_w * [s_sigma_3]_1
+        // secondScalar = alpha * beta * z_w
         //              * (wireEval0 + gamma + beta * sigmaEval0)
         //              * (wireEval1 + gamma + beta * sigmaEval1)
         //              * ...


### PR DESCRIPTION
Closes #1753

### This PR:

Fixes a comment in line PlonkVerifier.sol:769. See https://github.com/EspressoSystems/espresso-sequencer/issues/1753#issuecomment-2246650132 for context.