### PR TITLE
Fix time based upgrade

### DIFF
--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -132,8 +132,6 @@ impl Upgrade {
                 config.start_proposing_time = t.start_proposing_time.unix_timestamp();
                 config.stop_proposing_time = t.stop_proposing_time.unix_timestamp();
                 config.start_voting_time = t.start_voting_time.unwrap_or_default().unix_timestamp();
-                // this should not panic because Timestamp::max() constructs the maximum possible Unix timestamp
-                // using i64::MAX
                 config.stop_voting_time = t
                     .stop_voting_time
                     .unwrap_or(Timestamp::max())

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -136,7 +136,7 @@ impl Upgrade {
                 // using i64::MAX
                 config.stop_voting_time = t
                     .stop_voting_time
-                    .unwrap_or(Timestamp::max().expect("overflow"))
+                    .unwrap_or(Timestamp::max())
                     .unix_timestamp();
                 config.start_proposing_view = 0;
                 config.stop_proposing_view = u64::MAX;

--- a/types/src/v0/utils.rs
+++ b/types/src/v0/utils.rs
@@ -1,11 +1,3 @@
-use std::{
-    cmp::{min, Ordering},
-    fmt::{self, Debug, Display, Formatter},
-    num::ParseIntError,
-    str::FromStr,
-    time::Duration,
-};
-
 use anyhow::Context;
 use async_std::task::sleep;
 use clap::Parser;
@@ -15,7 +7,16 @@ use rand::Rng;
 use sequencer_utils::{impl_serde_from_string_or_integer, ser::FromStringOrInteger};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use time::{format_description::well_known::Rfc3339 as TimestampFormat, OffsetDateTime};
+use std::{
+    cmp::{min, Ordering},
+    fmt::{self, Debug, Display, Formatter},
+    num::ParseIntError,
+    str::FromStr,
+    time::Duration,
+};
+use time::{
+    format_description::well_known::Rfc3339 as TimestampFormat, macros::time, Date, OffsetDateTime,
+};
 
 /// Information about the genesis state which feeds into the genesis block header.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -40,10 +41,8 @@ impl Timestamp {
         self.0.unix_timestamp() as u64
     }
 
-    pub fn max() -> anyhow::Result<Self> {
-        Ok(Self(
-            OffsetDateTime::from_unix_timestamp(i64::MAX).context("overflow")?,
-        ))
+    pub fn max() -> Self {
+        Self(OffsetDateTime::new_utc(Date::MAX, time!(23:59)))
     }
 }
 


### PR DESCRIPTION
- building  OffsetDateTime from i64::MAX panics as the upper bound on the timestamp range is much smaller than that so this is fixed by using the from_utc() function. This function is internally used by from_unix_timestamp()
- adds test for time based chain config upgrade