### PR TITLE
Fix compose file configuration for node-validator and block-explorer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -662,9 +662,12 @@ services:
     ports:
       - "$ESPRESSO_NODE_VALIDATOR_PORT:$ESPRESSO_NODE_VALIDATOR_PORT"
     environment:
+      - RUST_LOG
+      - RUST_LOG_FORMAT
+      - ESPRESSO_NODE_VALIDATOR_PORT
       - ESPRESSO_NODE_VALIDATOR_STAKE_TABLE_SOURCE_BASE_URL=http://sequencer0:$ESPRESSO_SEQUENCER_API_PORT/v0/
       - ESPRESSO_NODE_VALIDATOR_LEAF_STREAM_SOURCE_BASE_URL=http://sequencer0:$ESPRESSO_SEQUENCER_API_PORT/v0/
-      - ESPRESSO_NODE_VALIDATOR_INITIAL_NODE_PUBLIC_BASE_URLS=http://sequencer0:$ESPRESSO_SEQUENCER_API_PORT,http://sequencer1:$ESPRESSO_SEQUENCER1_API_PORT,http://sequencer2:$ESPRESSO_SEQUENCER2_API_PORT,http://sequencer3:$ESPRESSO_SEQUENCER3_API_PORT,http://sequencer4:$ESPRESSO_SEQUENCER4_API_PORT
+      - ESPRESSO_NODE_VALIDATOR_INITIAL_NODE_PUBLIC_BASE_URLS=http://sequencer0:$ESPRESSO_SEQUENCER_API_PORT/,http://sequencer1:$ESPRESSO_SEQUENCER_API_PORT/,http://sequencer2:$ESPRESSO_SEQUENCER_API_PORT/,http://sequencer3:$ESPRESSO_SEQUENCER_API_PORT/,http://sequencer4:$ESPRESSO_SEQUENCER_API_PORT/
     depends_on:
       sequencer0:
         condition: service_healthy
@@ -733,7 +736,8 @@ services:
     ports:
       - "$ESPRESSO_BLOCK_EXPLORER_PORT:3000"
     environment:
-      - QUERY_SERVICE_URI:http://localhost:$ESPRESSO_SEQUENCER1_API_PORT/v0/
+      - QUERY_SERVICE_URI=http://localhost:$ESPRESSO_SEQUENCER1_API_PORT/v0/
+      - NODE_VALIDATOR_URI=ws://localhost:$ESPRESSO_NODE_VALIDATOR_PORT/v0/
     depends_on:
       sequencer1:
         condition: service_healthy

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -10,6 +10,7 @@ environment:
   - ESPRESSO_DEMO_L1_HTTP_PROVIDER=$ESPRESSO_SEQUENCER_L1_PROVIDER
   - ESPRESSO_STATE_RELAY_SERVER_URL=http://localhost:$ESPRESSO_STATE_RELAY_SERVER_PORT
   - QUERY_SERVICE_URI=http://localhost:$ESPRESSO_SEQUENCER1_API_PORT/v0/
+  - NODE_VALIDATOR_URI=ws://localhost:$ESPRESSO_NODE_VALIDATOR_PORT/v0/
 processes:
   # Cheating a bit here but since we don't usually have to debug go-ethereum
   # it's using the docker compose service which is a bit easier.
@@ -338,11 +339,11 @@ processes:
       failure_threshold: 100
 
   node_validator:
-    command: node-metrics --
+    command: RUST_LOG=debug node-metrics --
     environment:
       - ESPRESSO_NODE_VALIDATOR_STAKE_TABLE_SOURCE_BASE_URL=http://localhost:$ESPRESSO_SEQUENCER_API_PORT/v0/
       - ESPRESSO_NODE_VALIDATOR_LEAF_STREAM_SOURCE_BASE_URL=http://localhost:$ESPRESSO_SEQUENCER_API_PORT/v0/
-      - ESPRESSO_NODE_VALIDATOR_INITIAL_NODE_PUBLIC_BASE_URLS=http://localhost:$ESPRESSO_SEQUENCER_API_PORT,http://localhost:$ESPRESSO_SEQUENCER1_API_PORT,http://localhost:$ESPRESSO_SEQUENCER2_API_PORT,http://localhost:$ESPRESSO_SEQUENCER3_API_PORT,http://localhost:$ESPRESSO_SEQUENCER4_API_PORT
+      - ESPRESSO_NODE_VALIDATOR_INITIAL_NODE_PUBLIC_BASE_URLS=http://localhost:$ESPRESSO_SEQUENCER_API_PORT/,http://localhost:$ESPRESSO_SEQUENCER1_API_PORT/,http://localhost:$ESPRESSO_SEQUENCER2_API_PORT/,http://localhost:$ESPRESSO_SEQUENCER3_API_PORT/,http://localhost:$ESPRESSO_SEQUENCER4_API_PORT/
     depends_on:
       broker_0:
         condition: process_healthy
@@ -656,7 +657,7 @@ processes:
 
   block-explorer:
     command:
-      docker run --rm -p $ESPRESSO_BLOCK_EXPLORER_PORT:3000 -e QUERY_SERVICE_URI
+      docker run --rm -p $ESPRESSO_BLOCK_EXPLORER_PORT:3000 -e QUERY_SERVICE_URI -e NODE_VALIDATOR_URI
       ghcr.io/espressosystems/espresso-block-explorer:main
     depends_on:
       sequencer1:


### PR DESCRIPTION
Fix docker-compose and process-compose for node-validator

The `node-validator` section of the `docker-compose.yaml` file has the environment variable
`ESPRESSO_NODE_VALIDATOR_INITIAL_NODE_PUBLIC_BASE_URLS` pointing at the incorrect
ports for all of the sequencers that are not `sequencer0`.  As a result, the other sequencers are
not correctly scraped and are not reflected in the data collected.  Additionally, the port that the
`node-validator` is meant to expose is not being forwarded to the container via the environment
variable `ESPRESSO_NODE_VALIDATOR_PORT`.  Finally, the local demo service doesn't produce
any visible logs while running.

Forwards the relevant needed environment variables for logging, and modifies the the ports in
the node public base URLs to correct the issue.

Add node validator configuration to process-compose and docker-compose

The block-explorer now has support for the node validator API, but has not been updated to point
to the relevant base URL for the service.  As a result, the Nodes Page will still generate fake data.

Updates the process-compose.yaml and docker-compose.yaml configuration to supply the
environment variable `NODE_VALIDATOR_URI` so that it points to the `node-validator` as a
websocket connection.

Closes #1832
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Corrects the configuration of the `node-validator` by ensuring that logging is enabled for the service.  Additionally, it corrects the list of initial public api urls supplied, by utilizing the internal port in the `docker-compose` file instead of the external exposed port.

Adds the node-validator url to the block-explorer in order to for the `Nodes Page` to reflect the data
of the local demo instead of just producing a bunch of fake data.

<!-- ### This PR does not: -->
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->
- process-compose.yaml
- docker-compose.yaml

### How to test this PR:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->
```sh
just demo-native
```

or

```sh
docker-compose up -d
```

With docker-compose, make sure you have the latest images by running the following:

```sh
docker-compose pull
```

Then, once things are up and running, visit the [block-explorer](http://localhost:3000/), and navigate to the [Nodes Page](http://localhost:3000/nodes) to see updating data for the local block-chain and nodes.  Please note that we've supplied fake node identity information for the nodes.

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
