### PR TITLE
reject transactions with size greater than  max block size

### DIFF
--- a/node-metrics/src/service/client_state/mod.rs
+++ b/node-metrics/src/service/client_state/mod.rs
@@ -1308,7 +1308,7 @@ pub mod tests {
         let (internal_client_message_sender, internal_client_message_receiver) = mpsc::channel(1);
         let (server_message_sender_1, mut server_message_receiver_1) = mpsc::channel(1);
         let (server_message_sender_2, mut server_message_receiver_2) = mpsc::channel(1);
-        let _process_internal_client_message_handle = InternalClientMessageProcessingTask::new(
+        let process_internal_client_message_handle = InternalClientMessageProcessingTask::new(
             internal_client_message_receiver,
             data_state,
             client_thread_state,
@@ -1359,6 +1359,8 @@ pub mod tests {
                 voters_1, voters_2
             ]))),
         );
+
+        drop(process_internal_client_message_handle)
     }
 
     #[async_std::test]

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -473,20 +473,16 @@ mod tests {
                 .await;
         }
 
-        // Now the `submit/submit` endpoint allows the extremely large transactions to be in the mempool.
-        // And we need to check whether this extremely large transaction blocks the building process.
-        // Currently the default value of `max_block_size` is 30720, and this transaction exceeds the limit.
-        // TODO: https://github.com/EspressoSystems/espresso-sequencer/issues/1777
         {
+            // transactions with size larger than max_block_size result in an error
             let extremely_large_tx = Transaction::new(100_u32.into(), vec![0; 50120]);
-            let extremely_large_hash: Commitment<Transaction> = api_client
-                .post("submit/submit")
+            api_client
+                .post::<Commitment<Transaction>>("submit/submit")
                 .body_json(&extremely_large_tx)
                 .unwrap()
                 .send()
                 .await
-                .unwrap();
-            assert_eq!(extremely_large_tx.commit(), extremely_large_hash);
+                .unwrap_err();
 
             // Now we send a small transaction to make sure this transaction can be included in a hotshot block.
             let tx = Transaction::new(100_u32.into(), vec![0; 3]);


### PR DESCRIPTION
Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1777

This PR

Rejects any transaction whose payload length is more than the max block size. The max block size parameter is found in the chain config, which can be updated through an upgrade. Therefore, we use the chain config from the validated state first, as the validated state is the mutable state of the node and the chain config, if present, will be the latest chain config. 

If the chain config is not present in the validated state, which may occur if the node has not seen an upgrade, we use the chain config from the node state. The node will automatically catch up and have an updated chain config in the validated state when building the header for the next block.