### PR TITLE
Move solver API paths to configuration

### DIFF
--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -391,9 +391,7 @@ pub async fn init_hotshot<
         ConsensusMetricsValue::new(metrics),
         da_storage,
         MarketplaceConfig {
-            auction_results_provider: Arc::new(SolverAuctionResultsProvider(
-                Url::from_str("https://some.solver").unwrap(),
-            )),
+            auction_results_provider: Arc::new(SolverAuctionResultsProvider::default()),
             fallback_builder_url: Url::from_str("https://some.builder").unwrap(),
         },
     )

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -762,9 +762,7 @@ pub mod testing {
                 None, // The public API URL
                 bind_version,
                 MarketplaceConfig::<SeqTypes, Node<network::Memory, P::Persistence>> {
-                    auction_results_provider: Arc::new(SolverAuctionResultsProvider(
-                        Url::from_str("https://some.solver").unwrap(),
-                    )),
+                    auction_results_provider: Arc::new(SolverAuctionResultsProvider::default()),
                     fallback_builder_url: Url::from_str("https://some.builder").unwrap(),
                 },
             )

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -99,9 +99,11 @@ where
     };
 
     let marketplace_config = MarketplaceConfig {
-        auction_results_provider: Arc::new(SolverAuctionResultsProvider(
-            opt.auction_results_solver_url,
-        )),
+        auction_results_provider: Arc::new(SolverAuctionResultsProvider {
+            url: opt.auction_results_solver_url,
+            marketplace_path: opt.marketplace_solver_path,
+            results_path: opt.auction_results_path,
+        }),
         fallback_builder_url: opt.fallback_builder_url,
     };
 

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -112,7 +112,20 @@ pub struct Options {
     )]
     #[derivative(Debug(format_with = "Display::fmt"))]
     pub auction_results_solver_url: Url,
-
+    #[clap(
+        long,
+        env = "ESPRESSO_MARKETPLACE_SOLVER_PATH",
+        default_value = "marketplace-solver/"
+    )]
+    /// API path of marketplace-solver
+    pub marketplace_solver_path: String,
+    #[clap(
+        long,
+        env = "ESPRESSO_AUCTION_RESULTS_PATH",
+        default_value = "auction_results/"
+    )]
+    /// API path of marketplace-solver auction results
+    pub auction_results_path: String,
     /// URL of generic builder
     #[clap(
         long,

--- a/types/src/v0/impls/auction.rs
+++ b/types/src/v0/impls/auction.rs
@@ -283,7 +283,21 @@ type SurfClient = surf_disco::Client<ServerError, <SequencerVersions as Versions
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// Auction Results provider holding the Url of the solver in order to fetch auction results.
-pub struct SolverAuctionResultsProvider(pub Url);
+pub struct SolverAuctionResultsProvider {
+    pub url: Url,
+    pub marketplace_path: String,
+    pub results_path: String,
+}
+
+impl Default for SolverAuctionResultsProvider {
+    fn default() -> Self {
+        Self {
+            url: Url::from_str("http://localhost:25000").unwrap(),
+            marketplace_path: "marketplace-solver/".into(),
+            results_path: "auction_results/".into(),
+        }
+    }
+}
 
 #[async_trait]
 impl<TYPES: NodeType> AuctionResultsProvider<TYPES> for SolverAuctionResultsProvider {
@@ -293,11 +307,11 @@ impl<TYPES: NodeType> AuctionResultsProvider<TYPES> for SolverAuctionResultsProv
         view_number: TYPES::Time,
     ) -> anyhow::Result<TYPES::AuctionResult> {
         let resp = SurfClient::new(
-            self.0
-                .join("marketplace-solver/")
+            self.url
+                .join(&self.marketplace_path)
                 .context("Malformed solver URL")?,
         )
-        .get::<TYPES::AuctionResult>(&format!("auction_results/{}", *view_number))
+        .get::<TYPES::AuctionResult>(&format!("{}{}", self.results_path, *view_number))
         .send()
         .await?;
         Ok(resp)


### PR DESCRIPTION
### This PR:
Moves URL paths for obtaining auction_results from solver to configuration. They were previously hard coded. 

