### PR TITLE
Update default `GossipSub` `mesh_n`

### DIFF
--- a/sequencer/src/bin/orchestrator.rs
+++ b/sequencer/src/bin/orchestrator.rs
@@ -67,7 +67,11 @@ struct Args {
 
     /// The number of nodes a Libp2p node should try to maintain
     /// a connection with at one time.
-    #[arg(long, env = "ESPRESSO_ORCHESTRATOR_LIBP2P_MESH_N", default_value = "4")]
+    #[arg(
+        long,
+        env = "ESPRESSO_ORCHESTRATOR_LIBP2P_MESH_N",
+        default_value = "20"
+    )]
     libp2p_mesh_n: usize,
 
     /// Seed to use for generating node keys.


### PR DESCRIPTION
This PR changes the orchestrator default to `20` from `4` for the number of connections `GossipSub` should try to maintain. 