### PR TITLE
/SlowEst/SlowTests

### DIFF
--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -1,4 +1,4 @@
-name: SlowEst
+name: Slow Tests
 
 on:
   push:
@@ -22,7 +22,7 @@ env:
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:
-  slowest:
+  slowtests:
     runs-on: ubuntu-latest
     steps:
       - name: Fix submodule permissions check
@@ -53,7 +53,7 @@ jobs:
           cargo nextest run --locked --release --workspace --all-features --no-run
         timeout-minutes: 90
 
-      - name: SlowEst
+      - name: Slow Tests
         env:
           CARGO_TERM_COLOR: always
         # Build test binary with `testing` feature, which requires `hotshot_example` config

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -22,7 +22,7 @@ env:
   RUST_LOG: info,libp2p=off,node=error
 
 jobs:
-  slowtests:
+  slow-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Fix submodule permissions check


### PR DESCRIPTION
Fixes an error of trying to be clever at the expense of clarity. With this `Slow Tests` workflow is now called Slow Tests.

Doesn't change any functionality, so if Pipelines pass it should be good.