### PR TITLE
Update `v0_1::ChainConfig::from(v0_3::ChainConfig)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "committable"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c989a517928da3346fce6f6f75794285420edc3ef42c995ced45519f065acd"
+checksum = "05a8809c2761232ce27226ef1ca1bc78b480b558406895848f76ab8fce04076c"
 dependencies = [
  "arbitrary",
  "ark-serialize",
@@ -9214,7 +9214,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.74",


### PR DESCRIPTION
Update `committable` version in sequencer and use it to coerce a v3 Commitment into a v1 commitment.
 
  * relevant upstream: https://github.com/EspressoSystems/commit/pull/52
  * removes a TODO.
  * adds tests

### This PR:
This removes a *best effort* (and untested) downgrade of ChainConfig commitment in favor of using raw bytes (recently added to `committable`). Previously a v1 `ResolvableChainConfig` was derived from a v3 version using a a full cycle of serialization/de-serialization. Now that we can create a Commitment from some bytes, we can avoid that extra work. Some tests have been added to confirm expectations. 



### Key places to review:

  * espresso-sequencer/types/src/v0/v0_3/chain_config.rs

