### PR TITLE
fee upgrade fixes

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1549,14 +1549,14 @@ mod test {
 
             // ChainConfigs will eventually be resolved
             if let Some(configs) = configs {
-                if height > new_version_first_view {
+                if height >= new_version_first_view {
                     for config in configs {
                         assert_eq!(config, chain_config_upgrade);
                     }
                     break; // if assertion did not panic, we need to exit the loop
                 }
             }
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_millis(200)).await;
         }
 
         network.server.shut_down().await;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1479,8 +1479,6 @@ mod test {
             },
         );
 
-        let stop_voting_view = 30u64;
-
         const NUM_NODES: usize = 5;
         let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
             .api_config(
@@ -1558,7 +1556,7 @@ mod test {
                     break;
                 }
             }
-            sleep(Duration::from_secs(1));
+            sleep(Duration::from_secs(1)).await;
         }
 
         network.server.shut_down().await;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1528,8 +1528,6 @@ mod test {
         client.connect(None).await;
         tracing::info!(port, "server running");
 
-        let expected: Vec<ChainConfig> = (0..NUM_NODES).map(|_| chain_config_upgrade).collect();
-
         loop {
             let height = client
                 .get::<ViewNumber>("status/block-height")
@@ -1549,11 +1547,13 @@ mod test {
                 .map(|state| state.chain_config.resolve())
                 .collect();
 
-            // ChainConfig will eventually be resolved
+            // ChainConfigs will eventually be resolved
             if let Some(configs) = configs {
                 if height > new_version_first_view {
-                    assert_eq!(expected, configs);
-                    break;
+                    for config in configs {
+                        assert_eq!(config, chain_config_upgrade);
+                    }
+                    break; // if assertion did not panic, we need to exit the loop
                 }
             }
             sleep(Duration::from_secs(1)).await;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -1562,8 +1562,6 @@ mod test {
         }
 
         network.server.shut_down().await;
-        // TODO I don't think this drop does anything.
-        drop(network);
     }
 
     #[async_std::test]

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -667,7 +667,6 @@ mod test {
             timestamp = "0x123def"
             hash = "0x80f5dd11f2bdda2814cb1ad94ef30a47de02cf28ad68c89e104c00c4e51bb7a5"
 
-
             [[upgrade]]
             version = "0.3"
             start_proposing_view = 1


### PR DESCRIPTION
Fee upgrade tests in the current form do not properly test the upgrade. See [this thread](https://github.com/EspressoSystems/espresso-sequencer/pull/1880/files#r1722867590). 

### This PR:
This PR fixes the bug and the tests and make some attempt at making the test more easy to follow (in order to make it easier to spot bugs).


### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
  * espresso-sequencer/sequencer/src/api.rs 

### How to test this PR: 
Convince yourself that 
  * the test will only succeed if chain_config is upgraded. 
  * it will fail if chain_config is not upgraded
