### PR TITLE
Fix namespace filtering for the fallback builder

### DIFF
--- a/marketplace-builder/src/builder.rs
+++ b/marketplace-builder/src/builder.rs
@@ -52,7 +52,9 @@ use surf_disco::Client;
 use tide_disco::{app, method::ReadState, App, Url};
 use vbs::version::{StaticVersion, StaticVersionType};
 
-use crate::hooks::{self, BidConfig, EspressoFallbackHooks, EspressoReserveHooks};
+use crate::hooks::{
+    self, fetch_namespaces_to_skip, BidConfig, EspressoFallbackHooks, EspressoReserveHooks,
+};
 
 #[derive(Clone, Debug)]
 pub struct BuilderConfig {
@@ -235,9 +237,12 @@ impl BuilderConfig {
             )
             .await?;
         } else {
+            // Fetch the namespaces upon initialization. It will be fetched every 20 views when
+            // handling events.
+            let namespaces_to_skip = fetch_namespaces_to_skip(solver_api_url.clone()).await;
             let hooks = Arc::new(hooks::EspressoFallbackHooks {
                 solver_api_url,
-                namespaces_to_skip: RwLock::new(None),
+                namespaces_to_skip: RwLock::new(namespaces_to_skip),
             });
             Self::start_service(
                 Arc::clone(&global_state),

--- a/marketplace-builder/src/hooks.rs
+++ b/marketplace-builder/src/hooks.rs
@@ -54,6 +54,8 @@ pub fn connect_to_solver(solver_api_url: Url) -> Client<SolverError, Marketplace
 /// - `Some` namespaces if the fetching succeeds, even if the list is empty.
 /// - `None` if the fetching fails.
 pub async fn fetch_namespaces_to_skip(solver_api_url: Url) -> Option<HashSet<NamespaceId>> {
+    // TODO: Make API path consistent between real and mock solvers.
+    // <https://github.com/EspressoSystems/espresso-sequencer/issues/1935>
     let solver_client = connect_to_solver(solver_api_url);
     match solver_client
         .get::<Vec<RollupRegistration>>("rollup_registrations")


### PR DESCRIPTION
Closes #1921.

### This PR:
* Fetches the namespaces from the solver when constructing the fallback builder, not relying on the next fetch on view 20.
* Adds a helper function to connect to the solver and get the registration info.

### This PR does not:
* Fix the API inconsistency between real and mock solvers, as mentioned in the TODO comment.
  * Issue: https://github.com/EspressoSystems/espresso-sequencer/issues/1935.