### PR TITLE
perf: reuse free mem for each chal

### DIFF
--- a/contracts/src/libraries/PlonkVerifier.sol
+++ b/contracts/src/libraries/PlonkVerifier.sol
@@ -286,11 +286,8 @@ library PlonkVerifier {
             {
                 mstore(statePtr, 0x0) // init state
                 // preimage len: state(0x20) + transcript(0x7c0)
-                mstore(add(dataPtr, 0x7c0), keccak256(statePtr, 0x7e0))
-                // update new state (by updating state pointer)
-                statePtr := add(dataPtr, 0x7c0)
-                // empty transcript
-                dataPtr := add(statePtr, 0x20)
+                // overwrite previous state at freePtr
+                mstore(statePtr, keccak256(statePtr, 0x7e0))
                 // (mod p) to get beta
                 mstore(add(res, 0x60), mod(mload(statePtr), p))
             }
@@ -298,11 +295,8 @@ library PlonkVerifier {
             // challenge: gamma
             {
                 // preimage len: state(0x20) + transcript(0x0)
-                mstore(dataPtr, keccak256(statePtr, 0x20))
-                // update new state (by updating state pointer)
-                statePtr := dataPtr
-                // empty transcript
-                dataPtr := add(statePtr, 0x20)
+                // overwrite previous state at freePtr
+                mstore(statePtr, keccak256(statePtr, 0x20))
                 // (mod p) to get gamma
                 mstore(add(res, 0x80), mod(mload(statePtr), p))
             }
@@ -315,11 +309,7 @@ library PlonkVerifier {
             {
                 // preimage len: state(0x20) + transcript(0x40)
                 let alpha := keccak256(statePtr, 0x60)
-                // update new state (by updating state pointer)
-                statePtr := add(dataPtr, 0x40)
                 mstore(statePtr, alpha)
-                // empty transcript
-                dataPtr := add(statePtr, 0x20)
                 // (mod p) to get challenge
                 mstore(res, mod(alpha, p))
 
@@ -348,11 +338,8 @@ library PlonkVerifier {
             // challenge: zeta
             {
                 // preimage len: state(0x20) + transcript(0x140)
-                mstore(add(dataPtr, 0x140), keccak256(statePtr, 0x160))
-                // update new state (by updating state pointer)
-                statePtr := add(dataPtr, 0x140)
-                // empty transcript
-                dataPtr := add(statePtr, 0x20)
+                // overwrite previous state at freePtr
+                mstore(statePtr, keccak256(statePtr, 0x160))
                 // (mod p) to get challenge
                 mstore(add(res, 0xa0), mod(mload(statePtr), p))
             }
@@ -371,11 +358,8 @@ library PlonkVerifier {
             // challenge: v
             {
                 // preimage len: state(0x20) + transcript(0x140)
-                mstore(add(dataPtr, 0x140), keccak256(statePtr, 0x160))
-                // update new state (by updating state pointer)
-                statePtr := add(dataPtr, 0x140)
-                // empty transcript
-                dataPtr := add(statePtr, 0x20)
+                // overwrite previous state at freePtr
+                mstore(statePtr, keccak256(statePtr, 0x160))
                 // (mod p) to get challenge
                 mstore(add(res, 0xc0), mod(mload(statePtr), p))
             }


### PR DESCRIPTION
Closes #1917 

This is the last comments in the above issue, and a follow-up of #1738.

### This PR:

Instead of continuously expanding the free memory space, with every challenge generation, we reuse the free memory. 

according to Jakov from CommonPrefix, this could leads to gas efficiency: 

> Yes, there is. The key reason lies in how memory allocation and expansion work. Initially, memory is allocated in chunks, and as more memory is allocated, the gas cost increases.
> 
> Given that the stored data is no longer needed after hashing, you can simply reuse the already allocated memory. This avoids unnecessary memory expansion and results in lower gas costs.

in our particular case, we didn't observe any improvement, but it's still a good advice to implement and adhere to in the future.
