### PR TITLE
run marketplace builder if base version >= marketplace version

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -539,7 +539,9 @@ pub mod test_helpers {
                 legacy_builder_url = url;
             };
 
-            if <V as Versions>::Upgrade::VERSION >= MarketplaceVersion::VERSION {
+            if <V as Versions>::Upgrade::VERSION >= MarketplaceVersion::VERSION
+                || <V as Versions>::Base::VERSION >= MarketplaceVersion::VERSION
+            {
                 let (task, url) = run_marketplace_builder::<{ NUM_NODES }>(
                     cfg.network_config.marketplace_builder_port(),
                     NodeState::default(),


### PR DESCRIPTION
For now, the upgrade version is always greater than the base version, so this will enable the marketplace builder. However, we can set the upgrade version to be less than the base version if we want to disable upgrades, as the upgrade version type is always passed to HotShot. In that case, this base version condition would still enable the marketplace builder.