### PR TITLE
Set `pipefail` in demo-native action

### DIFF
--- a/.github/workflows/test-demo-native.yml
+++ b/.github/workflows/test-demo-native.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Test Demo
         run: |
           export PATH="$PWD/target/release:$PATH"
+          set -o pipefail
           scripts/demo-native --tui=false &
           timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'


### PR DESCRIPTION
This bubbles the exit status of `smoke-test` up to the CI runner.
Otherwise the pipe will exit w/ success since `sed` exits w/ `0`.
