### PR TITLE
Make API path consistent between real and mock solvers

### DIFF
--- a/marketplace-builder/src/hooks.rs
+++ b/marketplace-builder/src/hooks.rs
@@ -27,6 +27,7 @@ use espresso_types::NamespaceId;
 use hotshot_types::traits::node_implementation::NodeType;
 
 use marketplace_solver::SolverError;
+use marketplace_solver::SOLVER_API_PATH;
 use sequencer::SequencerApiVersion;
 use surf_disco::Client;
 
@@ -43,9 +44,7 @@ pub struct BidConfig {
 }
 
 pub fn connect_to_solver(solver_api_url: Url) -> Client<SolverError, MarketplaceVersion> {
-    Client::<SolverError, MarketplaceVersion>::new(
-        solver_api_url.join("marketplace-solver/").unwrap(),
-    )
+    Client::<SolverError, MarketplaceVersion>::new(solver_api_url.join(SOLVER_API_PATH).unwrap())
 }
 
 /// Fetch registered namespaces from the solver and construct the list of namespaces to skip.

--- a/marketplace-solver/src/lib.rs
+++ b/marketplace-solver/src/lib.rs
@@ -10,3 +10,5 @@ pub use events::*;
 pub use options::*;
 
 type SolverResult<T> = Result<T, SolverError>;
+
+pub const SOLVER_API_PATH: &str = "marketplace-solver";

--- a/marketplace-solver/src/testing.rs
+++ b/marketplace-solver/src/testing.rs
@@ -19,8 +19,8 @@ use crate::{
 };
 
 pub struct MockSolver {
-    pub events_api: Url,
-    pub solver_api: Url,
+    pub events_url: Url,
+    pub solver_url: Url,
     pub state: Arc<RwLock<GlobalState>>,
     pub database: PostgresClient,
     pub handles: Vec<JoinHandle<()>>,
@@ -29,7 +29,7 @@ pub struct MockSolver {
 
 impl MockSolver {
     pub fn solver_api(&self) -> Url {
-        self.solver_api.clone()
+        self.solver_url.clone().join(SOLVER_API_PATH).unwrap()
     }
 
     pub fn state(&self) -> Arc<RwLock<GlobalState>> {
@@ -50,9 +50,9 @@ impl Drop for MockSolver {
 impl MockSolver {
     pub async fn init() -> Self {
         let (tmp_db, database) = setup_mock_database().await;
-        let (url, event_api_handle, generate_events_handle) = run_mock_event_service();
+        let (events_url, event_api_handle, generate_events_handle) = run_mock_event_service();
 
-        let client = EventsServiceClient::new(url.clone()).await;
+        let client = EventsServiceClient::new(events_url.clone()).await;
         let startup_info = client.get_startup_info().await.unwrap();
         let stream = client.get_event_stream().await.unwrap();
 
@@ -80,7 +80,7 @@ impl MockSolver {
         let mut api = define_api(Default::default()).unwrap();
         api.with_version(env!("CARGO_PKG_VERSION").parse().unwrap());
 
-        app.register_module::<SolverError, MarketplaceVersion>("solver_api", api)
+        app.register_module::<SolverError, MarketplaceVersion>(SOLVER_API_PATH, api)
             .unwrap();
 
         let solver_api_port = pick_unused_port().expect("no free port");
@@ -93,8 +93,6 @@ impl MockSolver {
             }
         });
 
-        let solver_api = solver_url.join(SOLVER_API_PATH).unwrap();
-
         let handles = vec![
             generate_events_handle,
             event_handler_handle,
@@ -103,8 +101,8 @@ impl MockSolver {
         ];
 
         MockSolver {
-            events_api: url,
-            solver_api,
+            events_url,
+            solver_url,
             state,
             database,
             tmp_db,

--- a/marketplace-solver/src/testing.rs
+++ b/marketplace-solver/src/testing.rs
@@ -15,7 +15,7 @@ use crate::{
     define_api, handle_events,
     mock::run_mock_event_service,
     state::{GlobalState, SolverState, StakeTable},
-    EventsServiceClient, SolverError,
+    EventsServiceClient, SolverError, SOLVER_API_PATH,
 };
 
 pub struct MockSolver {
@@ -93,7 +93,7 @@ impl MockSolver {
             }
         });
 
-        let solver_api = solver_url.join("solver_api").unwrap();
+        let solver_api = solver_url.join(SOLVER_API_PATH).unwrap();
 
         let handles = vec![
             generate_events_handle,

--- a/sequencer/src/bin/dev-rollup.rs
+++ b/sequencer/src/bin/dev-rollup.rs
@@ -9,7 +9,7 @@ use espresso_types::{
 };
 use hotshot::types::BLSPubKey;
 use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
-use marketplace_solver::SolverError;
+use marketplace_solver::{SolverError, SOLVER_API_PATH};
 
 use sequencer_utils::logging;
 use url::Url;
@@ -126,7 +126,7 @@ async fn register(opt: RegisterArgs) -> Result<()> {
     } = opt;
 
     let client = surf_disco::Client::<SolverError, MarketplaceVersion>::new(
-        solver_url.join("marketplace-solver").unwrap(),
+        solver_url.join(SOLVER_API_PATH).unwrap(),
     );
 
     let (pubkey, privkey) = if let Some(privkey) = private_key {
@@ -185,7 +185,7 @@ async fn update(opt: UpdateArgs) -> Result<()> {
     } = opt;
 
     let client = surf_disco::Client::<SolverError, MarketplaceVersion>::new(
-        solver_url.join("marketplace-solver").unwrap(),
+        solver_url.join(SOLVER_API_PATH).unwrap(),
     );
     let (pubkey, privkey) = if let Some(privkey) = private_key {
         let privkey = <BLSPubKey as SignatureKey>::PrivateKey::from_str(&privkey)


### PR DESCRIPTION
Closes #1935.

### This PR:
* Adds a const for the solver API path.
* Replaces the paths used in `connect_to_solver` and `MockSolver` with the const to make the builder and mock solver consistent.

### Key places to review:
* Where the paths are replaced by the const.
* Whether any place with an inconsistent path is missed.

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
