### PR TITLE
Move postgres readiness into the container

### DIFF
--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -603,14 +603,14 @@ processes:
 
   sequencer-db-0:
     command:
-      docker run -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $ESPRESSO_SEQUENCER0_DB_PORT:5432 postgres
+      docker run --name sequencer-db-0 --rm -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $ESPRESSO_SEQUENCER0_DB_PORT:5432 postgres
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=root
       - POSTGRES_DB=sequencer
     readiness_probe:
       exec:
-        command: pg_isready -h localhost -p $ESPRESSO_SEQUENCER0_DB_PORT
+        command: docker exec sequencer-db-0 pg_isready
       initial_delay_seconds: 5
       period_seconds: 5
       timeout_seconds: 4
@@ -621,14 +621,14 @@ processes:
 
   sequencer-db-1:
     command:
-      docker run -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $ESPRESSO_SEQUENCER1_DB_PORT:5432 postgres
+      docker run --name sequencer-db-1 --rm -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $ESPRESSO_SEQUENCER1_DB_PORT:5432 postgres
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=root
       - POSTGRES_DB=sequencer
     readiness_probe:
       exec:
-        command: pg_isready -h localhost -p $ESPRESSO_SEQUENCER1_DB_PORT
+        command: docker exec sequencer-db-1 pg_isready
       initial_delay_seconds: 5
       period_seconds: 5
       timeout_seconds: 4
@@ -639,14 +639,14 @@ processes:
 
   solver-db:
     command:
-      docker run -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $MARKETPLACE_SOLVER_POSTGRES_PORT:5432 postgres
+      docker run --name solver-db --rm -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p $MARKETPLACE_SOLVER_POSTGRES_PORT:5432 postgres
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=root
       - POSTGRES_DB=solver
     readiness_probe:
       exec:
-        command: pg_isready -h localhost -p $MARKETPLACE_SOLVER_POSTGRES_PORT
+        command: docker exec solver-db pg_isready
       initial_delay_seconds: 5
       period_seconds: 5
       timeout_seconds: 4


### PR DESCRIPTION
Its confusing running things in docker and then requiring host setup to check the containerized app.
