### PR TITLE
add test config file

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.default]
+slow-timeout = "2m"
+default-filter = 'not test(slow_)'
+retries = 2
+
+[profile.slow]
+default-filter = 'test(slow_)'
+
+[profile.all]
+default-filter = 'all()'

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -56,9 +56,10 @@ jobs:
       - name: Slow Tests
         env:
           CARGO_TERM_COLOR: always
+          NEXTEST_PROFILE: slow
         # Build test binary with `testing` feature, which requires `hotshot_example` config
         run: |
           export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
-          cargo nextest run --locked --release --workspace --all-features --verbose -E 'test(slow_)'
+          cargo nextest run --locked --release --workspace --all-features --verbose
         timeout-minutes: 25

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -61,5 +61,5 @@ jobs:
         run: |
           export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
-          cargo nextest run --locked --release --workspace --all-features --verbose
+          cargo nextest run --locked --release --workspace --all-features --verbose --no-fail-fast
         timeout-minutes: 25

--- a/.github/workflows/test-demo-native-marketplace.yml
+++ b/.github/workflows/test-demo-native-marketplace.yml
@@ -10,7 +10,6 @@ on:
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
   schedule:
     - cron: "0 0 * * 1"
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-demo-native-marketplace.yml
+++ b/.github/workflows/test-demo-native-marketplace.yml
@@ -10,6 +10,7 @@ on:
       - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
   schedule:
     - cron: "0 0 * * 1"
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,5 @@ jobs:
         run: |
           export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
-          cargo nextest run --locked --release --workspace --all-features --retries 2 --verbose -E '!test(slow_)'
-        timeout-minutes: 10
+          cargo nextest run --locked --release --workspace --all-features --verbose --profile ci
+        timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,5 @@ jobs:
         run: |
           export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
-          cargo nextest run --locked --release --workspace --all-features --verbose
+          cargo nextest run --locked --release --workspace --all-features --verbose --no-fail-fast
         timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,5 @@ jobs:
         run: |
           export RUSTFLAGS="$RUSTFLAGS --cfg hotshot_example"
           export PATH="$PWD/target/release:$PATH"
-          cargo nextest run --locked --release --workspace --all-features --verbose --profile ci
+          cargo nextest run --locked --release --workspace --all-features --verbose
         timeout-minutes: 5

--- a/justfile
+++ b/justfile
@@ -39,14 +39,14 @@ anvil *args:
 
 test:
 	@echo 'Omitting slow tests. Use `test-slow` for those. Or `test-all` for all tests.'
-	cargo nextest run --locked --release --workspace --all-features --retries 2 --verbose -E '!test(slow_)'
+	cargo nextest run --locked --release --workspace --all-features --verbose 
 
 test-slow:
 	@echo 'Only slow tests are included. Use `test` for those deemed not slow. Or `test-all` for all tests.'
-	cargo nextest run --locked --release --workspace --all-features --verbose -E 'test(slow_)'
+	cargo nextest run --locked --release --workspace --all-features --verbose --profile slow
 
 test-all:
-	cargo nextest run --locked --release --workspace --all-features --verbose
+	cargo nextest run --locked --release --workspace --all-features --verbose --profile all
 
 clippy:
     cargo clippy --workspace --all-features --all-targets -- -D warnings


### PR DESCRIPTION
Move test options to profiles. This helps clean up the command line a little, and should add more flexibility for future changes. Also addes `--no-fail-fast` option to run all the tests even after one fails.