### PR TITLE
only allow marketplace fee validation on marketplace verioned headers

### DIFF
--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -77,6 +77,19 @@ impl NodeState {
         )
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub fn mock_v3() -> Self {
+        use vbs::version::StaticVersion;
+
+        Self::new(
+            0,
+            ChainConfig::default(),
+            L1Client::new("http://localhost:3331".parse().unwrap(), 10000),
+            mock::MockStateCatchup::default(),
+            StaticVersion::<0, 3>::version(),
+        )
+    }
+
     pub fn with_l1(mut self, l1_client: L1Client) -> Self {
         self.l1_client = l1_client;
         self

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1111,6 +1111,31 @@ mod test {
         };
 
         validate_builder_fee(&header).unwrap();
+    }
+
+    #[async_std::test]
+    async fn test_validate_builder_fee_marketplace() {
+        setup_logging();
+        setup_backtrace();
+
+        let max_block_size = 10;
+
+        let validated_state = ValidatedState::default();
+        let instance_state = NodeState::mock_v3().with_chain_config(ChainConfig {
+            base_fee: 1000.into(), // High base fee
+            max_block_size: max_block_size.into(),
+            ..validated_state.chain_config.resolve().unwrap()
+        });
+
+        let parent = Leaf::genesis(&instance_state.genesis_state, &instance_state).await;
+        let header = parent.block_header().clone();
+
+        debug!("{:?}", header.version());
+
+        let key_pair = EthKeyPair::random();
+        let account = key_pair.fee_account();
+
+        let data = header.fee_info()[0].amount().as_u64().unwrap();
 
         // test v3 sig
         let sig = FeeAccount::sign_sequencing_fee_marketplace(&key_pair, data).unwrap();


### PR DESCRIPTION
We need to be able to continue marketplace efforts, but we don't want to allow replay attacks. Note that we generally account for versioning earlier to avoid such version checks leaking to the surface, but I'm not thinking of a better way to do this at this time. 