### PR TITLE
Update `tide-disco`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7535,7 +7535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -9851,9 +9851,9 @@ dependencies = [
 
 [[package]]
 name = "tide-disco"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e81752cd71cc517973c6ff743919848d7c9890331f38c43abadfb49eede3a6"
+checksum = "11d7970b9fb963d9652bdedd3022521998734a029e92bb6c80d83b58edd88e58"
 dependencies = [
  "anyhow",
  "async-h1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ strum = { version = "0.26", features = ["derive"] }
 surf-disco = "0.9"
 sqlx = { version = "^0.8", features = ["postgres", "macros"] }
 tagged-base64 = "0.4"
-tide-disco = "0.9"
+tide-disco = "0.9.1"
 thiserror = "1.0.61"
 tracing = "0.1"
 bytesize = "1.3"

--- a/node-metrics/Cargo.toml
+++ b/node-metrics/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { version = "^1.0.113", optional = true }
 surf-disco = { workspace = true }
-tide-disco = { version = "0.9.0" }
+tide-disco = { workspace = true }
 time = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
Fixes an issue where we couldn't use non-root users in the docker containers