### PR TITLE
Tb/coverage next

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ default-filter = 'package(tests)'
 retries = 2
 
 [profile.coverage]
-default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover) | package(tests))'
+default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | test(test_catchup) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover) | package(tests))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ default-filter = 'package(tests)'
 retries = 2
 
 [profile.coverage]
-default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover))'
+default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover)) | package(tests))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ default-filter = 'package(tests)'
 retries = 2
 
 [profile.coverage]
-default-filter = '!test(slow_) | !test(service::test::test_) | !test(uint_bytes) | !package(contract-bindings) | !package(gen-vk-contract) | !package(hotshot-contract-adapter) | !test(diff-test-hotshot)'
+default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | test(diff-test-hotshot))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,3 +22,6 @@ retries = 2
 slow-timeout = "2m"
 default-filter = 'package(tests)'
 retries = 2
+
+[profile.coverage]
+default-filter = '!test(slow_) | !test(service::test::test_) | !test(uint_bytes) | !package(contract-bindings) | !package(gen-vk-contract) | !package(hotshot-contract-adapter) | !test(diff-test-hotshot)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ default-filter = 'package(tests)'
 retries = 2
 
 [profile.coverage]
-default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | test(diff-test-hotshot))'
+default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ default-filter = 'package(tests)'
 retries = 2
 
 [profile.coverage]
-default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover)) | package(tests))'
+default-filter = 'not (test(slow_) | test(service::test::test_) | test(uint_bytes) | test(diff-test-hotshot) | package(contract-bindings) | package(gen-vk-contract) | package(hotshot-contract-adapter) | package(hotshot-state-prover) | package(tests))'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ env:
   CARGO_TERM_COLOR: always
   NEXTEST_PROFILE: coverage
   COVERAGE_RUSTFLAGS: >
-    -Z threads=8 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
+    --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
     hotshot_example
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
         with:
           version: nightly
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 
@@ -47,8 +47,7 @@ jobs:
       # Separate build step for easier identification of failures and timings.
       - name: Build tests for coverage
         run: |
-          cargo +nightly llvm-cov --no-report nextest --all-features
-          cargo +nightly llvm-cov --no-report --doc --all-features
+          cargo llvm-cov --no-report nextest --all-features
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 90
@@ -56,7 +55,7 @@ jobs:
       # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
         run: |
-          cargo +nightly llvm-cov report --doctests --lcov --output-path lcov.info
+          cargo llvm-cov report --doctests --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 120

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,9 +51,7 @@ jobs:
           cargo llvm-cov --no-report nextest --all-features
           cargo llvm-cov --no-report --doc --all-features
         env:
-          CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
-          RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
         timeout-minutes: 90
 
       # TODO investigate why `uint_bytes` fail in coverage runs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          $CARGO_TEST_CMD -- --skip service::test::test_ --skip slow_
+          $CARGO_TEST_CMD -- --skip service::test::test_ --skip slow_ --skip uint_bytes
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,13 +34,12 @@ jobs:
         with:
           version: nightly
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
-
 
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,21 +44,14 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
 
-      # Separate build step for easier identification of failures and timings.
+      # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Build tests for coverage
         run: |
           cargo llvm-cov --no-report nextest --all-features
-        env:
-          RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
-        timeout-minutes: 90
-
-      # TODO investigate why `uint_bytes` fail in coverage runs
-      - name: Run tests with coverage
-        run: |
           cargo llvm-cov report --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
-        timeout-minutes: 120
+        timeout-minutes: 90
 
       - name: Coveralls upload
         uses: coverallsapp/github-action@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
 
-      # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Collect coverage data
         run: |
           cargo llvm-cov --no-report nextest --all-features
@@ -55,6 +54,6 @@ jobs:
         timeout-minutes: 90
 
       - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,6 +53,7 @@ jobs:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
 
+      # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
         run: |
           $CARGO_TEST_CMD -- --skip service::test::test_ --skip slow_ --skip uint_bytes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Collect coverage data
-        run: cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --all-features --no-fail-fast --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 90

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,14 +15,13 @@ concurrency:
 
 env:
   COVERAGE_RUSTFLAGS: >
-    -Z threads=8 -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Cllvm-args=--inline-threshold=0
+    -Z threads=8 -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Cllvm-args=--inline-threshold=0
     -Zpanic_abort_tests -Cdebuginfo=2 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
     hotshot_example
   COVERAGE_RUSTDOCFLAGS: >
-    -Z threads=8 -Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
-    -Zpanic_abort_tests
+    -Z threads=8 -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
   CARGO_TEST_CMD: >
-    cargo +nightly test --locked --all-features --no-fail-fast --release --workspace --exclude contract-bindings
+    cargo +nightly test --locked --all-features --no-fail-fast --workspace --exclude contract-bindings
     --exclude gen-vk-contract --exclude hotshot-contract-adapter --exclude diff-test-hotshot
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,7 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
-        timeout-minutes: 90
+        timeout-minutes: 120
 
       - uses: alekitto/grcov@v0.2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,11 +15,11 @@ concurrency:
 
 env:
   COVERAGE_RUSTFLAGS: >
-    -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
+    -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Cllvm-args=--inline-threshold=0
     -Zpanic_abort_tests -Cdebuginfo=2 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
     hotshot_example
   COVERAGE_RUSTDOCFLAGS: >
-    -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
+    -Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
     -Zpanic_abort_tests
   CARGO_TEST_CMD: >
     cargo +nightly test --locked --all-features --no-fail-fast --release --workspace --exclude contract-bindings

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,10 +45,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       # TODO investigate why `uint_bytes` fail in coverage runs
-      - name: Build tests for coverage
+      - name: Collect coverage data
         run: |
           cargo llvm-cov --no-report nextest --all-features
           cargo llvm-cov report --lcov --output-path lcov.info
+          ls 
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 90

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,8 +48,8 @@ jobs:
       # Separate build step for easier identification of failures and timings.
       - name: Build tests for coverage
         run: |
-          cargo llvm-cov --no-report nextest --all-features
-          cargo llvm-cov --no-report --doc --all-features
+          cargo +nightly llvm-cov --no-report nextest --all-features
+          cargo +nightly llvm-cov --no-report --doc --all-features
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 90
@@ -57,7 +57,7 @@ jobs:
       # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
         run: |
-          cargo llvm-cov report --doctests --lcov --output-path lcov.info
+          cargo +nightly llvm-cov report --doctests --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 120

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - release-*
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -14,15 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
+
+  CARGO_TERM_COLOR: always
+  NEXTEST_PROFILE: coverage
   COVERAGE_RUSTFLAGS: >
-    -Z threads=8 -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Cllvm-args=--inline-threshold=0
-    -Zpanic_abort_tests -Cdebuginfo=2 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
+    -Z threads=8 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
     hotshot_example
-  COVERAGE_RUSTDOCFLAGS: >
-    -Z threads=8 -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
-  CARGO_TEST_CMD: >
-    cargo +nightly test --locked --all-features --no-fail-fast --release --workspace --exclude contract-bindings
-    --exclude gen-vk-contract --exclude hotshot-contract-adapter --exclude diff-test-hotshot
 
 jobs:
   code-coverage:
@@ -36,18 +34,23 @@ jobs:
         with:
           version: nightly
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
 
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
+
       # Separate build step for easier identification of failures and timings.
       - name: Build tests for coverage
         run: |
-          $CARGO_TEST_CMD --no-run
+          cargo llvm-cov --no-report nextest --all-features
+          cargo llvm-cov --no-report --doc --all-features
         env:
-          # Do not exceed the memory limit of the public github runner during cargo build.
-          # CARGO_BUILD_JOBS: "2"
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
@@ -56,20 +59,13 @@ jobs:
       # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
         run: |
-          $CARGO_TEST_CMD -- --skip service::test::test_ --skip slow_ --skip uint_bytes
+          cargo llvm-cov report --doctests --lcov --output-path lcov.info
         env:
-          CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
-          RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
         timeout-minutes: 120
-
-      - uses: alekitto/grcov@v0.2
-        with:
-          config: .github/grcov.yml
-        id: coverage
 
       - name: Coveralls upload
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
+          files: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          $CARGO_TEST_CMD -- --skip service::test::test_
+          $CARGO_TEST_CMD -- --skip service::test::test_ --skip slow_
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,10 +45,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Collect coverage data
-        run: |
-          cargo llvm-cov --no-report nextest --all-features
-          cargo llvm-cov report --lcov --output-path lcov.info
-          ls 
+        run: cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 90

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,7 @@ jobs:
           $CARGO_TEST_CMD --no-run
         env:
           # Do not exceed the memory limit of the public github runner during cargo build.
-          CARGO_BUILD_JOBS: "2"
+          # CARGO_BUILD_JOBS: "2"
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
       # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
         run: |
-          cargo llvm-cov report --doctests --lcov --output-path lcov.info
+          cargo llvm-cov report --lcov --output-path lcov.info
         env:
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
         timeout-minutes: 120

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,4 +57,3 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          files: lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,6 +52,7 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
+        timeout-minutes: 90
 
       # TODO investigate why `uint_bytes` fail in coverage runs
       - name: Run tests with coverage
@@ -61,6 +62,7 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: ${{ env.COVERAGE_RUSTFLAGS }}
           RUSTDOCFLAGS: ${{ env.COVERAGE_RUSTDOCFLAGS }}
+        timeout-minutes: 90
 
       - uses: alekitto/grcov@v0.2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ env:
   COVERAGE_RUSTDOCFLAGS: >
     -Z threads=8 -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
   CARGO_TEST_CMD: >
-    cargo +nightly test --locked --all-features --no-fail-fast --workspace --exclude contract-bindings
+    cargo +nightly test --locked --all-features --no-fail-fast --release --workspace --exclude contract-bindings
     --exclude gen-vk-contract --exclude hotshot-contract-adapter --exclude diff-test-hotshot
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,11 +15,11 @@ concurrency:
 
 env:
   COVERAGE_RUSTFLAGS: >
-    -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Cllvm-args=--inline-threshold=0
+    -Z threads=8 -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Cllvm-args=--inline-threshold=0
     -Zpanic_abort_tests -Cdebuginfo=2 --cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std" --cfg
     hotshot_example
   COVERAGE_RUSTDOCFLAGS: >
-    -Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
+    -Z threads=8 -Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
     -Zpanic_abort_tests
   CARGO_TEST_CMD: >
     cargo +nightly test --locked --all-features --no-fail-fast --release --workspace --exclude contract-bindings
@@ -27,7 +27,7 @@ env:
 
 jobs:
   code-coverage:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/flake.nix
+++ b/flake.nix
@@ -273,9 +273,9 @@
           ];
           CARGO_INCREMENTAL = "0";
           shellHook = ''
-            RUSTFLAGS="$RUSTFLAGS -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Cdebuginfo=2"
+            RUSTFLAGS="$RUSTFLAGS -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests -Cdebuginfo=2 -Cllvm-args=--inline-threshold=0"
           '';
-          RUSTDOCFLAGS = "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests";
+          RUSTDOCFLAGS = "-Zprofile -Ccodegen-units=1 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests";
         });
 
       devShells.rustShell =

--- a/justfile
+++ b/justfile
@@ -146,4 +146,4 @@ dev-download-srs:
     @AZTEC_SRS_PATH="$PWD/data/aztec20/kzg10-aztec20-srs-65544.bin" ./scripts/download_srs_aztec.sh
 
 next-coverage:
-	cargo +nightly llvm-cov nextest --all-features --profile coverage
+	cargo llvm-cov nextest --all-features --profile coverage

--- a/justfile
+++ b/justfile
@@ -144,4 +144,6 @@ download-srs:
 dev-download-srs:
     @echo "Check existence or download SRS for dev/test"
     @AZTEC_SRS_PATH="$PWD/data/aztec20/kzg10-aztec20-srs-65544.bin" ./scripts/download_srs_aztec.sh
- 
+
+next-coverage:
+	cargo llvm-cov nextest --all-features --profile coverage

--- a/justfile
+++ b/justfile
@@ -146,4 +146,4 @@ dev-download-srs:
     @AZTEC_SRS_PATH="$PWD/data/aztec20/kzg10-aztec20-srs-65544.bin" ./scripts/download_srs_aztec.sh
 
 next-coverage:
-	cargo llvm-cov nextest --all-features --profile coverage
+	cargo +nightly llvm-cov nextest --all-features --profile coverage

--- a/justfile
+++ b/justfile
@@ -130,7 +130,7 @@ gas-benchmarks:
 # the lcov output is pushed to coveralls.
 code-coverage:
   @echo "Running code coverage"
-  cargo llvm-cov nextest --all-features --profile coverage --lcov --output-path lcov.info --no-fail-fast
+  cargo llvm-cov nextest --all-features --profile coverage --no-fail-fast --open
 
 # Download Aztec's SRS for production
 download-srs:

--- a/justfile
+++ b/justfile
@@ -130,7 +130,7 @@ gas-benchmarks:
 # the lcov output is pushed to coveralls.
 code-coverage:
   @echo "Running code coverage"
-  nix develop .#coverage -c cargo nextest run --all-features --no-fail-fast --release --retries 2 -E 'test(v0::impls::block::uint_bytes::test)' 
+  nix develop .#coverage -c cargo test --all-features --no-fail-fast --release --workspace -- --skip service::test::test_
   grcov . -s . --binary-path $CARGO_TARGET_DIR/debug/ -t html --branch --ignore-not-existing -o $CARGO_TARGET_DIR/coverage/ \
       --ignore 'contract-bindings/*' --ignore 'contracts/*'
   @echo "HTML report available at: $CARGO_TARGET_DIR/coverage/index.html"

--- a/justfile
+++ b/justfile
@@ -130,10 +130,7 @@ gas-benchmarks:
 # the lcov output is pushed to coveralls.
 code-coverage:
   @echo "Running code coverage"
-  nix develop .#coverage -c cargo test --all-features --no-fail-fast --release --workspace -- --skip service::test::test_
-  grcov . -s . --binary-path $CARGO_TARGET_DIR/debug/ -t html --branch --ignore-not-existing -o $CARGO_TARGET_DIR/coverage/ \
-      --ignore 'contract-bindings/*' --ignore 'contracts/*'
-  @echo "HTML report available at: $CARGO_TARGET_DIR/coverage/index.html"
+  cargo llvm-cov nextest --all-features --profile coverage --lcov --output-path lcov.info --no-fail-fast
 
 # Download Aztec's SRS for production
 download-srs:
@@ -144,6 +141,3 @@ download-srs:
 dev-download-srs:
     @echo "Check existence or download SRS for dev/test"
     @AZTEC_SRS_PATH="$PWD/data/aztec20/kzg10-aztec20-srs-65544.bin" ./scripts/download_srs_aztec.sh
-
-next-coverage:
-	cargo llvm-cov nextest --all-features --profile coverage

--- a/justfile
+++ b/justfile
@@ -130,7 +130,7 @@ gas-benchmarks:
 # the lcov output is pushed to coveralls.
 code-coverage:
   @echo "Running code coverage"
-  nix develop .#coverage -c cargo test --all-features --no-fail-fast --release --workspace -- --skip service::test::test_
+  nix develop .#coverage -c cargo nextest run --all-features --no-fail-fast --release --retries 2 -E 'test(v0::impls::block::uint_bytes::test)' 
   grcov . -s . --binary-path $CARGO_TARGET_DIR/debug/ -t html --branch --ignore-not-existing -o $CARGO_TARGET_DIR/coverage/ \
       --ignore 'contract-bindings/*' --ignore 'contracts/*'
   @echo "HTML report available at: $CARGO_TARGET_DIR/coverage/index.html"
@@ -144,3 +144,4 @@ download-srs:
 dev-download-srs:
     @echo "Check existence or download SRS for dev/test"
     @AZTEC_SRS_PATH="$PWD/data/aztec20/kzg10-aztec20-srs-65544.bin" ./scripts/download_srs_aztec.sh
+ 


### PR DESCRIPTION
Move code-coverage to `llvm-cov nextest`. 

Closes https://github.com/EspressoSystems/espresso-sequencer/issues/1863. Superceeds: https://github.com/EspressoSystems/espresso-sequencer/pull/1895

  * filter out more tests (see `./config/nextest.toml`)
  * update justfile
  * use `buildjet`