### PR TITLE
docs: update invalid link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To generate the documentation locally and view it in the browser, run
 
 ## Building and running
 
-Docker images and the [docker-compose-demo.yaml](docker-compose-demo.yaml) file are provided for convenience. The
+Docker images and the [docker-compose.yaml](docker-compose.yaml) file are provided for convenience. The
 Docker-based demo fetches the images from the `ghcr` repository, where they are updated with every push to `main` on
 GitHub. For testing uncommitted changes, you can also run the binaries by manually building and running the services.
 

--- a/README.md
+++ b/README.md
@@ -182,13 +182,6 @@ Running the script will save a file with details about the deployment in `contra
 The gas consumption for verifying a plonk proof as well as updating the state of the light client contract can be seen
 by running:
 
-```
-> just gas-benchmarks
-> cat gas-benchmarks.txt
-[PASS] test_verify_succeeds() (gas: 507774)
-[PASS] testCorrectUpdateBench() (gas: 594533)
-```
-
 In order to profile the gas consumption of the light client contract do the following:
 
 1. Set the environment variables `SEPOLIA_RPC_URL`, `MNEMONIC` and `ETHERSCAN_API_KEY`.


### PR DESCRIPTION
### This PR:
Corrects the invalid link referred in the readme document.
While studying the readme, I found one of the referred link is invalid "docker-compose-demo.yaml", after checking the file structure, I think the correct file mentioned should be "docker-compose.yaml.

### This PR does not:
Includes any code changes.

### Key places to review:
the new linked file whether it is valid now.

### Things tested:
no needs to test as only doc modified
