### PR TITLE
Make L1 finalized block required in genesis file

### DIFF
--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -258,11 +258,8 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
 
     let l1_client = L1Client::new(l1_params.url, l1_params.events_max_block_range);
     let l1_genesis = match genesis.l1_finalized {
-        Some(L1Finalized::Block(b)) => Some(b),
-        Some(L1Finalized::Number { number }) => {
-            Some(l1_client.wait_for_finalized_block(number).await)
-        }
-        None => None,
+        L1Finalized::Block(b) => b,
+        L1Finalized::Number { number } => l1_client.wait_for_finalized_block(number).await,
     };
 
     let instance_state = NodeState {
@@ -270,7 +267,7 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
         l1_client,
         genesis_header: genesis.header,
         genesis_state: genesis_state.clone(),
-        l1_genesis,
+        l1_genesis: Some(l1_genesis),
         peers: Arc::new(StatePeers::<SequencerApiVersion>::from_urls(
             network_params.state_peers,
             network_params.catchup_backoff,

--- a/data/genesis/cappuccino.toml
+++ b/data/genesis/cappuccino.toml
@@ -26,3 +26,6 @@ base_fee = '1 wei'
 max_block_size = '30mb'
 fee_recipient = '0x0000000000000000000000000000000000000000'
 fee_contract = '0x9d08cb3361b071ec1e2f3c206ac9c08d67385547'
+
+[l1_finalized]
+number = 0

--- a/data/genesis/decaf.toml
+++ b/data/genesis/decaf.toml
@@ -14,3 +14,6 @@ fee_contract = '0x0000000000000000000000000000000000000000'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
+
+[l1_finalized]
+number = 6762603 # Estimated on Sepolia: 25 Sep 2024 18:00 UTC

--- a/data/genesis/demo-marketplace.toml
+++ b/data/genesis/demo-marketplace.toml
@@ -14,6 +14,9 @@ fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'
 [header]
 timestamp = "1970-01-01T00:00:00Z"
 
+[l1_finalized]
+number = 0
+
 [[upgrade]]
 version = "0.3"
 start_proposing_view = 5

--- a/data/genesis/demo.toml
+++ b/data/genesis/demo.toml
@@ -14,6 +14,9 @@ fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'
 [header]
 timestamp = "1970-01-01T00:00:00Z"
 
+[l1_finalized]
+number = 0
+
 [[upgrade]]
 version = "0.2"
 start_proposing_view = 5

--- a/data/genesis/mainnet.toml
+++ b/data/genesis/mainnet.toml
@@ -14,3 +14,6 @@ fee_contract = '0x0000000000000000000000000000000000000000'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
+
+[l1_finalized]
+number = 20879898 # Estimated on Ethereum: 2 Oct 2024 18:00 UTC

--- a/data/genesis/staging.toml
+++ b/data/genesis/staging.toml
@@ -13,3 +13,6 @@ fee_contract = '0xa15bb66138824a1c7167f5e85b957d04dd34e468'
 
 [header]
 timestamp = "1970-01-01T00:00:00Z"
+
+[l1_finalized]
+number = 0

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -48,7 +48,7 @@ pub struct Genesis {
     pub stake_table: StakeTableConfig,
     #[serde(default)]
     pub accounts: HashMap<FeeAccount, FeeAmount>,
-    pub l1_finalized: Option<L1Finalized>,
+    pub l1_finalized: L1Finalized,
     pub header: GenesisHeader,
     #[serde(rename = "upgrade", with = "upgrade_ser")]
     #[serde(default)]
@@ -369,7 +369,7 @@ mod test {
         );
         assert_eq!(
             genesis.l1_finalized,
-            Some(L1Finalized::Block(L1BlockInfo {
+            L1Finalized::Block(L1BlockInfo {
                 number: 64,
                 timestamp: 0x123def.into(),
                 hash: H256([
@@ -377,7 +377,7 @@ mod test {
                     0xf3, 0x0a, 0x47, 0xde, 0x02, 0xcf, 0x28, 0xad, 0x68, 0xc8, 0x9e, 0x10, 0x4c,
                     0x00, 0xc4, 0xe5, 0x1b, 0xb7, 0xa5
                 ])
-            }))
+            })
         );
     }
 
@@ -398,6 +398,9 @@ mod test {
 
             [header]
             timestamp = 123456
+
+            [l1_finalized]
+            number = 0
         }
         .to_string();
 
@@ -421,7 +424,7 @@ mod test {
             }
         );
         assert_eq!(genesis.accounts, HashMap::default());
-        assert_eq!(genesis.l1_finalized, None);
+        assert_eq!(genesis.l1_finalized, L1Finalized::Number { number: 0 });
     }
 
     #[test]
@@ -448,10 +451,7 @@ mod test {
         .to_string();
 
         let genesis: Genesis = toml::from_str(&toml).unwrap_or_else(|err| panic!("{err:#}"));
-        assert_eq!(
-            genesis.l1_finalized,
-            Some(L1Finalized::Number { number: 42 })
-        );
+        assert_eq!(genesis.l1_finalized, L1Finalized::Number { number: 42 });
     }
 
     #[async_std::test]
@@ -679,6 +679,9 @@ mod test {
 
             [header]
             timestamp = "2024-05-16T11:20:28-04:00"
+
+            [l1_finalized]
+            number = 0
         }
         .to_string();
 

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -375,18 +375,15 @@ pub async fn init_node<P: PersistenceOptions, V: Versions>(
 
     let l1_client = L1Client::new(l1_params.url, l1_params.events_max_block_range);
     let l1_genesis = match genesis.l1_finalized {
-        Some(L1Finalized::Block(b)) => Some(b),
-        Some(L1Finalized::Number { number }) => {
-            Some(l1_client.wait_for_finalized_block(number).await)
-        }
-        None => None,
+        L1Finalized::Block(b) => b,
+        L1Finalized::Number { number } => l1_client.wait_for_finalized_block(number).await,
     };
     let instance_state = NodeState {
         chain_config: genesis.chain_config,
         l1_client,
         genesis_header: genesis.header,
         genesis_state,
-        l1_genesis,
+        l1_genesis: Some(l1_genesis),
         peers: catchup::local_and_remote(
             persistence_opt,
             StatePeers::<SequencerApiVersion>::from_urls(

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -259,7 +259,7 @@ mod test {
     use portpicker::pick_unused_port;
     use sequencer::{
         api::options::{Http, Status},
-        genesis::StakeTableConfig,
+        genesis::{L1Finalized, StakeTableConfig},
         persistence::fs,
         SequencerApiVersion,
     };
@@ -285,7 +285,7 @@ mod test {
             chain_config: Default::default(),
             stake_table: StakeTableConfig { capacity: 10 },
             accounts: Default::default(),
-            l1_finalized: Default::default(),
+            l1_finalized: L1Finalized::Number { number: 0 },
             header: Default::default(),
             upgrades: Default::default(),
             base_version: Version { major: 0, minor: 1 },


### PR DESCRIPTION
This makes it harder to accidentally start a new chain from L1 genesis, the previous default. That would have caused sequencer nodes upon startup to read all L1 events since genesis, which on an L1 that is already millions of blocks deep, like Sepolia or Ethereum, requires a huge amount of L1 RPC requests.
