### PR TITLE
Validate fee account proof matches the requested account during catchup

### DIFF
--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -136,13 +136,14 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await
             {
                 Ok(res) => {
-                    if res.proof.account == account.into() {
-                        match res.proof.verify(&fee_merkle_tree_root) {
-                            Ok(_) => return Ok(res),
-                            Err(err) => tracing::warn!("Error verifying account proof: {}", err),
-                        }
-                    } else {
+                    if res.proof.account != account.into() {
                         tracing::warn!("Invalid proof received from peer {:?}", client.url);
+                        continue;
+                    }
+
+                    match res.proof.verify(&fee_merkle_tree_root) {
+                        Ok(_) => return Ok(res),
+                        Err(err) => tracing::warn!("Error verifying account proof: {}", err),
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
This PR adds a check to validate that the peer response for the account matches the requested account proof.