### PR TITLE
rename threshold for escape hatch lag function to minimize confusion

### DIFF
--- a/contract-bindings/src/light_client.rs
+++ b/contract-bindings/src/light_client.rs
@@ -309,7 +309,7 @@ pub mod light_client {
                                 ),
                             },
                             ::ethers::core::abi::ethabi::Param {
-                                name: ::std::borrow::ToOwned::to_owned("threshold"),
+                                name: ::std::borrow::ToOwned::to_owned("blockThreshold"),
                                 kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
                                 internal_type: ::core::option::Option::Some(
                                     ::std::borrow::ToOwned::to_owned("uint256"),
@@ -1057,10 +1057,10 @@ pub mod light_client {
         pub fn lag_over_escape_hatch_threshold(
             &self,
             block_number: ::ethers::core::types::U256,
-            threshold: ::ethers::core::types::U256,
+            block_threshold: ::ethers::core::types::U256,
         ) -> ::ethers::contract::builders::ContractCall<M, bool> {
             self.0
-                .method_hash([224, 48, 51, 1], (block_number, threshold))
+                .method_hash([224, 48, 51, 1], (block_number, block_threshold))
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `newFinalizedState` (0x2063d4f7) function
@@ -2384,7 +2384,7 @@ pub mod light_client {
     )]
     pub struct LagOverEscapeHatchThresholdCall {
         pub block_number: ::ethers::core::types::U256,
-        pub threshold: ::ethers::core::types::U256,
+        pub block_threshold: ::ethers::core::types::U256,
     }
     ///Container type for all input parameters for the `newFinalizedState` function with signature `newFinalizedState((uint64,uint64,uint256),((uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),(uint256,uint256),uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))` and selector `0x2063d4f7`
     #[derive(

--- a/contracts/src/LightClient.sol
+++ b/contracts/src/LightClient.sol
@@ -347,12 +347,13 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         );
     }
 
-    /// @notice checks if the state updates lag behind the specified threshold based on the provided
+    /// @notice checks if the state updates lag behind the specified block threshold based on the
+    /// provided
     /// block number.
     /// @param blockNumber The block number to compare against the latest state updates
-    /// @param threshold The number of blocks updates to this contract is allowed to lag behind
-    /// @return bool returns true if the lag exceeds the threshold; otherwise, false
-    function lagOverEscapeHatchThreshold(uint256 blockNumber, uint256 threshold)
+    /// @param blockThreshold The number of blocks updates this contract is allowed to lag behind
+    /// @return bool returns true if the lag exceeds the blockThreshold; otherwise, false
+    function lagOverEscapeHatchThreshold(uint256 blockNumber, uint256 blockThreshold)
         public
         view
         virtual
@@ -395,7 +396,7 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
             revert InsufficientSnapshotHistory();
         }
 
-        return blockNumber - prevBlock > threshold;
+        return blockNumber - prevBlock > blockThreshold;
     }
 
     /// @notice get the HotShot commitment that represents the Merkle root containing the leaf at


### PR DESCRIPTION
Closes #2075 


### This PR:
- renames `threshold` to `blockThreshold` in `lagOverEscapeHatchThreshold` threshold

### This PR does not:
- change any implementation details

### Key places to review:
- rename and comments

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
