### PR TITLE
I02 - update the comments to reflect when the permissionedProver is utilized

### DIFF
--- a/contracts/src/LightClient.sol
+++ b/contracts/src/LightClient.sol
@@ -33,10 +33,10 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     /// @notice upgrade event when the proxy updates the implementation it's pointing to
     event Upgrade(address implementation);
 
-    /// @notice a permissioned prover is needed to interact `newFinalizedState`
+    /// @notice when a permissioned prover is set, this event is emitted.
     event PermissionedProverRequired(address permissionedProver);
 
-    /// @notice a permissioned prover is no longer needed to interact `newFinalizedState`
+    /// @notice when the permissioned prover is unset, this event is emitted.
     event PermissionedProverNotRequired();
 
     // === System Parameters ===
@@ -53,9 +53,8 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     LightClientState public finalizedState;
 
     /// @notice the address of the prover that can call the newFinalizedState function when the
-    /// contract is
-    /// in permissioned prover mode. This address is address(0) when the contract is not in the
-    /// permissioned prover mode
+    /// contract is in permissioned prover mode. This address is address(0) when the contract is
+    /// not in permissioned prover mode
     address public permissionedProver;
 
     /// @notice Max number of seconds worth of state commitments to record based on this block
@@ -219,8 +218,7 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     /// period has to be submitted
     /// before any newer state can be accepted since the stake table commitments of that block
     /// become the snapshots used for vote verifications later on.
-    /// @dev in this version, only a permissioned prover doing the computations
-    /// can call this function
+    /// @dev if the permissionedProver is set, only the permissionedProver can call this function
     /// @dev the state history for `stateHistoryRetentionPeriod` L1 blocks are also recorded in the
     /// `stateHistoryCommitments` array
     /// @notice While `newState.stakeTable*` refers to the (possibly) new stake table states,
@@ -279,10 +277,9 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         }
     }
 
-    /// @notice set the permissionedProverMode to true and set the permissionedProver to the
-    /// non-zero address provided
+    /// @notice set the permissionedProver to the non-zero address provided
     /// @dev this function can also be used to update the permissioned prover once it's a different
-    /// address
+    /// address to the current permissioned prover
     function setPermissionedProver(address prover) public virtual onlyOwner {
         if (prover == address(0)) {
             revert InvalidAddress();
@@ -294,8 +291,8 @@ contract LightClient is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         emit PermissionedProverRequired(permissionedProver);
     }
 
-    /// @notice set the permissionedProverMode to false and set the permissionedProver to address(0)
-    /// @dev if it was already disabled (permissioneProverMode == false), then revert with
+    /// @notice set the permissionedProver to address(0)
+    /// @dev if it was already disabled, then revert with the error, NoChangeRequired
     function disablePermissionedProverMode() public virtual onlyOwner {
         if (isPermissionedProverEnabled()) {
             permissionedProver = address(0);


### PR DESCRIPTION
Closes #2073 
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- instead of making the permissionedProver mandatory when initializing the contract, it updates the comments to reflect the fact that permissionedProver mode is a toggle

### Key places to review:
- wherever permissionedProver is mentioned
- also review the updated docs https://github.com/EspressoSystems/gitbook/pull/24

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
