### PR TITLE
fix prover service for docker demo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
     image: ghcr.io/espressosystems/espresso-sequencer/deploy:main
     command: deploy --only fee-contract
     environment:
+      - ESPRESSO_SEQUENCER_ETH_MULTISIG_ADDRESS
       - ESPRESSO_SEQUENCER_L1_PROVIDER
       - ESPRESSO_DEPLOYER_ACCOUNT_INDEX
       - RUST_LOG


### PR DESCRIPTION
The prover service on the main branch crashes in the Docker demo due to a panic caused by failed validation of the light client proxy address. This issue does not occur in the native demo, where everything works as expected.

The issue arose because the contracts in the Docker demo were deployed to different addresses than those in the native demo due to one additional transaction—specifically, a transfer of ownership—which resulted in a different nonce.

This PR fixes it by passing the env variable : `ESPRESSO_SEQUENCER_ETH_MULTISIG_ADDRESS` so that both native demo and docker demo deploy contracts at the addresses specified in .env file