### PR TITLE
Add option to wait for L1 genesis by timestamp instead of block number

### DIFF
--- a/builder/src/permissioned.rs
+++ b/builder/src/permissioned.rs
@@ -274,6 +274,11 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
     let l1_genesis = match genesis.l1_finalized {
         L1Finalized::Block(b) => b,
         L1Finalized::Number { number } => l1_client.wait_for_finalized_block(number).await,
+        L1Finalized::Timestamp { timestamp } => {
+            l1_client
+                .wait_for_finalized_block_with_timestamp(timestamp.unix_timestamp().into())
+                .await
+        }
     };
 
     let instance_state = NodeState {

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -396,6 +396,11 @@ pub async fn init_node<P: PersistenceOptions, V: Versions>(
     let l1_genesis = match genesis.l1_finalized {
         L1Finalized::Block(b) => b,
         L1Finalized::Number { number } => l1_client.wait_for_finalized_block(number).await,
+        L1Finalized::Timestamp { timestamp } => {
+            l1_client
+                .wait_for_finalized_block_with_timestamp(timestamp.unix_timestamp().into())
+                .await
+        }
     };
     let instance_state = NodeState {
         chain_config: genesis.chain_config,

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -206,11 +206,11 @@ impl L1Client {
         // The finalized block jumps by more than 1 at a time, so we might not have found the
         // earliest block with the desired timestamp. Work backwards until we find it.
         loop {
-            let prev = self.wait_for_block(block.number - 1).await;
-            if prev.timestamp < timestamp {
+            let parent = self.wait_for_block(block.number - 1).await;
+            if parent.timestamp < timestamp {
                 return block;
             }
-            block = prev;
+            block = parent;
         }
     }
 

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -181,7 +181,9 @@ impl L1Client {
         // Sleep until approximately the right time for the desired block to appear.
         let now = U256::from(OffsetDateTime::now_utc().unix_timestamp() as u64);
         if timestamp > now {
-            sleep(Duration::from_secs((timestamp - now).as_u64())).await;
+            let dur = (timestamp - now).as_u64();
+            tracing::warn!("sleeping for {dur:?}, until {timestamp}");
+            sleep(Duration::from_secs(dur)).await;
         }
 
         // Wait until the finalized block has timestamp greater or equal to `timestamp`.
@@ -193,6 +195,11 @@ impl L1Client {
             if block.timestamp >= timestamp {
                 break block;
             }
+            tracing::info!(
+                %timestamp,
+                ?block,
+                "waiting for finalized block with sufficient timestamp"
+            );
             sleep(interval).await;
         };
 


### PR DESCRIPTION
This allows us to specify the `l1_finalized` in our genesis file by timestamp, instead of block number. This makes it much easier to configure the network to start up from a future L1 block, as we typically do in testnet and mainnet deployments. The alternative is to calculate the expected L1 block number based on an average of 12 seconds per L1 block, which is tedious, error prone, and subject to drift due to L1 reorgs.

### This PR:
* Adds an option to specify the `l1_finalized` section in the genesis file by timestamp only
* Adds an L1 client function `wait_for_finalized_block_with_timestamp` to get the earliest finalized block with timestamp greater than or equal to a specified timestamp

### Key places to review:
* `wait_for_finalized_block_with_timestamp`, convince yourself it is deterministic