### PR TITLE
fix: use correct PlonkVerifier in deployer.rs

### DIFF
--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -42,6 +42,9 @@ tracing = { workspace = true }
 url = { workspace = true }
 vbs = { workspace = true }
 
+[dev-dependencies]
+sequencer-utils = { path = "../utils", features = ["testing"] }
+
 [features]
 default = ["parallel"]
 std = ["ark-std/std", "ark-ff/std"]

--- a/utils/src/deployer.rs
+++ b/utils/src/deployer.rs
@@ -9,7 +9,7 @@ use contract_bindings::{
     light_client_mock::LIGHTCLIENTMOCK_ABI,
     light_client_state_update_vk::LightClientStateUpdateVK,
     light_client_state_update_vk_mock::LightClientStateUpdateVKMock,
-    plonk_verifier_2::PlonkVerifier2,
+    plonk_verifier::PlonkVerifier,
 };
 use derive_more::Display;
 use ethers::{
@@ -191,7 +191,7 @@ pub async fn deploy_light_client_contract<M: Middleware + 'static>(
     let plonk_verifier = contracts
         .deploy_tx(
             Contract::PlonkVerifier,
-            PlonkVerifier2::deploy(l1.clone(), ())?,
+            PlonkVerifier::deploy(l1.clone(), ())?,
         )
         .await?;
     let vk = contracts
@@ -254,7 +254,7 @@ pub async fn deploy_mock_light_client_contract<M: Middleware + 'static>(
     let plonk_verifier = contracts
         .deploy_tx(
             Contract::PlonkVerifier,
-            PlonkVerifier2::deploy(l1.clone(), ())?,
+            PlonkVerifier::deploy(l1.clone(), ())?,
         )
         .await?;
     let vk = contracts
@@ -490,7 +490,7 @@ pub mod test_helpers {
         fee_contract::{FeeContract, FEECONTRACT_ABI, FEECONTRACT_BYTECODE},
         light_client::{LightClient, LIGHTCLIENT_ABI},
         light_client_state_update_vk::LightClientStateUpdateVK,
-        plonk_verifier_2::PlonkVerifier2,
+        plonk_verifier::PlonkVerifier,
     };
     use ethers::{prelude::*, solc::artifacts::BytecodeObject};
     use hotshot_contract_adapter::light_client::LightClientConstructorArgs;
@@ -507,7 +507,7 @@ pub mod test_helpers {
         let plonk_verifier = contracts
             .deploy_tx(
                 Contract::PlonkVerifier,
-                PlonkVerifier2::deploy(l1.clone(), ())?,
+                PlonkVerifier::deploy(l1.clone(), ())?,
             )
             .await?;
         let vk = contracts


### PR DESCRIPTION
separate the part of the changes originally included in #2148

### This PR:

- Switch to the right version of PlonkVerifier (in the deployer.rs we incorrectly deployed PlonkVerifier2.sol which is secure but less efficient)
