### PR TITLE
Update hotshot-builder-core to point to hotfix tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-core"
 version = "0.1.47"
-source = "git+https://github.com/EspressoSystems/marketplace-builder-core?tag=0.1.47#526782bbe1b04d76c0b931b00cd266017089c20b"
+source = "git+https://github.com/EspressoSystems/marketplace-builder-core?tag=0.1.47-ts-hotfix-block-size#bca0dbc0919442aadbc893b4e51eb616e87e7b7e"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ futures = "0.3"
 hotshot = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.74", features = ["dependency-tasks"] }
 # Hotshot imports
 hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.74" }
-hotshot-builder-core = { git = "https://github.com/EspressoSystems/marketplace-builder-core", tag = "0.1.47" }
+hotshot-builder-core = { git = "https://github.com/EspressoSystems/marketplace-builder-core", tag = "0.1.47-ts-hotfix-block-size" }
 marketplace-builder-core = { git = "https://github.com/EspressoSystems/marketplace-builder-core", tag = "0.1.47" }
 hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.46" }
 hotshot-orchestrator = { git = "https://github.com/EspressoSystems/hotshot", tag = "0.5.74" }


### PR DESCRIPTION
The `marketplace-builder-core` tag `0.1.47-ts-hotfix-block-size` contains an adjustment
to change the initial block size limit from 100 kb to 5Mb. This should allow a larger
start point before scaling to the appropriate throughput size as determined by how long
it takes to compute the transactions based on size.
