### PR TITLE
Cleanup builder.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,6 @@ dependencies = [
  "hotshot-stake-table",
  "hotshot-state-prover",
  "hotshot-types 0.1.11 (git+https://www.github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch2)",
- "jf-merkle-tree",
  "jf-signature",
  "libp2p",
  "libp2p-networking 0.5.78 (git+https://github.com/EspressoSystems//HotShot.git?tag=0.5.78-patch2)",

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -48,6 +48,6 @@ vbs = { workspace = true }
 vec1 = { workspace = true }
 
 [dev-dependencies]
+jf-signature = { workspace = true, features = ["bls"] }
 sequencer = { path = "../sequencer", features = ["testing"] }
 tempfile = { workspace = true }
-jf-signature = { workspace = true, features = ["bls"] }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -31,8 +31,6 @@ hotshot-orchestrator = { workspace = true }
 hotshot-stake-table = { workspace = true }
 hotshot-state-prover = { path = "../hotshot-state-prover" }
 hotshot-types = { workspace = true }
-jf-merkle-tree = { workspace = true }
-jf-signature = { workspace = true, features = ["bls"] }
 libp2p = { workspace = true }
 libp2p-networking = { workspace = true }
 marketplace-builder-shared = { workspace = true }
@@ -52,3 +50,4 @@ vec1 = { workspace = true }
 [dev-dependencies]
 sequencer = { path = "../sequencer", features = ["testing"] }
 tempfile = { workspace = true }
+jf-signature = { workspace = true, features = ["bls"] }


### PR DESCRIPTION
Builder had defined `#![alllow(unused_imports)]` at the top. Remove and clean them up. 


