### PR TITLE
fix: ubuntu build

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,8 +22,3 @@ retries = 2
 slow-timeout = "2m"
 default-filter = 'package(tests)'
 retries = 2
-
-[profile.exclude-sql]
-slow-timeout = "2m"
-default-filter = 'not (test(slow_) | test(/sql/) | package(tests))'
-retries = 2

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,3 +22,8 @@ retries = 2
 slow-timeout = "2m"
 default-filter = 'package(tests)'
 retries = 2
+
+[profile.exclude-sql]
+slow-timeout = "2m"
+default-filter = 'not (test(slow_) | test(/sql/) | package(tests))'
+retries = 2

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -7,6 +7,10 @@
     sudo apt-get update
     sudo apt-get install -y curl cmake pkg-config libssl-dev protobuf-compiler git postgresql-client lsb-release gpg
 
+## Install docker
+
+Refer to https://docs.docker.com/engine/install/ubuntu
+
 ## Install just
 
 Just is not available in the official ubuntu repos.
@@ -23,7 +27,7 @@ Just is not available in the official ubuntu repos.
 
 ## Install nextest test runner
 
-    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.s /th | bash
     cargo binstall cargo-nextest --secure --no-confirm
 
 ## Install foundry
@@ -48,7 +52,7 @@ To run the SQL tests docker needs to be installed and running.
     export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
     export "PATH=$PWD/target/release:$PATH"
     cargo build --release --bin diff-test
-    just test --profile exclude-sql
+    just test --no-fail-fast
 
 ## Run the foundry tests
 

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -16,10 +16,15 @@ Just is not available in the official ubuntu repos.
     sudo apt-get update
     sudo apt-get install -y just
 
-## Install rustup
+## Install rust dependencies
 
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
     source $HOME/.cargo/env
+
+## Install nextest test runner
+
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    cargo binstall cargo-nextest --secure --no-confirm
 
 ## Install foundry
 
@@ -43,7 +48,7 @@ To run the SQL tests docker needs to be installed and running.
     export RUSTFLAGS='--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
     export "PATH=$PWD/target/release:$PATH"
     cargo build --release --bin diff-test
-    cargo test --release --all-features -- --skip sql
+    just test --profile exclude-sql
 
 ## Run the foundry tests
 

--- a/doc/ubuntu.md
+++ b/doc/ubuntu.md
@@ -27,7 +27,7 @@ Just is not available in the official ubuntu repos.
 
 ## Install nextest test runner
 
-    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.s /th | bash
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     cargo binstall cargo-nextest --secure --no-confirm
 
 ## Install foundry

--- a/justfile
+++ b/justfile
@@ -37,9 +37,9 @@ docker-stop-rm:
 anvil *args:
     docker run -p 127.0.0.1:8545:8545 ghcr.io/foundry-rs/foundry:latest "anvil {{args}}"
 
-test:
+test *args:
 	@echo 'Omitting slow tests. Use `test-slow` for those. Or `test-all` for all tests.'
-	cargo nextest run --locked --release --workspace --all-features --verbose 
+	cargo nextest run --locked --release --workspace --all-features --verbose {{args}}
 
 test-slow:
 	@echo 'Only slow tests are included. Use `test` for those deemed not slow. Or `test-all` for all tests.'


### PR DESCRIPTION
- install and use nextest
- add nextest profile to skip sql tests

### This PR:
Fixes the ubuntu installation instructions and the CI workflow that executes them.

### How to test this PR
Run `scripts/ubuntu-install-test-no-nix-docker` to test the installation inside docker. Note that the tests that need postgres database will fail because we don't have docker available inside the docker container.
