### PR TITLE
Add index on `quorum_proposals.leaf_hash`

### DIFF
--- a/sequencer/api/migrations/V42__index_quorum_proposal_leaf_hash.sql
+++ b/sequencer/api/migrations/V42__index_quorum_proposal_leaf_hash.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX quorum_proposals_leaf_hash_idx ON quorum_proposals (leaf_hash);


### PR DESCRIPTION
We look up by this column during state reconstruction, so we should probably index it. The unique index will also prevent us from inserting quorum proposals with different views but the same hash, which should not be possible and would be a logic error if it happened.
