### PR TITLE
Do not load entire leaf just to get anchor view

### DIFF
--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -533,9 +533,8 @@ async fn fetch_proposal_chain<N, P, V>(
 
 async fn load_anchor_view(persistence: &impl SequencerPersistence) -> ViewNumber {
     loop {
-        match persistence.load_anchor_leaf().await {
-            Ok(Some((leaf, _))) => break leaf.view_number(),
-            Ok(None) => break ViewNumber::genesis(),
+        match persistence.load_anchor_view().await {
+            Ok(view) => break view,
             Err(err) => {
                 tracing::warn!("error loading anchor view: {err:#}");
                 sleep(Duration::from_secs(1)).await;

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -365,6 +365,11 @@ mod persistence_tests {
             final_qc,
         ];
 
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
+            ViewNumber::genesis()
+        );
+
         let consumer = EventCollector::default();
         let leaf_chain = leaves
             .iter()
@@ -381,6 +386,10 @@ mod persistence_tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
+            ViewNumber::new(2)
+        );
 
         for i in 0..=2 {
             assert_eq!(
@@ -430,6 +439,10 @@ mod persistence_tests {
             storage.load_anchor_leaf().await.unwrap(),
             Some((leaves[2].clone(), qcs[2].clone()))
         );
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
+            leaves[2].view_number()
+        );
 
         // Process a second decide event.
         let consumer = EventCollector::default();
@@ -442,6 +455,10 @@ mod persistence_tests {
             )
             .await
             .unwrap();
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
+            ViewNumber::new(3)
+        );
 
         // A decide event should have been processed.
         let events = consumer.events.read().await;
@@ -643,6 +660,10 @@ mod persistence_tests {
                 .view_number(),
             ViewNumber::new(1)
         );
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
+            ViewNumber::new(1)
+        );
 
         // Now decide remaining leaves successfully. We should now garbage collect and process a
         // decide event for all the leaves.
@@ -684,6 +705,10 @@ mod persistence_tests {
                 .unwrap()
                 .0
                 .view_number(),
+            ViewNumber::new(3)
+        );
+        assert_eq!(
+            storage.load_anchor_view().await.unwrap(),
             ViewNumber::new(3)
         );
 

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -401,6 +401,14 @@ impl SequencerPersistence for Persistence {
         Ok(Some((leaf, qc)))
     }
 
+    async fn load_anchor_view(&self) -> anyhow::Result<ViewNumber> {
+        let mut tx = self.db.read().await?;
+        let (view,) = query_as::<(i64,)>("SELECT coalesce(max(view), 0) FROM anchor_leaf")
+            .fetch_one(tx.as_mut())
+            .await?;
+        Ok(ViewNumber::new(view as u64))
+    }
+
     async fn load_undecided_state(
         &self,
     ) -> anyhow::Result<Option<(CommitmentMap<Leaf>, BTreeMap<ViewNumber, View<SeqTypes>>)>> {

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -603,6 +603,13 @@ pub trait SequencerPersistence: Sized + Send + Sync + 'static {
         &self,
         decided_upgrade_certificate: Option<UpgradeCertificate<SeqTypes>>,
     ) -> anyhow::Result<()>;
+
+    async fn load_anchor_view(&self) -> anyhow::Result<ViewNumber> {
+        match self.load_anchor_leaf().await? {
+            Some((leaf, _)) => Ok(leaf.view_number()),
+            None => Ok(ViewNumber::genesis()),
+        }
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
We have seen heavy load on water DBs due to loading the anchor leaf in the proposal fetching task. This is because the leaves are very large because we store the payload in the leaf, which we should not do. That is a separate bug with a separate fix. This fix addresses the fact that we shouldn't need to load the leaf at all in this task, since we only care about the view number.

### This PR:
* Adds a dedicated `load_anchor_view` persistence function
* Implements this function efficiently for SQL storage
 
### This PR does not:
* Implement `load_anchor_view` efficiently for FS storage, since to get the view number we'd have to load the whole file and deserialize the leaf anyways, because view is not stored separately. Thus, it is easier to just call `load_anchor_leaf` and pull out the view number
