### PR TITLE
Ensure consistency of decide events

### DIFF
--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -206,12 +206,15 @@ impl Inner {
         Ok(())
     }
 
-    fn decide_event(&self, view: ViewNumber) -> anyhow::Result<Event<SeqTypes>> {
-        // Construct a chain of all decided leaves up to `view` which have not yet been garbage
-        // collected.
+    async fn generate_decide_events(
+        &self,
+        view: ViewNumber,
+        consumer: &impl EventConsumer,
+    ) -> anyhow::Result<()> {
+        // Generate a decide event for each leaf, to be processed by the event consumer. We make a
+        // separate event for each leaf because it is possible we have non-consecutive leaves in our
+        // storage, which would not be valid as a single decide with a single leaf chain.
         let mut leaves = BTreeMap::new();
-        let mut high_qc: Option<QuorumCertificate<SeqTypes>> = None;
-
         for entry in fs::read_dir(self.decided_leaf_path())? {
             let entry = entry?;
             let path = entry.path();
@@ -261,14 +264,7 @@ impl Inner {
                 delta: Default::default(),
             };
 
-            leaves.insert(v, info);
-            if let Some(high_qc) = &mut high_qc {
-                if v > high_qc.view_number.u64() {
-                    *high_qc = qc;
-                }
-            } else {
-                high_qc = Some(qc);
-            }
+            leaves.insert(v, (info, qc));
         }
 
         // The invariant is that the oldest existing leaf in the `anchor_leaf` table -- if there is
@@ -282,15 +278,20 @@ impl Inner {
             }
         }
 
-        let high_qc = high_qc.context("no new leaves at decide event")?;
-        Ok(Event {
-            view_number: view,
-            event: EventType::Decide {
-                qc: Arc::new(high_qc),
-                block_size: None,
-                leaf_chain: Arc::new(leaves.into_values().rev().collect()),
-            },
-        })
+        for (view, (leaf, qc)) in leaves {
+            consumer
+                .handle_event(&Event {
+                    view_number: ViewNumber::new(view),
+                    event: EventType::Decide {
+                        qc: Arc::new(qc),
+                        leaf_chain: Arc::new(vec![leaf]),
+                        block_size: None,
+                    },
+                })
+                .await?;
+        }
+
+        Ok(())
     }
 
     fn load_da_proposal(
@@ -466,17 +467,9 @@ impl SequencerPersistence for Persistence {
         // persist the decided leaves successfully, and the event processing will just run again at
         // the next decide. If there is an error here, we just log it and return early with success
         // to prevent GC from running before the decided leaves are processed.
-        match inner.decide_event(view) {
-            Ok(event) => {
-                if let Err(err) = consumer.handle_event(&event).await {
-                    tracing::warn!(?view, "event processing failed: {err:#}");
-                    return Ok(());
-                }
-            }
-            Err(err) => {
-                tracing::warn!(?view, "event creation: {err:#}");
-                return Ok(());
-            }
+        if let Err(err) = inner.generate_decide_events(view, consumer).await {
+            tracing::warn!(?view, "event processing failed: {err:#}");
+            return Ok(());
         }
 
         if let Err(err) = inner.collect_garbage(view) {

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -744,60 +744,45 @@ async fn collect_garbage(
         leaves
     };
 
-    // Collate all the information by view number and construct a chain of leaves and a chain of
-    // corresponding QCs.
-    let (leaf_chain, qcs): (Vec<_>, Vec<_>) = leaves
-        .into_iter()
-        // Go in reverse chronological order, as expected by Decide events.
-        .rev()
-        .map(|(view, (mut leaf, qc))| {
-            // Include the VID share if available.
-            let vid_share = vid_shares.remove(&view);
-            if vid_share.is_none() {
-                tracing::debug!(view, "VID share not available at decide");
-            }
+    // Generate a decide event for each leaf, to be processed by the event consumer. We make a
+    // separate event for each leaf because it is possible we have non-consecutive leaves in our
+    // storage, which would not be valid as a single decide with a single leaf chain.
+    for (view, (mut leaf, qc)) in leaves {
+        // Include the VID share if available.
+        let vid_share = vid_shares.remove(&view);
+        if vid_share.is_none() {
+            tracing::debug!(view, "VID share not available at decide");
+        }
 
-            // Fill in the full block payload using the DA proposals we had persisted.
-            if let Some(proposal) = da_proposals.remove(&view) {
-                let payload =
-                    Payload::from_bytes(&proposal.encoded_transactions, &proposal.metadata);
-                leaf.fill_block_payload_unchecked(payload);
-            } else {
-                tracing::debug!(view, "DA proposal not available at decide");
-            }
+        // Fill in the full block payload using the DA proposals we had persisted.
+        if let Some(proposal) = da_proposals.remove(&view) {
+            let payload = Payload::from_bytes(&proposal.encoded_transactions, &proposal.metadata);
+            leaf.fill_block_payload_unchecked(payload);
+        } else {
+            tracing::debug!(view, "DA proposal not available at decide");
+        }
 
-            (
-                LeafInfo {
-                    leaf,
-                    vid_share,
+        let leaf_info = LeafInfo {
+            leaf,
+            vid_share,
 
-                    // Note: the following fields are not used in Decide event processing, and
-                    // should be removed. For now, we just default them.
-                    state: Default::default(),
-                    delta: Default::default(),
+            // Note: the following fields are not used in Decide event processing, and
+            // should be removed. For now, we just default them.
+            state: Default::default(),
+            delta: Default::default(),
+        };
+        tracing::debug!(?view, ?qc, ?leaf_info, "generating decide event");
+        consumer
+            .handle_event(&Event {
+                view_number: ViewNumber::new(view),
+                event: EventType::Decide {
+                    leaf_chain: Arc::new(vec![leaf_info]),
+                    qc: Arc::new(qc),
+                    block_size: None,
                 },
-                qc,
-            )
-        })
-        .unzip();
-
-    // Generate decide event for the consumer.
-    let Some(final_qc) = qcs.into_iter().next() else {
-        tracing::info!(?view, "no new leaves at decide");
-        return Ok(());
-    };
-    tracing::debug!(?view, ?final_qc, ?leaf_chain, "generating decide event");
-
-    consumer
-        .handle_event(&Event {
-            view_number: view,
-            event: EventType::Decide {
-                leaf_chain: Arc::new(leaf_chain),
-                qc: Arc::new(final_qc),
-                block_size: None,
-            },
-        })
-        .await?;
+            })
+            .await?;
+    }
 
     // Now that we have definitely processed leaves up to `view`, we can update
     // `last_processed_view` so we don't process these leaves again. We may still fail at this


### PR DESCRIPTION
The logic for moving data from consensus storae to archive storage was sometimes generating an invalid decide event, because it made a chain of non-consecutive leaves originating from multiple separate events. This fixes the issue and prevents it from happening again by generating a separate decide event for each leaf in consensus storage.

Also adds a regression test.
