### PR TITLE
CI: skip ARM build on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,8 @@ jobs:
   build-dockers:
     runs-on: ubuntu-latest
     needs: [build]
-    # run if `build` succeeded and build-arm succeeded or was skipped
-    if: success() && (needs.build.result == 'success' && (needs.build-arm.result == 'success' || needs.build-arm.result == 'skipped'))
+    # run if `build` succeeded
+    if: ${{ always() && !cancelled() && needs.build.result == 'success' }}
     outputs:
       sequencer-tag: ${{ steps.sequencer.outputs.tags }}
       cdn-broker-tag: ${{ steps.cdn-broker.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   RUSTFLAGS: '--cfg async_executor_impl="async-std" --cfg async_channel_impl="async-std"'
   RUST_LOG: info,libp2p=off,node=error
+  DOCKER_PLATFORMS: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
 
 jobs:
   build:
@@ -86,6 +87,7 @@ jobs:
             target/release/dev-rollup
 
   build-arm:
+    if: github.event_name != 'pull_request'
     runs-on: buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Fix submodule permissions check
@@ -174,6 +176,7 @@ jobs:
           path: target/amd64/release
 
       - name: Download executables ARM
+        if: github.event_name != 'pull_request'
         uses: actions/download-artifact@v4
         with:
           name: aarch64-unknown-linux-gnu-services
@@ -298,7 +301,7 @@ jobs:
         with:
           context: ./
           file: ./docker/sequencer.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.sequencer.outputs.tags }}
           labels: ${{ steps.sequencer.outputs.labels }}
@@ -308,7 +311,7 @@ jobs:
         with:
           context: ./
           file: ./docker/cdn-broker.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.cdn-broker.outputs.tags }}
           labels: ${{ steps.cdn-broker.outputs.labels }}
@@ -318,7 +321,7 @@ jobs:
         with:
           context: ./
           file: ./docker/cdn-marshal.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.cdn-marshal.outputs.tags }}
           labels: ${{ steps.cdn-marshal.outputs.labels }}
@@ -328,7 +331,7 @@ jobs:
         with:
           context: ./
           file: ./docker/cdn-whitelist.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.cdn-whitelist.outputs.tags }}
           labels: ${{ steps.cdn-whitelist.outputs.labels }}
@@ -338,7 +341,7 @@ jobs:
         with:
           context: ./
           file: ./docker/state-relay-server.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.state-relay-server.outputs.tags }}
           labels: ${{ steps.state-relay-server.outputs.labels }}
@@ -348,7 +351,7 @@ jobs:
         with:
           context: ./
           file: ./docker/prover-service.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prover-service.outputs.tags }}
           labels: ${{ steps.prover-service.outputs.labels }}
@@ -358,7 +361,7 @@ jobs:
         with:
           context: ./
           file: ./docker/orchestrator.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.orchestrator.outputs.tags }}
           labels: ${{ steps.orchestrator.outputs.labels }}
@@ -368,7 +371,7 @@ jobs:
         with:
           context: ./
           file: ./docker/submit-transactions.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.submit-transactions.outputs.tags }}
           labels: ${{ steps.submit-transactions.outputs.labels }}
@@ -378,7 +381,7 @@ jobs:
         with:
           context: ./
           file: ./docker/deploy.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.deploy.outputs.tags }}
           labels: ${{ steps.deploy.outputs.labels }}
@@ -388,7 +391,7 @@ jobs:
         with:
           context: ./
           file: ./docker/permissionless-builder.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.builder.outputs.tags }}
           labels: ${{ steps.builder.outputs.labels }}
@@ -398,7 +401,7 @@ jobs:
         with:
           context: ./
           file: ./docker/nasty-client.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.nasty-client.outputs.tags }}
           labels: ${{ steps.nasty-client.outputs.labels }}
@@ -408,7 +411,7 @@ jobs:
         with:
           context: ./
           file: ./docker/espresso-dev-node.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.espresso-dev-node.outputs.tags }}
           labels: ${{ steps.espresso-dev-node.outputs.labels }}
@@ -417,7 +420,7 @@ jobs:
         with:
           context: ./
           file: ./docker/espresso-bridge.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.bridge.outputs.tags }}
           labels: ${{ steps.bridge.outputs.labels }}
@@ -427,7 +430,7 @@ jobs:
         with:
           context: ./
           file: ./docker/marketplace-solver.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.marketplace-solver.outputs.tags }}
           labels: ${{ steps.marketplace-solver.outputs.labels }}
@@ -437,7 +440,7 @@ jobs:
         with:
           context: ./
           file: ./docker/marketplace-builder.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.marketplace-builder.outputs.tags }}
           labels: ${{ steps.marketplace-builder.outputs.labels }}
@@ -447,7 +450,7 @@ jobs:
         with:
           context: ./
           file: ./docker/node-validator.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.node-validator.outputs.tags }}
           labels: ${{ steps.node-validator.outputs.labels }}
@@ -457,7 +460,7 @@ jobs:
         with:
           context: ./
           file: ./docker/dev-rollup.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.dev-rollup.outputs.tags }}
           labels: ${{ steps.dev-rollup.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,9 +144,9 @@ jobs:
 
   build-dockers:
     runs-on: ubuntu-latest
-    needs: [build]
-    # run if `build` succeeded
-    if: ${{ always() && !cancelled() && needs.build.result == 'success' }}
+    needs: [build, build_arm]
+    # if build_arm is skipped, run this job anyway
+    if: ${{ !(failure() || cancelled()) }}
     outputs:
       sequencer-tag: ${{ steps.sequencer.outputs.tags }}
       cdn-broker-tag: ${{ steps.cdn-broker.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,9 @@ jobs:
 
   build-dockers:
     runs-on: ubuntu-latest
-    needs: [build, build-arm]
+    needs: [build]
+    # run if `build` succeeded and build-arm succeeded or was skipped
+    if: success() && (needs.build.result == 'success' && (needs.build-arm.result == 'success' || needs.build-arm.result == 'skipped'))
     outputs:
       sequencer-tag: ${{ steps.sequencer.outputs.tags }}
       cdn-broker-tag: ${{ steps.cdn-broker.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
 
   build-dockers:
     runs-on: ubuntu-latest
-    needs: [build, build_arm]
+    needs: [build, build-arm]
     # if build_arm is skipped, run this job anyway
     if: ${{ !(failure() || cancelled()) }}
     outputs:


### PR DESCRIPTION
The arm build uses buildjet and costs money. There is relatively little utility in running it on every PR. If necessary it can be triggered explicitly via workflow dispatch.

It will build the docker images in PRs but only for x86. This way we would still catch most issues in the dockerfiles before merge to main, even though we aren't building them for arm.