### PR TITLE
WIP: basic mutation testing with cargo mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,4 @@
+# cargo-mutants configuration
+
+# profile = "mutants" # Build without debug symbols
+test_tool = "nextest"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,15 @@
+# cargo-mutants does not seem to support specifying the nextest profile? :(
 [profile.default]
 slow-timeout = "2m"
-default-filter = 'not (test(slow_) | package(tests))'
-retries = 2
+default-filter = """not (test(slow_) | package(tests) \
+  | test(test_fee_upgrade_time_based) \
+  | test(test_fee_upgrade_view_based) \
+  | test(test_marketplace_upgrade_time_based) \
+  | test(test_marketplace_upgrade_view_based) \
+  | test(test_process_client_handling_stream_subscribe_voters) \
+  | test(test_process_client_handling_stream_subscribe_node_identity) \
+  )"""
+retries = 0
 
 # The restart tests run an entire sequencing network, and so are quite resource intensive.
 [[profile.default.overrides]]
@@ -22,3 +30,18 @@ retries = 2
 slow-timeout = "2m"
 default-filter = 'package(tests)'
 retries = 2
+
+# # Profile to be used with mutant testing.
+# # The upgrade tests are slow.
+# # The process_client_handling_stream_subscribe_... tests may hang.
+# [profile.fast-non-flaky]
+# slow-timeout = "2m"
+# default-filter = """not (test(slow_) | package(tests) \
+#   | test(test_fee_upgrade_time_based) \
+#   | test(test_fee_upgrade_view_based) \
+#   | test(test_marketplace_upgrade_time_based) \
+#   | test(test_marketplace_upgrade_view_based) \
+#   | test(test_process_client_handling_stream_subscribe_voters) \
+#   | test(test_process_client_handling_stream_subscribe_node_identity) \
+#   )"""
+# retries = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,16 @@ strip = "debuginfo"
 [profile.dev.package."*"]
 opt-level = 3
 
+[profile.test]
+inherits = "dev"
+# Minimal opt-level to run api::test::test_{catchup,restart}
+opt-level = 1
+
+# [profile.mutants]
+# inherits = "dev"
+# debug = "none"
+
+
 [patch."https://github.com/EspressoSystems/HotShot.git"]
 hotshot = { git = "https://www.github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch5" }
 hotshot-builder-api = { git = "https://www.github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch5" }

--- a/flake.lock
+++ b/flake.lock
@@ -264,16 +264,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726463316,
-        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     ];
   };
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
 
   inputs.nixpkgs-cross-overlay.url =
@@ -175,11 +175,6 @@
           nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal.override {
             extensions = [ "rust-analyzer" ];
           });
-          # nixWithFlakes allows pre v2.4 nix installations to use
-          # flake commands (like `nix flake update`)
-          nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
-            exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-          '';
           solc = pkgs.solc-bin.latest;
         in
         mkShell (rustEnvVars // {
@@ -195,14 +190,14 @@
             # Rust tools
             cargo-audit
             cargo-edit
-            cargo-sort
+            cargo-mutants
             cargo-nextest
+            cargo-sort
             typos
             just
             nightlyToolchain.passthru.availableComponents.rust-analyzer
 
             # Tools
-            nixWithFlakes
             nixpkgs-fmt
             entr
             process-compose


### PR DESCRIPTION
Close #2227 

- Update nixpkgs to get latest cargo-mutants.
- Remove nixWithFlakes from flake.nix because it would have to be changed to work with the latest version of nixpkgs and I think we no longer need it.
- Create a non-flaky test profile.
- Run with `cargo mutants`.
- Inspect output and `./mutants.out` directory

For example `./mutants.out/missed.txt` looks like this

    contract-bindings/src/plonk_verifier_2.rs:463:13: replace plonk_verifier_2::<impl AbiEncode for PlonkVerifier2Calls>::encode -> Vec<u8> with vec![]
    hotshot-state-prover/src/mock_ledger.rs:496:57: replace + with * in gen_circuit_for_test
    hotshot-state-prover/src/mock_ledger.rs:496:53: replace * with / in gen_circuit_for_test
    hotshot-state-prover/src/mock_ledger.rs:149:9: replace MockLedger::elapse_without_block with ()
    contract-bindings/src/light_client_mock.rs:1928:21: replace == with != in light_client_mock::<impl ContractRevert for LightClientMockErrors>::valid_selector
    contract-bindings/src/erc1967_proxy.rs:319:13: replace erc1967_proxy::<impl AbiEncode for ERC1967ProxyErrors>::encode -> ::std::vec::Vec<u8> with vec![0]
    hotshot-state-prover/src/circuit.rs:236:29: replace % with / in build

To make it really useful further configuration is likely necessary, such as marking some functions to not mutate them.