### PR TITLE
Revert slow tests back to `--release` profile

### DIFF
--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -44,7 +44,7 @@ jobs:
           submodules: recursive
 
       - name: Configure Environment
-        run: PATH="$PWD/target/debug:$PATH"
+        run: PATH="$PWD/target/release:$PATH"
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -53,12 +53,12 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --locked --bin diff-test --profile test
-          cargo nextest run --locked --workspace --all-features --no-run
+          cargo build --locked --bin diff-test --release
+          cargo nextest run --locked --release --workspace --all-features --no-run
         timeout-minutes: 90
 
       - name: Slow Test
         env:
           NEXTEST_PROFILE: slow
-        run: cargo nextest run --locked --workspace --all-features --verbose --no-fail-fast --nocapture
+        run: cargo nextest run --locked --release --workspace --all-features --verbose --no-fail-fast --nocapture
         timeout-minutes: 40


### PR DESCRIPTION
Fixes test failure on main.

### This PR:
In #2209 tests were moved from `--release` to `--profile test`. It worked for the `test` workflow but slow tests were not thoroughly tested. As a quick fix, this moves *only* slow tests back to `--release`. In a followup we can investigate further improvements to the test profile or possibly reusing artifacts from `build` job in slow tests (instead of building them twice).

