### PR TITLE
Arity is already available as an associated constant.

### DIFF
--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -7,9 +7,7 @@ use std::{
 
 use anyhow::Result;
 use committable::Committable;
-use espresso_types::{
-    FeeAccount, FeeMerkleTree, NamespaceId, NsProof, PubKey, Transaction, FEE_MERKLE_TREE_ARITY,
-};
+use espresso_types::{FeeAccount, FeeMerkleTree, NamespaceId, NsProof, PubKey, Transaction};
 use futures::{try_join, FutureExt};
 use hotshot_query_service::merklized_state::Snapshot;
 use hotshot_query_service::{
@@ -27,6 +25,7 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, Versions},
     },
 };
+use jf_merkle_tree::MerkleTreeScheme;
 use serde::{de::Error as _, Deserialize, Serialize};
 use snafu::OptionExt;
 use tagged_base64::TaggedBase64;
@@ -54,7 +53,7 @@ where
     Ver: 'static + StaticVersionType,
     <State as ReadState>::State: Send
         + Sync
-        + MerklizedStateDataSource<SeqTypes, FeeMerkleTree, FEE_MERKLE_TREE_ARITY>
+        + MerklizedStateDataSource<SeqTypes, FeeMerkleTree, { FeeMerkleTree::ARITY }>
         + MerklizedStateHeightPersistence,
 {
     let mut options = merklized_state::Options::default();

--- a/types/src/v0/mod.rs
+++ b/types/src/v0/mod.rs
@@ -183,7 +183,7 @@ pub type NetworkConfig = hotshot_types::network::NetworkConfig<PubKey>;
 
 pub use self::impls::{NodeState, SolverAuctionResultsProvider, ValidatedState};
 pub use crate::v0_1::{
-    BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_ARITY, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN,
-    NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
+    BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
+    NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
 };
 use crate::v0_3::SolverAuctionResults;

--- a/types/src/v0/v0_1/state.rs
+++ b/types/src/v0/v0_1/state.rs
@@ -15,11 +15,12 @@ use std::collections::HashSet;
 pub type BlockMerkleTree = LightWeightSHA3MerkleTree<Commitment<Header>>;
 pub type BlockMerkleCommitment = <BlockMerkleTree as MerkleTreeScheme>::Commitment;
 
-pub type FeeMerkleTree = UniversalMerkleTree<FeeAmount, Sha3Digest, FeeAccount, 256, Sha3Node>;
+pub type FeeMerkleTree = UniversalMerkleTree<FeeAmount, Sha3Digest, FeeAccount, FEE_MERKLE_TREE_ARITY, Sha3Node>;
 pub type FeeMerkleCommitment = <FeeMerkleTree as MerkleTreeScheme>::Commitment;
 
 pub const BLOCK_MERKLE_TREE_HEIGHT: usize = 32;
 pub const FEE_MERKLE_TREE_HEIGHT: usize = 20;
+const FEE_MERKLE_TREE_ARITY: usize = 256;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Delta {

--- a/types/src/v0/v0_1/state.rs
+++ b/types/src/v0/v0_1/state.rs
@@ -15,12 +15,11 @@ use std::collections::HashSet;
 pub type BlockMerkleTree = LightWeightSHA3MerkleTree<Commitment<Header>>;
 pub type BlockMerkleCommitment = <BlockMerkleTree as MerkleTreeScheme>::Commitment;
 
-pub type FeeMerkleTree = UniversalMerkleTree<FeeAmount, Sha3Digest, FeeAccount, FEE_MERKLE_TREE_ARITY, Sha3Node>;
+pub type FeeMerkleTree = UniversalMerkleTree<FeeAmount, Sha3Digest, FeeAccount, 256, Sha3Node>;
 pub type FeeMerkleCommitment = <FeeMerkleTree as MerkleTreeScheme>::Commitment;
 
 pub const BLOCK_MERKLE_TREE_HEIGHT: usize = 32;
 pub const FEE_MERKLE_TREE_HEIGHT: usize = 20;
-pub const FEE_MERKLE_TREE_ARITY: usize = 256;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Delta {


### PR DESCRIPTION
I think it is slightly better if we always access the associated constant instead of duplicating it into a stand-alone constant in addition to the associated one.
