### PR TITLE
Add pipefail to docker demo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,7 +478,7 @@ jobs:
           labels: ${{ steps.dev-rollup.outputs.labels }}
 
   test-demo:
-    # if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [build-dockers]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,7 +478,7 @@ jobs:
           labels: ${{ steps.dev-rollup.outputs.labels }}
 
   test-demo:
-    if: ${{ github.event_name != 'pull_request' }}
+    # if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [build-dockers]
     steps:
@@ -531,4 +531,5 @@ jobs:
       - name: Test docker demo
         run: |
           just demo &
+          set -o pipefail
           timeout -v 600 scripts/smoke-test-demo | sed -e 's/^/smoke-test: /;'


### PR DESCRIPTION
docker demo is succeeding on main, even though services never become ready. The error in the logs is: 

```bash
dependency failed to start: container espresso-sequencer-sequencer1-1 exited (101)
error: Recipe `demo` failed on line 8 with exit code 1
```
example run: https://github.com/EspressoSystems/espresso-sequencer/actions/runs/11706340826/job/32604796112


In addition, !pull_request filter has been temporarily removed so we can reproduce in this PR. 

