### PR TITLE
Clean up logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,9 +2578,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2967,7 +2969,7 @@ dependencies = [
  "cld",
  "committable",
  "contract-bindings",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "dyn-clone 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers",
  "fluent-asserter",
@@ -8798,7 +8800,7 @@ dependencies = [
  "contract-bindings",
  "csv",
  "derivative",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "dotenvy",
  "dyn-clone 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot",
@@ -8870,7 +8872,7 @@ dependencies = [
  "clap",
  "committable",
  "contract-bindings",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "ethers",
  "futures",
  "hotshot-contract-adapter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ blake3 = "1.5"
 circular-buffer = "0.1.7"
 clap = { version = "4.4", features = ["derive", "env", "string"] }
 cld = "0.5"
-derive_more = "0.99.17"
+derive_more = { version = "1.0", features = ["full"] }
 es-version = { git = "https://github.com/EspressoSystems/es-version.git", branch = "main" }
 dotenvy = "0.15"
 dyn-clone = "1.0"

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -293,7 +293,7 @@ impl<
         Ok(tree)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, instance))]
     async fn get_frontier(
         &self,
         instance: &NodeState,
@@ -383,7 +383,7 @@ impl<N: ConnectedNetwork<PubKey>, V: Versions, P: SequencerPersistence> CatchupD
         retain_accounts(&state.fee_merkle_tree, accounts.iter().copied())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, _instance))]
     async fn get_frontier(
         &self,
         _instance: &NodeState,

--- a/sequencer/src/bin/keygen.rs
+++ b/sequencer/src/bin/keygen.rs
@@ -19,11 +19,11 @@ use tracing::info_span;
 #[derive(Clone, Copy, Debug, Display, Default, ValueEnum)]
 enum Scheme {
     #[default]
-    #[display(fmt = "all")]
+    #[display("all")]
     All,
-    #[display(fmt = "bls")]
+    #[display("bls")]
     Bls,
-    #[display(fmt = "schnorr")]
+    #[display("schnorr")]
     Schnorr,
 }
 

--- a/sequencer/src/bin/utils/keygen.rs
+++ b/sequencer/src/bin/utils/keygen.rs
@@ -18,11 +18,11 @@ use tracing::info_span;
 #[derive(Clone, Copy, Debug, Display, Default, ValueEnum)]
 enum Scheme {
     #[default]
-    #[display(fmt = "all")]
+    #[display("all")]
     All,
-    #[display(fmt = "bls")]
+    #[display("bls")]
     Bls,
-    #[display(fmt = "schnorr")]
+    #[display("schnorr")]
     Schnorr,
 }
 

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -12,11 +12,12 @@ use super::state::ValidatedState;
 /// Represents the immutable state of a node.
 ///
 /// For mutable state, use `ValidatedState`.
-#[derive(Debug, Clone)]
+#[derive(derive_more::Debug, Clone)]
 pub struct NodeState {
     pub node_id: u64,
     pub chain_config: crate::v0_3::ChainConfig,
     pub l1_client: L1Client,
+    #[debug("{}", peers.name())]
     pub peers: Arc<dyn StateCatchup>,
     pub genesis_header: GenesisHeader,
     pub genesis_state: ValidatedState,
@@ -253,6 +254,10 @@ pub mod mock {
 
         fn backoff(&self) -> &BackoffParams {
             &self.backoff
+        }
+
+        fn name(&self) -> String {
+            "MockStateCatchup".into()
         }
     }
 }

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -303,7 +303,7 @@ impl L1Client {
                     // Update the state snapshot;
                     let mut state = state.lock().await;
                     if head > state.snapshot.head {
-                        tracing::info!(head, old_head = state.snapshot.head, "L1 head updated");
+                        tracing::debug!(head, old_head = state.snapshot.head, "L1 head updated");
                         state.snapshot.head = head;
                         // Emit an event about the new L1 head. Ignore send errors; it just means no
                         // one is listening to events right now.
@@ -326,7 +326,7 @@ impl L1Client {
                                 .ok();
                         }
                     }
-                    tracing::info!("updated L1 snapshot to {:?}", state.snapshot);
+                    tracing::debug!("updated L1 snapshot to {:?}", state.snapshot);
                 }
 
                 tracing::error!("L1 block stream ended unexpectedly, trying to re-establish");

--- a/types/src/v0/utils.rs
+++ b/types/src/v0/utils.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use async_std::task::sleep;
 use bytesize::ByteSize;
 use clap::Parser;
-use derive_more::{Display, From, Into};
+use derive_more::{From, Into};
 use futures::future::BoxFuture;
 use rand::Rng;
 use sequencer_utils::{impl_serde_from_string_or_integer, ser::FromStringOrInteger};
@@ -43,8 +43,8 @@ pub struct GenesisHeader {
     pub timestamp: Timestamp,
 }
 
-#[derive(Hash, Copy, Clone, Debug, Display, PartialEq, Eq, From, Into)]
-#[display(fmt = "{}", "_0.format(&TimestampFormat).unwrap()")]
+#[derive(Hash, Copy, Clone, Debug, derive_more::Display, PartialEq, Eq, From, Into)]
+#[display("{}", _0.format(&TimestampFormat).unwrap())]
 pub struct Timestamp(OffsetDateTime);
 
 impl_serde_from_string_or_integer!(Timestamp);

--- a/types/src/v0/v0_1/chain_config.rs
+++ b/types/src/v0/v0_1/chain_config.rs
@@ -8,11 +8,11 @@ use serde::{Deserialize, Serialize};
 use crate::{FeeAccount, FeeAmount};
 
 #[derive(Default, Hash, Copy, Clone, Debug, Display, PartialEq, Eq, From, Into)]
-#[display(fmt = "{_0}")]
+#[display("{_0}")]
 pub struct ChainId(pub U256);
 
 #[derive(Hash, Copy, Clone, Debug, Default, Display, PartialEq, Eq, From, Into, Deref)]
-#[display(fmt = "{_0}")]
+#[display("{_0}")]
 pub struct BlockSize(pub(crate) u64);
 
 /// Global variables for an Espresso blockchain.

--- a/types/src/v0/v0_1/fee_info.rs
+++ b/types/src/v0/v0_1/fee_info.rs
@@ -25,7 +25,7 @@ use crate::FeeMerkleTree;
     From,
     Into,
 )]
-#[display(fmt = "{_0}")]
+#[display("{_0}")]
 pub struct FeeAmount(pub U256);
 
 // New Type for `Address` in order to implement `CanonicalSerialize` and
@@ -46,7 +46,7 @@ pub struct FeeAmount(pub U256);
     From,
     Into,
 )]
-#[display(fmt = "{_0:x}")]
+#[display("{_0:x}")]
 pub struct FeeAccount(pub Address);
 
 #[derive(

--- a/types/src/v0/v0_1/transaction.rs
+++ b/types/src/v0/v0_1/transaction.rs
@@ -37,5 +37,5 @@ pub struct Transaction {
     PartialOrd,
     Ord,
 )]
-#[display(fmt = "{_0}")]
+#[display("{_0}")]
 pub struct NamespaceId(pub(crate) u64);

--- a/utils/src/deployer.rs
+++ b/utils/src/deployer.rs
@@ -53,17 +53,17 @@ pub struct DeployedContracts {
 /// An identifier for a particular contract.
 #[derive(Clone, Copy, Debug, Display, PartialEq, Eq, Hash)]
 pub enum Contract {
-    #[display(fmt = "ESPRESSO_SEQUENCER_PLONK_VERIFIER_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_PLONK_VERIFIER_ADDRESS")]
     PlonkVerifier,
-    #[display(fmt = "ESPRESSO_SEQUENCER_LIGHT_CLIENT_STATE_UPDATE_VK_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_LIGHT_CLIENT_STATE_UPDATE_VK_ADDRESS")]
     StateUpdateVK,
-    #[display(fmt = "ESPRESSO_SEQUENCER_LIGHT_CLIENT_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_LIGHT_CLIENT_ADDRESS")]
     LightClient,
-    #[display(fmt = "ESPRESSO_SEQUENCER_LIGHT_CLIENT_PROXY_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_LIGHT_CLIENT_PROXY_ADDRESS")]
     LightClientProxy,
-    #[display(fmt = "ESPRESSO_SEQUENCER_FEE_CONTRACT_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_FEE_CONTRACT_ADDRESS")]
     FeeContract,
-    #[display(fmt = "ESPRESSO_SEQUENCER_FEE_CONTRACT_PROXY_ADDRESS")]
+    #[display("ESPRESSO_SEQUENCER_FEE_CONTRACT_PROXY_ADDRESS")]
     FeeContractProxy,
 }
 


### PR DESCRIPTION
Demotes some logging and cleans up some instrumentation to avoid overly noisy output that isn't cause for concern.

### This PR:

* In catchup, demote retryable failures from WARN to INFO. We now only WARN if the overall operation fails (failed to fetch from any provider) or if we fail to fetch from a single provider in a way that indicates that provider is malicious (e.g. invalid Merkle proof) instead of just unreachable (e.g. HTTP error)
* Add instance state to `skip` list for `instrument`, since it generates a very large debug output with each log
* Remove `Debug` requirement from `StateCatchup` trait. This was generating a huge dump of useless data for the SQL provider in particular. Instead, we have a function `name() -> String` which is meant to be a short, readable identifier of the provider. We now use this when logging information about a specific catchup provider
* Update `derive_more`, so we could customize the `Debug` impl of `NodeState` to use the `name()` function of the nested `Box<dyn StateCatchup>`, instead of the `Debug` impl. This update was a breaking change and thus required minor tweaks to a lot of other uses of `derive_more`.
* Demote `timed out fetching proposal` from WARN to INFO. This happens normally when we are fetching an old proposal that the rest of the network has already GCed, and the task will eventually just exit on its own
* Demote `background task exited` from INFO to DEBUG for short-lived tasks (proposal fetching) only
* Demote L1 logging that happens every L1 block from INFO to DEBUG

