### PR TITLE
Fix uint64 underflow in SequencerClient

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -106,3 +106,21 @@ impl SequencerClient {
         Ok(balance)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Regression test for a bug where the block number underflowed. This test would panic
+    // on the previous implementation, as long as overflow checks are enabled.
+    #[async_std::test]
+    async fn test_regression_block_number_underflow() {
+        let client = SequencerClient::new("http://dummy-url:3030".parse().unwrap());
+        assert_eq!(
+            client
+                .get_espresso_balance(Address::zero(), Some(0))
+                .await
+                .unwrap(),
+            0.into()
+        )
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,8 @@ services:
       - ACCOUNT_INDEX=$ESPRESSO_BUILDER_ETH_ACCOUNT_INDEX
       - AMOUNT=1000000000000000000
       - CONFIRMATIONS=1
+      - RUST_LOG
+      - RUST_LOG_FORMAT
     depends_on:
       deploy-sequencer-contracts:
         condition: service_completed_successfully

--- a/sequencer/src/bin/espresso-bridge.rs
+++ b/sequencer/src/bin/espresso-bridge.rs
@@ -159,7 +159,7 @@ async fn deposit(opt: Deposit) -> anyhow::Result<()> {
     let initial_balance = espresso
         .get_espresso_balance(l1.address(), None)
         .await
-        .context("getting Espresso block height")?;
+        .context("getting Espresso balance")?;
     tracing::debug!(%initial_balance, "initial balance");
 
     // Send the deposit transaction.


### PR DESCRIPTION
This underflow causes the fund-builder service to query for the block with block number max(uint64) when the demo is started and the current block height is still zero.

To test 

```
scripts/build-docker-images-native
just demo --force-recreate --renew-anon-volumes 
``` 
and run `scripts/smoke-test-demo` in another terminal.

We should also add a regression tests for this, or run our demo with non-release build (enabled overflow checks).

Also increases the number of retries from 5 to 10, so we would retry for a total of 2 seconds instead of 1. I figured it doesn't hurt to fail a second later.
