### PR TITLE
Add Inscriptions Service

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,9 @@
+[default]
+extend-ignore-re = [
+  # Ignore any use of the address macro from alloy that includes hexadecimal.
+  "address!\\(\\\"[0-9a-fA-F]{40}\\\"\\)",
+]
+
 [files]
 extend-exclude = [
   "*.json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -135,6 +136,471 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "alloy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea8ebf106e84a1c37f86244df7da0c7587e697b71a0d565cce079449b85ac6f8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport-http",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed961a48297c732a5d97ee321aa8bb5009ecadbcb077d8bec90cb54e651629"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ef9e96462d0b9fee9008c53c1f3d017b9498fcdef3ad8d728db98afef47955"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85132f2698b520fab3f54beed55a44389f7006a7b557a0261e1e69439dcc1572"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "derive_more 1.0.0",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69e06cf9c37be824b9d26d6d101114fdde6af0c87de2828b414c05c4b3daa71"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde15e14944a88bd6a57d325e9a49b75558746fe16aaccc79713ae50a6a9574c"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded610181f3dad5810f6ff12d1a99994cf9b42d2fcb7709029352398a5da5ae6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5979e0d5a7bf9c7eb79749121e8256e59021af611322aee56e77e20776b4b3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204237129086ce5dc17a58025e93739b01b45313841f98fa339eb1d780511e57"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514f70ee2a953db21631cd817b13a1571474ec77ddc03d47616d5e8203489fde"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd58d377699e6cfeab52c4a9d28bdc4ef37e2bd235ff2db525071fe37a2e9af5"
+dependencies = [
+ "alloy-rlp",
+ "bytes 1.7.1",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.0",
+ "hex-literal",
+ "indexmap 2.5.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4814d141ede360bb6cd1b4b064f1aab9de391e7c4d0d4d50ac89ea4bc1e25fbd"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.12.5",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.12.8",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes 1.7.1",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc2bd1e7403463a5f2c61e955bcc9d3072b63aa177442b0f9aa6a6d22a941e3"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.8",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b034779a4850b4b03f5be5ea674a1cf7d746b2da762b34d1860ab45e48ca27"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "derive_more 1.0.0",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592c185d7100258c041afac51877660c7bf6213447999787197db4842f0e938e"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6614f02fc1d5b079b2a4a5320018317b506fd0a6d67c1fd5542a71201724986c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "coins-bip32 0.12.0",
+ "coins-bip39 0.12.0",
+ "k256",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1b42ac8f45e2f49f4bcdd72cbfde0bb148f5481d403774ffa546e48b83efc1"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06318f1778e57f36333e850aa71bd1bb5e560c10279e236622faae0470c50412"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaebb9b0ad61a41345a22c9279975c0cdd231b97947b10d7aad1cf0a7181e4a5"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c71028bfbfec210e24106a542aad3def7caf1a70e2c05710e92a98481980d3"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d7fb042d68ddfe79ccb23359de3007f6d4d53c13f703b64fb0db422132111"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be77579633ebbc1266ae6fd7694f75c408beb1aeb6865d0b18f22893c265a061"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest 0.12.8",
+ "serde_json",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -228,8 +694,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -239,9 +705,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
  "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -251,8 +717,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -263,8 +729,8 @@ checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -274,11 +740,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-relations",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "ark-snark",
- "ark-std",
+ "ark-std 0.4.0",
  "blake2",
  "derivative",
  "digest 0.10.7",
@@ -291,10 +757,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -311,8 +777,8 @@ checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -323,8 +789,8 @@ checksum = "ba6d678bb98a7e4f825bd4e332e93ac4f5a114ce2e3340dee4d7dc1c7ab5b323"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -335,8 +801,26 @@ checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -345,10 +829,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -362,10 +846,32 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -389,9 +895,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "rayon",
@@ -405,11 +911,11 @@ checksum = "5a741492629ffcd228337676dc223a28551aa6792eedb8a2a22c767f00df6c89"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "rayon",
@@ -421,10 +927,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
  "tracing",
  "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -434,7 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -456,10 +972,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
 dependencies = [
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -471,10 +987,10 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly-commit",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "directories",
  "hex-literal",
  "rand 0.8.5",
@@ -482,6 +998,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "ureq",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -999,7 +1525,7 @@ name = "atomic_store"
 version = "0.1.3"
 source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.4#64c092596e889b9f376fd4bae8974404c43cd12c"
 dependencies = [
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "bincode",
  "regex",
  "serde",
@@ -1069,7 +1595,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -1419,6 +1945,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,7 +2127,7 @@ version = "0.4.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.4.5#f6cc7c2fc53eaa52a4901e775d9be7ac820af72c"
 dependencies = [
  "anyhow",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "async-trait",
  "capnp",
  "capnpc",
@@ -1620,7 +2161,7 @@ version = "0.4.0"
 source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.4.7#5406fde54e61058428a7b55e1a98b699f0f606f1"
 dependencies = [
  "anyhow",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "async-trait",
  "capnp",
  "capnpc",
@@ -1764,7 +2305,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
 dependencies = [
  "bs58",
- "coins-core",
+ "coins-core 0.8.7",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "k256",
+ "serde",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core 0.12.0",
  "digest 0.10.7",
  "hmac 0.12.1",
  "k256",
@@ -1780,7 +2337,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
  "bitvec",
- "coins-bip32",
+ "coins-bip32 0.8.7",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec",
+ "coins-bip32 0.12.0",
  "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.12.2",
@@ -1804,6 +2377,25 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -1863,7 +2455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05a8809c2761232ce27226ef1ca1bc78b480b558406895848f76ab8fce04076c"
 dependencies = [
  "arbitrary",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "bitvec",
  "derivative",
  "derive_more 0.99.18",
@@ -2582,6 +3174,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2597,8 +3190,8 @@ source = "git+https://github.com/EspressoSystems/solidity-bn254.git#050a98a3b389
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
  "clap",
  "ethers",
 ]
@@ -2610,9 +3203,9 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-std",
+ "ark-std 0.4.0",
  "clap",
  "diff-test-bn254",
  "ethers",
@@ -2955,7 +3548,7 @@ name = "espresso-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "async-compatibility-layer",
  "async-std",
  "async-trait",
@@ -3286,8 +3879,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
 dependencies = [
  "async-trait",
- "coins-bip32",
- "coins-bip39",
+ "coins-bip32 0.8.7",
+ "coins-bip39 0.8.7",
  "const-hex",
  "elliptic-curve",
  "eth-keystore",
@@ -3400,6 +3993,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes 1.7.1",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,7 +4065,7 @@ checksum = "1bebadab126f8120d410b677ed95eee4ba6eb7c6dd8e34a5ec88a08050e26132"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spinning_top",
+ "spinning_top 0.2.5",
 ]
 
 [[package]]
@@ -3555,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3565,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -3594,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -3638,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3660,15 +4264,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-ticker"
@@ -3693,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3708,6 +4312,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "fxhash"
@@ -3802,6 +4412,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top 0.3.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,6 +4518,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3973,6 +4605,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -4219,10 +4854,10 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "contract-bindings",
  "diff-test-bn254",
  "ethers",
@@ -4370,7 +5005,7 @@ version = "0.1.62"
 source = "git+https://github.com/EspressoSystems/hotshot-query-service?tag=0.1.67#a523f51da80d826bd09415af1d7e0077354d96e5"
 dependencies = [
  "anyhow",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "async-compatibility-layer",
  "async-lock 3.4.0",
  "async-std",
@@ -4424,9 +5059,9 @@ source = "git+https://www.github.com/EspressoSystems/HotShot.git?tag=0.5.78-patc
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "ethereum-types",
  "hotshot-types 0.1.11 (git+https://www.github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch10)",
@@ -4446,9 +5081,9 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-srs",
- "ark-std",
+ "ark-std 0.4.0",
  "async-std",
  "clap",
  "contract-bindings",
@@ -4585,10 +5220,10 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ed-on-bn254",
- "ark-ff",
- "ark-serialize",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "ark-srs",
- "ark-std",
+ "ark-std 0.4.0",
  "async-compatibility-layer",
  "async-lock 2.8.0",
  "async-std",
@@ -4644,10 +5279,10 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ed-on-bn254",
- "ark-ff",
- "ark-serialize",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "ark-srs",
- "ark-std",
+ "ark-std 0.4.0",
  "async-compatibility-layer",
  "async-lock 2.8.0",
  "async-std",
@@ -4923,7 +5558,7 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "socket2 0.5.7",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -5136,6 +5771,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "inscriptions"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-dyn-abi",
+ "async-compatibility-layer",
+ "async-std",
+ "async-trait",
+ "bincode",
+ "circular-buffer",
+ "clap",
+ "const-hex",
+ "espresso-types",
+ "futures",
+ "governor",
+ "hotshot",
+ "hotshot-builder-api",
+ "hotshot-query-service",
+ "hotshot-types 0.1.11 (git+https://www.github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch10)",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "surf-disco",
+ "tide-disco",
+ "toml",
+ "tracing",
+ "url",
+ "vbs",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5258,7 +5924,7 @@ name = "jf-commitment"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
- "ark-std",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -5266,8 +5932,8 @@ name = "jf-crhf"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -5279,9 +5945,9 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "displaydoc",
@@ -5303,10 +5969,10 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "displaydoc",
  "itertools 0.12.1",
@@ -5321,10 +5987,10 @@ version = "0.5.1"
 source = "git+https://github.com/EspressoSystems/jellyfish?tag=jf-plonk-v0.5.1#7e2eeef8c06a12f17015d457f1b3ea80b0de3333"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "displaydoc",
  "downcast-rs",
@@ -5351,8 +6017,8 @@ name = "jf-prf"
 version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14f1a501b0b0dc391f1dffa1b8374fb"
 dependencies = [
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -5365,10 +6031,10 @@ dependencies = [
  "ark-bn254",
  "ark-bw6-761",
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "displaydoc",
  "downcast-rs",
@@ -5394,8 +6060,8 @@ dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ed-on-bls12-381",
  "ark-ed-on-bn254",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
  "displaydoc",
  "itertools 0.12.1",
  "jf-commitment",
@@ -5413,9 +6079,9 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "blst",
  "derivative",
  "digest 0.10.7",
@@ -5442,10 +6108,10 @@ dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ed-on-bls12-381",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "displaydoc",
  "rand_chacha 0.3.1",
@@ -5462,10 +6128,10 @@ source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.5#7d71dbeff14
 dependencies = [
  "anyhow",
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "displaydoc",
@@ -5553,6 +6219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -6783,6 +7459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "node-metrics"
 version = "0.1.0"
 dependencies = [
@@ -6821,6 +7503,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -7477,6 +8165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7602,6 +8296,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7672,6 +8388,8 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
@@ -7679,6 +8397,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.4",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -7738,6 +8458,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -7869,6 +8604,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -7935,6 +8671,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -8406,6 +9151,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes 1.7.1",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rust-ini"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8440,6 +9215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -8580,6 +9364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8645,6 +9441,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "schnellru"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+dependencies = [
+ "ahash 0.8.11",
+ "cfg-if",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -8740,7 +9547,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -8759,6 +9575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8775,8 +9600,8 @@ name = "sequencer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ark-ff",
- "ark-serialize",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "async-broadcast",
  "async-compatibility-layer",
  "async-once-cell",
@@ -8856,7 +9681,7 @@ name = "sequencer-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "async-compatibility-layer",
  "async-std",
  "async-trait",
@@ -9072,6 +9897,16 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -9342,6 +10177,15 @@ name = "spinning_top"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -9855,6 +10699,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf42e81491fb8871b74df3d222c64ae8cbc1269ea509fa768a3ed3e1b0ac8cb"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9940,8 +10796,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b74bbf1db405a3fd2c6f8cd403bfa14727faa145925efe3012fa270b61551f1"
 dependencies = [
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "base64 0.22.1",
  "crc-any",
  "serde",
@@ -10351,6 +11207,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.14",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10436,7 +11293,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10463,7 +11320,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10487,6 +11344,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite 0.2.14",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -10954,6 +11825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11091,6 +11971,20 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "wasmtimer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "contracts/rust/diff-test",
   "contracts/rust/gen-vk-contract",
   "hotshot-state-prover",
+  "inscriptions",
   "marketplace-builder",
   "marketplace-solver",
   "node-metrics",

--- a/docker/inscriptions.Dockerfile
+++ b/docker/inscriptions.Dockerfile
@@ -20,8 +20,6 @@ COPY zkevm-node-additions /app/zkevm-node-additions
 COPY .env .envrc Cargo.toml Cargo.lock /app/
 WORKDIR /app
 
-# RUN apk add --no-cache g++ openssl-dev
-
 RUN RUSTFLAGS="--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"" cargo build  --release --all-targets --all-features
 
 FROM ubuntu:jammy

--- a/docker/inscriptions.Dockerfile
+++ b/docker/inscriptions.Dockerfile
@@ -1,0 +1,43 @@
+FROM rust:1.82.0 AS builder
+COPY builder /app/builder
+COPY client /app/client
+COPY common /app/common
+COPY contract-bindings /app/contract-bindings
+COPY contracts /app/contracts
+COPY data /app/data
+COPY geth-config /app/geth-config
+COPY hotshot-state-prover /app/hotshot-state-prover
+COPY inscriptions /app/inscriptions
+COPY marketplace-builder /app/marketplace-builder
+COPY marketplace-solver /app/marketplace-solver
+COPY node-metrics /app/node-metrics
+COPY scripts /app/scripts
+COPY sequencer /app/sequencer
+COPY tests /app/tests
+COPY types /app/types
+COPY utils /app/utils
+COPY zkevm-node-additions /app/zkevm-node-additions
+COPY .env .envrc Cargo.toml Cargo.lock /app/
+WORKDIR /app
+
+# RUN apk add --no-cache g++ openssl-dev
+
+RUN RUSTFLAGS="--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"" cargo build  --release --all-targets --all-features
+
+FROM ubuntu:jammy
+ARG TARGETARCH
+
+RUN apt-get update \
+    &&  apt-get install -y curl libcurl4 wait-for-it tini \
+    &&  rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["tini", "--"]
+
+COPY --from=builder /app/target/release/inscriptions /bin/inscriptions
+RUN chmod +x /bin/inscriptions
+
+# Run a web server on this port by default. Port can be overridden by the container orchestrator.
+ENV ESPRESSO_INSCRIPTIONS_PORT=80
+
+CMD [ "/bin/inscriptions"]
+HEALTHCHECK --interval=1s --timeout=1s --retries=100 CMD curl --fail http://localhost:${ESPRESSO_INSCRIPTIONS_PORT}/healthcheck  || exit 1
+EXPOSE ${ESPRESSO_INSCRIPTIONS_PORT}

--- a/inscriptions/Cargo.toml
+++ b/inscriptions/Cargo.toml
@@ -25,7 +25,7 @@ hotshot = { workspace = true }
 hotshot-builder-api = { workspace = true }
 hotshot-query-service = { workspace = true }
 serde = { workspace = true }
-sqlx = "0.8"
+sqlx = { workspace = true, features = ["runtime-async-std", "postgres"] }
 surf-disco = { workspace = true }
 tide-disco = { workspace = true }
 toml = { workspace = true }

--- a/inscriptions/Cargo.toml
+++ b/inscriptions/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "inscriptions"
+description = "A toy program to demonstrate the liveness and interactivity within the Espresso mainnet"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[features]
+testing = ["serde_json"]
+
+[dependencies]
+alloy = { version = "0.5.3", features = ["dyn-abi", "signers", "signer-local", "signer-mnemonic", "sol-types"] }
+alloy-dyn-abi = { version = "0.8.5", features = [ "std", "eip712" ] }
+async-compatibility-layer = { workspace = true }
+async-std = { workspace = true }
+async-trait = { workspace = true }
+bincode = { workspace = true }
+circular-buffer = { workspace = true }
+clap = { workspace = true }
+const-hex = { version = "^1.10" }
+espresso-types = { path = "../types", features = ["testing"] }
+futures = { workspace = true }
+governor = { version = "^0.7.0" }
+hotshot = { workspace = true }
+hotshot-builder-api = { workspace = true }
+hotshot-query-service = { workspace = true }
+serde = { workspace = true }
+sqlx = "0.8"
+surf-disco = { workspace = true }
+tide-disco = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+
+# Dependencies for feature `testing`
+hotshot-types = { workspace = true }
+serde_json = { version = "^1.0.113", optional = true }
+vbs = { workspace = true }
+# reqwest = { workspace = true }
+# time = { workspace = true }

--- a/inscriptions/migrations/20241107210344_initialize.sql
+++ b/inscriptions/migrations/20241107210344_initialize.sql
@@ -1,0 +1,70 @@
+-- Add migration script here
+
+-- last_read_block is meant to be a table with a single row that stores the
+-- last read block number.
+CREATE TABLE last_read_block (
+    id INTEGER PRIMARY KEY,
+    block_number BIGINT NOT NULL
+);
+
+-- We shouldn't need an index for this table, as there **SHOULD** only be a
+-- single row in this table.
+
+-- Write a single row into this table to seed it for future updates.
+INSERT INTO last_read_block (id, block_number) VALUES (0, 0);
+
+
+-- pending_put_inscription_request is meant to store the requests that are
+-- pending to be sent to the espresso chain.
+CREATE TABLE pending_put_inscription_request (
+    id SERIAL PRIMARY KEY,
+    ins_hash BYTEA NOT NULL UNIQUE,
+    ins_address VARCHAR NOT NULL,
+    ins_time BIGINT NOT NULL
+);
+
+-- We would like to be able to query this table by the hash of the inscription,
+-- as well as the time that the inscription was created.
+CREATE INDEX pending_put_inscription_request_hash_index ON pending_put_inscription_request (ins_hash);
+CREATE INDEX pending_put_inscription_request_time_index ON pending_put_inscription_request (ins_time);
+
+-- sync_event is an enum that represents the two different types of events
+-- that we want to keep track of for tracking the performance of our
+-- inscription submission process.
+CREATE TYPE sync_event AS ENUM ('submit', 'confirmed');
+
+-- pending_put_inscriptions_event is meant to store the key events that occur
+-- during the submission of an inscription to the espresso chain, as well as
+-- the receipt of that inscription.
+CREATE TABLE pending_put_inscriptions_event (
+    id SERIAL PRIMARY KEY,
+    ins_id BIGINT NOT NULL REFERENCES pending_put_inscription_request (id) ON DELETE RESTRICT,
+    event_type sync_event NOT NULL,
+    event_time BIGINT NOT NULL
+);
+
+-- We would like to be able to query this table by the hash of the inscription,
+-- as well as the type of event that occurred.
+--
+-- We want to be able to retrieve the put_inscription requests that are lacking
+-- a confirmation event.
+CREATE INDEX pending_put_inscriptions_event_id_and_sync_event ON pending_put_inscriptions_event (ins_id, event_type);
+
+-- confirmed_inscriptions is meant to store the inscriptions that have been
+-- confirmed by the espresso chain.
+CREATE TABLE confirmed_inscriptions (
+    id SERIAL PRIMARY KEY,
+    ins_hash BYTEA NOT NULL UNIQUE,
+    ins_address VARCHAR NOT NULL,
+    ins_time BIGINT NOT NULL,
+
+    chain_block_height BIGINT NOT NULL,
+    chain_txn_offset BIGINT NOT NULL
+);
+
+-- We would like to be able to retrieve the confirmed inscriptions by their
+-- hash, the address of the wallet, and the time that the inscription was
+-- created.
+CREATE INDEX confirmed_inscriptions_hash_index ON confirmed_inscriptions (ins_hash);
+CREATE INDEX confirmed_inscriptions_time_index ON confirmed_inscriptions (ins_time);
+CREATE INDEX confirmed_inscriptions_block_index ON confirmed_inscriptions (ins_address);

--- a/inscriptions/migrations/20241111202304_num_transactions.sql
+++ b/inscriptions/migrations/20241111202304_num_transactions.sql
@@ -1,0 +1,2 @@
+-- Start Tracking number of transactions that have been tracked.
+ALTER TABLE last_read_block ADD COLUMN num_transaction BIGINT NOT NULL DEFAULT 0;

--- a/inscriptions/src/api/inscriptions/mod.rs
+++ b/inscriptions/src/api/inscriptions/mod.rs
@@ -1,0 +1,1 @@
+pub mod v0;

--- a/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
+++ b/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
@@ -250,6 +250,8 @@ pub async fn create_inscriptions_processing(
         num_inscriptions,
     } = persistence.retrieve_last_received_block().await?;
 
+    tracing::debug!("launching service with the following recovered stats: block_height: {}, num_transactions: {}, num_inscriptions: {}", block_height, num_transactions, num_inscriptions);
+
     // Restore the previous number of transactions and the block height.
     data_state.add_num_transactions(block_height, num_transactions);
     data_state.add_num_inscriptions(block_height, num_inscriptions);

--- a/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
+++ b/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
@@ -250,7 +250,7 @@ pub async fn create_inscriptions_processing(
         num_inscriptions,
     } = persistence.retrieve_last_received_block().await?;
 
-    tracing::debug!("launching service with the following recovered stats: block_height: {}, num_transactions: {}, num_inscriptions: {}", block_height, num_transactions, num_inscriptions);
+    tracing::info!("launching service with the following recovered stats: block_height: {}, num_transactions: {}, num_inscriptions: {}", block_height, num_transactions, num_inscriptions);
 
     // Restore the previous number of transactions and the block height.
     data_state.add_num_transactions(block_height, num_transactions);

--- a/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
+++ b/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
@@ -1,0 +1,269 @@
+use std::{num::NonZeroU32, sync::Arc};
+
+use crate::{
+    service::{
+        client_id::ClientId,
+        client_message::InternalClientMessage,
+        client_state::{
+            ClientThreadState, InternalClientMessageProcessingTask,
+            ProcessDistributeInscriptionHandlingTask, ProcessRecordInscriptionHandlingTask,
+        },
+        data_state::{DataState, ProcessBlockStreamTask},
+        espresso_inscription::EspressoInscription,
+        server_message::ServerMessage,
+    },
+    Options,
+};
+use alloy::signers::local::PrivateKeySigner;
+use async_std::sync::RwLock;
+use espresso_types::{NamespaceId, SeqTypes};
+use futures::channel::mpsc::{self, Receiver, Sender};
+use governor::{Quota, RateLimiter};
+use hotshot_query_service::availability::BlockQueryData;
+use url::Url;
+
+pub struct InscriptionsAPI {
+    pub process_internal_client_message_handle: Option<InternalClientMessageProcessingTask>,
+    pub process_block_stream_handle: Option<ProcessBlockStreamTask>,
+    pub process_distribute_inscription_handle: Option<ProcessDistributeInscriptionHandlingTask>,
+    pub process_record_inscription_handle: Option<ProcessRecordInscriptionHandlingTask>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InscriptionsConfig {
+    /// The URL to submit inscriptions to
+    submit_url: Url,
+
+    /// inscription_namespace_id is the NamespaceId that is used to identify
+    /// the Inscriptions that are being submitted to the Espresso Block Chain.
+    inscription_namespace_id: NamespaceId,
+
+    /// put_inscriptions_per_second is the setting to effectively rate limit
+    /// the number of inscriptions that can be submitted to the Espresso
+    /// Transaction mempool per second.
+    put_inscriptions_per_second: u32,
+}
+
+impl From<&Options> for InscriptionsConfig {
+    fn from(options: &Options) -> Self {
+        InscriptionsConfig {
+            submit_url: options.submit_base_url(),
+            inscription_namespace_id: options.inscriptions_namespace_id(),
+            put_inscriptions_per_second: options.put_inscriptions_per_second(),
+        }
+    }
+}
+
+impl InscriptionsConfig {
+    /// submit_url returns the URL that is used to submit inscriptions to the
+    /// Espresso Block Chain.
+    fn submit_url(&self) -> Url {
+        self.submit_url.clone()
+    }
+
+    /// inscription_namespace_id returns the NamespaceId that is used to
+    /// identify the Inscriptions that are being submitted to the Espresso
+    /// Block Chain.
+    fn inscription_namespace_id(&self) -> NamespaceId {
+        self.inscription_namespace_id
+    }
+
+    /// put_inscriptions_per_second returns the number of inscriptions that can
+    /// be submitted to the Espresso Block Chain per second.
+    fn put_inscriptions_per_second(&self) -> u32 {
+        self.put_inscriptions_per_second
+    }
+}
+
+#[cfg(test)]
+impl InscriptionsConfig {
+    fn new_testing(submit_url: Url) -> Self {
+        InscriptionsConfig {
+            submit_url,
+            inscription_namespace_id: NamespaceId::from(0x7e57u32),
+            put_inscriptions_per_second: 20,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CreateInscriptionsProcessingError {}
+
+/**
+ * create_inscriptions_processing is a function that creates a inscriptions
+ * service processing environment.  This function will create a number of tasks
+ * that will be responsible for processing the data streams that are coming in
+ * from the various sources.  This function will also create the data state that
+ * will be used to store the state of the network.
+ */
+pub async fn create_inscriptions_processing(
+    config: InscriptionsConfig,
+    internal_client_message_receiver: Receiver<InternalClientMessage<Sender<ServerMessage>>>,
+    block_receiver: Receiver<BlockQueryData<SeqTypes>>,
+    put_inscriptions_receiver: Receiver<EspressoInscription>,
+    signer: PrivateKeySigner,
+) -> Result<InscriptionsAPI, CreateInscriptionsProcessingError> {
+    let client_thread_state = ClientThreadState::<Sender<ServerMessage>>::new(
+        Default::default(),
+        ClientId::from_count(1),
+    );
+
+    let rate_limiter = {
+        let Some(non_zero_limit) = NonZeroU32::new(config.put_inscriptions_per_second()) else {
+            panic!("Failed to create non-zero limit");
+        };
+
+        RateLimiter::direct(Quota::per_second(non_zero_limit))
+    };
+
+    let data_state = DataState::new(Default::default(), signer.address());
+
+    let data_state = Arc::new(RwLock::new(data_state));
+    let client_thread_state = Arc::new(RwLock::new(client_thread_state));
+    let (inscription_sender, inscription_receiver) = mpsc::channel(32);
+
+    let process_internal_client_message_handle = InternalClientMessageProcessingTask::new(
+        internal_client_message_receiver,
+        data_state.clone(),
+        client_thread_state.clone(),
+    );
+
+    let process_block_stream_handle = ProcessBlockStreamTask::new(
+        config.inscription_namespace_id(),
+        block_receiver,
+        data_state.clone(),
+        inscription_sender,
+    );
+
+    let process_distribute_inscription_handle = ProcessDistributeInscriptionHandlingTask::new(
+        client_thread_state.clone(),
+        inscription_receiver,
+    );
+
+    let process_record_inscription_handle = ProcessRecordInscriptionHandlingTask::new(
+        rate_limiter,
+        config.inscription_namespace_id(),
+        signer,
+        put_inscriptions_receiver,
+        config.submit_url(),
+    );
+
+    Ok(InscriptionsAPI {
+        process_internal_client_message_handle: Some(process_internal_client_message_handle),
+        process_block_stream_handle: Some(process_block_stream_handle),
+        process_distribute_inscription_handle: Some(process_distribute_inscription_handle),
+        process_record_inscription_handle: Some(process_record_inscription_handle),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        api::inscriptions::v0::{
+            Error, HotshotQueryServiceBlockStreamRetriever, ProcessProduceBlockStreamTask,
+            StateClientMessageSender, STATIC_VER_0_1,
+        },
+        service::{
+            client_message::InternalClientMessage, espresso_inscription::EspressoInscription,
+            server_message::ServerMessage,
+        },
+    };
+    use alloy::signers::local::PrivateKeySigner;
+    use futures::channel::mpsc::{self, Sender};
+    use tide_disco::App;
+    use url::Url;
+
+    #[derive(Clone)]
+    struct TestState(
+        Sender<InternalClientMessage<Sender<ServerMessage>>>,
+        Sender<EspressoInscription>,
+    );
+
+    #[async_trait::async_trait]
+    impl StateClientMessageSender<Sender<ServerMessage>> for TestState {
+        fn internal_client_message_sender(
+            &self,
+        ) -> Sender<InternalClientMessage<Sender<ServerMessage>>> {
+            self.0.clone()
+        }
+
+        async fn put_inscription(&self, inscription: EspressoInscription) -> Result<(), Error> {
+            let mut sender = self.1.clone();
+
+            match sender.try_send(inscription) {
+                Ok(_) => {
+                    return Ok(());
+                }
+                Err(err) => {
+                    tracing::error!("error sending inscription: {:?}", err);
+                    Err(Error::TooManyRequests)
+                }
+            }
+        }
+    }
+
+    #[async_std::test]
+    #[ignore]
+    async fn test_full_setup_example() {
+        let (internal_client_message_sender, internal_client_message_receiver) = mpsc::channel(32);
+        let (put_inscription_sender, put_inscription_receiver) = mpsc::channel(32);
+        let state = TestState(internal_client_message_sender, put_inscription_sender);
+
+        let mut app: App<_, crate::api::inscriptions::v0::Error> = App::with_state(state);
+        let inscriptions_api_result = super::super::define_api::<TestState>();
+        let inscriptions_api = match inscriptions_api_result {
+            Ok(inscriptions_api) => inscriptions_api,
+            Err(err) => {
+                panic!("error defining inscriptions api: {:?}", err);
+            }
+        };
+
+        match app.register_module("inscriptions", inscriptions_api) {
+            Ok(_) => {}
+            Err(err) => {
+                panic!("error registering inscriptions api: {:?}", err);
+            }
+        }
+
+        let (block_sender, block_receiver) = mpsc::channel(10);
+
+        let process_consume_leaves = ProcessProduceBlockStreamTask::new(
+            HotshotQueryServiceBlockStreamRetriever::new(
+                "https://query.decaf.testnet.espresso.network/v0"
+                    .parse()
+                    .unwrap(),
+            ),
+            block_sender,
+        );
+
+        let inscriptions_task_state = match super::create_inscriptions_processing(
+            super::InscriptionsConfig::new_testing(
+                Url::parse("http://localhost:8000/v0/submit/submit").unwrap(),
+            ),
+            internal_client_message_receiver,
+            block_receiver,
+            put_inscription_receiver,
+            PrivateKeySigner::random(),
+        )
+        .await
+        {
+            Ok(inscriptions_task_state) => inscriptions_task_state,
+
+            Err(err) => {
+                panic!("error defining inscriptions api: {:?}", err);
+            }
+        };
+
+        // We would like to wait until being signaled
+        let app_serve_handle = async_std::task::spawn(async move {
+            let app_serve_result = app.serve("0.0.0.0:9000", STATIC_VER_0_1).await;
+            tracing::info!("app serve result: {:?}", app_serve_result);
+        });
+        tracing::info!("now listening on port 9000");
+
+        app_serve_handle.await;
+
+        drop(inscriptions_task_state);
+        drop(process_consume_leaves);
+    }
+}

--- a/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
+++ b/inscriptions/src/api/inscriptions/v0/create_inscriptions_api.rs
@@ -1,4 +1,7 @@
-use std::{num::NonZeroU32, sync::Arc};
+use std::{
+    num::{NonZero, NonZeroU32},
+    sync::Arc,
+};
 
 use crate::{
     service::{
@@ -6,31 +9,44 @@ use crate::{
         client_message::InternalClientMessage,
         client_state::{
             ClientThreadState, InternalClientMessageProcessingTask,
-            ProcessDistributeInscriptionHandlingTask, ProcessRecordInscriptionHandlingTask,
+            ProcessDistributeInscriptionHandlingTask, ProcessPutInscriptionToChainTask,
+            ProcessRecordPutInscriptionRequestTask,
         },
-        data_state::{DataState, ProcessBlockStreamTask},
+        data_state::{DataState, ProcessBlockStreamTask, MAX_LOCAL_INSCRIPTION_HISTORY},
         espresso_inscription::EspressoInscription,
         server_message::ServerMessage,
+        storage::{
+            in_memory::HeightCachingInMemory, postgres::PostgresPersistence, InscriptionPersistence,
+        },
     },
     Options,
 };
 use alloy::signers::local::PrivateKeySigner;
 use async_std::sync::RwLock;
-use espresso_types::{NamespaceId, SeqTypes};
-use futures::channel::mpsc::{self, Receiver, Sender};
+use espresso_types::NamespaceId;
+use futures::{
+    channel::mpsc::{self, Receiver, Sender},
+    SinkExt,
+};
 use governor::{Quota, RateLimiter};
-use hotshot_query_service::availability::BlockQueryData;
 use url::Url;
+
+use super::{HotshotQueryServiceBlockStreamRetriever, ProcessProduceBlockStreamTask};
 
 pub struct InscriptionsAPI {
     pub process_internal_client_message_handle: Option<InternalClientMessageProcessingTask>,
     pub process_block_stream_handle: Option<ProcessBlockStreamTask>,
     pub process_distribute_inscription_handle: Option<ProcessDistributeInscriptionHandlingTask>,
-    pub process_record_inscription_handle: Option<ProcessRecordInscriptionHandlingTask>,
+    pub process_put_inscription_to_chain_handle: Option<ProcessPutInscriptionToChainTask>,
+    pub process_record_put_inscription_handle: Option<ProcessRecordPutInscriptionRequestTask>,
+    pub process_produce_blocks_handle: Option<ProcessProduceBlockStreamTask>,
 }
 
 #[derive(Debug, Clone)]
 pub struct InscriptionsConfig {
+    /// The URL to the block stream source
+    block_stream_source_base_url: Url,
+
     /// The URL to submit inscriptions to
     submit_url: Url,
 
@@ -42,15 +58,60 @@ pub struct InscriptionsConfig {
     /// the number of inscriptions that can be submitted to the Espresso
     /// Transaction mempool per second.
     put_inscriptions_per_second: u32,
+
+    /// postgres_url is the URL to the Postgres database that is used to store
+    /// the inscriptions.
+    postgres_url: Url,
+
+    /// minimum_start_block is the minimum block that the inscriptions service
+    /// should start processing from.
+    minimum_start_block: u64,
 }
 
-impl From<&Options> for InscriptionsConfig {
-    fn from(options: &Options) -> Self {
-        InscriptionsConfig {
+#[derive(Debug)]
+pub enum CreateInscriptionsConfigError {
+    UrlParseError(url::ParseError),
+    SetPathError,
+    SetPortError,
+    SetUsernameError,
+    SetPasswordError,
+    SetHostError,
+}
+
+impl From<url::ParseError> for CreateInscriptionsConfigError {
+    fn from(err: url::ParseError) -> Self {
+        CreateInscriptionsConfigError::UrlParseError(err)
+    }
+}
+
+impl TryFrom<&Options> for InscriptionsConfig {
+    type Error = CreateInscriptionsConfigError;
+
+    fn try_from(options: &Options) -> Result<Self, Self::Error> {
+        let mut postgres_url = Url::parse("postgres://localhost/")?;
+
+        postgres_url.set_path(options.postgres_database().as_str());
+        postgres_url
+            .set_port(Some(options.postgres_port()))
+            .or(Err(CreateInscriptionsConfigError::SetPortError))?;
+        postgres_url
+            .set_username(options.postgres_user().as_str())
+            .or(Err(CreateInscriptionsConfigError::SetUsernameError))?;
+        postgres_url
+            .set_password(Some(options.postgres_password().as_str()))
+            .or(Err(CreateInscriptionsConfigError::SetPasswordError))?;
+        postgres_url
+            .set_host(Some(options.postgres_host().as_str()))
+            .or(Err(CreateInscriptionsConfigError::SetHostError))?;
+
+        Ok(InscriptionsConfig {
+            block_stream_source_base_url: options.block_stream_source_base_url(),
             submit_url: options.submit_base_url(),
             inscription_namespace_id: options.inscriptions_namespace_id(),
+            postgres_url,
             put_inscriptions_per_second: options.put_inscriptions_per_second(),
-        }
+            minimum_start_block: options.minimum_block_height(),
+        })
     }
 }
 
@@ -73,21 +134,65 @@ impl InscriptionsConfig {
     fn put_inscriptions_per_second(&self) -> u32 {
         self.put_inscriptions_per_second
     }
+
+    /// minimum_start_block returns the minimum block that the inscriptions
+    /// service should start processing from.
+    fn minimum_start_block(&self) -> u64 {
+        self.minimum_start_block
+    }
+
+    /// postgres_url returns the URL to the Postgres database that is used to
+    /// store the inscriptions service persistent state.
+    fn postgres_url(&self) -> Url {
+        self.postgres_url.clone()
+    }
+
+    /// block_stream_source_base_url returns the base URL to the block stream
+    /// source that originates from the availability API of the HotShot
+    /// Query Service.
+    fn block_stream_source_base_url(&self) -> Url {
+        self.block_stream_source_base_url.clone()
+    }
 }
 
 #[cfg(test)]
 impl InscriptionsConfig {
-    fn new_testing(submit_url: Url) -> Self {
+    fn new_testing(block_stream_source_base_url: Url, submit_url: Url, postgres_url: Url) -> Self {
         InscriptionsConfig {
+            block_stream_source_base_url,
             submit_url,
+            postgres_url,
             inscription_namespace_id: NamespaceId::from(0x7e57u32),
             put_inscriptions_per_second: 20,
+            minimum_start_block: 0,
         }
     }
 }
 
 #[derive(Debug)]
-pub enum CreateInscriptionsProcessingError {}
+pub enum CreateInscriptionsProcessingError {
+    PostgresError(sqlx::Error),
+    MigrationError(sqlx::migrate::MigrateError),
+    CreateInscriptionsConfigError(CreateInscriptionsConfigError),
+}
+
+impl From<sqlx::Error> for CreateInscriptionsProcessingError {
+    fn from(err: sqlx::Error) -> Self {
+        CreateInscriptionsProcessingError::PostgresError(err)
+    }
+}
+
+impl From<sqlx::migrate::MigrateError> for CreateInscriptionsProcessingError {
+    fn from(err: sqlx::migrate::MigrateError) -> Self {
+        CreateInscriptionsProcessingError::MigrationError(err)
+    }
+}
+
+impl From<CreateInscriptionsConfigError> for CreateInscriptionsProcessingError {
+    fn from(err: CreateInscriptionsConfigError) -> Self {
+        CreateInscriptionsProcessingError::CreateInscriptionsConfigError(err)
+    }
+}
 
 /**
  * create_inscriptions_processing is a function that creates a inscriptions
@@ -99,8 +204,9 @@ pub enum CreateInscriptionsProcessingError {}
 pub async fn create_inscriptions_processing(
     config: InscriptionsConfig,
     internal_client_message_receiver: Receiver<InternalClientMessage<Sender<ServerMessage>>>,
-    block_receiver: Receiver<BlockQueryData<SeqTypes>>,
-    put_inscriptions_receiver: Receiver<EspressoInscription>,
+    put_inscription_record_receiver: Receiver<EspressoInscription>,
+    put_inscription_to_chain_receiver: Receiver<EspressoInscription>,
+    put_inscription_to_chain_sender: Sender<EspressoInscription>,
     signer: PrivateKeySigner,
 ) -> Result<InscriptionsAPI, CreateInscriptionsProcessingError> {
     let client_thread_state = ClientThreadState::<Sender<ServerMessage>>::new(
@@ -116,7 +222,79 @@ pub async fn create_inscriptions_processing(
         RateLimiter::direct(Quota::per_second(non_zero_limit))
     };
 
-    let data_state = DataState::new(Default::default(), signer.address());
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(5)
+        .connect(config.postgres_url().to_string().as_str())
+        .await?;
+
+    // Run all of the migrations
+    sqlx::migrate!().run(&pool).await?;
+
+    let persistence = Arc::new(HeightCachingInMemory::new(PostgresPersistence::new(pool)));
+
+    let (block_sender, block_receiver) = mpsc::channel(10);
+
+    let mut data_state = DataState::new(Default::default(), persistence.clone(), signer.address());
+
+    let limit = NonZero::<usize>::new(MAX_LOCAL_INSCRIPTION_HISTORY).unwrap();
+    let latest_inscriptions_result = persistence
+        .retrieve_latest_inscription_and_chain_details(limit)
+        .await;
+
+    {
+        // Retrieve the latest inscriptions
+        let latest_inscriptions = match latest_inscriptions_result {
+            Ok(latest_inscriptions) => latest_inscriptions,
+            Err(err) => {
+                tracing::error!("error retrieving latest inscriptions: {:?}", err);
+                panic!("error retrieving latest inscriptions: {:?}", err);
+            }
+        };
+
+        tracing::info!(
+            "bootstrapping with {} previously loaded inscriptions",
+            latest_inscriptions.len()
+        );
+
+        // populate the latest inscriptions
+        for inscription_and_chain_details in latest_inscriptions {
+            data_state.add_latest_inscription(inscription_and_chain_details);
+        }
+    }
+
+    // Retrieve all pending put inscriptions request, and front-load them.
+    {
+        let pending_inscriptions_result = persistence.retrieve_pending_put_inscriptions().await;
+
+        let pending_inscriptions = match pending_inscriptions_result {
+            Ok(pending_inscriptions) => pending_inscriptions,
+            Err(err) => {
+                tracing::error!("error retrieving pending inscriptions: {:?}", err);
+                panic!("error retrieving pending inscriptions: {:?}", err);
+            }
+        };
+
+        tracing::info!(
+            "bootstrapping with {} previous put inscription requests",
+            pending_inscriptions.len()
+        );
+
+        let mut put_inscription_to_chain_sender = put_inscription_to_chain_sender;
+
+        for inscription in pending_inscriptions {
+            if let Err(err) = put_inscription_to_chain_sender.send(inscription).await {
+                tracing::error!("error sending inscription to chain: {:?}", err);
+                panic!("error sending inscription to chain: {:?}", err);
+            }
+        }
+    }
+
+    let process_produce_blocks = ProcessProduceBlockStreamTask::new(
+        HotshotQueryServiceBlockStreamRetriever::new(config.block_stream_source_base_url()),
+        persistence.clone(),
+        config.minimum_start_block(),
+        block_sender,
+    );
 
     let data_state = Arc::new(RwLock::new(data_state));
     let client_thread_state = Arc::new(RwLock::new(client_thread_state));
@@ -140,29 +318,34 @@ pub async fn create_inscriptions_processing(
         inscription_receiver,
     );
 
-    let process_record_inscription_handle = ProcessRecordInscriptionHandlingTask::new(
+    let process_record_put_inscription_handle = ProcessRecordPutInscriptionRequestTask::new(
+        data_state.clone(),
+        put_inscription_record_receiver,
+    );
+
+    let process_put_inscription_to_chain_handle = ProcessPutInscriptionToChainTask::new(
         rate_limiter,
+        data_state.clone(),
         config.inscription_namespace_id(),
         signer,
-        put_inscriptions_receiver,
+        put_inscription_to_chain_receiver,
         config.submit_url(),
     );
 
     Ok(InscriptionsAPI {
+        process_produce_blocks_handle: Some(process_produce_blocks),
         process_internal_client_message_handle: Some(process_internal_client_message_handle),
         process_block_stream_handle: Some(process_block_stream_handle),
         process_distribute_inscription_handle: Some(process_distribute_inscription_handle),
-        process_record_inscription_handle: Some(process_record_inscription_handle),
+        process_put_inscription_to_chain_handle: Some(process_put_inscription_to_chain_handle),
+        process_record_put_inscription_handle: Some(process_record_put_inscription_handle),
     })
 }
 
 #[cfg(test)]
 mod test {
     use crate::{
-        api::inscriptions::v0::{
-            Error, HotshotQueryServiceBlockStreamRetriever, ProcessProduceBlockStreamTask,
-            StateClientMessageSender, STATIC_VER_0_1,
-        },
+        api::inscriptions::v0::{Error, StateClientMessageSender, STATIC_VER_0_1},
         service::{
             client_message::InternalClientMessage, espresso_inscription::EspressoInscription,
             server_message::ServerMessage,
@@ -177,6 +360,7 @@ mod test {
     struct TestState(
         Sender<InternalClientMessage<Sender<ServerMessage>>>,
         Sender<EspressoInscription>,
+        Sender<EspressoInscription>,
     );
 
     #[async_trait::async_trait]
@@ -188,9 +372,18 @@ mod test {
         }
 
         async fn put_inscription(&self, inscription: EspressoInscription) -> Result<(), Error> {
-            let mut sender = self.1.clone();
+            let mut sender1 = self.1.clone();
+            let mut sender2 = self.2.clone();
 
-            match sender.try_send(inscription) {
+            match sender2.try_send(inscription.clone()) {
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::error!("error sending inscription: {:?}", err);
+                    return Err(Error::TooManyRequests);
+                }
+            }
+
+            match sender1.try_send(inscription) {
                 Ok(_) => {
                     return Ok(());
                 }
@@ -206,8 +399,14 @@ mod test {
     #[ignore]
     async fn test_full_setup_example() {
         let (internal_client_message_sender, internal_client_message_receiver) = mpsc::channel(32);
-        let (put_inscription_sender, put_inscription_receiver) = mpsc::channel(32);
-        let state = TestState(internal_client_message_sender, put_inscription_sender);
+        let (put_inscription_to_chain_sender, put_inscription_to_chain_receiver) =
+            mpsc::channel(32);
+        let (put_inscription_record_sender, put_inscription_record_receiver) = mpsc::channel(32);
+        let state = TestState(
+            internal_client_message_sender,
+            put_inscription_record_sender,
+            put_inscription_to_chain_sender.clone(),
+        );
 
         let mut app: App<_, crate::api::inscriptions::v0::Error> = App::with_state(state);
         let inscriptions_api_result = super::super::define_api::<TestState>();
@@ -225,24 +424,16 @@ mod test {
             }
         }
 
-        let (block_sender, block_receiver) = mpsc::channel(10);
-
-        let process_consume_leaves = ProcessProduceBlockStreamTask::new(
-            HotshotQueryServiceBlockStreamRetriever::new(
-                "https://query.decaf.testnet.espresso.network/v0"
-                    .parse()
-                    .unwrap(),
-            ),
-            block_sender,
-        );
-
         let inscriptions_task_state = match super::create_inscriptions_processing(
             super::InscriptionsConfig::new_testing(
+                Url::parse("http://query.main.net.espresso.network/v0/").unwrap(),
                 Url::parse("http://localhost:8000/v0/submit/submit").unwrap(),
+                Url::parse("postgres://localhost/inscriptions").unwrap(),
             ),
             internal_client_message_receiver,
-            block_receiver,
-            put_inscription_receiver,
+            put_inscription_record_receiver,
+            put_inscription_to_chain_receiver,
+            put_inscription_to_chain_sender,
             PrivateKeySigner::random(),
         )
         .await
@@ -264,6 +455,5 @@ mod test {
         app_serve_handle.await;
 
         drop(inscriptions_task_state);
-        drop(process_consume_leaves);
     }
 }

--- a/inscriptions/src/api/inscriptions/v0/inscriptions.toml
+++ b/inscriptions/src/api/inscriptions/v0/inscriptions.toml
@@ -48,3 +48,13 @@ Block Chain provided they meet the following criteria:
 - The Inscription service is not currently over capacity for submitting
   data to the Block Chain.
 """
+
+[route.inscriptions_for_wallet_address]
+PATH = ["inscriptions_for_wallet_address/:address"]
+":address" = "Literal"
+DOC = """
+Retrieve a collection of the most recent inscriptions for the given Wallet
+Address.
+
+It will return the confirmed inscriptions from the Mainnet.
+"""

--- a/inscriptions/src/api/inscriptions/v0/inscriptions.toml
+++ b/inscriptions/src/api/inscriptions/v0/inscriptions.toml
@@ -1,0 +1,50 @@
+# Copyright (c) 2022 Espresso Systems (espressosys.com)
+# This file is part of the HotShot Query Service library.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program. If not,
+# see <https://www.gnu.org/licenses/>.
+
+[meta]
+FORMAT_VERSION = "0.1.0"
+NAME = "inscriptions"
+DESCRIPTION = """
+The inscriptions  API provides an endpoint that allows for the near real-time
+streaming of confirmed Inscriptions coming from an Espresso Block Chain.
+
+The data that is provided by this API can be used to submit new inscriptions
+to the Inscriptions demo, as well as stream incoming inscriptions to other
+users in near real-time.
+"""
+
+[route.stream_inscriptions]
+PATH = ["inscriptions"]
+METHOD = "SOCKET"
+DOC = """
+The inscriptions endpoint will stream committed inscriptions to the users
+who open it.  All inscriptions as they are confirmed in near real-time will
+be sent to any user who has connected via this endpoint.
+"""
+
+[route.put_inscription]
+PATH = ["put_inscription"]
+METHOD = "POST"
+DOC = """
+The put_inscription endpoint allows users to submit new Inscriptions to the
+Inscriptions service.  These submissions are meant to have a body that can
+be decoded into an InscriptionAndSignature structure.
+
+This InscriptionAndSignature structures will be accepted and recorded in the
+Block Chain provided they meet the following criteria:
+
+- The message in the structure matches what is expected
+- The signature is valid for the contents of the Inscription with the
+  appropriate configuration.
+- The Inscription service is not currently over capacity for submitting
+  data to the Block Chain.
+"""

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -548,7 +548,7 @@ impl ProcessProduceBlockStreamTask {
                 }
             };
 
-            let block_height = std::cmp::min(minimum_start_block_height, last_stats.num_blocks);
+            let block_height = std::cmp::max(minimum_start_block_height, last_stats.num_blocks);
 
             // Retrieve a stream
             let Ok(stream) =

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -562,7 +562,7 @@ impl ProcessProduceBlockStreamTask {
                 .await
                 .ok()
                 // we want to start **after** the last block we received.
-                .map(|(height, _)| std::cmp::max(height + 1, minimum_start_block_height));
+                .map(|stats| std::cmp::max(stats.num_blocks + 1, minimum_start_block_height));
 
             let block_stream_result = block_stream_receiver.retrieve_stream(block_height).await;
 

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -564,6 +564,8 @@ impl ProcessProduceBlockStreamTask {
                 // we want to start **after** the last block we received.
                 .map(|stats| std::cmp::max(stats.num_blocks + 1, minimum_start_block_height));
 
+            tracing::debug!("attempt {attempt} to connect to block stream, at height: {}, with minimum_start_block_height: {minimum_start_block_height}", block_height.unwrap_or(0));
+
             let block_stream_result = block_stream_receiver.retrieve_stream(block_height).await;
 
             let block_stream = match block_stream_result {

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -1,0 +1,611 @@
+pub mod create_inscriptions_api;
+
+use crate::service::client_message::InternalClientMessage;
+use crate::service::espresso_inscription::{EspressoInscription, InscriptionAndSignature};
+use crate::service::server_message::ServerMessage;
+use crate::service::{validate_inscription_and_signature, InscriptionVerificationError};
+use async_std::task::JoinHandle;
+use espresso_types::{BackoffParams, SeqTypes};
+use futures::channel::mpsc::SendError;
+use futures::select;
+use futures::{
+    channel::mpsc::{self, Sender},
+    FutureExt, Sink, SinkExt, Stream, StreamExt,
+};
+use hotshot_query_service::availability::BlockQueryData;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tide_disco::socket::Connection;
+use tide_disco::RequestError;
+use tide_disco::{api::ApiError, Api};
+use url::Url;
+use vbs::version::{StaticVersion, StaticVersionType, Version};
+
+/// CONSTANT for protocol major version
+pub const VERSION_MAJ: u16 = 0;
+
+/// CONSTANT for protocol minor version
+pub const VERSION_MIN: u16 = 1;
+
+pub const VERSION_0_1: Version = Version {
+    major: VERSION_MAJ,
+    minor: VERSION_MIN,
+};
+
+/// Constant for the version of this API.
+pub const BASE_VERSION: Version = VERSION_0_1;
+
+/// Specific type for version 0.1
+pub type Version01 = StaticVersion<VERSION_MAJ, VERSION_MIN>;
+
+// Static instance of the Version01 type
+pub const STATIC_VER_0_1: Version01 = StaticVersion {};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Error {
+    UnhandledTideDisco(tide_disco::StatusCode, String),
+    UnhandledSurfDisco(surf_disco::StatusCode, String),
+
+    InscriptionAndSignatureUnpack(RequestError),
+    InvalidInscription(InscriptionVerificationError),
+
+    TooManyRequests,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UnhandledSurfDisco(status, msg) => {
+                write!(f, "Unhandled Surf Disco Error: {} - {}", status, msg)
+            }
+
+            Self::UnhandledTideDisco(status, msg) => {
+                write!(f, "Unhandled Tide Disco Error: {} - {}", status, msg)
+            }
+
+            Self::InscriptionAndSignatureUnpack(err) => {
+                write!(f, "Failed to unpack InscriptionAndSignature: {}", err)
+            }
+
+            Self::InvalidInscription(err) => {
+                write!(f, "Invalid Inscription: {}", err)
+            }
+
+            Self::TooManyRequests => {
+                write!(f, "Too Many Requests")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl tide_disco::Error for Error {
+    fn catch_all(status: tide_disco::StatusCode, msg: String) -> Self {
+        Self::UnhandledTideDisco(status, msg)
+    }
+
+    fn status(&self) -> tide_disco::StatusCode {
+        match self {
+            Self::UnhandledSurfDisco(status, _) => *status,
+            Self::UnhandledTideDisco(status, _) => *status,
+
+            Self::InscriptionAndSignatureUnpack(_) => tide_disco::StatusCode::BAD_REQUEST,
+            Self::InvalidInscription(_) => tide_disco::StatusCode::BAD_REQUEST,
+
+            Self::TooManyRequests => tide_disco::StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LoadApiError {
+    Toml(toml::de::Error),
+    Api(ApiError),
+}
+
+impl From<toml::de::Error> for LoadApiError {
+    fn from(err: toml::de::Error) -> Self {
+        LoadApiError::Toml(err)
+    }
+}
+
+impl From<ApiError> for LoadApiError {
+    fn from(err: ApiError) -> Self {
+        LoadApiError::Api(err)
+    }
+}
+
+pub(crate) fn load_api<State: 'static, ApiVer: StaticVersionType + 'static>(
+    default: &str,
+) -> Result<Api<State, Error, ApiVer>, LoadApiError> {
+    let toml: toml::Value = toml::from_str(default)?;
+    Ok(Api::new(toml)?)
+}
+
+#[derive(Debug)]
+pub enum LoadTomlError {
+    Io(std::io::Error),
+    Toml(toml::de::Error),
+    Utf8(std::str::Utf8Error),
+}
+
+impl From<std::io::Error> for LoadTomlError {
+    fn from(err: std::io::Error) -> Self {
+        LoadTomlError::Io(err)
+    }
+}
+
+impl From<toml::de::Error> for LoadTomlError {
+    fn from(err: toml::de::Error) -> Self {
+        LoadTomlError::Toml(err)
+    }
+}
+
+impl From<std::str::Utf8Error> for LoadTomlError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        LoadTomlError::Utf8(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum DefineApiError {
+    LoadApiError(LoadApiError),
+    LoadTomlError(LoadTomlError),
+    ApiError(ApiError),
+}
+
+impl From<LoadApiError> for DefineApiError {
+    fn from(err: LoadApiError) -> Self {
+        DefineApiError::LoadApiError(err)
+    }
+}
+
+impl From<LoadTomlError> for DefineApiError {
+    fn from(err: LoadTomlError) -> Self {
+        DefineApiError::LoadTomlError(err)
+    }
+}
+
+impl From<ApiError> for DefineApiError {
+    fn from(err: ApiError) -> Self {
+        DefineApiError::ApiError(err)
+    }
+}
+
+/// [StateClientMessageSender] allows for the retrieval of a [Sender] for sending
+/// messages received from the client to the Server for request processing.
+#[async_trait::async_trait]
+pub trait StateClientMessageSender<K> {
+    /// [internal_client_message_sender] retrieves a [Sender] for sending
+    /// messages to the server.
+    fn internal_client_message_sender(&self) -> Sender<InternalClientMessage<K>>;
+
+    /// [put_inscription] attempts to send an [EspressoInscription] to the server
+    /// for processing.  If the server is over capacity, then it should return
+    /// an error indicating that the service is rate limited.
+    async fn put_inscription(&self, inscription: EspressoInscription) -> Result<(), Error>;
+}
+
+#[derive(Debug)]
+pub enum EndpointError {}
+
+pub fn define_api<State>() -> Result<Api<State, Error, Version01>, DefineApiError>
+where
+    State: StateClientMessageSender<Sender<ServerMessage>> + Send + Sync + 'static,
+{
+    let mut api = load_api::<State, Version01>(include_str!("./inscriptions.toml"))?;
+
+    api.with_version("0.0.1".parse().unwrap())
+        .socket(
+            "stream_inscriptions",
+            move |_req, socket: Connection<ServerMessage, (), Error, Version01>, state| {
+                async move {
+                    // We consume socket messages here so we can more quickly
+                    // realize if we are disconnected, and just in case the
+                    // client actually sends us something.
+                    let mut socket_stream = socket.clone();
+                    let mut socket_sink = socket;
+
+                    let mut internal_client_message_sender = state.internal_client_message_sender();
+                    let (server_message_sender, mut server_message_receiver) = mpsc::channel(32);
+
+                    // Let's register ourselves with the Server
+                    if let Err(err) = internal_client_message_sender
+                        .send(InternalClientMessage::Connected(server_message_sender))
+                        .await
+                    {
+                        // This means that the client_message_sender is closed
+                        // we need to exit the stream.
+                        tracing::info!(
+                            "client message sender is closed before first message: {}",
+                            err
+                        );
+                        return Ok(());
+                    }
+
+                    // We should receive a response from the server that identifies us
+                    // uniquely.
+                    let client_id = if let Some(ServerMessage::YouAre(client_id)) =
+                        server_message_receiver.next().await
+                    {
+                        client_id
+                    } else {
+                        // The channel is closed, and this client should be removed
+                        // we need to exit the stream
+                        tracing::info!("server message receiver closed before first message",);
+                        return Ok(());
+                    };
+
+                    loop {
+                        let mut next_server_message = server_message_receiver.next().fuse();
+                        let mut next_client_message = socket_stream.next().fuse();
+
+                        select! {
+                            client_message = next_client_message => {
+                                if let Some(Ok(_)) = client_message {
+                                    tracing::debug!("received message from client, not expecting any input from the client, ignoring it");
+                                } else {
+                                    tracing::debug!("client disconnected: {:?}", client_id);
+                                    // The client has disconnected, we need to exit the stream
+                                    break;
+                                }
+                            },
+
+                            server_message = next_server_message => {
+                                let Some(server_message) = server_message else {
+                                    break;
+                                } ;
+
+                                tracing::debug!(
+                                    "received relay message from server, forwarding to client: {:?}, server message: {:?}",
+                                    client_id,
+                                    server_message,
+                                );
+
+                                // We want to forward the message to the client
+                                if let Err(err) = socket_sink.send(&server_message).await {
+                                    // This means that the socket is closed
+                                    tracing::debug!(
+                                        "failed to relay message to client, socket is closed: {}",
+                                        err
+                                    );
+                                    break;
+                                }
+
+
+                            }
+                        }
+                    }
+
+                    // We don't actually care if this fails or not, as we're exiting
+                    // this function anyway, and these Senders and Receivers will
+                    // automatically be dropped.
+                    _ = internal_client_message_sender
+                        .send(InternalClientMessage::Disconnected(client_id))
+                        .await;
+
+                    Ok(())
+                }
+                .boxed()
+            },
+        )?
+        .at("put_inscription", move |params, state| {
+            async move {
+                // Decode the InscriptionAndSignature from the request
+                let inscription_and_signature = params
+                    .body_auto::<InscriptionAndSignature, Version01>(STATIC_VER_0_1)
+                    .map_err(Error::InscriptionAndSignatureUnpack)?;
+
+                // Validate that the InscriptionAndSignature is valid
+                validate_inscription_and_signature(&inscription_and_signature)
+                    .map_err(Error::InvalidInscription)?;
+
+                tracing::debug!(
+                    "received valid inscription for put_inscription: {:?}",
+                    inscription_and_signature
+                );
+
+                // attempts to send the InscriptionAndSignature to the server,
+                // if we're over capacity, indicate that we are rate limited.
+                // let mut put_inscription_sender = state.put_inscription_sender();
+
+                // Attempt to send the message for processing, if the queue is
+                // full, then return back a rate limiting warning.
+                if let Err(err) =
+                state.put_inscription(inscription_and_signature.inscription).await
+                    // put_inscription_sender.try_send(inscription_and_signature.inscription)
+                {
+                    tracing::debug!(
+                        "failed to send put_inscription to server, queue is likely full: {:?}",
+                        err
+                    );
+
+                    return Err(Error::TooManyRequests);
+                }
+
+                // We have successfully sent the message to the server for processing
+                tracing::debug!("successfully send put_inscription message to server");
+
+                Ok(())
+            }
+            .boxed()
+        })?;
+    Ok(api)
+}
+
+/// BlockStreamRetriever is a general trait that allows for the retrieval of a
+/// list of Blocks from a source. The specific implementation doesn't care about
+/// the source, only that it is able to retrieve a stream of Blocks.
+///
+/// This allows us to swap the implementation of the [BlockStreamRetriever] for
+/// testing purposes, or for newer sources in the future.
+pub trait BlockStreamRetriever: Send {
+    type Item;
+    type ItemError: std::error::Error + Send;
+    type Error: std::error::Error + Send;
+    type Stream: Stream<Item = Result<Self::Item, Self::ItemError>> + Send + Unpin;
+    type Future: Future<Output = Result<Self::Stream, Self::Error>> + Send;
+
+    /// [retrieve_stream] retrieves a stream of [BlockQueryData]s from the source.  It
+    /// expects the current block height to be provided so that it can determine
+    /// the starting block height to retrieve the stream of [BlockQueryData]s from.
+    ///
+    /// It should check the current height of the chain so that it only needs
+    /// to retrieve the number of older blocks that are needed, instead of
+    /// starting from the beginning of time.
+    fn retrieve_stream(&self, current_block_height: Option<u64>) -> Self::Future;
+}
+
+/// [HotshotQueryServiceBlockStreamRetriever] is a [BlockStreamRetriever] that
+/// retrieves a stream of [Block]s from the Hotshot Query Service.  It expects
+/// the base URL of the Hotshot Query Service to be provided so that it can
+/// make the request to the Hotshot Query Service.
+pub struct HotshotQueryServiceBlockStreamRetriever {
+    base_url: Url,
+}
+
+impl HotshotQueryServiceBlockStreamRetriever {
+    /// [new] creates a new [HotshotQueryServiceBlockStreamRetriever] that
+    /// will use the given base [Url] to be able to retrieve the stream of
+    /// [Block]s from the Hotshot Query Service.
+    ///
+    /// The [Url] is expected to point to the the API version root of the
+    /// Hotshot Query Service.  Example:
+    ///   https://example.com/v0
+    pub fn new(base_url: Url) -> Self {
+        Self { base_url }
+    }
+}
+
+impl BlockStreamRetriever for HotshotQueryServiceBlockStreamRetriever {
+    type Item = BlockQueryData<SeqTypes>;
+    type ItemError = hotshot_query_service::Error;
+    type Error = hotshot_query_service::Error;
+    type Stream = surf_disco::socket::Connection<
+        BlockQueryData<SeqTypes>,
+        surf_disco::socket::Unsupported,
+        Self::ItemError,
+        Version01,
+    >;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
+
+    fn retrieve_stream(&self, current_block_height: Option<u64>) -> Self::Future {
+        let client = surf_disco::Client::new(self.base_url.clone());
+        async move {
+            let block_height_result = client.get("status/block-height").send().await;
+            let block_height: u64 = match block_height_result {
+                Ok(block_height) => block_height,
+                Err(err) => {
+                    tracing::info!("retrieve block height request failed: {}", err);
+                    return Err(err);
+                }
+            };
+
+            let latest_block_start = block_height.saturating_sub(50);
+            let start_block_height = if let Some(known_height) = current_block_height {
+                std::cmp::min(known_height, latest_block_start)
+            } else {
+                latest_block_start
+            };
+
+            let blocks_stream_result = client
+                .socket(&format!(
+                    "availability/stream/blocks/{}",
+                    start_block_height
+                ))
+                .subscribe::<BlockQueryData<SeqTypes>>()
+                .await;
+
+            let blocks_stream = match blocks_stream_result {
+                Ok(blocks_stream) => blocks_stream,
+                Err(err) => {
+                    tracing::info!("retrieve blocks stream failed: {}", err);
+                    return Err(err);
+                }
+            };
+
+            Ok(blocks_stream)
+        }
+        .boxed()
+    }
+}
+
+/// [RetrieveBlockStreamError] indicates the various failure conditions that can
+/// occur when attempting to retrieve a stream of [Block]s using the
+/// [ProcessProduceBlockStreamTask::retrieve_block_stream] function.
+enum RetrieveBlockStreamError {
+    /// [MaxAttemptsExceeded] indicates that the maximum number of attempts to
+    /// attempt to retrieve the [Stream] of [Block]s has been exceeded.
+    /// In this case, it doesn't make sense to continue to re-attempt to
+    /// reconnect to the service, as it does not seem to be available.
+    MaxAttemptsExceeded,
+}
+
+/// [ProcessProduceBlockStreamTask] is a task that produce a stream of [BlockQueryData]s
+/// from the Hotshot Query Service.  It will attempt to retrieve the [BlockQueryData]s
+/// from the Hotshot Query Service and then send them to the [Sink] provided.
+pub struct ProcessProduceBlockStreamTask {
+    pub task_handle: Option<JoinHandle<()>>,
+}
+
+impl ProcessProduceBlockStreamTask {
+    /// [new] creates a new [ProcessProduceBlockStreamTask] that produces a
+    /// stream of [BlockQueryData]s from the Hotshot Query Service.
+    ///
+    /// Calling this function will create an async task that will start
+    /// processing immediately.  The task's handle will be stored in the
+    /// returned state.
+    pub fn new<R, K>(block_stream_retriever: R, block_sender: K) -> Self
+    where
+        R: BlockStreamRetriever<Item = BlockQueryData<SeqTypes>> + Send + Sync + 'static,
+        K: Sink<BlockQueryData<SeqTypes>, Error = SendError>
+            + Clone
+            + Send
+            + Sync
+            + Unpin
+            + 'static,
+    {
+        let task_handle = async_std::task::spawn(Self::connect_and_process_blocks(
+            block_stream_retriever,
+            block_sender,
+        ));
+
+        Self {
+            task_handle: Some(task_handle),
+        }
+    }
+
+    async fn connect_and_process_blocks<R, K>(block_stream_retriever: R, block_sender: K)
+    where
+        R: BlockStreamRetriever<Item = BlockQueryData<SeqTypes>>,
+        K: Sink<BlockQueryData<SeqTypes>, Error = SendError>
+            + Clone
+            + Send
+            + Sync
+            + Unpin
+            + 'static,
+    {
+        // We want to try and ensure that we are connected to the HotShot Query
+        // Service, and are consuming blocks.
+        // - If we are able to connect, then we can start relaying Blocks into
+        //   the block sender.
+        // - If we are not able to connect, then we should sleep, and retry
+        //   until we are able to reconnect.  Each failure **should** make some
+        //   noise so that if we are never able to reconnect, we are at least
+        //   telling someone about it.
+        // - If the task for consuming the blocks completes, then we should
+        //   also attempt to reestablish the connection to start consuming
+        //   the blocks again.
+
+        loop {
+            // Retrieve a stream
+            let Ok(stream) = Self::retrieve_block_stream(&block_stream_retriever).await else {
+                panic!("failed to retrieve block stream");
+            };
+
+            // Consume the blocks of a stream
+            Self::process_consume_block_stream::<R, K>(stream, block_sender.clone()).await;
+            tracing::warn!("block stream ended, will attempt to re-acquire block stream");
+        }
+    }
+
+    /// [retrieve_block_stream] attempts to retrieve the Stream of Blocks from
+    /// the given [BlockStreamRetriever].
+    ///
+    /// This function will loop on failure until it is able to retrieve the
+    /// [Stream].  This does mean that it could potentially get in a state
+    /// where it can loop indefinitely.
+    ///
+    /// This function also implements exponential backoff with a maximum
+    /// delay of 5 seconds.
+    async fn retrieve_block_stream<R>(
+        block_stream_receiver: &R,
+    ) -> Result<R::Stream, RetrieveBlockStreamError>
+    where
+        R: BlockStreamRetriever<Item = BlockQueryData<SeqTypes>>,
+    {
+        let backoff_params = BackoffParams::default();
+        let mut delay = Duration::ZERO;
+
+        for attempt in 1..=100 {
+            let block_stream_result = block_stream_receiver.retrieve_stream(None).await;
+
+            let block_stream = match block_stream_result {
+                Err(error) => {
+                    // We failed to retrieve the stream. We will try again, but we
+                    // should sleep for a bit before so as not to overwhelm the
+                    // service.
+
+                    delay = backoff_params.backoff(delay);
+
+                    if delay == Duration::ZERO {
+                        panic!("backoff is invalid")
+                    }
+                    tracing::warn!(
+                        "attempt {attempt} to connect to block stream failed with error {error} sleeping for {:?}", delay
+                    );
+                    async_std::task::sleep(delay).await;
+                    continue;
+                }
+
+                Ok(blocks_stream) => blocks_stream,
+            };
+
+            return Ok(block_stream);
+        }
+
+        Err(RetrieveBlockStreamError::MaxAttemptsExceeded)
+    }
+
+    /// [process_consume_block_stream] produces a stream of [Block]s from the
+    /// Hotshot Query Service.  It will attempt to retrieve the [Block]s from the
+    /// Hotshot Query Service and then send them to the [Sink] provided.  If the
+    /// [Sink] is closed, or if the Stream ends prematurely, then the function
+    /// will return.
+    async fn process_consume_block_stream<R, K>(blocks_stream: R::Stream, block_sender: K)
+    where
+        R: BlockStreamRetriever<Item = BlockQueryData<SeqTypes>>,
+        K: Sink<BlockQueryData<SeqTypes>, Error = SendError>
+            + Clone
+            + Send
+            + Sync
+            + Unpin
+            + 'static,
+    {
+        let mut block_sender = block_sender;
+        let mut blocks_stream = blocks_stream;
+
+        loop {
+            let block_result = blocks_stream.next().await;
+            let block = if let Some(Ok(block)) = block_result {
+                block
+            } else {
+                tracing::info!("block stream closed");
+                break;
+            };
+
+            let block_send_result = block_sender.send(block).await;
+            if let Err(err) = block_send_result {
+                tracing::info!("block sender closed: {}", err);
+                break;
+            }
+        }
+    }
+}
+
+/// [Drop] implementation for [ProcessProduceBlockStreamTask] that will cancel
+/// the task if it hasn't already been completed.
+impl Drop for ProcessProduceBlockStreamTask {
+    fn drop(&mut self) {
+        if let Some(task_handle) = self.task_handle.take() {
+            async_std::task::block_on(task_handle.cancel());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -668,7 +668,7 @@ impl ProcessProduceBlockStreamTask {
             };
 
             let block_height = block.header().height();
-            if block_height < starting_block_height {
+            if block_height <= starting_block_height {
                 tracing::info!(
                     "block height {block_height} is less than starting block height {starting_block_height}, skipping",
                 );

--- a/inscriptions/src/api/inscriptions/v0/mod.rs
+++ b/inscriptions/src/api/inscriptions/v0/mod.rs
@@ -554,7 +554,7 @@ impl ProcessProduceBlockStreamTask {
         Persistence: InscriptionPersistence,
     {
         let backoff_params = BackoffParams::default();
-        let mut delay = Duration::ZERO;
+        let mut delay = Duration::from_millis(50);
 
         for attempt in 1..=100 {
             let block_height = persistence
@@ -562,7 +562,7 @@ impl ProcessProduceBlockStreamTask {
                 .await
                 .ok()
                 // we want to start **after** the last block we received.
-                .map(|height| std::cmp::max(height + 1, minimum_start_block_height));
+                .map(|(height, _)| std::cmp::max(height + 1, minimum_start_block_height));
 
             let block_stream_result = block_stream_receiver.retrieve_stream(block_height).await;
 

--- a/inscriptions/src/api/mod.rs
+++ b/inscriptions/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod inscriptions;

--- a/inscriptions/src/lib.rs
+++ b/inscriptions/src/lib.rs
@@ -1,0 +1,254 @@
+pub mod api;
+pub mod service;
+
+use api::inscriptions::v0::{
+    create_inscriptions_api::{create_inscriptions_processing, InscriptionsConfig},
+    Error, HotshotQueryServiceBlockStreamRetriever, ProcessProduceBlockStreamTask,
+    StateClientMessageSender, STATIC_VER_0_1,
+};
+use async_std::sync::RwLock;
+use clap::Parser;
+use espresso_types::NamespaceId;
+use futures::channel::mpsc::{self, Sender};
+use service::{client_message::InternalClientMessage, espresso_inscription::EspressoInscription};
+use std::sync::Arc;
+use tide_disco::App;
+use url::Url;
+
+/// Options represents the configuration options that are available for running
+/// the inscriptions service via the [run_standalone_service] function.
+/// These options are configurable via command line arguments or environment
+/// variables.
+#[derive(Parser, Clone, Debug)]
+pub struct Options {
+    /// block_stream_source_base_url is the base URL for the availability API
+    /// endpoint that is provided by Espresso Sequencers.
+    ///
+    /// This endpoint is expected to point to the version root path of the
+    /// URL.
+    /// Example:
+    ///   - https://query.cappuccino.testnet.espresso.network/v0/
+    #[clap(long, env = "ESPRESSO_INSCRIPTIONS_BLOCK_STREAM_SOURCE_BASE_URL")]
+    block_stream_source_base_url: Url,
+
+    /// submit_base_url is the base URL for the submit endpoint that is
+    /// used for submitting data to the Espresso Block Chain.
+    ///
+    /// Please note that this can be either the submission endpoint for
+    /// the Espresso Block Chain (which can be either the public mempool
+    /// URL or the private mempool URL) or the submission endpoint for
+    /// the Espresso Block Chain's Ingestion Service.
+    ///
+    /// Example:
+    ///   - https://query.cappucino.testnet.espresso.network/v0/submit
+    #[clap(long, env = "ESPRESSO_INSCRIPTIONS_SUBMIT_BASE_URL")]
+    submit_base_url: Url,
+
+    /// signer_mnemonic is the mnemonic that is used to generate the private
+    /// key that will be used to sign the Inscriptions that are being
+    /// submitted to the Espresso Block Chain.
+    #[clap(
+        long,
+        env = "ESPRESSO_INSCRIPTIONS_SIGNER_MNEMONIC",
+        default_value = "test test test test test test test test test test test test test test switch"
+    )]
+    signer_mnemonic: String,
+
+    /// port is the port that the API service will be listening on.  If not
+    /// specified, it will default to 9001.
+    #[clap(long, env = "ESPRESSO_INSCRIPTIONS_PORT", default_value = "9001")]
+    port: u16,
+
+    /// put_inscription_buffer_size is the size of the buffer that is used
+    /// to store pending inscriptions that are waiting to be submitted to
+    /// the Espresso Block Chain.
+    ///
+    /// If the queue is at capacity, the service will return an error indicating
+    /// that the service is too busy to accept new requests.
+    #[clap(
+        long,
+        env = "ESPRESSO_INSCRIPTIONS_PUT_INSCRIPTION_BUFFER_SIZE",
+        default_value = "1024"
+    )]
+    put_inscription_buffer_size: usize,
+
+    /// put_inscriptions_per_second is the number of inscriptions that can be
+    /// submitted to the Espresso Block Chain per second.
+    ///
+    /// This is used to throttle the number of inscriptions that are being
+    /// submitted to the Espresso Block Chain.
+    #[clap(
+        long,
+        env = "ESPRESSO_INSCRIPTIONS_PUT_INSCRIPTIONS_PER_SECOND",
+        default_value = "50"
+    )]
+    put_inscriptions_per_second: u32,
+
+    /// inscriptions_namespace_id represents the [espresso_types::NamespaceId]
+    /// for the Espresso Inscription transactions that will be submitted to the
+    /// Espresso Block Chain.
+    ///
+    /// Note: Just for fun, the the default value of the
+    /// NamespaceId is the ASCII representation of "SIGN" in Big Endian Order.
+    #[clap(
+        long,
+        env = "ESPRESSO_INSCRIPTIONS_NAMESPACE_ID",
+        default_value = "0x5349474e"
+    )]
+    inscriptions_namespace_id: u32,
+}
+
+impl Options {
+    /// block_stream_source_base_url returns the base URL for the availability
+    /// API endpoint that is provided by Espresso Sequencers.
+    pub fn block_stream_source_base_url(&self) -> Url {
+        self.block_stream_source_base_url.clone()
+    }
+
+    /// submit_base_url returns the base URL for the submit endpoint that is
+    /// used for submitting data to the Espresso Block Chain.
+    pub fn submit_base_url(&self) -> Url {
+        self.submit_base_url.clone()
+    }
+
+    /// signer_mnemonic returns the mnemonic that is used to generate the
+    /// private key that will be used to sign the Inscriptions that are being
+    /// submitted to the Espresso Block Chain.
+    ///
+    /// It is also utilized to verify the data coming back from the Espresso
+    /// Block Chain.
+    pub fn signer_mnemonic(&self) -> &str {
+        &self.signer_mnemonic
+    }
+
+    /// port returns the port that the API service will be listening on.
+    /// If not specified, it will default to 9001.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// put_inscription_buffer_size returns the size of the buffer that is used
+    /// to store pending inscriptions that are waiting to be submitted to
+    /// the Espresso Block Chain.
+    pub fn put_inscription_buffer_size(&self) -> usize {
+        self.put_inscription_buffer_size
+    }
+
+    /// put_inscriptions_per_second returns the number of inscriptions that can
+    /// be submitted to the Espresso Block Chain per second.
+    pub fn put_inscriptions_per_second(&self) -> u32 {
+        self.put_inscriptions_per_second
+    }
+
+    /// inscriptions_namespace_id returns the [espresso_types::NamespaceId]
+    /// for the Espresso Inscription transactions that will be submitted to the
+    /// Espresso Block Chain.
+    pub fn inscriptions_namespace_id(&self) -> NamespaceId {
+        NamespaceId::from(self.inscriptions_namespace_id)
+    }
+}
+
+/// MainState represents the State of the application this is available to
+/// tide_disco.
+struct MainState<K> {
+    internal_client_message_sender: Sender<InternalClientMessage<K>>,
+
+    put_inscription_sender: Arc<RwLock<Sender<EspressoInscription>>>,
+}
+
+#[async_trait::async_trait]
+impl<K> StateClientMessageSender<K> for MainState<K>
+where
+    K: Send,
+{
+    fn internal_client_message_sender(&self) -> Sender<InternalClientMessage<K>> {
+        self.internal_client_message_sender.clone()
+    }
+
+    async fn put_inscription(&self, inscription: EspressoInscription) -> Result<(), Error> {
+        let mut sender = self.put_inscription_sender.write_arc().await;
+
+        match sender.try_send(inscription) {
+            Ok(_) => {
+                return Ok(());
+            }
+            Err(err) => {
+                tracing::error!("error sending inscription: {:?}", err);
+                Err(Error::TooManyRequests)
+            }
+        }
+    }
+}
+
+/// Run the service by itself.
+///
+/// This function will run the inscription demo as its own service.  It has some
+/// options that allow it to be configured in order for it to operate
+/// effectively.
+pub async fn run_standalone_service(options: Options) {
+    let (internal_client_message_sender, internal_client_message_receiver) = mpsc::channel(32);
+    let (put_inscription_sender, put_inscription_receiver) =
+        mpsc::channel(options.put_inscription_buffer_size);
+    let state = MainState {
+        internal_client_message_sender,
+        put_inscription_sender: Arc::new(RwLock::new(put_inscription_sender)),
+    };
+
+    let mut app: App<_, api::inscriptions::v0::Error> = App::with_state(state);
+    let inscriptions_api =
+        api::inscriptions::v0::define_api().expect("error defining inscriptions api");
+
+    match app.register_module("inscriptions", inscriptions_api) {
+        Ok(_) => {}
+        Err(err) => {
+            panic!("error registering inscriptions api: {:?}", err);
+        }
+    }
+
+    let (block_sender, block_receiver) = mpsc::channel(10);
+
+    let _process_consume_blocks = ProcessProduceBlockStreamTask::new(
+        HotshotQueryServiceBlockStreamRetriever::new(options.block_stream_source_base_url()),
+        block_sender,
+    );
+
+    let signer = match alloy::signers::local::MnemonicBuilder::<
+        alloy::signers::local::coins_bip39::English,
+    >::default()
+    .phrase(options.signer_mnemonic())
+    .build()
+    {
+        Ok(signer) => signer,
+        Err(err) => {
+            panic!(
+                "failed to generate private key signer from mnemonic: {:?}",
+                err
+            );
+        }
+    };
+
+    let _inscriptions_task_state = match create_inscriptions_processing(
+        InscriptionsConfig::from(&options),
+        internal_client_message_receiver,
+        block_receiver,
+        put_inscription_receiver,
+        signer,
+    )
+    .await
+    {
+        Ok(inscriptions_task_state) => inscriptions_task_state,
+
+        Err(err) => {
+            panic!("error defining inscriptions api: {:?}", err);
+        }
+    };
+
+    let port = options.port();
+    // We would like to wait until being signaled
+    let app_serve_handle = async_std::task::spawn(async move {
+        let app_serve_result = app.serve(format!("0.0.0.0:{}", port), STATIC_VER_0_1).await;
+        tracing::info!("app serve result: {:?}", app_serve_result);
+    });
+
+    app_serve_handle.await;
+}

--- a/inscriptions/src/main.rs
+++ b/inscriptions/src/main.rs
@@ -1,0 +1,11 @@
+use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
+use clap::Parser;
+use inscriptions::{run_standalone_service, Options};
+
+#[async_std::main]
+async fn main() {
+    setup_logging();
+    setup_backtrace();
+
+    run_standalone_service(Options::parse()).await;
+}

--- a/inscriptions/src/service/client_id/mod.rs
+++ b/inscriptions/src/service/client_id/mod.rs
@@ -1,0 +1,164 @@
+use serde::{Deserialize, Serialize};
+use std::ops::{Add, AddAssign};
+
+/// [ClientId] represents the unique identifier for a client that is connected
+/// to the server.
+///
+/// Example:
+/// ```rust
+/// # use inscriptions::service::client_id::ClientId;
+///
+/// let client_id = ClientId::from_count(1);
+///
+/// # assert_eq!(ClientId::from_count(1), client_id);
+/// let client_id_2 = client_id + 1;
+///
+/// # assert_ne!(client_id, client_id_2);
+///
+/// let mut client_id_3 = client_id;
+/// client_id_3 += 1;
+///
+/// # assert_eq!(client_id_2, client_id_3);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClientId(u64);
+
+impl ClientId {
+    pub fn from_count(count: u64) -> Self {
+        ClientId(count)
+    }
+}
+
+/// [Add] implements basic addition for [ClientId], which allows [u64]s to be
+/// added to the [ClientId] for convenience.
+///
+/// Example:
+///
+/// ```rust
+///
+/// # use inscriptions::service::client_id::ClientId;
+///
+/// let client_id = ClientId::from_count(1);
+/// let new_client_id = client_id + 1;
+///
+/// # assert_eq!(ClientId::from_count(2), new_client_id);
+/// # assert_ne!(client_id, new_client_id);
+/// ```
+impl Add<u64> for ClientId {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        ClientId(self.0 + rhs)
+    }
+}
+
+/// [AddAssign] implements basic addition for [ClientId], which allows [u64]s to
+/// be added to the mutable [ClientId] for convenience.
+///
+/// Example:
+///
+/// ```rust
+/// # use inscriptions::service::client_id::ClientId;
+///
+/// let mut client_id = ClientId::from_count(1);
+/// client_id += 1;
+///
+/// # assert_eq!(ClientId::from_count(2), client_id);
+/// ```
+impl AddAssign<u64> for ClientId {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientId;
+
+    #[test]
+    fn test_client_id_debug() {
+        let client_id = ClientId::from_count(1);
+        assert_eq!(format!("{:?}", client_id), "ClientId(1)");
+    }
+
+    #[test]
+    #[allow(clippy::clone_on_copy)]
+    fn test_client_id_clone() {
+        let client_id = ClientId::from_count(1);
+        let cloned_client_id = client_id.clone();
+        assert_eq!(client_id, cloned_client_id);
+    }
+
+    #[test]
+    fn test_client_id_partial_eq() {
+        let client_id_1 = ClientId::from_count(1);
+        let client_id_2 = ClientId::from_count(2);
+        let client_id_3 = ClientId::from_count(1);
+
+        assert_ne!(client_id_1, client_id_2);
+        assert_eq!(client_id_1, client_id_3);
+    }
+
+    #[test]
+    fn test_client_id_eq() {
+        let client_id_1 = ClientId::from_count(1);
+
+        client_id_1.assert_receiver_is_total_eq();
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let hash_1 = {
+            let client_id = ClientId::from_count(1);
+            let mut hasher = DefaultHasher::new();
+            client_id.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let hash_2 = {
+            let client_id = ClientId::from_count(2);
+            let mut hasher = DefaultHasher::new();
+            client_id.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let hash_3 = {
+            let client_id = ClientId::from_count(1);
+            let mut hasher = DefaultHasher::new();
+            client_id.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        assert_eq!(hash_1, hash_3);
+        assert_ne!(hash_1, hash_2);
+        assert_ne!(hash_2, hash_3);
+    }
+
+    #[test]
+    fn test_add() {
+        let client_id = ClientId::from_count(1);
+        let new_client_id = client_id + 1;
+        assert_eq!(new_client_id, ClientId::from_count(2));
+    }
+
+    #[test]
+    fn test_add_assign() {
+        let mut client_id = ClientId::from_count(1);
+        client_id += 1;
+        assert_eq!(client_id, ClientId::from_count(2));
+    }
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn test_serialization() {
+        use serde_json;
+        let client_id = ClientId::from_count(1);
+        let serialized = serde_json::to_string(&client_id).unwrap();
+        let deserialized: ClientId = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized, client_id);
+    }
+}

--- a/inscriptions/src/service/client_message/mod.rs
+++ b/inscriptions/src/service/client_message/mod.rs
@@ -1,0 +1,63 @@
+use super::client_id::ClientId;
+
+/// InternalClientMessage represents the message requests that the client can
+/// send to the server.  These messages are request that the client can send
+/// in order for the server to send back responses that correspond to the
+/// request.
+#[derive(Debug)]
+pub enum InternalClientMessage<K> {
+    Connected(K),
+    Disconnected(ClientId),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InternalClientMessage;
+    use super::*;
+    use crate::service::server_message::ServerMessage;
+    use std::iter::zip;
+
+    impl<K> PartialEq for InternalClientMessage<K> {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                // We don't care about the [Sender] here, as it is unable to be
+                // compared.
+                (Self::Connected(_), Self::Connected(_)) => true,
+                (Self::Disconnected(lhs), Self::Disconnected(rhs)) => lhs == rhs,
+                _ => false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_internal_client_message_partial_eq() {
+        let (sender, _) = futures::channel::mpsc::channel::<ServerMessage>(1);
+        let messages = [
+            InternalClientMessage::Connected(sender),
+            InternalClientMessage::Disconnected(ClientId::from_count(1)),
+        ];
+
+        for (l, r) in zip(messages.iter(), messages.iter()) {
+            assert_eq!(l, r);
+        }
+
+        for i in 1..messages.len() {
+            for (l, r) in zip(
+                messages.iter(),
+                messages.iter().skip(i).chain(messages.iter().take(i)),
+            ) {
+                assert_ne!(l, r);
+            }
+        }
+
+        for j in 2..12 {
+            let iter_messages = [InternalClientMessage::Disconnected(ClientId::from_count(j))];
+
+            // We skip the first message, as we don't want to include the
+            // Connected message.
+            for (l, r) in zip(messages.iter().skip(1), iter_messages.iter()) {
+                assert_ne!(l, r);
+            }
+        }
+    }
+}

--- a/inscriptions/src/service/client_state/mod.rs
+++ b/inscriptions/src/service/client_state/mod.rs
@@ -714,7 +714,7 @@ pub mod tests {
             RetrieveLatestInscriptionAndChainDetailsError, RetrievePendingPutInscriptionsError,
         },
     };
-    use alloy::signers::local::PrivateKeySigner;
+    use alloy::{primitives::Address, signers::local::PrivateKeySigner};
     use async_std::sync::RwLock;
     use espresso_types::SeqTypes;
     use futures::channel::mpsc::{self, Sender};
@@ -778,6 +778,14 @@ pub mod tests {
         async fn retrieve_last_received_block(
             &self,
         ) -> Result<Stats, RetrieveLastReceivedBlockError> {
+            todo!();
+        }
+
+        async fn retrieved_latest_inscriptions_for_address(
+            &self,
+            _address: Address,
+        ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>
+        {
             todo!();
         }
     }

--- a/inscriptions/src/service/client_state/mod.rs
+++ b/inscriptions/src/service/client_state/mod.rs
@@ -661,7 +661,7 @@ pub mod tests {
     use super::{ClientThreadState, InternalClientMessageProcessingTask};
     use crate::service::{
         client_id::ClientId,
-        data_state::DataState,
+        data_state::{DataState, Stats},
         espresso_inscription::{EspressoInscription, InscriptionAndChainDetails},
         server_message::ServerMessage,
         storage::{
@@ -734,7 +734,7 @@ pub mod tests {
 
         async fn retrieve_last_received_block(
             &self,
-        ) -> Result<(u64, u64), RetrieveLastReceivedBlockError> {
+        ) -> Result<Stats, RetrieveLastReceivedBlockError> {
             todo!();
         }
     }

--- a/inscriptions/src/service/client_state/mod.rs
+++ b/inscriptions/src/service/client_state/mod.rs
@@ -335,7 +335,6 @@ impl InternalClientMessageProcessingTask {
                     "internal client message processing encountered an error: {}",
                     err,
                 );
-                return;
             }
         }
     }

--- a/inscriptions/src/service/data_state/mod.rs
+++ b/inscriptions/src/service/data_state/mod.rs
@@ -1,0 +1,328 @@
+use std::sync::Arc;
+
+use alloy::primitives::Address;
+use async_std::{sync::RwLock, task::JoinHandle};
+use circular_buffer::CircularBuffer;
+use espresso_types::{NamespaceId, Payload, SeqTypes};
+use futures::{channel::mpsc::SendError, Sink, SinkExt, Stream, StreamExt};
+use hotshot_query_service::availability::{BlockQueryData, QueryablePayload};
+use hotshot_types::traits::block_contents::BlockHeader;
+use sqlx::types::time::OffsetDateTime;
+
+use super::{
+    espresso_inscription::{
+        ChainDetails, InscriptionAndChainDetails, InscriptionAndSignatureFromService,
+    },
+    validate_inscription_and_signature_from_service,
+};
+
+/// MAX_LOCAL_INSCRIPTION_HISTORY represents the last N records that are stored within the
+/// DataState structure for the various different sample types.
+const MAX_LOCAL_INSCRIPTION_HISTORY: usize = 100;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubmitInscriptionError {
+    BufferIsFull,
+}
+
+/// [DataState] represents the state of the data that is being stored within
+/// the service.
+pub struct DataState {
+    latest_inscriptions: CircularBuffer<MAX_LOCAL_INSCRIPTION_HISTORY, InscriptionAndChainDetails>,
+
+    address: Address,
+}
+
+impl DataState {
+    /// [new] creates a new [DataState] structure that will store the latest
+    /// inscriptions that are being processed by the service.
+    pub fn new(
+        latest_inscriptions: CircularBuffer<
+            MAX_LOCAL_INSCRIPTION_HISTORY,
+            InscriptionAndChainDetails,
+        >,
+        address: Address,
+    ) -> Self {
+        Self {
+            latest_inscriptions,
+            address,
+        }
+    }
+
+    /// [latest_inscriptions] returns an iterator that will iterate over the
+    /// latest inscriptions that are stored within the [DataState].
+    pub fn latest_inscriptions(&self) -> impl Iterator<Item = &InscriptionAndChainDetails> {
+        self.latest_inscriptions.iter()
+    }
+
+    /// [add_latest_inscription] adds a new inscription to the [DataState].
+    /// If the buffer is full, an error will be returned.
+    pub fn add_latest_inscription(&mut self, block: InscriptionAndChainDetails) {
+        self.latest_inscriptions.push_back(block);
+    }
+
+    /// [address] returns the address that is associated with the [DataState].
+    pub fn address(&self) -> Address {
+        self.address
+    }
+
+    /// [current_inscriptions] returns the current inscriptions that are stored
+    /// within the [DataState].
+    pub fn current_inscriptions(&self) -> Vec<InscriptionAndChainDetails> {
+        self.latest_inscriptions.iter().cloned().collect()
+    }
+}
+
+/// [ProcessBlockError] represents the error that can occur when processing
+/// a [Block].
+#[derive(Debug)]
+pub enum ProcessBlockError {
+    BlockSendError(SendError),
+}
+
+impl std::fmt::Display for ProcessBlockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProcessBlockError::BlockSendError(err) => {
+                write!(f, "error sending block detail to sender: {}", err)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProcessBlockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ProcessBlockError::BlockSendError(err) => Some(err),
+        }
+    }
+}
+
+/// [process_incoming_block] is a helper function that will process an incoming
+/// [Block] and update the [DataState] with the new information.
+/// Additionally, the block that is contained within the [Block] will be
+/// computed into a [BlockDetail] and sent to the [Sink] so that it can be
+/// processed for real-time considerations.
+async fn process_incoming_block<BDSink, E>(
+    inscription_namespace: NamespaceId,
+    block: BlockQueryData<SeqTypes>,
+    data_state: Arc<RwLock<DataState>>,
+    mut inscription_sender: BDSink,
+) -> Result<(), ProcessBlockError>
+where
+    Payload: QueryablePayload<SeqTypes>,
+    E: std::fmt::Display + std::fmt::Debug,
+    BDSink: Sink<InscriptionAndChainDetails, Error = E> + Unpin,
+{
+    let mut inscriptions = Vec::<InscriptionAndChainDetails>::new();
+
+    let address = {
+        let data_state_read_lock_guard = data_state.read().await;
+        data_state_read_lock_guard.address()
+    };
+
+    for (offset, (_, transaction)) in block.payload().enumerate(block.metadata()).enumerate() {
+        let block_height = block.header().block_number();
+
+        if transaction.namespace() != inscription_namespace {
+            // Skip anything that isn't in the correct namespace
+            continue;
+        }
+
+        tracing::debug!("processing transaction with correct namespace ({block_height}-{offset})");
+
+        let decode_result =
+            bincode::deserialize::<InscriptionAndSignatureFromService>(transaction.payload());
+        let Ok(inscription_and_signature) = decode_result else {
+            // We failed to decode the transaction, this can happen if some other
+            // service is utilizing our namespace id.
+            tracing::info!(
+                "failed to decode inscription from transaction ({block_height}-{offset}), is not the type of data expected.  This indicates someone else is also using our namespace id, or an alternative serialization scheme",
+            );
+            continue;
+        };
+
+        // Alright, we have a valid inscription, but did we make it, or is it
+        // from some other third party?
+
+        let validation_result =
+            validate_inscription_and_signature_from_service(&inscription_and_signature, address);
+
+        if let Err(err) = validation_result {
+            // We have an error, the specific error type does not matter that
+            // much.  Ultimately it means that this is a message we didn't
+            // sign.
+
+            tracing::info!("skipping inscription from transaction ({block_height}-{offset}), validation of inscription failed: {}", err);
+            continue;
+        }
+
+        inscriptions.push(InscriptionAndChainDetails {
+            inscription: inscription_and_signature.inscription,
+            chain_details: ChainDetails {
+                block: block.header().block_number(),
+                offset: offset as u64,
+            },
+        });
+    }
+
+    {
+        let mut data_state_write_lock_guard = data_state.write().await;
+        for inscription in &inscriptions {
+            data_state_write_lock_guard.add_latest_inscription(inscription.clone());
+        }
+    }
+
+    if inscriptions.is_empty() {
+        // We have no inscriptions to process
+        return Ok(());
+    }
+
+    let inscriptions_count = inscriptions.len();
+    for inscription in inscriptions {
+        let feed_result = inscription_sender.feed(inscription).await;
+        if let Err(err) = feed_result {
+            tracing::error!(
+                "failed to enqueue inscription for dissemination, encountered error: {:?}",
+                err
+            );
+            // We skipped an inscription?
+            continue;
+        }
+    }
+
+    let Err(err) = inscription_sender.flush().await else {
+        // We have an error flushing the sink.
+        tracing::debug!(
+            "successfully flushed {} inscriptions to the sender",
+            inscriptions_count
+        );
+        return Ok(());
+    };
+
+    tracing::error!(
+        "failed to flush inscription sender, encountered error: {:?}",
+        err
+    );
+    Ok(())
+}
+
+/// [ProcessBlockStreamTask] represents the task that is responsible for
+/// processing a stream of incoming [Block]s.
+pub struct ProcessBlockStreamTask {
+    pub task_handle: Option<JoinHandle<()>>,
+}
+
+impl ProcessBlockStreamTask {
+    /// [new] creates a new [ProcessBlockStreamTask] that will process a stream
+    /// of incoming [Block]s.
+    ///
+    /// Calling this function will create an asynchronous task that will start
+    /// processing immediately. The handle for the task will be stored within
+    /// the returned structure.
+    pub fn new<S, K>(
+        inscription_namespace_id: NamespaceId,
+        block_receiver: S,
+        data_state: Arc<RwLock<DataState>>,
+        inscription_sender: K,
+    ) -> Self
+    where
+        S: Stream<Item = BlockQueryData<SeqTypes>> + Send + Sync + Unpin + 'static,
+        K: Sink<InscriptionAndChainDetails, Error = SendError>
+            + Clone
+            + Send
+            + Sync
+            + Unpin
+            + 'static,
+    {
+        let task_handle = async_std::task::spawn(Self::process_block_stream(
+            block_receiver,
+            inscription_namespace_id,
+            data_state.clone(),
+            inscription_sender,
+        ));
+
+        Self {
+            task_handle: Some(task_handle),
+        }
+    }
+
+    /// [process_block_stream] allows for the consumption of a [Stream] when
+    /// attempting to process new incoming [Block]s.
+    async fn process_block_stream<S, ISink>(
+        mut stream: S,
+        inscription_namespace_id: NamespaceId,
+        data_state: Arc<RwLock<DataState>>,
+        inscription_sender: ISink,
+    ) where
+        S: Stream<Item = BlockQueryData<SeqTypes>> + Unpin,
+        ISink: Sink<InscriptionAndChainDetails, Error = SendError> + Clone + Unpin,
+    {
+        loop {
+            let block_result = stream.next().await;
+            let block = if let Some(block) = block_result {
+                block
+            } else {
+                // We have reached the end of the stream
+                tracing::error!("process leaf stream: end of stream reached for leaf stream.");
+                return;
+            };
+
+            let now_timestamp = OffsetDateTime::now_utc().unix_timestamp() as u64;
+            let block_timestamp = block.header().timestamp();
+            tracing::debug!(
+                "received block from stream: {}, block timestamp: {block_timestamp}, now timestamp: {now_timestamp}, potential latency / clock drift combination: {}",
+                block.header().block_number(),
+                now_timestamp - block_timestamp,
+            );
+
+            if let Err(err) = process_incoming_block(
+                inscription_namespace_id,
+                block,
+                data_state.clone(),
+                inscription_sender.clone(),
+            )
+            .await
+            {
+                // We have an error that prevents us from continuing
+                tracing::error!("process leaf stream: error processing leaf: {}", err);
+
+                // At the moment, all underlying errors are due to `SendError`
+                // which will ultimately mean that further processing attempts
+                // will fail, and be fruitless.
+                match err {
+                    ProcessBlockError::BlockSendError(_) => {
+                        panic!("ProcessBlockStreamTask: process_incoming_block failed, underlying sink is closed, blocks will stagnate: {}", err)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// [Drop] implementation for [ProcessBlockStreamTask] that will cancel the
+/// task if it is dropped.
+impl Drop for ProcessBlockStreamTask {
+    fn drop(&mut self) {
+        let task_handle = self.task_handle.take();
+        if let Some(task_handle) = task_handle {
+            async_std::task::block_on(task_handle.cancel());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use governor::{Quota, RateLimiter};
+
+    #[test]
+    fn test_governor_rate_limiter() {
+        let quota = Quota::per_second(NonZeroU32::new(1).unwrap());
+        let rate_limiter = RateLimiter::direct(quota);
+
+        assert!(rate_limiter.check().is_ok());
+        assert!(rate_limiter.check().is_err());
+    }
+}

--- a/inscriptions/src/service/data_state/mod.rs
+++ b/inscriptions/src/service/data_state/mod.rs
@@ -91,8 +91,8 @@ impl<Persistence> DataState<Persistence> {
         self.latest_inscriptions.iter().cloned().collect()
     }
 
-    pub fn persistence(&self) -> &Persistence {
-        &self.persistence
+    pub fn persistence(&self) -> Arc<Persistence> {
+        self.persistence.clone()
     }
 
     /// [stats] returns the statistics that are being tracked by the service.
@@ -252,11 +252,14 @@ where
         );
     }
 
+    let persistence = {
+        let data_state_read_lock = data_state.read_arc().await;
+        data_state_read_lock.persistence()
+    };
+
     for inscription in inscriptions {
         {
-            let state = data_state.read_arc().await;
-            if let Err(err) = state
-                .persistence()
+            if let Err(err) = persistence
                 .record_confirmed_inscription_and_chain_details(&inscription)
                 .await
             {

--- a/inscriptions/src/service/espresso_inscription/mod.rs
+++ b/inscriptions/src/service/espresso_inscription/mod.rs
@@ -1,0 +1,83 @@
+use std::str::FromStr;
+
+use alloy::{signers::Signature, sol};
+use const_hex::hex;
+
+sol! {
+    /// [EspressoInscription] represents the raw Inscription data that the user
+    /// will be signing utilizing his/her wallet to add to the Block Chain.
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct EspressoInscription {
+        address address;
+        string message;
+        uint64 time;
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct HexSignature(pub Signature);
+
+impl<'de> serde::de::Deserialize<'de> for HexSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+
+        Signature::from_str(&string)
+            .map(HexSignature)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::ser::Serialize for HexSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let bytes: [u8; 65] = self.0.into();
+        let string = hex::encode(bytes);
+        serializer.serialize_str(&string)
+    }
+}
+
+/// [InscriptionAndSignature] represents a combination of an [EspressoInscription]
+/// and a [Signature] that is coming from a user's submitted data.  This
+/// combination is used to represent the raw message that the user is signing,
+/// along with a signature to verify that the signature matches the contents
+/// of the data being signed.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct InscriptionAndSignature {
+    pub(crate) inscription: EspressoInscription,
+    pub(crate) signature: HexSignature,
+}
+
+/// [InscriptionAndSignatureFromService] represents a combination of an
+/// [EspressoInscription] that has been validated and found to be valid.
+/// The [Signature] contained within is meant to come from the Service itself
+/// and is used to verify that information coming into the service from the
+/// Espresso Block Chain itself is valid, and accurate.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct InscriptionAndSignatureFromService {
+    pub(crate) inscription: EspressoInscription,
+    pub(crate) signature: HexSignature,
+}
+
+/// [ChainDetails] represents the details of the chain that corresponds to the
+/// Espresso Block Chain. This information can be utilized to determine the
+/// appropriate Block Explorer link.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct ChainDetails {
+    pub(crate) block: u64,
+    pub(crate) offset: u64,
+}
+
+/// [InscriptionAndChainDetails] represents a combination of an
+/// [EspressoInscription] and [ChainDetails] that is used to represent the
+/// Inscription that has been submitted to the Espresso Block Chain, along with
+/// the details of the block and transaction offset that this applies to.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct InscriptionAndChainDetails {
+    pub(crate) inscription: EspressoInscription,
+    pub(crate) chain_details: ChainDetails,
+}

--- a/inscriptions/src/service/espresso_inscription/mod.rs
+++ b/inscriptions/src/service/espresso_inscription/mod.rs
@@ -14,6 +14,9 @@ sol! {
     }
 }
 
+/// [HexSignature] is a wrapper around the [Signature] type so that the
+/// signature can be encoded and decoded from a hex representation
+/// directly.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct HexSignature(pub Signature);
 

--- a/inscriptions/src/service/mod.rs
+++ b/inscriptions/src/service/mod.rs
@@ -1,0 +1,217 @@
+pub mod client_id;
+pub mod client_message;
+pub mod client_state;
+pub mod data_state;
+pub mod espresso_inscription;
+pub mod server_message;
+pub mod storage;
+
+use alloy::{
+    primitives::Address,
+    signers::Signature,
+    sol_types::{eip712_domain, Eip712Domain, SolStruct},
+};
+use espresso_inscription::{
+    EspressoInscription, InscriptionAndSignature, InscriptionAndSignatureFromService,
+};
+use serde::{Deserialize, Serialize};
+
+/// [ESPRESSO_INSCRIPTION_MESSAGE] represents the text contents of the message
+/// to be signed.
+pub const ESPRESSO_INSCRIPTION_MESSAGE: &str = "An Infinite Garden has no walls";
+
+/// [ESPRESSO_EIP712_DOMAIN] represents the EIP712 Domain for the Espresso
+/// Inscription dAPP Domain.
+pub const ESPRESSO_EIP712_DOMAIN: Eip712Domain = eip712_domain! {
+    name: "Espresso Inscription",
+};
+
+/// [InscriptionVerificationResult] represents the potential results of
+/// verifying an Inscription and a Signature from the Espresso Inscription
+/// Front-End.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum InscriptionVerificationError {
+    InvalidInscriptionMessage,
+    InvalidSignature,
+}
+
+impl std::fmt::Display for InscriptionVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            InscriptionVerificationError::InvalidInscriptionMessage => {
+                write!(f, "InvalidInscriptionMessage")
+            }
+            InscriptionVerificationError::InvalidSignature => write!(f, "InvalidSignature"),
+        }
+    }
+}
+
+impl std::error::Error for InscriptionVerificationError {}
+
+/// [validate_inscription_and_signature_matches_address] validates an
+/// [InscriptionAndSignatureFromService] by ensuring that the signature matches
+/// the address given in the function.
+pub fn validate_inscription_and_signature_matches_address(
+    inscription: &EspressoInscription,
+    signature: &Signature,
+    address: Address,
+) -> Result<(), InscriptionVerificationError> {
+    if inscription.message != ESPRESSO_INSCRIPTION_MESSAGE {
+        return Err(InscriptionVerificationError::InvalidInscriptionMessage);
+    }
+
+    let recovered_address = signature
+        .recover_address_from_prehash(&inscription.eip712_signing_hash(&ESPRESSO_EIP712_DOMAIN))
+        .unwrap();
+
+    if recovered_address != address {
+        return Err(InscriptionVerificationError::InvalidSignature);
+    }
+
+    Ok(())
+}
+
+/// [validate_inscription_and_signature_from_service] validates an
+/// [InscriptionAndSignatureFromService] by ensuring that the signature
+/// matches the address given in the function.
+pub fn validate_inscription_and_signature_from_service(
+    inscription_and_signature: &InscriptionAndSignatureFromService,
+    address: Address,
+) -> Result<(), InscriptionVerificationError> {
+    let inscription = &inscription_and_signature.inscription;
+    let signature = &inscription_and_signature.signature;
+
+    validate_inscription_and_signature_matches_address(inscription, &signature.0, address)
+}
+
+/// [validate_inscription_and_signature] validates an Inscription by ensuring
+/// that the signed message matches what is expected, and that the signature
+/// does indeed match the address contained within the [EspressoInscription].
+pub fn validate_inscription_and_signature(
+    inscription_and_signature: &InscriptionAndSignature,
+) -> Result<(), InscriptionVerificationError> {
+    let inscription = &inscription_and_signature.inscription;
+    let signature = &inscription_and_signature.signature;
+
+    validate_inscription_and_signature_matches_address(
+        inscription,
+        &signature.0,
+        inscription.address,
+    )
+}
+
+/// [generate_inscription_and_signature] generates a completely valid
+/// [InscriptionAndSignature] for testing purposes.
+#[cfg(test)]
+fn generate_inscription_and_signature(message: &str) -> InscriptionAndSignature {
+    use alloy::signers::{local::PrivateKeySigner, SignerSync};
+    use espresso_inscription::HexSignature;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let signer = PrivateKeySigner::random();
+    let message = EspressoInscription {
+        address: signer.address(),
+        message: message.to_string(),
+        time: now,
+    };
+
+    let signature = signer
+        .sign_hash_sync(&message.eip712_signing_hash(&ESPRESSO_EIP712_DOMAIN))
+        .unwrap();
+
+    InscriptionAndSignature {
+        inscription: message,
+        signature: HexSignature(signature),
+    }
+}
+
+/// [test_signing_and_verifying_signature] tests and ensures that the
+/// [validate_inscription_and_signature] returns [InscriptionVerificationResult::Valid]
+/// when provided a completely valid [InscriptionAndSignature].
+#[test]
+fn test_signing_and_verifying_signature_result_valid() {
+    let inscription_and_signature =
+        generate_inscription_and_signature(ESPRESSO_INSCRIPTION_MESSAGE);
+
+    assert_eq!(
+        validate_inscription_and_signature(&inscription_and_signature),
+        Ok(())
+    );
+}
+
+/// [test_signing_and_verifying_signature_result_invalid_message] tests and
+/// ensures that the [validate_inscription_and_signature] returns
+/// [InscriptionVerificationResult::InvalidInscriptionMessage] when provided an
+/// [InscriptionAndSignature] whose [EspressoInscription]'s message does not
+/// match the expected message, [ESPRESSO_INSCRIPTION_MESSAGE].
+#[test]
+fn test_signing_and_verifying_signature_result_invalid_message() {
+    let inscription_and_signature = generate_inscription_and_signature("Invalid Message");
+
+    assert_eq!(
+        validate_inscription_and_signature(&inscription_and_signature),
+        Err(InscriptionVerificationError::InvalidInscriptionMessage)
+    );
+}
+
+/// [test_signing_and_verifying_signature_result_invalid_message] tests and
+/// ensures that the [validate_inscription_and_signature] returns
+/// [InscriptionVerificationResult::InvalidInscriptionMessage] when provided an
+/// [InscriptionAndSignature] whose [EspressoInscription]'s address does not
+/// match the recovered address from the signature.
+#[test]
+fn test_signing_and_verifying_signature_result_invalid_signature() {
+    use alloy::primitives::address;
+
+    let inscription_and_signature =
+        generate_inscription_and_signature(ESPRESSO_INSCRIPTION_MESSAGE);
+    let InscriptionAndSignature {
+        inscription,
+        signature,
+    } = inscription_and_signature;
+    let EspressoInscription { message, time, .. } = inscription;
+
+    let inscription_and_signature = InscriptionAndSignature {
+        inscription: EspressoInscription {
+            address: address!("0000000000000000000000000000000000000001"),
+            message,
+            time,
+        },
+        signature,
+    };
+
+    assert_eq!(
+        validate_inscription_and_signature(&inscription_and_signature),
+        Err(InscriptionVerificationError::InvalidSignature)
+    );
+}
+
+/// [test_signing_and_verifying_signature_result_is_valid_for_sample_javascript_signature]
+/// tests and ensures that the [validate_inscription_and_signature] returns
+/// [InscriptionVerificationResult::Valid] when provided an
+/// [InscriptionAndSignature] that was signed by the sample JavaScript code.
+#[test]
+fn test_signing_and_verifying_signature_result_is_valid_for_sample_javascript_signature() {
+    use alloy::primitives::address;
+    use espresso_inscription::HexSignature;
+    use std::str::FromStr;
+
+    let inscription_and_signature = InscriptionAndSignature {
+        inscription: EspressoInscription {
+            address: address!("2BB6723A754D21D5BA0F22Fc062e34E6CE47A0Cc"),
+            message: ESPRESSO_INSCRIPTION_MESSAGE.to_string(),
+            time: 1730469480,
+
+        },
+        signature: HexSignature(Signature::from_str("0xbc72f48c817fc6865e7051c64fd1194bb5b696eb0d70e6e5a35c99378db1e3c17e70ee1e65b81b7d8dfee918cf7cab9691fa5bc59ebb64b84d070ff3a872e1f41b").unwrap()),
+    };
+
+    assert_eq!(
+        validate_inscription_and_signature(&inscription_and_signature),
+        Ok(())
+    );
+}

--- a/inscriptions/src/service/server_message/mod.rs
+++ b/inscriptions/src/service/server_message/mod.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use super::{client_id::ClientId, espresso_inscription::InscriptionAndChainDetails};
+use serde::{Deserialize, Serialize};
+
+/// [ServerMessage] represents the messages that the server can send to the
+/// client for a response.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ServerMessage {
+    /// This allows the client to know what client_id they have been assigned
+    YouAre(ClientId),
+
+    /// LatestInscription is a message that is meant to show the most recent
+    /// inscription that has arrived.
+    LatestInscription(Arc<InscriptionAndChainDetails>),
+
+    /// InscriptionSnapshot is a message that is when a user is first
+    /// connecting to the WebSocket.  It immediately relays to the user
+    /// the current list of inscriptions that should be displayed.
+    InscriptionSnapshot(Arc<Vec<InscriptionAndChainDetails>>),
+}
+
+#[cfg(test)]
+impl PartialEq for ServerMessage {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::YouAre(lhs), Self::YouAre(rhg)) => lhs == rhg,
+            (Self::InscriptionSnapshot(_), Self::InscriptionSnapshot(_)) => true,
+            (Self::LatestInscription(_), Self::LatestInscription(_)) => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/inscriptions/src/service/server_message/mod.rs
+++ b/inscriptions/src/service/server_message/mod.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use super::{client_id::ClientId, espresso_inscription::InscriptionAndChainDetails};
+use super::{
+    client_id::ClientId, data_state::Stats, espresso_inscription::InscriptionAndChainDetails,
+};
 use serde::{Deserialize, Serialize};
 
 /// [ServerMessage] represents the messages that the server can send to the
 /// client for a response.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ServerMessage {
     /// This allows the client to know what client_id they have been assigned
     YouAre(ClientId),
@@ -18,6 +20,10 @@ pub enum ServerMessage {
     /// connecting to the WebSocket.  It immediately relays to the user
     /// the current list of inscriptions that should be displayed.
     InscriptionSnapshot(Arc<Vec<InscriptionAndChainDetails>>),
+
+    /// Stats is a message that is meant to show the current stats of the
+    /// Block Chain.
+    Stats(Stats),
 }
 
 #[cfg(test)]

--- a/inscriptions/src/service/storage/in_memory.rs
+++ b/inscriptions/src/service/storage/in_memory.rs
@@ -3,6 +3,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use alloy::primitives::Address;
 use espresso_types::SeqTypes;
 use hotshot_query_service::availability::BlockQueryData;
 
@@ -117,5 +118,15 @@ where
             .store(stats.num_transactions, Ordering::SeqCst);
 
         Ok(stats)
+    }
+
+    async fn retrieved_latest_inscriptions_for_address(
+        &self,
+        address: Address,
+    ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>
+    {
+        self.persistence
+            .retrieved_latest_inscriptions_for_address(address)
+            .await
     }
 }

--- a/inscriptions/src/service/storage/in_memory.rs
+++ b/inscriptions/src/service/storage/in_memory.rs
@@ -1,0 +1,106 @@
+use std::{
+    num::NonZero,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use crate::service::espresso_inscription::{EspressoInscription, InscriptionAndChainDetails};
+
+use super::{
+    InscriptionPersistence, RecordConfirmedInscriptionAndChainDetailsError,
+    RecordLastReceivedBlockError, RecordPendingPutInscriptionError,
+    ResolvePendingPutInscriptionError, RetrieveLastReceivedBlockError,
+    RetrieveLatestInscriptionAndChainDetailsError, RetrievePendingPutInscriptionsError,
+};
+
+/// [HeightCachingInMemory] is a wrapper around an [InscriptionPersistence] that
+/// caches the last received block height in memory for quick retrieval without
+/// having to continually query the underlying storage.
+pub struct HeightCachingInMemory<Persistence> {
+    persistence: Persistence,
+    last_received_block: AtomicU64,
+}
+
+impl<Persistence> HeightCachingInMemory<Persistence> {
+    /// [new] creates a new [HeightCachingInMemory] with the given storage.
+    pub fn new(storage: Persistence) -> Self {
+        Self {
+            persistence: storage,
+            last_received_block: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<Storage> InscriptionPersistence for HeightCachingInMemory<Storage>
+where
+    Storage: InscriptionPersistence + Send + Sync,
+{
+    async fn record_pending_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), RecordPendingPutInscriptionError> {
+        self.persistence
+            .record_pending_put_inscription(inscription)
+            .await
+    }
+
+    async fn record_submit_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), ResolvePendingPutInscriptionError> {
+        self.persistence
+            .record_submit_put_inscription(inscription)
+            .await
+    }
+
+    async fn retrieve_pending_put_inscriptions(
+        &self,
+    ) -> Result<Vec<EspressoInscription>, RetrievePendingPutInscriptionsError> {
+        self.persistence.retrieve_pending_put_inscriptions().await
+    }
+
+    async fn record_confirmed_inscription_and_chain_details(
+        &self,
+        inscription_and_block_details: &InscriptionAndChainDetails,
+    ) -> Result<(), RecordConfirmedInscriptionAndChainDetailsError> {
+        self.persistence
+            .record_confirmed_inscription_and_chain_details(inscription_and_block_details)
+            .await
+    }
+
+    async fn retrieve_latest_inscription_and_chain_details(
+        &self,
+        number_of_inscriptions: NonZero<usize>,
+    ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>
+    {
+        self.persistence
+            .retrieve_latest_inscription_and_chain_details(number_of_inscriptions)
+            .await
+    }
+
+    async fn record_last_received_block(
+        &self,
+        block: u64,
+    ) -> Result<(), RecordLastReceivedBlockError> {
+        let result = self.persistence.record_last_received_block(block).await;
+
+        if result.is_ok() {
+            self.last_received_block.store(block, Ordering::SeqCst);
+        }
+
+        result
+    }
+
+    async fn retrieve_last_received_block(&self) -> Result<u64, RetrieveLastReceivedBlockError> {
+        if self.last_received_block.load(Ordering::SeqCst) != 0 {
+            return Ok(self.last_received_block.load(Ordering::SeqCst));
+        }
+
+        // fallback to the underlying storage for boot-strapping
+        let block_height = self.persistence.retrieve_last_received_block().await?;
+        self.last_received_block
+            .store(block_height, Ordering::SeqCst);
+
+        Ok(block_height)
+    }
+}

--- a/inscriptions/src/service/storage/mod.rs
+++ b/inscriptions/src/service/storage/mod.rs
@@ -1,0 +1,198 @@
+use std::num::NonZero;
+pub mod in_memory;
+pub mod postgres;
+
+use super::espresso_inscription::{EspressoInscription, InscriptionAndChainDetails};
+
+/// [RecordPendingPutInscriptionError] is an error that occurs when attempting
+/// to record a pending put inscription.
+#[derive(Debug)]
+pub enum RecordPendingPutInscriptionError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for RecordPendingPutInscriptionError {
+    fn from(error: sqlx::Error) -> Self {
+        RecordPendingPutInscriptionError::SqlxError(error)
+    }
+}
+
+/// [ResolvePendingPutInscriptionError] is an error that occurs when attempting
+/// to resolve a pending put inscription.
+#[derive(Debug)]
+pub enum ResolvePendingPutInscriptionError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for ResolvePendingPutInscriptionError {
+    fn from(error: sqlx::Error) -> Self {
+        ResolvePendingPutInscriptionError::SqlxError(error)
+    }
+}
+
+/// [RetrievePendingPutInscriptionsError] is an error that occurs when
+/// attempting to retrieve all pending put inscriptions.
+#[derive(Debug)]
+pub enum RetrievePendingPutInscriptionsError {
+    SqlxError(sqlx::Error),
+    TryFromSliceError(core::array::TryFromSliceError),
+    FromHexError(const_hex::FromHexError),
+}
+
+impl From<sqlx::Error> for RetrievePendingPutInscriptionsError {
+    fn from(error: sqlx::Error) -> Self {
+        RetrievePendingPutInscriptionsError::SqlxError(error)
+    }
+}
+
+impl From<std::array::TryFromSliceError> for RetrievePendingPutInscriptionsError {
+    fn from(error: std::array::TryFromSliceError) -> Self {
+        RetrievePendingPutInscriptionsError::TryFromSliceError(error)
+    }
+}
+
+impl From<const_hex::FromHexError> for RetrievePendingPutInscriptionsError {
+    fn from(error: const_hex::FromHexError) -> Self {
+        RetrievePendingPutInscriptionsError::FromHexError(error)
+    }
+}
+
+/// [RecordConfirmedInscriptionAndChainDetailsError] is an error that occurs
+/// when attempting to record a confirmed inscription and chain details.
+#[derive(Debug)]
+pub enum RecordConfirmedInscriptionAndChainDetailsError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for RecordConfirmedInscriptionAndChainDetailsError {
+    fn from(error: sqlx::Error) -> Self {
+        RecordConfirmedInscriptionAndChainDetailsError::SqlxError(error)
+    }
+}
+
+/// [RetrieveLatestInscriptionAndChainDetailsError] is an error that occurs
+/// when attempting to retrieve the latest inscriptions and chain details.
+#[derive(Debug)]
+pub enum RetrieveLatestInscriptionAndChainDetailsError {
+    SqlxError(sqlx::Error),
+    TryFromSliceError(core::array::TryFromSliceError),
+    FromHexError(const_hex::FromHexError),
+}
+
+impl From<sqlx::Error> for RetrieveLatestInscriptionAndChainDetailsError {
+    fn from(error: sqlx::Error) -> Self {
+        RetrieveLatestInscriptionAndChainDetailsError::SqlxError(error)
+    }
+}
+
+impl From<std::array::TryFromSliceError> for RetrieveLatestInscriptionAndChainDetailsError {
+    fn from(error: std::array::TryFromSliceError) -> Self {
+        RetrieveLatestInscriptionAndChainDetailsError::TryFromSliceError(error)
+    }
+}
+
+impl From<const_hex::FromHexError> for RetrieveLatestInscriptionAndChainDetailsError {
+    fn from(error: const_hex::FromHexError) -> Self {
+        RetrieveLatestInscriptionAndChainDetailsError::FromHexError(error)
+    }
+}
+
+/// [RecordLastReceivedBlockError] is an error that occurs when attempting to
+/// record the last received block.
+#[derive(Debug)]
+pub enum RecordLastReceivedBlockError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for RecordLastReceivedBlockError {
+    fn from(error: sqlx::Error) -> Self {
+        RecordLastReceivedBlockError::SqlxError(error)
+    }
+}
+
+/// [RetrieveLastReceivedBlockError] is an error that occurs when attempting to
+/// retrieve the last received block.
+#[derive(Debug)]
+pub enum RetrieveLastReceivedBlockError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for RetrieveLastReceivedBlockError {
+    fn from(error: sqlx::Error) -> Self {
+        RetrieveLastReceivedBlockError::SqlxError(error)
+    }
+}
+
+/// [InscriptionPersistence] is a trait that governs the parts of data that we
+/// need to store in order to minimize any loss of inscription data due to a
+/// service restart.
+///
+/// This trait is predominately concerned with the persistence of the
+/// inscriptions service's state. As such the information being stored and
+/// retrieved is only concerned with restoring and populating the service's
+/// state.
+///
+/// There may be some elements for the archival of inscriptions that are not
+/// explicitly covered by this trait, but can be implied by it.
+#[async_trait::async_trait]
+pub trait InscriptionPersistence {
+    /// [record_pending_put_inscription] records a pending put inscription.
+    /// This is used to store inscriptions that are waiting to be submitted to
+    /// the Espresso Block Chain in order to ensure we do not miss any
+    /// submissions.
+    async fn record_pending_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), RecordPendingPutInscriptionError>;
+
+    /// [record_submit_put_inscription] resolves a pending put inscription.
+    /// This is used to clean the pending inscription from being considered
+    /// again in the future.
+    async fn record_submit_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), ResolvePendingPutInscriptionError>;
+
+    /// [retrieve_pending_put_inscriptions] retrieves the pending put
+    /// inscriptions from the stor that have not yet been resolved.
+    async fn retrieve_pending_put_inscriptions(
+        &self,
+    ) -> Result<Vec<EspressoInscription>, RetrievePendingPutInscriptionsError>;
+
+    /// [record_confirmed_inscription_and_chain_details] records a confirmed
+    /// inscription and block details.  This is used to store the confirmed
+    /// inscriptions that have been submitted to the Espresso Block Chain and
+    /// have been received back.
+    async fn record_confirmed_inscription_and_chain_details(
+        &self,
+        inscription_and_block_details: &InscriptionAndChainDetails,
+    ) -> Result<(), RecordConfirmedInscriptionAndChainDetailsError>;
+
+    /// [retrieve_latest_inscription_and_chain_details] retrieves the latest
+    /// inscriptions and chain details from the store.  This is used to retrieve
+    /// the latest inscriptions that have been confirmed by the Espresso Block
+    /// Chain.
+    ///
+    /// This is used during bootstrap in order to quickly repopulate the
+    /// inscription list that is stored in memory.
+    async fn retrieve_latest_inscription_and_chain_details(
+        &self,
+        number_of_inscriptions: NonZero<usize>,
+    ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>;
+
+    /// [record_last_received_block] records the last received block from the
+    /// Espresso Block Chain.  This is used to store the last block that has been
+    /// received from the Espresso Block Chain.
+    ///
+    /// This is useful for ensuring that we do not reprocess previously missed
+    /// blocks.
+    async fn record_last_received_block(
+        &self,
+        block: u64,
+    ) -> Result<(), RecordLastReceivedBlockError>;
+
+    /// [retrieve_last_received_block] retrieves the last received block height
+    /// from the Espresso Block Chain.  This is used to help bootstrap the
+    /// block stream to ensure that we do not miss processing any blocks.
+    async fn retrieve_last_received_block(&self) -> Result<u64, RetrieveLastReceivedBlockError>;
+}

--- a/inscriptions/src/service/storage/mod.rs
+++ b/inscriptions/src/service/storage/mod.rs
@@ -5,7 +5,10 @@ pub mod postgres;
 use espresso_types::SeqTypes;
 use hotshot_query_service::availability::BlockQueryData;
 
-use super::espresso_inscription::{EspressoInscription, InscriptionAndChainDetails};
+use super::{
+    data_state::Stats,
+    espresso_inscription::{EspressoInscription, InscriptionAndChainDetails},
+};
 
 /// [DecodeEspressoInscriptionError] is an error that occurs when attempting to
 /// decode an EspressoInscription from the database.
@@ -218,7 +221,5 @@ pub trait InscriptionPersistence {
     /// and number of transactions from the Espresso Block Chain.  This is used
     /// to help bootstrap the block stream to ensure that we do not miss
     /// processing any blocks.
-    async fn retrieve_last_received_block(
-        &self,
-    ) -> Result<(u64, u64), RetrieveLastReceivedBlockError>;
+    async fn retrieve_last_received_block(&self) -> Result<Stats, RetrieveLastReceivedBlockError>;
 }

--- a/inscriptions/src/service/storage/mod.rs
+++ b/inscriptions/src/service/storage/mod.rs
@@ -2,6 +2,9 @@ use std::num::NonZero;
 pub mod in_memory;
 pub mod postgres;
 
+use espresso_types::SeqTypes;
+use hotshot_query_service::availability::BlockQueryData;
+
 use super::espresso_inscription::{EspressoInscription, InscriptionAndChainDetails};
 
 /// [DecodeEspressoInscriptionError] is an error that occurs when attempting to
@@ -208,11 +211,14 @@ pub trait InscriptionPersistence {
     /// blocks.
     async fn record_last_received_block(
         &self,
-        block: u64,
+        block: &BlockQueryData<SeqTypes>,
     ) -> Result<(), RecordLastReceivedBlockError>;
 
-    /// [retrieve_last_received_block] retrieves the last received block height
-    /// from the Espresso Block Chain.  This is used to help bootstrap the
-    /// block stream to ensure that we do not miss processing any blocks.
-    async fn retrieve_last_received_block(&self) -> Result<u64, RetrieveLastReceivedBlockError>;
+    /// [retrieve_last_received_block] retrieves the last received block height,
+    /// and number of transactions from the Espresso Block Chain.  This is used
+    /// to help bootstrap the block stream to ensure that we do not miss
+    /// processing any blocks.
+    async fn retrieve_last_received_block(
+        &self,
+    ) -> Result<(u64, u64), RetrieveLastReceivedBlockError>;
 }

--- a/inscriptions/src/service/storage/mod.rs
+++ b/inscriptions/src/service/storage/mod.rs
@@ -2,6 +2,7 @@ use std::num::NonZero;
 pub mod in_memory;
 pub mod postgres;
 
+use alloy::primitives::Address;
 use espresso_types::SeqTypes;
 use hotshot_query_service::availability::BlockQueryData;
 
@@ -222,4 +223,12 @@ pub trait InscriptionPersistence {
     /// to help bootstrap the block stream to ensure that we do not miss
     /// processing any blocks.
     async fn retrieve_last_received_block(&self) -> Result<Stats, RetrieveLastReceivedBlockError>;
+
+    /// [retrieved_latest_inscriptions_for_address] retrieves the latest
+    /// inscriptions for a given address.  This is used to retrieve the latest
+    /// inscriptions that have been submitted by a given address.
+    async fn retrieved_latest_inscriptions_for_address(
+        &self,
+        address: Address,
+    ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>;
 }

--- a/inscriptions/src/service/storage/mod.rs
+++ b/inscriptions/src/service/storage/mod.rs
@@ -4,6 +4,33 @@ pub mod postgres;
 
 use super::espresso_inscription::{EspressoInscription, InscriptionAndChainDetails};
 
+/// [DecodeEspressoInscriptionError] is an error that occurs when attempting to
+/// decode an EspressoInscription from the database.
+#[derive(Debug)]
+pub enum DecodeEspressoInscriptionError {
+    SqlxError(sqlx::Error),
+    AddressDecodeError(String, const_hex::FromHexError),
+}
+
+impl From<sqlx::Error> for DecodeEspressoInscriptionError {
+    fn from(error: sqlx::Error) -> Self {
+        DecodeEspressoInscriptionError::SqlxError(error)
+    }
+}
+
+/// [DecodeChainDetailsError] is an error that occurs when attempting to decode
+/// the chain details from the database.
+#[derive(Debug)]
+pub enum DecodeChainDetailsError {
+    SqlxError(sqlx::Error),
+}
+
+impl From<sqlx::Error> for DecodeChainDetailsError {
+    fn from(error: sqlx::Error) -> Self {
+        DecodeChainDetailsError::SqlxError(error)
+    }
+}
+
 /// [RecordPendingPutInscriptionError] is an error that occurs when attempting
 /// to record a pending put inscription.
 #[derive(Debug)]
@@ -35,8 +62,7 @@ impl From<sqlx::Error> for ResolvePendingPutInscriptionError {
 #[derive(Debug)]
 pub enum RetrievePendingPutInscriptionsError {
     SqlxError(sqlx::Error),
-    TryFromSliceError(core::array::TryFromSliceError),
-    FromHexError(const_hex::FromHexError),
+    DecodeEspressoInscriptionError(DecodeEspressoInscriptionError),
 }
 
 impl From<sqlx::Error> for RetrievePendingPutInscriptionsError {
@@ -45,15 +71,9 @@ impl From<sqlx::Error> for RetrievePendingPutInscriptionsError {
     }
 }
 
-impl From<std::array::TryFromSliceError> for RetrievePendingPutInscriptionsError {
-    fn from(error: std::array::TryFromSliceError) -> Self {
-        RetrievePendingPutInscriptionsError::TryFromSliceError(error)
-    }
-}
-
-impl From<const_hex::FromHexError> for RetrievePendingPutInscriptionsError {
-    fn from(error: const_hex::FromHexError) -> Self {
-        RetrievePendingPutInscriptionsError::FromHexError(error)
+impl From<DecodeEspressoInscriptionError> for RetrievePendingPutInscriptionsError {
+    fn from(error: DecodeEspressoInscriptionError) -> Self {
+        RetrievePendingPutInscriptionsError::DecodeEspressoInscriptionError(error)
     }
 }
 
@@ -75,8 +95,8 @@ impl From<sqlx::Error> for RecordConfirmedInscriptionAndChainDetailsError {
 #[derive(Debug)]
 pub enum RetrieveLatestInscriptionAndChainDetailsError {
     SqlxError(sqlx::Error),
-    TryFromSliceError(core::array::TryFromSliceError),
-    FromHexError(const_hex::FromHexError),
+    DecodeEspressoInscriptionError(DecodeEspressoInscriptionError),
+    DecodeChainDetailsError(DecodeChainDetailsError),
 }
 
 impl From<sqlx::Error> for RetrieveLatestInscriptionAndChainDetailsError {
@@ -85,15 +105,15 @@ impl From<sqlx::Error> for RetrieveLatestInscriptionAndChainDetailsError {
     }
 }
 
-impl From<std::array::TryFromSliceError> for RetrieveLatestInscriptionAndChainDetailsError {
-    fn from(error: std::array::TryFromSliceError) -> Self {
-        RetrieveLatestInscriptionAndChainDetailsError::TryFromSliceError(error)
+impl From<DecodeEspressoInscriptionError> for RetrieveLatestInscriptionAndChainDetailsError {
+    fn from(error: DecodeEspressoInscriptionError) -> Self {
+        RetrieveLatestInscriptionAndChainDetailsError::DecodeEspressoInscriptionError(error)
     }
 }
 
-impl From<const_hex::FromHexError> for RetrieveLatestInscriptionAndChainDetailsError {
-    fn from(error: const_hex::FromHexError) -> Self {
-        RetrieveLatestInscriptionAndChainDetailsError::FromHexError(error)
+impl From<DecodeChainDetailsError> for RetrieveLatestInscriptionAndChainDetailsError {
+    fn from(error: DecodeChainDetailsError) -> Self {
+        RetrieveLatestInscriptionAndChainDetailsError::DecodeChainDetailsError(error)
     }
 }
 

--- a/inscriptions/src/service/storage/postgres.rs
+++ b/inscriptions/src/service/storage/postgres.rs
@@ -257,7 +257,7 @@ impl InscriptionPersistence for PostgresPersistence {
         // We shouldn't need a transaction, as we're just performing a read
         let mut conn = self.pool.acquire().await?;
 
-        let mut rows = sqlx::query("SELECT ins_address, ins_time, chain_block_height, chain_txn_offset FROM confirmed_inscriptions ORDER BY id DESC LIMIT $1")
+        let mut rows = sqlx::query("SELECT ins_address, ins_time, chain_block_height, chain_txn_offset FROM confirmed_inscriptions ORDER BY id ASC LIMIT $1")
             .bind(number_of_inscriptions.get() as i64)
             .fetch(&mut *conn);
 

--- a/inscriptions/src/service/storage/postgres.rs
+++ b/inscriptions/src/service/storage/postgres.rs
@@ -116,7 +116,7 @@ impl InscriptionPersistence for PostgresPersistence {
             // put_inscription.
             // This might imply that the pending put inscription hasn't been
             // stored yet.
-            tracing::warn!(
+            tracing::debug!(
                 "Failed to store event for 'submit' pending put inscription: {:?}",
                 inscription
             );

--- a/inscriptions/src/service/storage/postgres.rs
+++ b/inscriptions/src/service/storage/postgres.rs
@@ -1,0 +1,244 @@
+use futures::StreamExt;
+use std::num::NonZero;
+use std::time::SystemTime;
+
+use alloy::sol_types::SolStruct;
+use sqlx::Row;
+
+use crate::service::espresso_inscription::{
+    ChainDetails, EspressoInscription, InscriptionAndChainDetails,
+};
+use crate::service::ESPRESSO_INSCRIPTION_MESSAGE;
+
+use super::{
+    InscriptionPersistence, RecordConfirmedInscriptionAndChainDetailsError,
+    RecordLastReceivedBlockError, RecordPendingPutInscriptionError,
+    ResolvePendingPutInscriptionError, RetrieveLastReceivedBlockError,
+    RetrieveLatestInscriptionAndChainDetailsError, RetrievePendingPutInscriptionsError,
+};
+
+pub struct PostgresPersistence {
+    pool: sqlx::PgPool,
+}
+
+impl PostgresPersistence {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl InscriptionPersistence for PostgresPersistence {
+    async fn record_pending_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), RecordPendingPutInscriptionError> {
+        tracing::debug!("Recording pending put inscription: {:?}", inscription);
+        let mut conn = self.pool.begin().await?;
+        let result = sqlx::query("INSERT INTO pending_put_inscription_request (ins_hash, ins_address, ins_time) VALUES ($1, $2, $3)")
+            .bind(&inscription.eip712_hash_struct().0[..])
+            .bind(inscription.address.to_string())
+            // We shouldn't have a timestamp that gets close to i64::MAX, so
+            // this should be a relatively safe cast.
+            .bind(inscription.time as i64)
+            .execute(&mut *conn)
+            .await?;
+
+        if result.rows_affected() != 1 {
+            panic!();
+        }
+
+        // commit the transaction
+        conn.commit().await?;
+
+        Ok(())
+    }
+
+    async fn record_submit_put_inscription(
+        &self,
+        inscription: &EspressoInscription,
+    ) -> Result<(), ResolvePendingPutInscriptionError> {
+        tracing::debug!("Recording submit put inscription: {:?}", inscription);
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let mut conn = self.pool.begin().await?;
+
+        let result = sqlx::query("INSERT INTO pending_put_inscriptions_event (ins_id, event_type, event_time) VALUES((SELECT id FROM pending_put_inscription_request WHERE ins_hash = $1), 'submit', $2)")
+            .bind(&inscription.eip712_hash_struct().0[..])
+            .bind(now as i64)
+            .execute(&mut *conn)
+            .await?;
+
+        if result.rows_affected() != 1 {
+            panic!();
+        }
+
+        // commit the transaction
+        conn.commit().await?;
+
+        Ok(())
+    }
+
+    async fn retrieve_pending_put_inscriptions(
+        &self,
+    ) -> Result<Vec<EspressoInscription>, RetrievePendingPutInscriptionsError> {
+        tracing::debug!("Retrieving pending put inscriptions");
+        // We shouldn't need a transaction, as we're just performing a read
+        let mut conn = self.pool.acquire().await?;
+
+        let mut rows = sqlx::query("SELECT ins_address, ins_time FROM pending_put_inscription_request r LEFT JOIN pending_put_inscriptions_event e ON e.ins_id = r.id AND e.event_type = 'confirmed' WHERE e.id IS NULL")
+                    .fetch(&mut *conn);
+
+        let mut put_inscriptions = Vec::new();
+
+        while let Some(row) = rows.next().await {
+            let row = row?;
+            let ins_address_string: String = row.try_get("ins_address")?;
+            let ins_time: i64 = row.try_get("ins_time")?;
+            let inscription = EspressoInscription {
+                address: ins_address_string.parse()?,
+                message: ESPRESSO_INSCRIPTION_MESSAGE.to_string(),
+                time: ins_time as u64,
+            };
+
+            put_inscriptions.push(inscription);
+        }
+
+        Ok(put_inscriptions)
+    }
+
+    async fn record_confirmed_inscription_and_chain_details(
+        &self,
+        inscription_and_block_details: &InscriptionAndChainDetails,
+    ) -> Result<(), RecordConfirmedInscriptionAndChainDetailsError> {
+        tracing::debug!(
+            "Recording confirmed inscription and chain details: {:?}",
+            inscription_and_block_details
+        );
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let mut conn = self.pool.begin().await?;
+
+        let store_confirmed_inscription_result = sqlx::query("INSERT INTO confirmed_inscriptions (ins_hash, ins_address, ins_time, chain_block_height, chain_txn_offset) VALUES ($1, $2, $3, $4, $5)")
+            .bind(&inscription_and_block_details.inscription.eip712_hash_struct().0[..])
+            .bind(inscription_and_block_details.inscription.address.to_string())
+            .bind(inscription_and_block_details.inscription.time as i64)
+            .bind(inscription_and_block_details.chain_details.block as i64)
+            .bind(inscription_and_block_details.chain_details.offset as i64)
+            .execute(&mut *conn)
+            .await?;
+
+        if store_confirmed_inscription_result.rows_affected() != 1 {
+            panic!();
+        }
+
+        // If this fails... is that a problem?  It depends on the nature of the
+        // problem
+        let store_event_result = sqlx::query("INSERT INTO pending_put_inscriptions_event (ins_id, event_type, event_time) VALUES((SELECT id FROM pending_put_inscription_request WHERE ins_hash = $1), 'confirmed', $2)")
+            .bind(&inscription_and_block_details.inscription.eip712_hash_struct().0[..])
+            .bind(now as i64)
+            .execute(&mut *conn)
+            .await?;
+
+        if store_event_result.rows_affected() != 1 {
+            panic!();
+        }
+
+        // commit the result
+        conn.commit().await?;
+
+        Ok(())
+    }
+
+    async fn retrieve_latest_inscription_and_chain_details(
+        &self,
+        number_of_inscriptions: NonZero<usize>,
+    ) -> Result<Vec<InscriptionAndChainDetails>, RetrieveLatestInscriptionAndChainDetailsError>
+    {
+        tracing::debug!("Retrieving latest inscriptions and chain details");
+        // We shouldn't need a transaction, as we're just performing a read
+        let mut conn = self.pool.acquire().await?;
+
+        let mut rows = sqlx::query("SELECT ins_address, ins_time, chain_block_height, chain_txn_offset FROM confirmed_inscriptions ORDER BY id DESC LIMIT $1")
+            .bind(number_of_inscriptions.get() as i64)
+            .fetch(&mut *conn);
+
+        let mut inscription_and_chain_details = Vec::new();
+
+        while let Some(row) = rows.next().await {
+            let row = row?;
+            let ins_address_string: String = row.try_get("ins_address")?;
+            let ins_time: i64 = row.try_get("ins_time")?;
+            let inscription = EspressoInscription {
+                address: ins_address_string.parse()?,
+                message: ESPRESSO_INSCRIPTION_MESSAGE.to_string(),
+                time: ins_time as u64,
+            };
+            let block_height: i64 = row.try_get("chain_block_height")?;
+            let txn_offset: i64 = row.try_get("chain_txn_offset")?;
+            let chain_details = ChainDetails {
+                block: block_height as u64,
+                offset: txn_offset as u64,
+            };
+
+            inscription_and_chain_details.push(InscriptionAndChainDetails {
+                inscription,
+                chain_details,
+            });
+        }
+
+        Ok(inscription_and_chain_details)
+    }
+
+    async fn record_last_received_block(
+        &self,
+        block: u64,
+    ) -> Result<(), RecordLastReceivedBlockError> {
+        tracing::debug!("Recording last received block: {}", block);
+        let mut conn = self.pool.begin().await?;
+
+        let result = sqlx::query(
+            // Update the last read block if the new block number is greater than
+            // the current block number.
+            "UPDATE last_read_block SET block_number = $1 WHERE id = 0 AND $1 > block_number",
+        )
+        .bind(block as i64)
+        .execute(&mut *conn)
+        .await?;
+
+        if result.rows_affected() != 1 {
+            // We didn't actually store any update to the last read block.
+            // This implies that we received a block before or equal to our
+            // already stored block height.
+            panic!(
+                "attempt to record last block {}: it is not greater than the previous last read block",
+                block
+            );
+        }
+
+        // commit the result.
+        conn.commit().await?;
+
+        Ok(())
+    }
+
+    async fn retrieve_last_received_block(&self) -> Result<u64, RetrieveLastReceivedBlockError> {
+        tracing::debug!("Retrieving last received block");
+        // We shouldn't need a transaction, as we're just performing a read
+        let mut conn = self.pool.acquire().await?;
+
+        let row = sqlx::query("SELECT block_number FROM last_read_block")
+            .fetch_one(&mut *conn)
+            .await?;
+
+        let block_number: i64 = row.try_get("block_number")?;
+
+        Ok(block_number as u64)
+    }
+}


### PR DESCRIPTION
### This PR:
Tracks the overall progress of the implementation of the Inscriptions service.  It is specifically targeting a merge into `release-rogue` as that is what it was branched from.  The `release-rogue` branch was targeted explicitly to ensure compatability.  This is a DRAFT PR to ensure that it doesn't get directly merged.

This adds the `inscriptions` sub-crate into the sequencer repo for convenience of writing.  It is largely copied from the `node-metrics` implementation with state and message adjustments to work specifically for the inscriptions API itself.

This service is meant to be used with the inscriptions front-end ui demo.  Much of the implementation has been implemented quickly without a lot of time for testing or documentation due to time constraints.

### How to Test:

This service has a few environment variables that are important to be specified in order for things to be able to be run without issue.  Some of these environment variables should have special care taken when specifying them in order to ensure that the behavior can be run and verified in a reasonable time frame.

#### Environment Variables

The environment variables for this service are utilized to configure specific behavior, generally around targetting specific entries and data sources.

##### Persistence

This service utilizes `postgres` and `sqlx` to store all of its state.  It is important to have a postgres instance running, and configured properly in order for this service to run.

Before configuring the environment variables to run the service, the database needs to be setup and configured.  With a properly running `postgres` issue it is important to initialize the `postgres` database utilizing the `sqlx-cli`:

https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md

the `DATABASE_URL` environment variable **NEEDS** to be set for the `sqlx-cli` to be able to run.  After that, ensure that you run this command, with the environment variable setup correctly:

```sh
sqlx database create
```

Then these environment variables can be set in order to run migrations and make things work:
- POSTGRES_HOST
- POSTGRES_PORT
- POSTGRES_DATABASE
- POSTGRES_USER
- POSTGRES_PASSWORD

These environment variables have default values with the idea that the postgres server is accessible via `localhost` as if running in a `docker` container running locally. 

##### Sourcing Data

This service sources all of its data from the availability API's block stream endpoint.  This endpoint needs to be specified:
- ESPRESSO_INSCRIPTIONS_BLOCK_STREAM_SOURCE_BASE_URL

This expected value is meant to be the base version endpoint.

Example:
`https://query.decaf.testnet.espresso.network/v0/`

Additionally the variable `ESPRESSO_INSCRIPTIONS_MINIMUM_BLOCK_HEIGHT` **SHOULD** be specified in order to ensure that we don't start consuming all blocks from block height `0` (which is the default).

- ESPRESSO_INSCRIPTIONS_MINIMUM_BLOCK_HEIGHT

The first block on `decaf` that has an inscription with the default namespace id is `453728`.

The data coming in will be scanned for transactions that match the namespace and appear to be signed by the private key of the service.  Otherwise they get ignored.

The key for the service can be setup with a BIP39 mnemonic:
- ESPRESSO_INSCRIPTIONS_SIGNER_MNEMONIC

The namespaceID can be changed with:
- ESPRESSO_INSCRIPTIONS_NAMESPACE_ID


##### Submitting Data

The data will be submitted to a mempool of some sort. It is necessary to specify a URL endpoint to hit for submitting data.  This endpoint matches the configuration of the sequencer service.  You can target either public mempool submit endpoints or a private (the builder's) endpoint.

- ESPRESSO_INSCRIPTIONS_SUBMIT_BASE_URL

Examples:
`https://query.decaf.testnet.espresso.network/v0/submit`
`https://builder.decaf.testnet.espresso.network/v0/txn_submit`

Submissions get rate limited, and buffered to a configurable rate and buffer size using these environment variables:

- ESPRESSO_INSCRIPTIONS_PUT_INSCRIPTION_BUFFER_SIZE
- ESPRESSO_INSCRIPTIONS_PUT_INSCRIPTIONS_PER_SECOND
