### PR TITLE
Improve handling of large responses in nasty client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8660,6 +8660,7 @@ dependencies = [
  "async-once-cell",
  "async-trait",
  "bincode",
+ "bytesize",
  "cdn-broker 0.4.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.4.5)",
  "cdn-marshal 0.4.0 (git+https://github.com/EspressoSystems/Push-CDN?tag=0.4.5)",
  "clap",

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -16,10 +16,15 @@ testing = [
   "hotshot-query-service/testing",
 ]
 benchmarking = []
+nasty-client = ["reqwest", "bytesize"]
 
 [[bin]]
 name = "espresso-dev-node"
 required-features = ["testing"]
+
+[[bin]]
+name = "nasty-client"
+required-features = ["nasty-client"]
 
 [dev-dependencies]
 escargot = "0.5.10"
@@ -124,6 +129,10 @@ tracing-subscriber = "0.3.18"
 url = { workspace = true }
 vbs = { workspace = true }
 vec1 = { workspace = true }
+
+# Dependencies for nasty-client
+bytesize = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["hotshot-testing"]


### PR DESCRIPTION
Some of the responses to queries like payload queries and range queries can be up to a few megabytes. This change prevents distracting spurious warnings and errors for such responses.

### This PR:

* increases the HTTP client timeout to allow plenty of time to stream the response over the network
* only counts queries as slow if it takes longer than 1s to receive a response header -- the time it takes to stream the response does not count toward slow warnings, as this time is not taking computational resources on the server
