### PR TITLE
Add `from_bytes` method.

### DIFF
--- a/types/src/v0/impls/block/full_payload/ns_table.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table.rs
@@ -100,6 +100,13 @@ impl NsTable {
         self.len().in_bounds(index)
     }
 
+    /// Instantiate an `NsTable` from a byte slice.
+    pub fn from_bytes(bytes: &[u8]) -> NsTable {
+        NsTable {
+            bytes: bytes.to_vec(),
+        }
+    }
+
     /// Are the bytes of this [`NsTable`] uncorrupted?
     ///
     /// # Checks

--- a/types/src/v0/impls/block/full_payload/ns_table.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table.rs
@@ -101,7 +101,7 @@ impl NsTable {
     }
 
     /// Instantiate an `NsTable` from a byte slice.
-    pub fn from_bytes(bytes: &[u8]) -> NsTable {
+    pub fn from_bytes_unchecked(bytes: &[u8]) -> NsTable {
         NsTable {
             bytes: bytes.to_vec(),
         }

--- a/types/src/v0/impls/block/full_payload/ns_table/test.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table/test.rs
@@ -28,7 +28,7 @@ fn random_valid() {
 #[test]
 fn ns_table_from_bytes() {
     let bytes = Vec::from([0; NUM_NSS_BYTE_LEN]);
-    let ns_table = NsTable::from_bytes(&bytes);
+    let ns_table = NsTable::from_bytes_unchecked(&bytes);
     expect_valid(&ns_table);
 }
 

--- a/types/src/v0/impls/block/full_payload/ns_table/test.rs
+++ b/types/src/v0/impls/block/full_payload/ns_table/test.rs
@@ -26,6 +26,13 @@ fn random_valid() {
 }
 
 #[test]
+fn ns_table_from_bytes() {
+    let bytes = Vec::from([0; NUM_NSS_BYTE_LEN]);
+    let ns_table = NsTable::from_bytes(&bytes);
+    expect_valid(&ns_table);
+}
+
+#[test]
 fn ns_table_byte_len() {
     setup_test();
     let mut rng = jf_utils::test_rng();


### PR DESCRIPTION
Closes #2327

Adds `from_bytes` method to `NsTable` to facilitate nitro development (see issue).