### PR TITLE
flake: add target/debug to PATH

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build diff-test
         run: |
-          nix develop --accept-flake-config -c cargo build --locked --bin diff-test --release
+          nix develop --accept-flake-config -c cargo build --locked --bin diff-test --profile test
 
       - name: Run tests (quick version for PR)
         if: ${{ github.event_name == 'pull_request' }}

--- a/flake.nix
+++ b/flake.nix
@@ -225,12 +225,15 @@
           ++ lib.optionals (!stdenv.isDarwin) [ cargo-watch ] # broken on OSX
           ;
           shellHook = ''
-            # Add node binaries to PATH
+            # Add node binaries to PATH for development
             export PATH="$PWD/node_modules/.bin:$PATH"
+
             # Prevent cargo aliases from using programs in `~/.cargo` to avoid conflicts
             # with rustup installations.
             export CARGO_HOME=$HOME/.cargo-nix
-            export PATH="$PWD/$CARGO_TARGET_DIR/release:$PATH"
+
+            # Add rust binaries to PATH for native demo
+            export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PATH"
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";

--- a/justfile
+++ b/justfile
@@ -7,9 +7,9 @@ doc *args:
 demo *args:
     docker compose up {{args}}
 
-demo-native:
+demo-native *args:
     cargo build --profile test
-    scripts/demo-native
+    scripts/demo-native {{args}}
 
 demo-native-mp:
     cargo build --release


### PR DESCRIPTION
We now compile mostly with the "test" profile which uses the "target/debug" output path.
