### PR TITLE
Fix Typo in `doc/upgrades.md` for Article Usage

### DIFF
--- a/doc/upgrades.md
+++ b/doc/upgrades.md
@@ -23,7 +23,7 @@ An upgrade consists of two parts:
 
 ## Enabling an Upgrade
 
-To enable an upgrade in Hotshot protocol, it is essential to define the base version, the upgrade version, and a upgrade
+To enable an upgrade in Hotshot protocol, it is essential to define the base version, the upgrade version, and an upgrade
 hash:
 
 - **Base Version:** Represents the current version of the protocol (`0.1` in this example).


### PR DESCRIPTION
This PR resolves a grammatical error in the `doc/upgrades.md` file, improving readability and accuracy.  

#### Changes Made:  
- Corrected the usage of "a" to "an" before the word "upgrade" in the **Enabling an Upgrade** section.  

#### Key Place to Review:  
- Line 23 of `doc/upgrades.md`.  

This change ensures adherence to proper English grammar and enhances the documentation quality.  
