### PR TITLE
docker demo: read initial stake table from file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
     image: ghcr.io/espressosystems/espresso-sequencer/deploy:main
     command: deploy --only fee-contract,permissioned-stake-table
     environment:
+      - ESPRESSO_SEQUENCER_INITIAL_PERMISSIONED_STAKE_TABLE_PATH=/data/initial_stake_table.toml
       - ESPRESSO_SEQUENCER_ETH_MULTISIG_ADDRESS
       - ESPRESSO_SEQUENCER_L1_PROVIDER
       - ESPRESSO_SEQUENCER_L1_POLLING_INTERVAL
@@ -26,6 +27,8 @@ services:
       - RUST_LOG
       - RUST_LOG_FORMAT
       - ASYNC_STD_THREAD_COUNT
+    volumes:
+      - "./data/initial_stake_table.toml:/data/initial_stake_table.toml"
     depends_on:
       demo-l1-network:
         condition: service_healthy

--- a/sequencer/src/bin/deploy.rs
+++ b/sequencer/src/bin/deploy.rs
@@ -152,6 +152,7 @@ async fn main() -> anyhow::Result<()> {
     let genesis = light_client_genesis(&sequencer_url, opt.stake_table_capacity).boxed();
 
     let initial_stake_table = if let Some(path) = opt.initial_stake_table_path {
+        tracing::info!("Loading initial stake table from {:?}", path);
         Some(PermissionedStakeTableConfig::from_toml_file(&path)?.into())
     } else {
         None

--- a/utils/src/deployer.rs
+++ b/utils/src/deployer.rs
@@ -390,8 +390,8 @@ pub async fn deploy(
         // Transfer ownership to the multisig wallet if provided.
         if let Some(owner) = multisig_address {
             tracing::info!(
-                %light_client_proxy_address,
-                %owner,
+                ?light_client_proxy_address,
+                ?owner,
                 "transferring light client proxy ownership to multisig",
             );
             proxy.transfer_ownership(owner).send().await?.await?;
@@ -429,8 +429,8 @@ pub async fn deploy(
         // Transfer ownership to the multisig wallet if provided.
         if let Some(owner) = multisig_address {
             tracing::info!(
-                %fee_contract_proxy_address,
-                %owner,
+                ?fee_contract_proxy_address,
+                ?owner,
                 "transferring fee contract proxy ownership to multisig",
             );
             proxy.transfer_ownership(owner).send().await?.await?;
@@ -451,8 +451,8 @@ pub async fn deploy(
         // Transfer ownership to the multisig wallet if provided.
         if let Some(owner) = multisig_address {
             tracing::info!(
-                %stake_table_address,
-                %owner,
+                ?stake_table_address,
+                ?owner,
                 "transferring PermissionedStakeTable ownership to multisig",
             );
             stake_table.transfer_ownership(owner).send().await?.await?;


### PR DESCRIPTION
We are missing this in the docker demo.

- Avoid printing shortened Ethereum addresses