### PR TITLE
dependabot: group mainly external repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,32 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/"
-    # Group all updates together
     groups:
+      # The `all` group should include mainly updates from crates.io which are
+      # more likely to succeed without intervention.
       all:
         patterns:
-        - "*"
+          - "*"
+        exclude-patterns:
+          - "ark-*"
+          - "cdn-*"
+          - "hotshot-*"
+          - "jf-*"
+          - "marketplace-*"
+      ark:
+        patterns:
+          - "ark-*"
+      cdn:
+        patterns:
+          - "cdn-*"
+      hotshot:
+        patterns:
+          - "hotshot-*"
+      jf:
+        patterns:
+          - "jf-*"
+      marketplace:
+        patterns:
+          - "marketplace-*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Our own repos are mostly git depedencencies and often require manual intervention. This is an attempt to split out updates of third party depedencencies which are more likely to succeed without intervention.