### PR TITLE
Update the PATH environment variable to be able to run solidity tests…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,7 @@
             export CARGO_HOME=$HOME/.cargo-nix
 
             # Add rust binaries to PATH for native demo
-            export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PATH"
+            export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PWD/$CARGO_TARGET_DIR/release:$PATH"
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";

--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,7 @@
             export CARGO_HOME=$HOME/.cargo-nix
 
             # Add rust binaries to PATH for native demo
-            export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PWD/$CARGO_TARGET_DIR/release:$PATH"
+            export PATH="$PWD/$CARGO_TARGET_DIR/debug:$PATH"
           '' + self.checks.${system}.pre-commit-check.shellHook;
           RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           FOUNDRY_SOLC = "${solc}/bin/solc";

--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ sol-lint:
 # Build diff-test binary and forge test
 # Note: we use an invalid etherscan api key in order to avoid annoying warnings. See https://github.com/EspressoSystems/espresso-sequencer/issues/979
 sol-test:
-    cargo build --bin diff-test --release
+    cargo build --profile test --bin diff-test
     forge test
 
 # Deploys the light client contract on Sepolia and call it for profiling purposes.
@@ -141,7 +141,7 @@ lc-contract-profiling-sepolia:
     forge script contracts/script/LightClientCallNewFinalizedState.s.sol --sig "run(uint32 numInitValidators, address lcContractAddress)" {{NUM_INIT_VALIDATORS}} $LC_CONTRACT_ADDRESS --fork-url ${SEPOLIA_RPC_URL}  --broadcast  --chain-id sepolia
 
 gas-benchmarks:
-    cargo build --bin diff-test --release
+    cargo build --profile test --bin diff-test
     forge snapshot --mt "test_verify_succeeds|testCorrectUpdateBench"
     @[ -n "$(git diff --name-only .gas-snapshot)" ] && echo "⚠️ Uncommitted gas benchmarks, please stage them before committing." && exit 1 || exit 0
 


### PR DESCRIPTION
I made this PR because I was not able to run the solidity tests using nix. The problem was that the diff-test executable was not in the PATH environment variable.

### This PR:
Update the `PATH` environment variable in `flake.nix` so that the `diff-test` executable can be found.


### Key places to review:
`flake.nix` file.