### PR TITLE
Fix typo in README.md: corrected "human readable" to "human-readable" 

### DIFF
--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -358,7 +358,7 @@ forge script contracts/script/PlonkVerifier.s.sol:DeployPlonkVerifierScript \
 
 ```bash
 Error:
-error parsing abi for contract '_70c760a3e059d83dbf77da7f6778fbc0': couldn't parse ABI string as either human readable (1) or JSON (2):
+error parsing abi for contract '_70c760a3e059d83dbf77da7f6778fbc0': couldn't parse ABI string as either human-readable (1) or JSON (2):
 1. Illegal abi `{`, expected function
 2. data did not match any variant of untagged enum JsonContract
 error: Recipe `gen-bindings` failed on line 65 with exit code 1


### PR DESCRIPTION
This PR corrects a typographical issue in the `contracts/script/README.md` file. The term **"human readable"** was adjusted to **"human-readable"**, following standard conventions for hyphenating compound adjectives.  

### Key Changes  
- Corrected "human readable" to "human-readable" in the error message example.  

### Why this PR is necessary  
- Enhances the readability and grammatical correctness of the documentation.  
- Aligns the README with common English usage for compound adjectives.  

### Key places to review  
- `contracts/script/README.md`, line containing the error message example.  

### Checklist before merging  
- [ ] Ensure documentation changes are clear and concise.  
- [ ] Confirm no other typographical issues in related files.  
