### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To deploy to sepolia set `SEPOLIA_RPC_URL` and `MNEMONIC` env vars and run
 
     forge script DeployHotShot --broadcast --rpc-url sepolia
 
-To additionally verify the contact on etherscan set the `ETHERSCAN_API_KEY` env var and run
+To additionally verify the contract on etherscan set the `ETHERSCAN_API_KEY` env var and run
 
     forge script DeployHotShot --broadcast --rpc-url sepolia --verify
 

--- a/doc/upgrades.md
+++ b/doc/upgrades.md
@@ -71,7 +71,7 @@ Time based:
 
 - **start_voting_time:** UNIX timestamp at which voting for the upgrade proposal starts.
 - **stop_voting_time:** UNIX timestamp at which voting for the upgrade proposal stops.
-- **start_proposing_time:** the earliest UNIX timestamnp in which the node can propose an upgrade.
+- **start_proposing_time:** the earliest UNIX timestamp in which the node can propose an upgrade.
 - **stop_proposing_time:** UNIX timestamp after which the node stops proposing an upgrade.
 
 The window between `start_proposing_view/time` and `stop_proposing_view/time` should provide sufficient time for nodes


### PR DESCRIPTION
-contact-contract → Corrected to contract-contact (assuming this was intended).
-timestamnp → Corrected to timestamp.

These changes improve clarity and correct spelling errors