### PR TITLE
Use sync locks for stake table state

### DIFF
--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -18,7 +18,6 @@ use hotshot_types::{
     PeerConfig,
 };
 use itertools::Itertools;
-
 use std::sync::RwLock;
 use std::{
     cmp::max,
@@ -336,7 +335,6 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     /// Get all members of the committee for the current view
-
     fn committee_members(
         &self,
         _view_number: <SeqTypes as NodeType>::View,
@@ -446,7 +444,6 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     /// Get the total number of nodes in the committee
-
     fn total_nodes(&self, epoch: Epoch) -> usize {
         self.state
             .read()
@@ -457,7 +454,6 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     /// Get the total number of DA nodes in the committee
-
     fn da_total_nodes(&self, epoch: Epoch) -> usize {
         self.state
             .read()
@@ -468,7 +464,6 @@ impl Membership<SeqTypes> for EpochCommittees {
     }
 
     /// Get the voting success threshold for the committee
-
     fn success_threshold(&self, epoch: Epoch) -> NonZeroU64 {
         let quorum = self
             .state

--- a/types/src/v0/v0_1/l1.rs
+++ b/types/src/v0/v0_1/l1.rs
@@ -11,7 +11,12 @@ use hotshot_types::{
 };
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    num::NonZeroUsize,
+    sync::{self, Arc},
+    time::Duration,
+};
 use tokio::{
     sync::{Mutex, RwLock},
     task::JoinHandle,
@@ -111,6 +116,9 @@ pub struct L1Client {
     pub(crate) events_max_block_range: u64,
     /// Shared state updated by an asynchronous task which polls the L1.
     pub(crate) state: Arc<Mutex<L1State>>,
+    /// TODO: We need to be able to take out sync locks on this part of the
+    /// state. until the trait definition of Membership is updated in HotShot.
+    pub(crate) stake_table_state: sync::Arc<sync::RwLock<BTreeMap<EpochNumber, StakeTables>>>,
     /// Channel used by the async update task to send events to clients.
     pub(crate) sender: Sender<L1Event>,
     /// Receiver for events from the async update task.
@@ -140,7 +148,6 @@ pub(crate) enum RpcClient {
 pub(crate) struct L1State {
     pub(crate) snapshot: L1Snapshot,
     pub(crate) finalized: LruCache<u64, L1BlockInfo>,
-    pub(crate) stake_tables: BTreeMap<EpochNumber, StakeTables>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
We can't take out async locks on the stake table state at the moment. This PR moves this state out of L1 state and uses primitives from `std::sync` for it instead.