### PR TITLE
Replace raw subtraction w/ checked_sub

### DIFF
--- a/sequencer/src/api/sql.rs
+++ b/sequencer/src/api/sql.rs
@@ -208,7 +208,9 @@ async fn load_frontier<Mode: TransactionMode>(
 ) -> anyhow::Result<BlocksFrontier> {
     tx.get_path(
         Snapshot::<SeqTypes, BlockMerkleTree, { BlockMerkleTree::ARITY }>::Index(height),
-        height - 1,
+        height
+            .checked_sub(1)
+            .ok_or(anyhow::anyhow!("Subtract with overflow ({height})!"))?,
     )
     .await
     .context(format!("fetching frontier at height {height}"))


### PR DESCRIPTION


### This PR:
Replaces a raw `u64 - 1` with `checked_sub()`. I noticed some tests were panicking here, and I think handling this is best practice even if we don't think we will hit it. Especially since the fn where this is happening already returns `anyhow::Result`, so we don't need to refactor anything.

I put the integer being subtracted from in the error to distinguish from rust panic message.