### PR TITLE
store next epoch qc in persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.76"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=ma%2Fhotshot-0.5.83#77ad27d40201a8483ca6ad3af9040adf859d5607"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=ma%2Fhotshot-0.5.83#b6337c1a68949734d7a38acce8ea6b282379c443"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-core"
 version = "0.1.58"
-source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#8b6361e251840bb601f7af893b9bd868797c6362"
+source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#b128b5764e5d6e245beeaa42e9db1981f7aab732"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.57"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=ma%2Fhotshot-0.5.83#89b06b6007e88fd20bfc855d3f400b8fa045f379"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=ma%2Fhotshot-0.5.83#6c60698c3df4ca2788c3352740535c6965d24fe1"
 dependencies = [
  "async-broadcast",
  "async-lock 2.8.0",
@@ -6410,7 +6410,7 @@ dependencies = [
 [[package]]
 name = "marketplace-builder-core"
 version = "0.1.58"
-source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#8b6361e251840bb601f7af893b9bd868797c6362"
+source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#b128b5764e5d6e245beeaa42e9db1981f7aab732"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "marketplace-builder-shared"
 version = "0.1.58"
-source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#8b6361e251840bb601f7af893b9bd868797c6362"
+source = "git+https://github.com/EspressoSystems/marketplace-builder-core?branch=ma%2Fhotshot-0.5.83#b128b5764e5d6e245beeaa42e9db1981f7aab732"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -7753,7 +7753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -9297,7 +9297,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "async-trait",
  "clap",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.57"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=ma%2Fhotshot-0.5.83#89b06b6007e88fd20bfc855d3f400b8fa045f379"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=ma%2Fhotshot-0.5.83#6c60698c3df4ca2788c3352740535c6965d24fe1"
 dependencies = [
  "async-broadcast",
  "async-lock 2.8.0",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "hotshot-fakeapi"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4043,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.76"
-source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=ma%2Fhotshot-0.5.83#77ad27d40201a8483ca6ad3af9040adf859d5607"
+source = "git+https://github.com/EspressoSystems/hotshot-query-service?branch=ma%2Fhotshot-0.5.83#b6337c1a68949734d7a38acce8ea6b282379c443"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "hotshot-stake-table"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4201,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -5836,9 +5836,10 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "anyhow",
+ "async-lock 3.4.0",
  "async-trait",
  "bincode",
  "blake3",
@@ -7429,7 +7430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -10544,7 +10545,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.5.83"
-source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#f9bf48ebf53a5fa934614a13f4cbb3069c1e0fda"
+source = "git+https://github.com/EspressoSystems/hotshot?branch=bump%2F0.5.83#bd6781ccf26c67935e14f3d16273aa452982f0ba"
 dependencies = [
  "tracing",
 ]

--- a/sequencer/api/migrations/postgres/V402__next_epoch_qc.sql
+++ b/sequencer/api/migrations/postgres/V402__next_epoch_qc.sql
@@ -1,0 +1,5 @@
+CREATE TABLE next_epoch_quorum_certificate (
+    id bool PRIMARY KEY DEFAULT true,
+    data BYTEA
+);
+REVOKE DELETE, TRUNCATE ON next_epoch_quorum_certificate FROM public;

--- a/sequencer/api/migrations/sqlite/V203__next_epoch_qc.sql
+++ b/sequencer/api/migrations/sqlite/V203__next_epoch_qc.sql
@@ -1,0 +1,4 @@
+CREATE TABLE next_epoch_quorum_certificate (
+    id bool PRIMARY KEY DEFAULT true,
+    data BLOB
+);

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -11,7 +11,9 @@ use hotshot_types::{
     data::{DaProposal, QuorumProposal, QuorumProposal2, VidDisperseShare},
     event::{Event, EventType, HotShotAction, LeafInfo},
     message::{convert_proposal, Proposal},
-    simple_certificate::{QuorumCertificate, QuorumCertificate2, UpgradeCertificate},
+    simple_certificate::{
+        NextEpochQuorumCertificate2, QuorumCertificate, QuorumCertificate2, UpgradeCertificate,
+    },
     traits::{
         block_contents::{BlockHeader, BlockPayload},
         node_implementation::ConsensusTime,
@@ -164,6 +166,10 @@ impl Inner {
 
     fn upgrade_certificate_dir_path(&self) -> PathBuf {
         self.path.join("upgrade_certificate")
+    }
+
+    fn next_epoch_qc(&self) -> PathBuf {
+        self.path.join("next_epoch_quorum_certificate")
     }
 
     /// Overwrite a file if a condition is met.
@@ -839,6 +845,41 @@ impl SequencerPersistence for Persistence {
                 Ok(())
             },
         )
+    }
+
+    async fn store_next_epoch_quorum_certificate(
+        &self,
+        high_qc: NextEpochQuorumCertificate2<SeqTypes>,
+    ) -> anyhow::Result<()> {
+        let mut inner = self.inner.write().await;
+        let path = &inner.next_epoch_qc();
+
+        inner.replace(
+            path,
+            |_| {
+                // Always overwrite the previous file.
+                Ok(true)
+            },
+            |mut file| {
+                let bytes = bincode::serialize(&high_qc).context("serializing next epoch qc")?;
+                file.write_all(&bytes)?;
+                Ok(())
+            },
+        )
+    }
+
+    async fn load_next_epoch_quorum_certificate(
+        &self,
+    ) -> anyhow::Result<Option<NextEpochQuorumCertificate2<SeqTypes>>> {
+        let inner = self.inner.read().await;
+        let path = inner.next_epoch_qc();
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&path).context("read")?;
+        Ok(Some(
+            bincode::deserialize(&bytes).context("deserialize next epoch qc")?,
+        ))
     }
 
     async fn migrate_consensus(

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -12,7 +12,7 @@ use hotshot_types::{
     data::{DaProposal, QuorumProposal, QuorumProposal2, VidDisperseShare},
     event::{Event, EventType, HotShotAction, LeafInfo},
     message::Proposal,
-    simple_certificate::{QuorumCertificate2, UpgradeCertificate},
+    simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2, UpgradeCertificate},
     utils::View,
     vid::VidSchemeType,
 };
@@ -169,5 +169,18 @@ impl SequencerPersistence for NoStorage {
         ) -> Proposal<SeqTypes, QuorumProposal2<SeqTypes>>,
     ) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    async fn store_next_epoch_quorum_certificate(
+        &self,
+        _high_qc: NextEpochQuorumCertificate2<SeqTypes>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn load_next_epoch_quorum_certificate(
+        &self,
+    ) -> anyhow::Result<Option<NextEpochQuorumCertificate2<SeqTypes>>> {
+        Ok(None)
     }
 }


### PR DESCRIPTION
Hotshot now has a new function update_next_epoch_high_qc2() in its storage trait to update the next epoch qc in persistence. This PR adds storage for this quorum certificate and also loads it when loading the consensus data,