### PR TITLE
Fix Typos in `LightClient.t.sol` and `api.rs`

### DIFF
--- a/contracts/test/LightClient.t.sol
+++ b/contracts/test/LightClient.t.sol
@@ -109,7 +109,7 @@ contract LightClient_constructor_Test is LightClientCommonTest {
         lc = new LCMock(_genesis, _genesisStakeTableState, _stateHistoryRetentionPeriod);
     }
 
-    // test that initiazing the contract reverts when the stateHistoryRetentionPeriod is below the
+    // test that initializing the contract reverts when the stateHistoryRetentionPeriod is below the
     // required threshold
     function test_RevertWhen_InvalidStateHistoryRetentionPeriodOnSetUp() public {
         uint32 invalidRetentionPeriod = 10;

--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2452,7 +2452,7 @@ mod test {
             );
             receive_count += 1;
             if receive_count > total_count {
-                tracing::info!("Client Received atleast desired events, exiting loop");
+                tracing::info!("Client Received at least desired events, exiting loop");
                 break;
             }
         }


### PR DESCRIPTION
# Fix Typos in `LightClient.t.sol` and `api.rs`

## Description
This pull request fixes minor typos in the following files:

1. **`contracts/test/LightClient.t.sol`**:
   - Corrected `initiazing` to `initializing` in a comment.

2. **`sequencer/src/api.rs`**:
   - Fixed `atleast` to `at least` in a log message.

## Changes
- These changes improve code readability and maintain high-quality documentation and logs.
- **No functional changes**: The updates are purely related to comments and log messages.

### Context
Maintaining proper spelling and clarity in comments and logs ensures better code quality and easier maintenance for all contributors.

---

Feel free to suggest additional improvements!

