### PR TITLE
Clean up some noisy logging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1736735482,
-        "narHash": "sha256-QOA4jCDyyUM9Y2Vba+HSZ/5LdtCMGaTE/7NkkUzBr50=",
+        "lastModified": 1736907983,
+        "narHash": "sha256-fw55wVwpJW36Md2HZBKuxX3YHGeqsGsspPLtCMVr1Y8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cf960a1938ee91200fe0d2f7b2582fde2429d562",
+        "rev": "eaa365c911441e07e387ff6acc596619fc50b156",
         "type": "github"
       },
       "original": {

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -1362,10 +1362,11 @@ impl Provider<SeqTypes, VidCommonRequest> for Persistence {
             "SELECT data FROM vid_share WHERE payload_hash = $1 LIMIT 1",
         )
         .bind(req.0.to_string())
-        .fetch_one(tx.as_mut())
+        .fetch_optional(tx.as_mut())
         .await
         {
-            Ok((bytes,)) => bytes,
+            Ok(Some((bytes,))) => bytes,
+            Ok(None) => return None,
             Err(err) => {
                 tracing::warn!("error loading VID share: {err:#}");
                 return None;
@@ -1401,10 +1402,11 @@ impl Provider<SeqTypes, PayloadRequest> for Persistence {
             "SELECT data FROM da_proposal WHERE payload_hash = $1 LIMIT 1",
         )
         .bind(req.0.to_string())
-        .fetch_one(tx.as_mut())
+        .fetch_optional(tx.as_mut())
         .await
         {
-            Ok((bytes,)) => bytes,
+            Ok(Some((bytes,))) => bytes,
+            Ok(None) => return None,
             Err(err) => {
                 tracing::warn!("error loading DA proposal: {err:#}");
                 return None;
@@ -1440,7 +1442,7 @@ impl Provider<SeqTypes, LeafRequest<SeqTypes>> for Persistence {
         };
 
         let (leaf, qc) = match fetch_leaf_from_proposals(&mut tx, req).await {
-            Ok(res) => res,
+            Ok(res) => res?,
             Err(err) => {
                 tracing::info!("requested leaf not found in undecided proposals: {err:#}");
                 return None;
@@ -1460,22 +1462,28 @@ impl Provider<SeqTypes, LeafRequest<SeqTypes>> for Persistence {
 async fn fetch_leaf_from_proposals<Mode: TransactionMode>(
     tx: &mut Transaction<Mode>,
     req: LeafRequest<SeqTypes>,
-) -> anyhow::Result<(Leaf, QuorumCertificate<SeqTypes>)> {
+) -> anyhow::Result<Option<(Leaf, QuorumCertificate<SeqTypes>)>> {
     // Look for a quorum proposal corresponding to this leaf.
-    let (proposal_bytes,) =
+    let Some((proposal_bytes,)) =
         query_as::<(Vec<u8>,)>("SELECT data FROM quorum_proposals WHERE leaf_hash = $1 LIMIT 1")
             .bind(req.expected_leaf.to_string())
-            .fetch_one(tx.as_mut())
+            .fetch_optional(tx.as_mut())
             .await
-            .context("fetching proposal")?;
+            .context("fetching proposal")?
+    else {
+        return Ok(None);
+    };
 
     // Look for a QC corresponding to this leaf.
-    let (qc_bytes,) =
+    let Some((qc_bytes,)) =
         query_as::<(Vec<u8>,)>("SELECT data FROM quorum_certificate WHERE leaf_hash = $1 LIMIT 1")
             .bind(req.expected_leaf.to_string())
-            .fetch_one(tx.as_mut())
+            .fetch_optional(tx.as_mut())
             .await
-            .context("fetching QC")?;
+            .context("fetching QC")?
+    else {
+        return Ok(None);
+    };
 
     let proposal: Proposal<SeqTypes, QuorumProposal<SeqTypes>> =
         bincode::deserialize(&proposal_bytes).context("deserializing quorum proposal")?;
@@ -1483,7 +1491,7 @@ async fn fetch_leaf_from_proposals<Mode: TransactionMode>(
         bincode::deserialize(&qc_bytes).context("deserializing quorum certificate")?;
 
     let leaf = Leaf::from_quorum_proposal(&proposal.data);
-    Ok((leaf, qc))
+    Ok(Some((leaf, qc)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Don't log warning when a requested object is simply not found; it is considered normal for nodes to sometimes be missing this data. We should only warn when there is some other error when looking up the data (connection closed ,etc)