### PR TITLE
Not work link blocknative.rs

### DIFF
--- a/utils/src/blocknative.rs
+++ b/utils/src/blocknative.rs
@@ -11,7 +11,7 @@ use reqwest::{header::AUTHORIZATION, Client};
 use serde::Deserialize;
 use url::Url;
 
-const URL: &str = "https://api.blocknative.com/gasprices/blockprices";
+const URL: &str = "";
 
 /// A client over HTTP for the [BlockNative](https://www.blocknative.com/gas-estimator) gas tracker API
 /// that implements the `GasOracle` trait.


### PR DESCRIPTION
The link to the BlockNative API at https://api.blocknative.com/gasprices/blockprices was non-functional or incorrect, so it was updated to reflect the change.