### PR TITLE
Conditionally compile versions

### DIFF
--- a/.github/workflows/cargo-features.yml
+++ b/.github/workflows/cargo-features.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   cargo-features:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: taiki-e/install-action@cargo-hack
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   RUST_LOG: info,libp2p=off,node=error
+  RUSTFLAGS: "--cfg feature=\"fee\" --cfg feature=\"marketplace\""
   CARGO_TERM_COLOR: always
   # Save the process compose logs
   PC_LOGS: /tmp/pc.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,3 +223,12 @@ paste = "1.0"
 rand = "0.8.5"
 time = "0.3"
 trait-set = "0.3.0"
+
+[profile.test]
+opt-level = 1
+[profile.test.package.tests]
+opt-level = 0
+[profile.test.package.client]
+opt-level = 0
+[profile.test.package.hotshot-state-prover]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,13 @@ rand = "0.8.5"
 time = "0.3"
 trait-set = "0.3.0"
 
+[profile.dev]
+# No optimizations
+opt-level = 0
+# Skip compiling the debug information.
+debug = false
+# Skip linking symbols.
+strip = true
 [profile.test]
 opt-level = 1
 [profile.test.package.tests]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,19 +223,3 @@ paste = "1.0"
 rand = "0.8.5"
 time = "0.3"
 trait-set = "0.3.0"
-
-[profile.dev]
-# No optimizations
-opt-level = 0
-# Skip compiling the debug information.
-debug = false
-# Skip linking symbols.
-strip = true
-[profile.test]
-opt-level = 1
-[profile.test.package.tests]
-opt-level = 0
-[profile.test.package.client]
-opt-level = 0
-[profile.test.package.hotshot-state-prover]
-opt-level = 3

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["fee"]
 testing = [
     "hotshot-testing",
     "marketplace-builder-core",
@@ -15,6 +16,9 @@ testing = [
 ]
 benchmarking = []
 embedded-db = ["hotshot-query-service/embedded-db"]
+fee = []
+pos = []
+marketplace = []
 
 [[bin]]
 name = "espresso-dev-node"

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -38,6 +38,7 @@ pub async fn main() -> anyhow::Result<()> {
     let upgrade = genesis.upgrade_version;
 
     match (base, upgrade) {
+        #[cfg(all(feature = "fee", feature = "marketplace"))]
         (FeeVersion::VERSION, MarketplaceVersion::VERSION) => {
             run(
                 genesis,
@@ -47,6 +48,7 @@ pub async fn main() -> anyhow::Result<()> {
             )
             .await
         }
+        #[cfg(feature = "fee")]
         (FeeVersion::VERSION, _) => {
             run(
                 genesis,
@@ -56,6 +58,7 @@ pub async fn main() -> anyhow::Result<()> {
             )
             .await
         }
+        #[cfg(feature = "marketplace")]
         (MarketplaceVersion::VERSION, _) => {
             run(
                 genesis,

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -8,6 +8,7 @@ use super::{
     persistence, Genesis, L1Params, NetworkParams,
 };
 use clap::Parser;
+#[allow(unused_imports)]
 use espresso_types::{
     traits::NullEventConsumer, FeeVersion, MarketplaceVersion, SequencerVersions,
     SolverAuctionResultsProvider, V0_0,


### PR DESCRIPTION
Closes #2558 

With this change you can pass `--feature fee` to only compile fee version. The idea is to reduce compile time by targeting only those features you are currently working on / testing. For CI in its current state we will probably need to enable 2 versions most of the time.

 I'm not sure about configuration through the environment, but the following leads me to believe we can pass the proper configuration to `rustc`:

    RUSTFLAGS="--cfg feature=\"fee\"" cargo +nightly -Z unstable-options rustc --print cfg

Note that `--print` option of `cargo rustc` is only available on nightly.