### PR TITLE
don't restrict tests to run in serial

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,8 +3,14 @@
 slow-timeout = { period = "2m", terminate-after = 3 }
 default-filter = 'not (test(slow_) | package(tests))'
 retries = 2
-# TODO: ensure tests can run in parallel
-threads-required = 'num-test-threads'
+
+[[profile.default.overrides]]
+filter = """
+test(tests_2::catchup::test_all_restart) |
+test(tests_4::test_marketplace) |
+test(tests_6::test_epochs)
+"""
+retries = 10
 
 [[profile.default.overrides]]
 # These tests are fast if they work (usually about 150ms) but sometimes they
@@ -36,3 +42,14 @@ retries = 2
 slow-timeout = "2m"
 default-filter = 'package(tests)'
 retries = 2
+
+# Serial required
+# TRY 3 FAIL [   2.790s] hotshot-testing::tests_4 tests_4::test_marketplace::test_marketplace_builders_down::testtypes_::memoryimpl_::test_marketplace_builders_down
+# TRY 3 FAIL [   4.446s] hotshot-testing::tests_4 tests_4::test_marketplace::test_marketplace_fallback_builder_down::testtypes_::memoryimpl_::test_marketplace_fallback_builder_down
+# TRY 3 FAIL [   5.119s] hotshot-testing::tests_4 tests_4::test_marketplace::test_marketplace_upgrade::testtypes_::memoryimpl_::test_marketplace_upgrade
+#
+# FLAKY 2/3 [  12.037s] hotshot-testing::tests_2 tests_2::catchup::test_all_restart::testtypes_::pushcdnimpl_::test_all_restart
+# FLAKY 2/3 [  49.943s] hotshot-testing::tests_6 tests_6::test_epochs::test_combined_network_cdn_crash_with_epochs::testtypes_::combinedimpl_::test_combined_network_cdn_crash_with_epochs
+# FLAKY 2/3 [   6.968s] hotshot-testing::tests_6 tests_6::test_epochs::test_epoch_end::testtwostaketablestypes_::pushcdnimpl_::test_epoch_end
+# FLAKY 2/3 [ 125.353s] sequencer api::test::test_fee_upgrade_view_based
+# FLAKY 2/3 [   2.870s] sequencer api::test::test_hotshot_event_streaming

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,11 +4,13 @@ slow-timeout = { period = "2m", terminate-after = 3 }
 default-filter = 'not (test(slow_) | package(tests))'
 retries = 2
 
+# More flaky tests
 [[profile.default.overrides]]
 filter = """
 test(tests_2::catchup::test_all_restart) |
 test(tests_4::test_marketplace) |
-test(tests_6::test_epochs)
+test(tests_6::test_epochs) |
+test(tests_4::test_with_builder_failures::test_with_builder_failures::testtypes_::pushcdnimpl_::test_with_builder_failures)
 """
 retries = 10
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,10 +9,16 @@ retries = 2
 filter = """
 test(tests_2::catchup::test_all_restart) |
 test(tests_4::test_marketplace) |
-test(tests_6::test_epochs) |
-test(tests_4::test_with_builder_failures::test_with_builder_failures)
+test(tests_6::test_epochs)
 """
 retries = 10
+
+# Sometimes fails persistently in CI
+[[profile.default.overrides]]
+filter = """
+test(tests_4::test_with_builder_failures::test_with_builder_failures)
+"""
+threads-required = 2
 
 [[profile.default.overrides]]
 # These tests are fast if they work (usually about 150ms) but sometimes they

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,7 +10,7 @@ filter = """
 test(tests_2::catchup::test_all_restart) |
 test(tests_4::test_marketplace) |
 test(tests_6::test_epochs) |
-test(tests_4::test_with_builder_failures::test_with_builder_failures::testtypes_::pushcdnimpl_::test_with_builder_failures)
+test(tests_4::test_with_builder_failures::test_with_builder_failures)
 """
 retries = 10
 


### PR DESCRIPTION
This seems to work pretty well locally except for

```
tests_4::test_marketplace::test_marketplace_fallback_builder_down::testtypes_::memoryimpl_::test_marketplace_fallback_builder_down
```

which I can't seem to get to pass at all, even if it's running in isolation.