### PR TITLE
Per-crate licensing for HS

### DIFF
--- a/hotshot-builder-api/Cargo.toml
+++ b/hotshot-builder-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hotshot-builder-api"
 version = "0.1.7"
 edition = "2021"
+license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/hotshot-builder-core-refactored/Cargo.toml
+++ b/hotshot-builder-core-refactored/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hotshot-builder-core-refactored"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 marketplace-builder-shared = { workspace = true }

--- a/hotshot-builder-core/Cargo.toml
+++ b/hotshot-builder-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hotshot-builder-core"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 marketplace-builder-shared = { workspace = true }

--- a/hotshot-events-service/Cargo.toml
+++ b/hotshot-events-service/Cargo.toml
@@ -3,7 +3,6 @@ name = "hotshot-events-service"
 version = "0.1.57"
 edition = "2021"
 license = "MIT"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/hotshot-events-service/Cargo.toml
+++ b/hotshot-events-service/Cargo.toml
@@ -2,6 +2,8 @@
 name = "hotshot-events-service"
 version = "0.1.57"
 edition = "2021"
+license = "MIT"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/hotshot-example-types/Cargo.toml
+++ b/hotshot-example-types/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 description = "Types and traits for the HotShot consesus module"
 authors = { workspace = true }
+license = "MIT"
 
 [features]
 default = []

--- a/hotshot-examples/Cargo.toml
+++ b/hotshot-examples/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 name = "hotshot-examples"
 readme = "README.md"
 version = { workspace = true }
+license = "MIT"
 
 [features]
 default = ["docs", "doc-images", "hotshot-testing"]

--- a/hotshot-fakeapi/Cargo.toml
+++ b/hotshot-fakeapi/Cargo.toml
@@ -3,6 +3,7 @@ name = "hotshot-fakeapi"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/hotshot-macros/Cargo.toml
+++ b/hotshot-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "hotshot-macros"
 version = { workspace = true }
 edition = { workspace = true }
 description = "Macros for hotshot tests"
+license = "MIT"
 
 [dependencies]
 derive_builder = { workspace = true }

--- a/hotshot-orchestrator/Cargo.toml
+++ b/hotshot-orchestrator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hotshot-orchestrator"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/hotshot-stake-table/Cargo.toml
+++ b/hotshot-stake-table/Cargo.toml
@@ -4,6 +4,7 @@ description = "Stake table implementations for HotShot"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 ark-bn254 = "0.4"

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -5,6 +5,7 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 
+
 [dependencies]
 anyhow = { workspace = true }
 ark-bn254 = { workspace = true }

--- a/hotshot-state-prover/Cargo.toml
+++ b/hotshot-state-prover/Cargo.toml
@@ -5,7 +5,6 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 
-
 [dependencies]
 anyhow = { workspace = true }
 ark-bn254 = { workspace = true }

--- a/hotshot-task-impls/Cargo.toml
+++ b/hotshot-task-impls/Cargo.toml
@@ -4,6 +4,7 @@ description = "Async task implementations for consensus"
 edition = { workspace = true }
 name = "hotshot-task-impls"
 version = { workspace = true }
+license = "MIT"
 
 [features]
 example-upgrade = []

--- a/hotshot-task/Cargo.toml
+++ b/hotshot-task/Cargo.toml
@@ -3,6 +3,8 @@ authors = { workspace = true }
 name = "hotshot-task"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/hotshot-task/Cargo.toml
+++ b/hotshot-task/Cargo.toml
@@ -4,7 +4,6 @@ name = "hotshot-task"
 version = { workspace = true }
 edition = { workspace = true }
 license = "MIT"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/hotshot-testing/Cargo.toml
+++ b/hotshot-testing/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 description = "Types and traits for the HotShot consesus module"
 authors = { workspace = true }
+license = "MIT"
 
 [features]
 default = []

--- a/hotshot-types/Cargo.toml
+++ b/hotshot-types/Cargo.toml
@@ -4,6 +4,7 @@ description = "Types and traits for the HotShot consesus module"
 edition = "2021"
 name = "hotshot-types"
 version = "0.1.11"
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/hotshot-utils/Cargo.toml
+++ b/hotshot-utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "hotshot-utils"
 version = { workspace = true }
 edition = { workspace = true }
 description = "Utils"
+license = "MIT"
 
 [dependencies]
 tracing = { workspace = true }

--- a/hotshot/Cargo.toml
+++ b/hotshot/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 name = "hotshot"
 readme = "README.md"
 version = { workspace = true }
+license = "MIT"
 
 [features]
 default = ["docs", "doc-images"]

--- a/marketplace-builder-core/Cargo.toml
+++ b/marketplace-builder-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marketplace-builder-core"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 marketplace-builder-shared = { workspace = true }

--- a/marketplace-builder-shared/Cargo.toml
+++ b/marketplace-builder-shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marketplace-builder-shared"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/marketplace-builder/Cargo.toml
+++ b/marketplace-builder/Cargo.toml
@@ -4,6 +4,7 @@ description = "A standalone builder service, marketplace version"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [features]
 testing = ["hotshot-query-service", "sequencer-utils", "tempfile"]

--- a/request-response/Cargo.toml
+++ b/request-response/Cargo.toml
@@ -2,6 +2,7 @@
 name = "request-response"
 version = { workspace = true }
 edition = { workspace = true }
+license = "MIT"
 
 [dev-dependencies]
 serde = { workspace = true }


### PR DESCRIPTION
When we switched to a monorepo, we added HS crates to this repository. This PR switches all former [HS](https://github.com/EspressoSystems/HotShot/tree/main/crates) and [`marketplace-builder-core`](https://github.com/EspressoSystems/marketplace-builder-core/tree/main/crates) repos to use the MIT license. 