### PR TITLE
chore: Clarify AddAssign implementation comment

### DIFF
--- a/node-metrics/src/service/client_id/mod.rs
+++ b/node-metrics/src/service/client_id/mod.rs
@@ -52,7 +52,7 @@ impl Add<u64> for ClientId {
     }
 }
 
-/// [AddAssign] implements basic addition for [ClientId], which allows [u64]s to
+/// [AddAssign] implements basic addition assignment for [ClientId], which allows [u64]s to
 /// be added to the mutable [ClientId] for convenience.
 ///
 /// Example:


### PR DESCRIPTION
### This PR:

The comment for `AddAssign` mentioned "basic addition," which might be misleading since `AddAssign` is specifically for "addition assignment" (`+=`).
Updated the wording to make it clearer.

[x] PR description is clear enough for reviewers.
