### PR TITLE
Adds `sqlite-unbundled` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -1799,6 +1799,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -1812,7 +1832,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "shlex",
  "syn 2.0.95",
 ]
@@ -5746,7 +5766,7 @@ name = "icicle-cuda-runtime"
 version = "1.5.1"
 source = "git+https://github.com/ingonyama-zk/icicle.git?tag=v1.5.1#3d1e43365c8508fed6dfc6ddc7cc0abeb0fc7b9a"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "bitflags 1.3.2",
 ]
 
@@ -6579,6 +6599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,6 +7108,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "bindgen 0.69.5",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -8752,7 +8779,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "socket2 0.5.8",
  "thiserror 2.0.10",
@@ -8770,7 +8797,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
@@ -9416,6 +9443,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/hotshot-query-service/Cargo.toml
+++ b/hotshot-query-service/Cargo.toml
@@ -23,7 +23,11 @@ default = ["file-system-data-source", "metrics-data-source", "sql-data-source"]
 # Enables support for an embedded SQLite database instead of PostgreSQL.
 # Ideal for lightweight nodes that benefit from pruning and merklized state storage,
 # offering advantages over file system storage.
-embedded-db = []
+embedded-db = ["sqlx/sqlite"]
+
+# As above, enables support for an embedded SQLite database instead of PostgreSQL.
+# But uses system SQlite instead of compiling the bundled version
+sqlite-unbundled = ["sqlx/sqlite-unbundled"]
 
 # Enable the availability data source backed by the local file system.
 file-system-data-source = ["atomic_store"]
@@ -108,7 +112,6 @@ sqlx = { version = "0.8", features = [
     "bit-vec",
     "postgres",
     "runtime-tokio",
-    "sqlite",
     "tls-native-tls",
 ], optional = true }
 

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -1769,6 +1769,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2302,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -6206,10 +6246,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "libm"
@@ -6699,6 +6755,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -8165,7 +8222,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "socket2 0.5.8",
  "thiserror 2.0.10",
@@ -8183,7 +8240,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
@@ -8809,6 +8866,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/sequencer-sqlite/Cargo.toml
+++ b/sequencer-sqlite/Cargo.toml
@@ -6,8 +6,13 @@ name = "sequencer-sqlite"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["embedded-db"]
+sqlite-unbundled = ["sequencer/sqlite-unbundled"]
+embedded-db = ["sequencer/embedded-db"]
+
 [dependencies]
-sequencer = { path = "../sequencer" , features = ["embedded-db"] }
+sequencer = { path = "../sequencer" }
 tokio = { version = "1", default-features = false, features = [
 	"rt-multi-thread",
 	"macros",

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -15,7 +15,8 @@ testing = [
     "hotshot-query-service/testing"
 ]
 benchmarking = []
-embedded-db = ["hotshot-query-service/embedded-db"]
+embedded-db = ["hotshot-query-service/embedded-db", "sqlx/sqlite"]
+sqlite-unbundled = ["hotshot-query-service/sqlite-unbundled", "sqlx/sqlite-unbundled"]
 fee = []
 pos = []
 marketplace = []
@@ -109,7 +110,6 @@ sqlx = { workspace = true, features = [
 	"bit-vec",
 	"postgres",
 	"runtime-tokio",
-	"sqlite",
 	"tls-native-tls",
 ] }
 static_assertions = "1"


### PR DESCRIPTION
Adds `sqlite-unbundled` to turn on `sqlx/sqlite-unbundled`. With this enabled, native/system sqlite will be used. Avoiding the need to build sqlite itself. This will probably be preferred usage in most dev/ test cycles, as most systems have a way of providing a modern sqlite3, and compiling it is slow. Feature `embedded-db` should continue to work as before (with sqlx bundled sqlite), so this change shouldn't disrupt any current operations.

