### PR TITLE
CI: only build without lockfile if dependencies changed

### DIFF
--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -49,13 +49,14 @@ jobs:
             const repo = context.repo.repo;
             const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-            const commentBody = `Unable to build without Cargo.lock file.
+            const commentTitle = "Unable to build without Cargo.lock file"
+            const commentBody = `${commentTitle}.
 
             This means that after this change 3rd party projects may have
             difficulties using crates in this repo as a dependency. If this
             isn't easy to fix please open an issue so we can fix it later.
 
-            For the failing build see: ${runUrl}
+            For the first failing build see: ${runUrl}
 
             To reproduce locally run
 
@@ -74,7 +75,7 @@ jobs:
             });
 
             // Find existing comment
-            const existingComment = comments.find(c => c.body == commentBody);
+            const existingComment = comments.find(c => c.body.startsWith(commentTitle));
             if (!existingComment) {
               await github.rest.issues.createComment({
                 owner,
@@ -83,5 +84,5 @@ jobs:
                 body: commentBody
               });
             } else {
-              console.log("Already commentted.")
+              console.log("Already commented.")
             }

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -40,26 +40,45 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Unable to build without Cargo.lock file.
+        script: |
+          const issue_number = context.issue.number;
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
 
-              This means that after this change 3rd party projects may have
-              difficulties using crates in this repo as a dependency. If this
-              isn't easy to fix please open an issue so we can fix it later.
+          const commentBody = `Unable to build without Cargo.lock file.
 
-              To reproduce locally run
+          This means that after this change 3rd party projects may have
+          difficulties using crates in this repo as a dependency. If this
+          isn't easy to fix please open an issue so we can fix it later.
 
-              \`\`\`
-              cargo generate-lockfile
-              cargo check --all-targets
-              \`\`\`
+          To reproduce locally run
 
-              This PR can still be merged.`
-            })
+          \`\`\`
+          cargo generate-lockfile
+          cargo check --all-targets
+          \`\`\`
+
+          This PR can still be merged.`;
+
+          // Fetch existing comments
+          const { data: comments } = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number,
+          });
+
+          // Find existing comment
+          const existingComment = comments.find(c => c.body == commentBody);
+          if (!existingComment) {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: commentBody
+            });
+          } else {
+             console.log("Already commentted.")
+          }

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -11,10 +11,10 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   pull_request:
-    # Only run on PRs if dependencies were modified.
-    paths:
-      - "Cargo.lock"
-      - "**/Cargo.toml"
+    # # Only run on PRs if dependencies were modified.
+    # paths:
+    #   - "Cargo.lock"
+    #   - "**/Cargo.toml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   pull_request:
+    # Only run on PRs if dependencies were modified.
+    paths:
+      - "Cargo.lock"
+      - "**/Cargo.toml"
   workflow_dispatch:
 
 concurrency:
@@ -33,3 +37,30 @@ jobs:
         run: |
           cargo generate-lockfile
           cargo check --all-targets
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        # TODO uncomment
+        # if: failure()
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Unable to build without Cargo.lock file.
+
+              This means that after this change 3rd party projects may have
+              difficulties using crates in this repo as a dependency. If this
+              isn't easy to fix please open an issue so we can fix it later.
+
+              To reproduce locally run
+
+              \`\`\`
+              cargo generate-lockfile
+              cargo check --all-targets
+              \`\`\`
+
+              This PR can still be merged.`
+            })

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -11,10 +11,10 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   pull_request:
-    # # Only run on PRs if dependencies were modified.
-    # paths:
-    #   - "Cargo.lock"
-    #   - "**/Cargo.toml"
+    # Only run on PRs if dependencies were modified.
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -43,42 +43,45 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const issue_number = context.issue.number;
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
+          script: |
+            const issue_number = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-          const commentBody = `Unable to build without Cargo.lock file.
+            const commentBody = `Unable to build without Cargo.lock file.
 
-          This means that after this change 3rd party projects may have
-          difficulties using crates in this repo as a dependency. If this
-          isn't easy to fix please open an issue so we can fix it later.
+            This means that after this change 3rd party projects may have
+            difficulties using crates in this repo as a dependency. If this
+            isn't easy to fix please open an issue so we can fix it later.
 
-          To reproduce locally run
+            For the failing build see: ${runUrl}
 
-          \`\`\`
-          cargo generate-lockfile
-          cargo check --all-targets
-          \`\`\`
+            To reproduce locally run
 
-          This PR can still be merged.`;
+            \`\`\`
+            cargo generate-lockfile
+            cargo check --all-targets
+            \`\`\`
 
-          // Fetch existing comments
-          const { data: comments } = await github.rest.issues.listComments({
-            owner,
-            repo,
-            issue_number,
-          });
+            This PR can still be merged.`;
 
-          // Find existing comment
-          const existingComment = comments.find(c => c.body == commentBody);
-          if (!existingComment) {
-            await github.rest.issues.createComment({
+            // Fetch existing comments
+            const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
               issue_number,
-              body: commentBody
             });
-          } else {
-             console.log("Already commentted.")
-          }
+
+            // Find existing comment
+            const existingComment = comments.find(c => c.body == commentBody);
+            if (!existingComment) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: commentBody
+              });
+            } else {
+              console.log("Already commentted.")
+            }

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -40,8 +40,7 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
-        # TODO uncomment
-        # if: failure()
+        if: failure()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Lint](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/lint.yml/badge.svg)](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/lint.yml)
 [![Audit](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/audit.yml/badge.svg)](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/audit.yml)
 [![Ubuntu](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/ubuntu-install-without-nix.yml/badge.svg)](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/ubuntu-install-without-nix.yml)
+[![Build without lockfile](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/build-without-lockfile.yml/badge.svg)](https://github.com/EspressoSystems/espresso-sequencer/actions/workflows/build-without-lockfile.yml)
 [![Coverage Status](https://coveralls.io/repos/github/EspressoSystems/espresso-sequencer/badge.svg?branch=main)](https://coveralls.io/github/EspressoSystems/espresso-sequencer?branch=main)
 
 The Espresso Sequencer offers rollups credible neutrality and enhanced interoperability, without compromising on scale.


### PR DESCRIPTION
- Do not run this check on PRs unless dependencies are modified.
- Comment on the PR in case of failure to communicate that PR can still be merged. There is such an example comment below.
- Add badge to readme to make failures on main or scheduled builds visible.