### PR TITLE
Add a default port to ESPRESSO_SEQUENCER_API_PORT

### DIFF
--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -413,7 +413,7 @@ impl Options {
 #[derive(Parser, Clone, Copy, Debug)]
 pub struct Http {
     /// Port that the HTTP API will use.
-    #[clap(long, env = "ESPRESSO_SEQUENCER_API_PORT")]
+    #[clap(long, env = "ESPRESSO_SEQUENCER_API_PORT", default_value = "8080")]
     pub port: u16,
 
     /// Maximum number of concurrent HTTP connections the server will allow.


### PR DESCRIPTION
To reduce the number of required options to launch a basic sequencer docker, we want to set `ESPRESSO_SEQUENCER_API_PORT` to a sane default. Port 80 chosen since the API communicates over http.
