### PR TITLE
Fix builder compatibility with Decaf version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,7 +4936,6 @@ dependencies = [
  "futures",
  "hotshot-types",
  "serde",
- "serde_json",
  "tagged-base64",
  "thiserror 1.0.69",
  "tide-disco",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -57,7 +57,7 @@ pub mod testing {
         },
     };
     use hotshot_builder_api::v0_2::block_info::{
-        AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo,
+        AvailableBlockData, AvailableBlockHeaderInputV1, AvailableBlockInfo,
     };
     use hotshot_events_service::{
         events::{Error as EventStreamApiError, Options as EventStreamingApiOptions},
@@ -489,7 +489,7 @@ pub mod testing {
 
         // Test claiming block header input
         let _available_block_header = match builder_client
-                .get::<AvailableBlockHeaderInput<SeqTypes>>(&format!(
+                .get::<AvailableBlockHeaderInputV1<SeqTypes>>(&format!(
                     "block_info/claimheaderinput/{builder_commitment}/{view_num}/{hotshot_client_pub_key}/{encoded_signature}"
                 ))
                 .send()

--- a/hotshot-builder-api/Cargo.toml
+++ b/hotshot-builder-api/Cargo.toml
@@ -13,7 +13,6 @@ derive_more = { workspace = true, features = ["from"] }
 futures = { workspace = true }
 hotshot-types = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 tagged-base64 = { workspace = true }
 thiserror = { workspace = true }
 tide-disco = { workspace = true }

--- a/hotshot-builder-api/api/v0_1/builder.toml
+++ b/hotshot-builder-api/api/v0_1/builder.toml
@@ -60,7 +60,9 @@ Returns application-specific encoded transactions type
 """
 
 [route.claim_block_with_num_nodes]
-PATH = ["claimblockwithnumnodes/:block_hash/:view_number/:sender/:signature/:num_nodes"]
+PATH = [
+    "claimblockwithnumnodes/:block_hash/:view_number/:sender/:signature/:num_nodes",
+]
 ":block_hash" = "TaggedBase64"
 ":view_number" = "Integer"
 ":sender" = "TaggedBase64"
@@ -74,6 +76,19 @@ Returns application-specific encoded transactions type
 
 [route.claim_header_input]
 PATH = ["claimheaderinput/:block_hash/:view_number/:sender/:signature"]
+":block_hash" = "TaggedBase64"
+":view_number" = "Integer"
+":sender" = "TaggedBase64"
+":signature" = "TaggedBase64"
+DOC = """
+Get the specified block candidate.
+
+Returns application-specific block header type
+"""
+
+
+[route.claim_header_input_v2]
+PATH = ["claimheaderinput/v2/:block_hash/:view_number/:sender/:signature"]
 ":block_hash" = "TaggedBase64"
 ":view_number" = "Integer"
 ":sender" = "TaggedBase64"

--- a/hotshot-builder-api/src/v0_1/block_info.rs
+++ b/hotshot-builder-api/src/v0_1/block_info.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::BuilderSignatureKey, BlockPayload},
     utils::BuilderCommitment,
-    vid::VidCommitment,
+    vid::{VidCommitment, VidPrecomputeData},
 };
 use serde::{Deserialize, Serialize};
 
@@ -46,10 +46,9 @@ impl<TYPES: NodeType> AvailableBlockData<TYPES> {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct AvailableBlockHeaderInput<TYPES: NodeType> {
+pub struct AvailableBlockHeaderInputV1<TYPES: NodeType> {
     pub vid_commitment: VidCommitment,
-    #[serde(default)]
-    pub vid_precompute_data: Option<serde_json::Value>,
+    pub vid_precompute_data: VidPrecomputeData,
     // signature over vid_commitment, BlockPayload::Metadata, and offered_fee
     pub fee_signature:
         <<TYPES as NodeType>::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,
@@ -59,7 +58,37 @@ pub struct AvailableBlockHeaderInput<TYPES: NodeType> {
     pub sender: <TYPES as NodeType>::BuilderSignatureKey,
 }
 
-impl<TYPES: NodeType> AvailableBlockHeaderInput<TYPES> {
+impl<TYPES: NodeType> AvailableBlockHeaderInputV1<TYPES> {
+    pub fn validate_signature(
+        &self,
+        offered_fee: u64,
+        metadata: &<TYPES::BlockPayload as BlockPayload<TYPES>>::Metadata,
+    ) -> bool {
+        self.sender
+            .validate_builder_signature(&self.message_signature, self.vid_commitment.as_ref())
+            && self.sender.validate_fee_signature(
+                &self.fee_signature,
+                offered_fee,
+                metadata,
+                &self.vid_commitment,
+            )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(bound = "")]
+pub struct AvailableBlockHeaderInputV2<TYPES: NodeType> {
+    pub vid_commitment: VidCommitment,
+    // signature over vid_commitment, BlockPayload::Metadata, and offered_fee
+    pub fee_signature:
+        <<TYPES as NodeType>::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,
+    // signature over the current response
+    pub message_signature:
+        <<TYPES as NodeType>::BuilderSignatureKey as BuilderSignatureKey>::BuilderSignature,
+    pub sender: <TYPES as NodeType>::BuilderSignatureKey,
+}
+
+impl<TYPES: NodeType> AvailableBlockHeaderInputV2<TYPES> {
     pub fn validate_signature(
         &self,
         offered_fee: u64,

--- a/hotshot-builder-api/src/v0_1/data_source.rs
+++ b/hotshot-builder-api/src/v0_1/data_source.rs
@@ -13,7 +13,7 @@ use hotshot_types::{
 };
 
 use super::{
-    block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
+    block_info::{AvailableBlockData, AvailableBlockHeaderInputV1, AvailableBlockInfo},
     builder::{BuildError, TransactionStatus},
 };
 
@@ -55,7 +55,7 @@ pub trait BuilderDataSource<TYPES: NodeType> {
         view_number: u64,
         sender: TYPES::SignatureKey,
         signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError>;
+    ) -> Result<AvailableBlockHeaderInputV1<TYPES>, BuildError>;
 
     /// To get the builder's address
     async fn builder_address(&self) -> Result<TYPES::BuilderSignatureKey, BuildError>;

--- a/hotshot-builder-core-refactored/src/block_store.rs
+++ b/hotshot-builder-core-refactored/src/block_store.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use hotshot::traits::BlockPayload;
 use hotshot_builder_api::v0_1::block_info::AvailableBlockInfo;
 use hotshot_types::traits::signature_key::BuilderSignatureKey;
-use hotshot_types::vid::VidCommitment;
+use hotshot_types::vid::{VidCommitment, VidPrecomputeData};
 use marketplace_builder_shared::error::Error;
 use marketplace_builder_shared::utils::{BuilderKeys, WaitAndKeep};
 use marketplace_builder_shared::{
@@ -19,7 +19,7 @@ use hotshot_types::traits::node_implementation::NodeType;
 pub struct BlockInfo<Types: NodeType> {
     pub block_payload: Types::BlockPayload,
     pub metadata: <<Types as NodeType>::BlockPayload as BlockPayload<Types>>::Metadata,
-    pub vid_data: WaitAndKeep<VidCommitment>,
+    pub vid_data: WaitAndKeep<(VidCommitment, VidPrecomputeData)>,
     pub block_size: u64,
     pub offered_fee: u64,
     // Could we have included more transactions with this block, but chose not to?

--- a/hotshot-builder-core-refactored/src/service.rs
+++ b/hotshot-builder-core-refactored/src/service.rs
@@ -1,10 +1,15 @@
 use hotshot::types::Event;
-use hotshot_builder_api::v0_1::{
-    block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
-    builder::{define_api, submit_api, BuildError, Error as BuilderApiError, TransactionStatus},
-    data_source::{AcceptsTxnSubmits, BuilderDataSource},
+use hotshot_builder_api::{
+    v0_1::{
+        block_info::{AvailableBlockData, AvailableBlockInfo},
+        builder::{
+            define_api, submit_api, BuildError, Error as BuilderApiError, TransactionStatus,
+        },
+        data_source::{AcceptsTxnSubmits, BuilderDataSource},
+    },
+    v0_2::block_info::AvailableBlockHeaderInputV1,
 };
-use hotshot_types::traits::block_contents::{advz_commitment, Transaction};
+use hotshot_types::traits::block_contents::{precompute_vid_commitment, Transaction};
 use hotshot_types::traits::EncodeBytes;
 use hotshot_types::{
     event::EventType,
@@ -402,8 +407,9 @@ where
         let num_nodes = self.num_nodes.load(Ordering::Relaxed);
 
         let fut = async move {
-            let join_handle =
-                tokio::task::spawn_blocking(move || advz_commitment(&encoded_txns, num_nodes));
+            let join_handle = tokio::task::spawn_blocking(move || {
+                precompute_vid_commitment(&encoded_txns, num_nodes)
+            });
             join_handle.await.unwrap()
         };
 
@@ -561,7 +567,7 @@ where
     pub(crate) async fn claim_block_header_input_implementation(
         &self,
         block_id: BlockId<Types>,
-    ) -> Result<(bool, AvailableBlockHeaderInput<Types>), Error<Types>> {
+    ) -> Result<(bool, AvailableBlockHeaderInputV1<Types>), Error<Types>> {
         let metadata;
         let offered_fee;
         let truncated;
@@ -586,7 +592,7 @@ where
             vid_data = block_info.vid_data.clone();
         };
 
-        let vid_commitment = vid_data.resolve().await;
+        let (vid_commitment, vid_precompute_data) = vid_data.resolve().await;
 
         // sign over the vid commitment
         let signature_over_vid_commitment =
@@ -604,9 +610,9 @@ where
         )
         .map_err(Error::Signing)?;
 
-        let response = AvailableBlockHeaderInput::<Types> {
+        let response = AvailableBlockHeaderInputV1 {
             vid_commitment,
-            vid_precompute_data: None,
+            vid_precompute_data,
             fee_signature: signature_over_fee_info,
             message_signature: signature_over_vid_commitment,
             sender: self.builder_keys.0.clone(),
@@ -723,7 +729,7 @@ where
         view_number: u64,
         sender: Types::SignatureKey,
         signature: &<<Types as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<Types>, BuildError> {
+    ) -> Result<AvailableBlockHeaderInputV1<Types>, BuildError> {
         let start = Instant::now();
         // verify the signature
         if !sender.validate(signature, block_hash.as_ref()) {

--- a/hotshot-builder-core-refactored/src/testing/mod.rs
+++ b/hotshot-builder-core-refactored/src/testing/mod.rs
@@ -10,7 +10,7 @@ use async_broadcast::Sender;
 use committable::Commitment;
 use hotshot::rand::{thread_rng, Rng};
 use hotshot::types::{BLSPubKey, Event, EventType, SignatureKey};
-use hotshot_builder_api::v0_1::block_info::AvailableBlockHeaderInput;
+use hotshot_builder_api::v0_1::block_info::AvailableBlockHeaderInputV1;
 use hotshot_builder_api::v0_1::builder::BuildError;
 use hotshot_builder_api::v0_1::data_source::AcceptsTxnSubmits;
 use hotshot_builder_api::v0_1::{block_info::AvailableBlockInfo, data_source::BuilderDataSource};
@@ -105,7 +105,7 @@ impl TestServiceWrapper {
     pub(crate) async fn claim_block_header_input(
         &self,
         block_id: &BlockId<TestTypes>,
-    ) -> Result<AvailableBlockHeaderInput<TestTypes>, BuildError> {
+    ) -> Result<AvailableBlockHeaderInputV1<TestTypes>, BuildError> {
         self.proxy_global_state
             .claim_block_header_input(
                 &block_id.hash,

--- a/hotshot-task-impls/src/builder.rs
+++ b/hotshot-task-impls/src/builder.rs
@@ -128,7 +128,7 @@ impl<TYPES: NodeType, Ver: StaticVersionType> BuilderClient<TYPES, Ver> {
 
 /// Version 0.1
 pub mod v0_1 {
-    use hotshot_builder_api::v0_1::block_info::{AvailableBlockData, AvailableBlockHeaderInput};
+    use hotshot_builder_api::v0_1::block_info::{AvailableBlockData, AvailableBlockHeaderInputV2};
     pub use hotshot_builder_api::v0_1::Version;
     use hotshot_types::{
         constants::LEGACY_BUILDER_MODULE,
@@ -154,11 +154,11 @@ pub mod v0_1 {
             view_number: u64,
             sender: TYPES::SignatureKey,
             signature: &<<TYPES as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-        ) -> Result<AvailableBlockHeaderInput<TYPES>, BuilderClientError> {
+        ) -> Result<AvailableBlockHeaderInputV2<TYPES>, BuilderClientError> {
             let encoded_signature: TaggedBase64 = signature.clone().into();
             self.client
                 .get(&format!(
-                    "{LEGACY_BUILDER_MODULE}/claimheaderinput/{block_hash}/{view_number}/{sender}/{encoded_signature}"
+                    "{LEGACY_BUILDER_MODULE}/claimheaderinput/v2/{block_hash}/{view_number}/{sender}/{encoded_signature}"
                 ))
                 .send()
                 .await

--- a/hotshot-testing/src/block_builder/mod.rs
+++ b/hotshot-testing/src/block_builder/mod.rs
@@ -12,18 +12,19 @@ use async_trait::async_trait;
 use futures::Stream;
 use hotshot::{traits::BlockPayload, types::Event};
 use hotshot_builder_api::{
-    v0_1,
     v0_1::{
-        block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
+        self,
+        block_info::{AvailableBlockData, AvailableBlockInfo},
         builder::{Error, Options},
     },
+    v0_2::block_info::AvailableBlockHeaderInputV1,
     v0_99,
 };
 use hotshot_types::{
     constants::{LEGACY_BUILDER_MODULE, MARKETPLACE_BUILDER_MODULE},
     traits::{
-        block_contents::EncodeBytes,
-        node_implementation::{NodeType, Versions},
+        block_contents::{precompute_vid_commitment, EncodeBytes},
+        node_implementation::NodeType,
         signature_key::BuilderSignatureKey,
     },
 };
@@ -66,7 +67,7 @@ pub trait BuilderTask<TYPES: NodeType>: Send + Sync {
 struct BlockEntry<TYPES: NodeType> {
     metadata: AvailableBlockInfo<TYPES>,
     payload: Option<AvailableBlockData<TYPES>>,
-    header_input: Option<AvailableBlockHeaderInput<TYPES>>,
+    header_input: Option<AvailableBlockHeaderInputV1<TYPES>>,
 }
 
 /// Construct a tide disco app that mocks the builder API 0.1 + 0.3.
@@ -167,12 +168,12 @@ pub fn run_builder_source_0_1<TYPES, Source>(
 }
 
 /// Helper function to construct all builder data structures from a list of transactions
-async fn build_block<TYPES: NodeType, V: Versions>(
+async fn build_block<TYPES: NodeType>(
     transactions: Vec<TYPES::Transaction>,
     num_storage_nodes: Arc<RwLock<usize>>,
     pub_key: TYPES::BuilderSignatureKey,
     priv_key: <TYPES::BuilderSignatureKey as BuilderSignatureKey>::BuilderPrivateKey,
-    version: Version,
+    _version: Version,
 ) -> BlockEntry<TYPES>
 where
     <TYPES as NodeType>::InstanceState: Default,
@@ -187,11 +188,8 @@ where
 
     let commitment = block_payload.builder_commitment(&metadata);
 
-    let vid_commitment = hotshot_types::traits::block_contents::vid_commitment::<V>(
-        &block_payload.encode(),
-        *num_storage_nodes.read_arc().await,
-        version,
-    );
+    let (vid_commitment, vid_precompute_data) =
+        precompute_vid_commitment(&block_payload.encode(), *num_storage_nodes.read_arc().await);
 
     // Get block size from the encoded payload
     let block_size = block_payload.encode().len() as u64;
@@ -226,9 +224,9 @@ where
         offered_fee: 123,
         _phantom: std::marker::PhantomData,
     };
-    let header_input = AvailableBlockHeaderInput {
+    let header_input = AvailableBlockHeaderInputV1 {
         vid_commitment,
-        vid_precompute_data: None,
+        vid_precompute_data,
         message_signature: signature_over_vid_commitment.clone(),
         fee_signature: signature_over_fee_info,
         sender: pub_key,

--- a/hotshot-testing/src/block_builder/random.rs
+++ b/hotshot-testing/src/block_builder/random.rs
@@ -20,10 +20,13 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, Stream, StreamExt};
 use hotshot::types::{Event, EventType, SignatureKey};
-use hotshot_builder_api::v0_1::{
-    block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
-    builder::BuildError,
-    data_source::BuilderDataSource,
+use hotshot_builder_api::{
+    v0_1::{
+        block_info::{AvailableBlockData, AvailableBlockInfo},
+        builder::BuildError,
+        data_source::BuilderDataSource,
+    },
+    v0_2::block_info::AvailableBlockHeaderInputV1,
 };
 use hotshot_example_types::{block_types::TestTransaction, node_types::TestVersions};
 use hotshot_types::{
@@ -142,7 +145,7 @@ impl<TYPES: NodeType<Transaction = TestTransaction>> RandomBuilderTask<TYPES> {
 
             // Let new VID scheme ship with Epochs upgrade.
             let version = <V as Versions>::Epochs::VERSION;
-            let block = build_block::<TYPES, V>(
+            let block = build_block::<TYPES>(
                 transactions,
                 num_nodes.clone(),
                 pub_key.clone(),
@@ -331,7 +334,7 @@ impl<TYPES: NodeType> BuilderDataSource<TYPES> for RandomBuilderSource<TYPES> {
         _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
+    ) -> Result<AvailableBlockHeaderInputV1<TYPES>, BuildError> {
         if self.should_fail_claims.load(Ordering::Relaxed) {
             return Err(BuildError::Missing);
         }

--- a/hotshot-testing/src/block_builder/simple.rs
+++ b/hotshot-testing/src/block_builder/simple.rs
@@ -26,9 +26,10 @@ use hotshot::{
 use hotshot_builder_api::{
     v0_1::{
         self,
-        block_info::{AvailableBlockData, AvailableBlockHeaderInput, AvailableBlockInfo},
+        block_info::{AvailableBlockData, AvailableBlockInfo},
         builder::{BuildError, Error, Options},
     },
+    v0_2::block_info::AvailableBlockHeaderInputV1,
     v0_99,
 };
 use hotshot_example_types::node_types::TestVersions;
@@ -249,7 +250,7 @@ where
 
         // Let new VID scheme ships with Epochs upgrade
         let version = <TestVersions as Versions>::Epochs::VERSION;
-        let block_entry = build_block::<TYPES, TestVersions>(
+        let block_entry = build_block::<TYPES>(
             transactions,
             self.num_nodes.clone(),
             self.pub_key.clone(),
@@ -320,7 +321,7 @@ where
         _view_number: u64,
         _sender: TYPES::SignatureKey,
         _signature: &<TYPES::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<AvailableBlockHeaderInput<TYPES>, BuildError> {
+    ) -> Result<AvailableBlockHeaderInputV1<TYPES>, BuildError> {
         if self.should_fail_claims.load(Ordering::Relaxed) {
             return Err(BuildError::Missing);
         }

--- a/hotshot-types/src/traits/block_contents.rs
+++ b/hotshot-types/src/traits/block_contents.rs
@@ -9,6 +9,7 @@
 //! This module provides the [`Transaction`], [`BlockPayload`], and [`BlockHeader`] traits, which
 //! describe the behaviors that a block is expected to have.
 
+use jf_vid::precomputable::Precomputable;
 use std::{
     error::Error,
     fmt::{Debug, Display},
@@ -250,4 +251,20 @@ pub trait BlockHeader<TYPES: NodeType>:
 
     /// Get the results of the auction for this Header. Only used in post-marketplace versions
     fn get_auction_results(&self) -> Option<TYPES::AuctionResult>;
+}
+
+/// Compute the VID payload commitment along with precompute data reducing time in VID Disperse
+/// # Panics
+/// If the VID computation fails.
+#[must_use]
+#[allow(clippy::panic)]
+pub fn precompute_vid_commitment(
+    encoded_transactions: &[u8],
+    num_storage_nodes: usize,
+) -> (
+    <VidSchemeType as VidScheme>::Commit,
+    <VidSchemeType as Precomputable>::PrecomputeData,
+) {
+    let encoded_tx_len = encoded_transactions.len();
+    advz_scheme(num_storage_nodes).commit_only_precompute(encoded_transactions).unwrap_or_else(|err| panic!("VidScheme::commit_only failure:(num_storage_nodes,payload_byte_len)=({num_storage_nodes},{encoded_tx_len}) error: {err}"))
 }

--- a/hotshot-types/src/vid.rs
+++ b/hotshot-types/src/vid.rs
@@ -28,6 +28,7 @@ use jf_vid::{
         payload_prover::{LargeRangeProof, SmallRangeProof},
     },
     payload_prover::{PayloadProver, Statement},
+    precomputable::Precomputable,
     VidDisperse, VidResult, VidScheme,
 };
 use lazy_static::lazy_static;
@@ -109,6 +110,8 @@ pub type VidCommitment = <VidSchemeType as VidScheme>::Commit;
 pub type VidCommon = <VidSchemeType as VidScheme>::Common;
 /// VID share type
 pub type VidShare = <VidSchemeType as VidScheme>::Share;
+/// VID PrecomputeData type
+pub type VidPrecomputeData = <VidSchemeType as Precomputable>::PrecomputeData;
 /// VID proposal type
 pub type VidProposal<TYPES> = (
     Proposal<TYPES, HotShotVidDisperse<TYPES>>,
@@ -311,5 +314,32 @@ fn stmt_conversion(stmt: Statement<'_, VidSchemeType>) -> Statement<'_, Advz> {
         range: stmt.range,
         commit: stmt.commit,
         common: stmt.common,
+    }
+}
+
+impl Precomputable for VidSchemeType {
+    type PrecomputeData = <Advz as Precomputable>::PrecomputeData;
+
+    fn commit_only_precompute<B>(
+        &self,
+        payload: B,
+    ) -> VidResult<(Self::Commit, Self::PrecomputeData)>
+    where
+        B: AsRef<[u8]>,
+    {
+        self.0.commit_only_precompute(payload)
+    }
+
+    fn disperse_precompute<B>(
+        &self,
+        payload: B,
+        data: &Self::PrecomputeData,
+    ) -> VidResult<VidDisperse<Self>>
+    where
+        B: AsRef<[u8]>,
+    {
+        self.0
+            .disperse_precompute(payload, data)
+            .map(vid_disperse_conversion)
     }
 }

--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -4744,7 +4744,6 @@ dependencies = [
  "futures",
  "hotshot-types",
  "serde",
- "serde_json",
  "tagged-base64",
  "thiserror 1.0.69",
  "tide-disco",


### PR DESCRIPTION
### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

Fixes builder compatibility introduced by removing `vid_precompute_data`. We do this by:
- Adding a `v2` endpoint that supports the new type (without the field)
- Having new nodes hit the `v2` endpoint
- Adding back `vid_precompute` to the old endpoint so that older nodes work with the new builder

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
- Do any type-fu to have one type work for both. This seemed like the best way since the `precompute` field was completely unused; but `bincode` does not support optional fields and deserialization interop with `surf_disco` was proving complex 

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

This was tested locally and nodes on both the old and new versions are able to build nonempty blocks

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
