### PR TITLE
CI: pin qemu image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           # Temporary fix (See https://github.com/docker/setup-qemu-action/issues/198)
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Setup Docker BuildKit (buildx)
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           # Temporary fix (See https://github.com/docker/setup-qemu-action/issues/198)
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Setup Docker BuildKit (buildx)
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,12 @@ jobs:
           name: aarch64-unknown-linux-gnu-services
           path: target/arm64/release
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          # Temporary fix (See https://github.com/docker/setup-qemu-action/issues/198)
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
+
       - name: Setup Docker BuildKit (buildx)
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
This may fix the segfault we are seeing when installing libc-bin in docker.

Triggered a run here: https://github.com/EspressoSystems/espresso-sequencer/actions/runs/13457282462 hopefully this will try to build the ARM images too.

Edit: above failed, trying an even older image that seems to work for others here: https://github.com/EspressoSystems/espresso-sequencer/actions/runs/13457692187/attempts/1

Edit2: first run with qemu7 above passed, trying 2nd run here: https://github.com/EspressoSystems/espresso-sequencer/actions/runs/13457692187

Also trying to find out what image is actually being used.