### PR TITLE
chore: fix "injectible" → "injectable"

### DIFF
--- a/hotshot-example-types/src/auction_results_provider_types.rs
+++ b/hotshot-example-types/src/auction_results_provider_types.rs
@@ -33,7 +33,7 @@ pub struct TestAuctionResultsProvider<TYPES: NodeType> {
     /// particular outcome is met.
     pub solver_results: TYPES::AuctionResult,
 
-    /// A canned type to ensure that an error is thrown in absence of a true fault-injectible
+    /// A canned type to ensure that an error is thrown in absence of a true fault-injectable
     /// system for logical tests. This will guarantee that `fetch_auction_result` always throws an
     /// error.
     pub should_return_err: bool,


### PR DESCRIPTION
### This PR:

Fixes a typo where "injectible" was used, correcting it to "injectable".

### Key places to review:

The line where the typo "injectible" was found and corrected.

[x] PR description is clear enough for reviewers.

