### PR TITLE
Delay upgrade until configured block height

### DIFF
--- a/hotshot-task-impls/src/quorum_vote/mod.rs
+++ b/hotshot-task-impls/src/quorum_vote/mod.rs
@@ -17,6 +17,7 @@ use hotshot_task::{
 };
 use hotshot_types::{
     consensus::{ConsensusMetricsValue, OuterConsensus},
+    simple_certificate::{UpgradeCertificate},
     data::{Leaf2, QuorumProposalWrapper},
     drb::DrbComputation,
     event::Event,
@@ -316,6 +317,12 @@ pub struct QuorumVoteTaskState<TYPES: NodeType, I: NodeImplementation<TYPES>, V:
 
     /// Number of blocks in an epoch, zero means there are no epochs
     pub epoch_height: u64,
+
+    /// Upgrade certificate to enable epochs, staged until we reach the specified block height
+    pub staged_epoch_upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
+
+    /// Block height at which to enable the epoch upgrade
+    pub epoch_upgrade_block_height: u64,
 }
 
 impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskState<TYPES, I, V> {

--- a/hotshot/src/tasks/task_state.rs
+++ b/hotshot/src/tasks/task_state.rs
@@ -244,6 +244,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> CreateTaskState
             storage: Arc::clone(&handle.storage),
             upgrade_lock: handle.hotshot.upgrade_lock.clone(),
             epoch_height: handle.hotshot.config.epoch_height,
+            epoch_upgrade_block_height: handle.hotshot.config.epoch_start_block,
+            staged_epoch_upgrade_certificate: None,
             consensus_metrics,
         }
     }


### PR DESCRIPTION
### This PR:
Adds a configurable block height to the epoch upgrade, delaying it until that block height

### This PR does not:

### Key places to review:
