### PR TITLE
Pull in nightly rust-fmt, use vid rustfmt.toml

### DIFF
--- a/builder/src/bin/permissionless-builder.rs
+++ b/builder/src/bin/permissionless-builder.rs
@@ -122,11 +122,11 @@ async fn main() -> anyhow::Result<()> {
     match (base, upgrade) {
         (FeeVersion::VERSION, MarketplaceVersion::VERSION) => {
             run::<SequencerVersions<FeeVersion, MarketplaceVersion>>(genesis, opt).await
-        }
+        },
         (FeeVersion::VERSION, _) => run::<SequencerVersions<FeeVersion, V0_0>>(genesis, opt).await,
         (MarketplaceVersion::VERSION, _) => {
             run::<SequencerVersions<MarketplaceVersion, V0_0>>(genesis, opt).await
-        }
+        },
         _ => panic!(
             "Invalid base ({base}) and upgrade ({upgrade}) versions specified in the toml file."
         ),

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -40,6 +40,12 @@ pub fn run_builder_api_service(url: Url, source: ProxyGlobalState<SeqTypes>) {
 
 #[cfg(test)]
 pub mod testing {
+    use std::{
+        num::NonZeroUsize,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
     use async_lock::RwLock;
     use committable::Committable;
     use espresso_types::{
@@ -74,18 +80,13 @@ pub mod testing {
         },
         HotShotConfig, PeerConfig, ValidatorConfig,
     };
+    use jf_signature::bls_over_bn254::VerKey;
     use sequencer::{context::Consensus, network, SequencerApiVersion};
-    use std::{
-        num::NonZeroUsize,
-        sync::Arc,
-        time::{Duration, Instant},
-    };
     use surf_disco::Client;
     use vbs::version::StaticVersion;
 
     use super::*;
     use crate::non_permissioned::BuilderConfig;
-    use jf_signature::bls_over_bn254::VerKey;
 
     #[derive(Clone)]
     pub struct HotShotTestConfig {
@@ -414,10 +415,10 @@ pub mod testing {
         {
             Ok(response) => {
                 tracing::info!("Received txn submitted response : {:?}", response);
-            }
+            },
             Err(e) => {
                 panic!("Error submitting private transaction {:?}", e);
-            }
+            },
         }
 
         let seed = [207_u8; 32];
@@ -514,10 +515,10 @@ pub mod testing {
             Ok(response) => {
                 tracing::info!("Received Builder Key : {:?}", response);
                 assert_eq!(response, builder_pub_key);
-            }
+            },
             Err(e) => {
                 panic!("Error getting builder key {:?}", e);
-            }
+            },
         }
     }
 }

--- a/builder/src/non_permissioned.rs
+++ b/builder/src/non_permissioned.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, num::NonZeroUsize, time::Duration};
+use std::{collections::VecDeque, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use async_broadcast::broadcast;
@@ -22,10 +22,8 @@ use hotshot_types::{
         node_implementation::Versions, EncodeBytes,
     },
 };
-use marketplace_builder_shared::block::ParentBlockReferences;
-use marketplace_builder_shared::utils::EventServiceStream;
+use marketplace_builder_shared::{block::ParentBlockReferences, utils::EventServiceStream};
 use sequencer::{catchup::StatePeers, L1Params, SequencerApiVersion};
-use std::sync::Arc;
 use tide_disco::Url;
 use tokio::spawn;
 use vbs::version::StaticVersionType;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Context;
 use espresso_types::{FeeAccount, FeeAmount, FeeMerkleTree, Header};
 use ethers::types::Address;
@@ -6,7 +8,6 @@ use jf_merkle_tree::{
     prelude::{MerkleProof, Sha3Node},
     MerkleTreeScheme,
 };
-use std::time::Duration;
 use surf_disco::{
     error::ClientError,
     socket::{Connection, Unsupported},
@@ -110,7 +111,7 @@ impl SequencerClient {
                     } else {
                         sleep(Duration::from_millis(200)).await;
                     }
-                }
+                },
             }
         };
 

--- a/contract-bindings-alloy/src/erc1967proxy.rs
+++ b/contract-bindings-alloy/src/erc1967proxy.rs
@@ -94,8 +94,9 @@ interface ERC1967Proxy {
     clippy::empty_structs_with_brackets
 )]
 pub mod ERC1967Proxy {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -144,7 +145,7 @@ pub mod ERC1967Proxy {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -211,7 +212,7 @@ pub mod ERC1967Proxy {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -277,7 +278,7 @@ pub mod ERC1967Proxy {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -337,7 +338,7 @@ pub mod ERC1967Proxy {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -505,7 +506,7 @@ pub mod ERC1967Proxy {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -588,16 +589,16 @@ pub mod ERC1967Proxy {
             match self {
                 Self::AddressEmptyCode(_) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967InvalidImplementation(_) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967NonPayable(_) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FailedInnerCall(_) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -682,18 +683,18 @@ pub mod ERC1967Proxy {
             match self {
                 Self::AddressEmptyCode(inner) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::ERC1967InvalidImplementation(inner) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::ERC1967NonPayable(inner) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::FailedInnerCall(inner) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -701,18 +702,18 @@ pub mod ERC1967Proxy {
             match self {
                 Self::AddressEmptyCode(inner) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::ERC1967InvalidImplementation(inner) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::ERC1967NonPayable(inner) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::FailedInnerCall(inner) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -748,7 +749,7 @@ pub mod ERC1967Proxy {
                 Some(<Upgraded as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgraded as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgraded)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -772,7 +773,7 @@ pub mod ERC1967Proxy {
             match self {
                 Self::Upgraded(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/feecontract.rs
+++ b/contract-bindings-alloy/src/feecontract.rs
@@ -445,8 +445,9 @@ interface FeeContract {
     clippy::empty_structs_with_brackets
 )]
 pub mod FeeContract {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -495,7 +496,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -559,7 +560,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -619,7 +620,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -682,7 +683,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -748,7 +749,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -808,7 +809,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -868,7 +869,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -928,7 +929,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -988,7 +989,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1048,7 +1049,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1108,7 +1109,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1171,7 +1172,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1238,7 +1239,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1302,7 +1303,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1365,7 +1366,7 @@ pub mod FeeContract {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2055,7 +2056,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2122,7 +2123,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2151,7 +2152,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2236,7 +2237,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2265,7 +2266,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2351,7 +2352,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2380,7 +2381,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2470,7 +2471,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2503,7 +2504,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2593,7 +2594,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2622,7 +2623,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2708,7 +2709,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2737,7 +2738,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2819,7 +2820,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2848,7 +2849,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2930,7 +2931,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2959,7 +2960,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3041,7 +3042,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3070,7 +3071,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3149,7 +3150,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3178,7 +3179,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3260,7 +3261,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3289,7 +3290,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3383,7 +3384,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3415,7 +3416,7 @@ pub mod FeeContract {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3534,28 +3535,28 @@ pub mod FeeContract {
             match self {
                 Self::UPGRADE_INTERFACE_VERSION(_) => {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::balances(_) => <balancesCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::deposit(_) => <depositCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::getVersion(_) => <getVersionCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::initialize(_) => <initializeCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::maxDepositAmount(_) => {
                     <maxDepositAmountCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::minDepositAmount(_) => {
                     <minDepositAmountCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::owner(_) => <ownerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::proxiableUUID(_) => <proxiableUUIDCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::renounceOwnership(_) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::transferOwnership(_) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::upgradeToAndCall(_) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -3734,40 +3735,40 @@ pub mod FeeContract {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::balances(inner) => {
                     <balancesCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::deposit(inner) => {
                     <depositCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::getVersion(inner) => {
                     <getVersionCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::maxDepositAmount(inner) => {
                     <maxDepositAmountCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::minDepositAmount(inner) => {
                     <minDepositAmountCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::proxiableUUID(inner) => {
                     <proxiableUUIDCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::upgradeToAndCall(inner) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3777,40 +3778,40 @@ pub mod FeeContract {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::balances(inner) => {
                     <balancesCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::deposit(inner) => {
                     <depositCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::getVersion(inner) => {
                     <getVersionCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::maxDepositAmount(inner) => {
                     <maxDepositAmountCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::minDepositAmount(inner) => {
                     <minDepositAmountCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::proxiableUUID(inner) => {
                     <proxiableUUIDCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::upgradeToAndCall(inner) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -3883,49 +3884,49 @@ pub mod FeeContract {
             match self {
                 Self::AddressEmptyCode(_) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::DepositTooLarge(_) => {
                     <DepositTooLarge as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::DepositTooSmall(_) => {
                     <DepositTooSmall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967InvalidImplementation(_) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967NonPayable(_) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FailedInnerCall(_) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FunctionDoesNotExist(_) => {
                     <FunctionDoesNotExist as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidInitialization(_) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidUserAddress(_) => {
                     <InvalidUserAddress as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NoFunctionCalled(_) => {
                     <NoFunctionCalled as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NotInitializing(_) => {
                     <NotInitializing as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableInvalidOwner(_) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableUnauthorizedAccount(_) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(_) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(_) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -4142,57 +4143,57 @@ pub mod FeeContract {
             match self {
                 Self::AddressEmptyCode(inner) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::DepositTooLarge(inner) => {
                     <DepositTooLarge as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::DepositTooSmall(inner) => {
                     <DepositTooSmall as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::ERC1967InvalidImplementation(inner) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::ERC1967NonPayable(inner) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::FailedInnerCall(inner) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::FunctionDoesNotExist(inner) => {
                     <FunctionDoesNotExist as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::InvalidInitialization(inner) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::InvalidUserAddress(inner) => {
                     <InvalidUserAddress as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::NoFunctionCalled(inner) => {
                     <NoFunctionCalled as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::NotInitializing(inner) => {
                     <NotInitializing as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::OwnableInvalidOwner(inner) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(inner) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(inner) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(inner) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
             }
         }
         #[inline]
@@ -4200,57 +4201,57 @@ pub mod FeeContract {
             match self {
                 Self::AddressEmptyCode(inner) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::DepositTooLarge(inner) => {
                     <DepositTooLarge as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::DepositTooSmall(inner) => {
                     <DepositTooSmall as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::ERC1967InvalidImplementation(inner) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::ERC1967NonPayable(inner) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::FailedInnerCall(inner) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::FunctionDoesNotExist(inner) => {
                     <FunctionDoesNotExist as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::InvalidInitialization(inner) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::InvalidUserAddress(inner) => {
                     <InvalidUserAddress as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::NoFunctionCalled(inner) => {
                     <NoFunctionCalled as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::NotInitializing(inner) => {
                     <NotInitializing as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::OwnableInvalidOwner(inner) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(inner) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(inner) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(inner) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
             }
         }
     }
@@ -4323,31 +4324,31 @@ pub mod FeeContract {
                 Some(<Deposit as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Deposit as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Deposit)
-                }
+                },
                 Some(<Initialized as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Initialized as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::Initialized)
-                }
+                },
                 Some(<Log as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Log as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Log)
-                }
+                },
                 Some(<OwnershipTransferred as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <OwnershipTransferred as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::OwnershipTransferred)
-                }
+                },
                 Some(<Upgrade as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgrade as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgrade)
-                }
+                },
                 Some(<Upgraded as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgraded as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgraded)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -4367,11 +4368,11 @@ pub mod FeeContract {
                 Self::Deposit(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::Log(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::Upgraded(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
             }
@@ -4381,15 +4382,15 @@ pub mod FeeContract {
                 Self::Deposit(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::Log(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::Upgraded(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/iplonkverifier.rs
+++ b/contract-bindings-alloy/src/iplonkverifier.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1257,8 +1258,9 @@ interface IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -1398,7 +1400,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1964,7 +1966,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2510,7 +2512,7 @@ pub mod IPlonkVerifier {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2543,7 +2545,7 @@ pub mod IPlonkVerifier {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2674,7 +2676,7 @@ pub mod IPlonkVerifier {
             match self {
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -2682,7 +2684,7 @@ pub mod IPlonkVerifier {
             match self {
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/lightclient.rs
+++ b/contract-bindings-alloy/src/lightclient.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -562,8 +563,9 @@ library IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct PlonkProof { BN254.G1Point wire0; BN254.G1Point wire1; BN254.G1Point wire2; BN254.G1Point wire3; BN254.G1Point wire4; BN254.G1Point prodPerm; BN254.G1Point split0; BN254.G1Point split1; BN254.G1Point split2; BN254.G1Point split3; BN254.G1Point split4; BN254.G1Point zeta; BN254.G1Point zetaOmega; BN254.ScalarField wireEval0; BN254.ScalarField wireEval1; BN254.ScalarField wireEval2; BN254.ScalarField wireEval3; BN254.ScalarField wireEval4; BN254.ScalarField sigmaEval0; BN254.ScalarField sigmaEval1; BN254.ScalarField sigmaEval2; BN254.ScalarField sigmaEval3; BN254.ScalarField prodPermZetaOmegaEval; }
     ```*/
@@ -683,7 +685,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2368,8 +2370,9 @@ interface LightClient {
     clippy::empty_structs_with_brackets
 )]
 pub mod LightClient {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -2429,7 +2432,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2651,7 +2654,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2872,7 +2875,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2939,7 +2942,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3005,7 +3008,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3065,7 +3068,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3125,7 +3128,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3185,7 +3188,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3245,7 +3248,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3305,7 +3308,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3365,7 +3368,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3425,7 +3428,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3485,7 +3488,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3545,7 +3548,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3605,7 +3608,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3665,7 +3668,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3728,7 +3731,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3795,7 +3798,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3859,7 +3862,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3919,7 +3922,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3982,7 +3985,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4046,7 +4049,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4823,7 +4826,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -4890,7 +4893,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -4919,7 +4922,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5001,7 +5004,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5030,7 +5033,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5109,7 +5112,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5138,7 +5141,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5224,7 +5227,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5261,7 +5264,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5357,7 +5360,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5396,7 +5399,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5497,7 +5500,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5534,7 +5537,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5629,7 +5632,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5664,7 +5667,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5753,7 +5756,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5782,7 +5785,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5868,7 +5871,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5901,7 +5904,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6007,7 +6010,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6046,7 +6049,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6144,7 +6147,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6173,7 +6176,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6266,7 +6269,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6298,7 +6301,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6395,7 +6398,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6427,7 +6430,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6512,7 +6515,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6541,7 +6544,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6623,7 +6626,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6652,7 +6655,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6734,7 +6737,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6763,7 +6766,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6842,7 +6845,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6871,7 +6874,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6953,7 +6956,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6982,7 +6985,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7068,7 +7071,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7099,7 +7102,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7194,7 +7197,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7233,7 +7236,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7334,7 +7337,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7363,7 +7366,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7445,7 +7448,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7474,7 +7477,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7556,7 +7559,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7585,7 +7588,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7679,7 +7682,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7711,7 +7714,7 @@ pub mod LightClient {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7866,66 +7869,66 @@ pub mod LightClient {
             match self {
                 Self::UPGRADE_INTERFACE_VERSION(_) => {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::currentBlockNumber(_) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::disablePermissionedProverMode(_) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::finalizedState(_) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisStakeTableState(_) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisState(_) => <genesisStateCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::getHotShotCommitment(_) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getStateHistoryCount(_) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getVersion(_) => <getVersionCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::initialize(_) => <initializeCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::isPermissionedProverEnabled(_) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(_) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::newFinalizedState(_) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::owner(_) => <ownerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::permissionedProver(_) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::proxiableUUID(_) => <proxiableUUIDCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::renounceOwnership(_) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setPermissionedProver(_) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(_) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryCommitments(_) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryFirstIndex(_) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryRetentionPeriod(_) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::transferOwnership(_) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::upgradeToAndCall(_) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -8375,98 +8378,98 @@ pub mod LightClient {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::currentBlockNumber(inner) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::disablePermissionedProverMode(inner) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::finalizedState(inner) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::genesisStakeTableState(inner) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::genesisState(inner) => {
                     <genesisStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::getHotShotCommitment(inner) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getStateHistoryCount(inner) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getVersion(inner) => {
                     <getVersionCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::isPermissionedProverEnabled(inner) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(inner) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::newFinalizedState(inner) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::permissionedProver(inner) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::proxiableUUID(inner) => {
                     <proxiableUUIDCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setPermissionedProver(inner) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(inner) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryCommitments(inner) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryFirstIndex(inner) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryRetentionPeriod(inner) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::upgradeToAndCall(inner) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -8554,56 +8557,56 @@ pub mod LightClient {
             match self {
                 Self::AddressEmptyCode(_) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967InvalidImplementation(_) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967NonPayable(_) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FailedInnerCall(_) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InsufficientSnapshotHistory(_) => {
                     <InsufficientSnapshotHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidAddress(_) => <InvalidAddress as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidArgs(_) => <InvalidArgs as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidHotShotBlockForCommitmentCheck(_) => {
                     <InvalidHotShotBlockForCommitmentCheck as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidInitialization(_) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidMaxStateHistory(_) => {
                     <InvalidMaxStateHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidProof(_) => <InvalidProof as alloy_sol_types::SolError>::SELECTOR,
                 Self::NoChangeRequired(_) => {
                     <NoChangeRequired as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NotInitializing(_) => {
                     <NotInitializing as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OutdatedState(_) => <OutdatedState as alloy_sol_types::SolError>::SELECTOR,
                 Self::OwnableInvalidOwner(_) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableUnauthorizedAccount(_) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ProverNotPermissioned(_) => {
                     <ProverNotPermissioned as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(_) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(_) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::WrongStakeTableUsed(_) => {
                     <WrongStakeTableUsed as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -9175,17 +9178,17 @@ pub mod LightClient {
                         topics, data, validate,
                     )
                     .map(Self::Initialized)
-                }
+                },
                 Some(<NewState as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <NewState as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::NewState)
-                }
+                },
                 Some(<OwnershipTransferred as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <OwnershipTransferred as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::OwnershipTransferred)
-                }
+                },
                 Some(
                     <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::SIGNATURE_HASH,
                 ) => <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::decode_raw_log(
@@ -9197,15 +9200,15 @@ pub mod LightClient {
                         topics, data, validate,
                     )
                     .map(Self::PermissionedProverRequired)
-                }
+                },
                 Some(<Upgrade as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgrade as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgrade)
-                }
+                },
                 Some(<Upgraded as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgraded as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgraded)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -9224,17 +9227,17 @@ pub mod LightClient {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::Upgraded(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
             }
@@ -9243,23 +9246,23 @@ pub mod LightClient {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::Upgraded(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/lightclientarbitrum.rs
+++ b/contract-bindings-alloy/src/lightclientarbitrum.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -562,8 +563,9 @@ library IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct PlonkProof { BN254.G1Point wire0; BN254.G1Point wire1; BN254.G1Point wire2; BN254.G1Point wire3; BN254.G1Point wire4; BN254.G1Point prodPerm; BN254.G1Point split0; BN254.G1Point split1; BN254.G1Point split2; BN254.G1Point split3; BN254.G1Point split4; BN254.G1Point zeta; BN254.G1Point zetaOmega; BN254.ScalarField wireEval0; BN254.ScalarField wireEval1; BN254.ScalarField wireEval2; BN254.ScalarField wireEval3; BN254.ScalarField wireEval4; BN254.ScalarField sigmaEval0; BN254.ScalarField sigmaEval1; BN254.ScalarField sigmaEval2; BN254.ScalarField sigmaEval3; BN254.ScalarField prodPermZetaOmegaEval; }
     ```*/
@@ -683,7 +685,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1281,8 +1283,9 @@ library LightClient {
     clippy::empty_structs_with_brackets
 )]
 pub mod LightClient {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct LightClientState { uint64 viewNum; uint64 blockHeight; BN254.ScalarField blockCommRoot; }
     ```*/
@@ -1322,7 +1325,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1544,7 +1547,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2966,8 +2969,9 @@ interface LightClientArbitrum {
     clippy::empty_structs_with_brackets
 )]
 pub mod LightClientArbitrum {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -3016,7 +3020,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3083,7 +3087,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3149,7 +3153,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3209,7 +3213,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3269,7 +3273,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3329,7 +3333,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3389,7 +3393,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3449,7 +3453,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3509,7 +3513,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3569,7 +3573,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3629,7 +3633,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3689,7 +3693,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3749,7 +3753,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3809,7 +3813,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3872,7 +3876,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3939,7 +3943,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4003,7 +4007,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4063,7 +4067,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4126,7 +4130,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4190,7 +4194,7 @@ pub mod LightClientArbitrum {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4980,7 +4984,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5009,7 +5013,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5091,7 +5095,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5120,7 +5124,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5199,7 +5203,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5228,7 +5232,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5314,7 +5318,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5351,7 +5355,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5447,7 +5451,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5486,7 +5490,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5587,7 +5591,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5624,7 +5628,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5719,7 +5723,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5754,7 +5758,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5843,7 +5847,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5872,7 +5876,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5958,7 +5962,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5991,7 +5995,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6098,7 +6102,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6137,7 +6141,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6237,7 +6241,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6266,7 +6270,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6359,7 +6363,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6391,7 +6395,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6489,7 +6493,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6521,7 +6525,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6608,7 +6612,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6637,7 +6641,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6719,7 +6723,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6748,7 +6752,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6830,7 +6834,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6859,7 +6863,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6938,7 +6942,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6967,7 +6971,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7049,7 +7053,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7078,7 +7082,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7164,7 +7168,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7195,7 +7199,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7290,7 +7294,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7329,7 +7333,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7430,7 +7434,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7459,7 +7463,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7541,7 +7545,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7570,7 +7574,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7652,7 +7656,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7681,7 +7685,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7775,7 +7779,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7807,7 +7811,7 @@ pub mod LightClientArbitrum {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7962,66 +7966,66 @@ pub mod LightClientArbitrum {
             match self {
                 Self::UPGRADE_INTERFACE_VERSION(_) => {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::currentBlockNumber(_) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::disablePermissionedProverMode(_) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::finalizedState(_) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisStakeTableState(_) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisState(_) => <genesisStateCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::getHotShotCommitment(_) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getStateHistoryCount(_) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getVersion(_) => <getVersionCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::initialize(_) => <initializeCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::isPermissionedProverEnabled(_) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(_) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::newFinalizedState(_) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::owner(_) => <ownerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::permissionedProver(_) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::proxiableUUID(_) => <proxiableUUIDCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::renounceOwnership(_) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setPermissionedProver(_) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(_) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryCommitments(_) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryFirstIndex(_) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryRetentionPeriod(_) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::transferOwnership(_) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::upgradeToAndCall(_) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -8468,98 +8472,98 @@ pub mod LightClientArbitrum {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::currentBlockNumber(inner) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::disablePermissionedProverMode(inner) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::finalizedState(inner) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::genesisStakeTableState(inner) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::genesisState(inner) => {
                     <genesisStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::getHotShotCommitment(inner) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getStateHistoryCount(inner) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getVersion(inner) => {
                     <getVersionCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::isPermissionedProverEnabled(inner) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(inner) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::newFinalizedState(inner) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::permissionedProver(inner) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::proxiableUUID(inner) => {
                     <proxiableUUIDCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setPermissionedProver(inner) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(inner) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryCommitments(inner) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryFirstIndex(inner) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryRetentionPeriod(inner) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::upgradeToAndCall(inner) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -8647,56 +8651,56 @@ pub mod LightClientArbitrum {
             match self {
                 Self::AddressEmptyCode(_) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967InvalidImplementation(_) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967NonPayable(_) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FailedInnerCall(_) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InsufficientSnapshotHistory(_) => {
                     <InsufficientSnapshotHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidAddress(_) => <InvalidAddress as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidArgs(_) => <InvalidArgs as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidHotShotBlockForCommitmentCheck(_) => {
                     <InvalidHotShotBlockForCommitmentCheck as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidInitialization(_) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidMaxStateHistory(_) => {
                     <InvalidMaxStateHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidProof(_) => <InvalidProof as alloy_sol_types::SolError>::SELECTOR,
                 Self::NoChangeRequired(_) => {
                     <NoChangeRequired as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NotInitializing(_) => {
                     <NotInitializing as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OutdatedState(_) => <OutdatedState as alloy_sol_types::SolError>::SELECTOR,
                 Self::OwnableInvalidOwner(_) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableUnauthorizedAccount(_) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ProverNotPermissioned(_) => {
                     <ProverNotPermissioned as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(_) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(_) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::WrongStakeTableUsed(_) => {
                     <WrongStakeTableUsed as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -9268,17 +9272,17 @@ pub mod LightClientArbitrum {
                         topics, data, validate,
                     )
                     .map(Self::Initialized)
-                }
+                },
                 Some(<NewState as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <NewState as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::NewState)
-                }
+                },
                 Some(<OwnershipTransferred as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <OwnershipTransferred as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::OwnershipTransferred)
-                }
+                },
                 Some(
                     <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::SIGNATURE_HASH,
                 ) => <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::decode_raw_log(
@@ -9290,15 +9294,15 @@ pub mod LightClientArbitrum {
                         topics, data, validate,
                     )
                     .map(Self::PermissionedProverRequired)
-                }
+                },
                 Some(<Upgrade as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgrade as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgrade)
-                }
+                },
                 Some(<Upgraded as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgraded as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgraded)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -9317,17 +9321,17 @@ pub mod LightClientArbitrum {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::Upgraded(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
             }
@@ -9336,23 +9340,23 @@ pub mod LightClientArbitrum {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::Upgraded(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/lightclientmock.rs
+++ b/contract-bindings-alloy/src/lightclientmock.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -562,8 +563,9 @@ library IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct PlonkProof { BN254.G1Point wire0; BN254.G1Point wire1; BN254.G1Point wire2; BN254.G1Point wire3; BN254.G1Point wire4; BN254.G1Point prodPerm; BN254.G1Point split0; BN254.G1Point split1; BN254.G1Point split2; BN254.G1Point split3; BN254.G1Point split4; BN254.G1Point zeta; BN254.G1Point zetaOmega; BN254.ScalarField wireEval0; BN254.ScalarField wireEval1; BN254.ScalarField wireEval2; BN254.ScalarField wireEval3; BN254.ScalarField wireEval4; BN254.ScalarField sigmaEval0; BN254.ScalarField sigmaEval1; BN254.ScalarField sigmaEval2; BN254.ScalarField sigmaEval3; BN254.ScalarField prodPermZetaOmegaEval; }
     ```*/
@@ -683,7 +685,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1282,8 +1284,9 @@ library LightClient {
     clippy::empty_structs_with_brackets
 )]
 pub mod LightClient {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct LightClientState { uint64 viewNum; uint64 blockHeight; BN254.ScalarField blockCommRoot; }
     ```*/
@@ -1323,7 +1326,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1545,7 +1548,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1781,7 +1784,7 @@ pub mod LightClient {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3376,8 +3379,9 @@ interface LightClientMock {
     clippy::empty_structs_with_brackets
 )]
 pub mod LightClientMock {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -3426,7 +3430,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3493,7 +3497,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3559,7 +3563,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3619,7 +3623,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3679,7 +3683,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3739,7 +3743,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3799,7 +3803,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3859,7 +3863,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3919,7 +3923,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -3979,7 +3983,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4039,7 +4043,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4099,7 +4103,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4159,7 +4163,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4219,7 +4223,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4282,7 +4286,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4349,7 +4353,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4413,7 +4417,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4473,7 +4477,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4536,7 +4540,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -4600,7 +4604,7 @@ pub mod LightClientMock {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -5393,7 +5397,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5482,7 +5486,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5511,7 +5515,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5593,7 +5597,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5622,7 +5626,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5701,7 +5705,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5730,7 +5734,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5816,7 +5820,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5853,7 +5857,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5949,7 +5953,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -5988,7 +5992,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6089,7 +6093,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6126,7 +6130,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6221,7 +6225,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6256,7 +6260,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6345,7 +6349,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6374,7 +6378,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6460,7 +6464,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6493,7 +6497,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6600,7 +6604,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6639,7 +6643,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6739,7 +6743,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6768,7 +6772,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6861,7 +6865,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6893,7 +6897,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -6991,7 +6995,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7023,7 +7027,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7110,7 +7114,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7139,7 +7143,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7221,7 +7225,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7250,7 +7254,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7332,7 +7336,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7361,7 +7365,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7440,7 +7444,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7469,7 +7473,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7552,7 +7556,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7581,7 +7585,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7667,7 +7671,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7696,7 +7700,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7779,7 +7783,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7808,7 +7812,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7890,7 +7894,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -7919,7 +7923,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8012,7 +8016,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8043,7 +8047,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8130,7 +8134,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8161,7 +8165,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8256,7 +8260,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8295,7 +8299,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8396,7 +8400,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8425,7 +8429,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8507,7 +8511,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8536,7 +8540,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8618,7 +8622,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8647,7 +8651,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8741,7 +8745,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8773,7 +8777,7 @@ pub mod LightClientMock {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -8940,76 +8944,76 @@ pub mod LightClientMock {
             match self {
                 Self::UPGRADE_INTERFACE_VERSION(_) => {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::currentBlockNumber(_) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::disablePermissionedProverMode(_) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::finalizedState(_) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisStakeTableState(_) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::genesisState(_) => <genesisStateCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::getHotShotCommitment(_) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getStateHistoryCount(_) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::getVersion(_) => <getVersionCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::initialize(_) => <initializeCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::isPermissionedProverEnabled(_) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(_) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::newFinalizedState(_) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::owner(_) => <ownerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::permissionedProver(_) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::proxiableUUID(_) => <proxiableUUIDCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::renounceOwnership(_) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setFinalizedState(_) => {
                     <setFinalizedStateCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setHotShotDownSince(_) => {
                     <setHotShotDownSinceCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setHotShotUp(_) => <setHotShotUpCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::setPermissionedProver(_) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setStateHistory(_) => {
                     <setStateHistoryCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(_) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryCommitments(_) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryFirstIndex(_) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::stateHistoryRetentionPeriod(_) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::transferOwnership(_) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::upgradeToAndCall(_) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -9522,112 +9526,112 @@ pub mod LightClientMock {
                     <UPGRADE_INTERFACE_VERSIONCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::currentBlockNumber(inner) => {
                     <currentBlockNumberCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::disablePermissionedProverMode(inner) => {
                     <disablePermissionedProverModeCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::finalizedState(inner) => {
                     <finalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::genesisStakeTableState(inner) => {
                     <genesisStakeTableStateCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::genesisState(inner) => {
                     <genesisStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::getHotShotCommitment(inner) => {
                     <getHotShotCommitmentCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getStateHistoryCount(inner) => {
                     <getStateHistoryCountCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::getVersion(inner) => {
                     <getVersionCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::isPermissionedProverEnabled(inner) => {
                     <isPermissionedProverEnabledCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::lagOverEscapeHatchThreshold(inner) => {
                     <lagOverEscapeHatchThresholdCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::newFinalizedState(inner) => {
                     <newFinalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::permissionedProver(inner) => {
                     <permissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::proxiableUUID(inner) => {
                     <proxiableUUIDCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setFinalizedState(inner) => {
                     <setFinalizedStateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setHotShotDownSince(inner) => {
                     <setHotShotDownSinceCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::setHotShotUp(inner) => {
                     <setHotShotUpCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setPermissionedProver(inner) => {
                     <setPermissionedProverCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::setStateHistory(inner) => {
                     <setStateHistoryCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::setstateHistoryRetentionPeriod(inner) => {
                     <setstateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryCommitments(inner) => {
                     <stateHistoryCommitmentsCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryFirstIndex(inner) => {
                     <stateHistoryFirstIndexCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::stateHistoryRetentionPeriod(inner) => {
                     <stateHistoryRetentionPeriodCall as alloy_sol_types::SolCall>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::upgradeToAndCall(inner) => {
                     <upgradeToAndCallCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -9715,56 +9719,56 @@ pub mod LightClientMock {
             match self {
                 Self::AddressEmptyCode(_) => {
                     <AddressEmptyCode as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967InvalidImplementation(_) => {
                     <ERC1967InvalidImplementation as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ERC1967NonPayable(_) => {
                     <ERC1967NonPayable as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::FailedInnerCall(_) => {
                     <FailedInnerCall as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InsufficientSnapshotHistory(_) => {
                     <InsufficientSnapshotHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidAddress(_) => <InvalidAddress as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidArgs(_) => <InvalidArgs as alloy_sol_types::SolError>::SELECTOR,
                 Self::InvalidHotShotBlockForCommitmentCheck(_) => {
                     <InvalidHotShotBlockForCommitmentCheck as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidInitialization(_) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidMaxStateHistory(_) => {
                     <InvalidMaxStateHistory as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::InvalidProof(_) => <InvalidProof as alloy_sol_types::SolError>::SELECTOR,
                 Self::NoChangeRequired(_) => {
                     <NoChangeRequired as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NotInitializing(_) => {
                     <NotInitializing as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OutdatedState(_) => <OutdatedState as alloy_sol_types::SolError>::SELECTOR,
                 Self::OwnableInvalidOwner(_) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableUnauthorizedAccount(_) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::ProverNotPermissioned(_) => {
                     <ProverNotPermissioned as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(_) => {
                     <UUPSUnauthorizedCallContext as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(_) => {
                     <UUPSUnsupportedProxiableUUID as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::WrongStakeTableUsed(_) => {
                     <WrongStakeTableUsed as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -10336,17 +10340,17 @@ pub mod LightClientMock {
                         topics, data, validate,
                     )
                     .map(Self::Initialized)
-                }
+                },
                 Some(<NewState as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <NewState as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::NewState)
-                }
+                },
                 Some(<OwnershipTransferred as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <OwnershipTransferred as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::OwnershipTransferred)
-                }
+                },
                 Some(
                     <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::SIGNATURE_HASH,
                 ) => <PermissionedProverNotRequired as alloy_sol_types::SolEvent>::decode_raw_log(
@@ -10358,15 +10362,15 @@ pub mod LightClientMock {
                         topics, data, validate,
                     )
                     .map(Self::PermissionedProverRequired)
-                }
+                },
                 Some(<Upgrade as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgrade as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgrade)
-                }
+                },
                 Some(<Upgraded as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <Upgraded as alloy_sol_types::SolEvent>::decode_raw_log(topics, data, validate)
                         .map(Self::Upgraded)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -10385,17 +10389,17 @@ pub mod LightClientMock {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
                 Self::Upgraded(inner) => alloy_sol_types::private::IntoLogData::to_log_data(inner),
             }
@@ -10404,23 +10408,23 @@ pub mod LightClientMock {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::NewState(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverNotRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::PermissionedProverRequired(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::Upgrade(inner) => alloy_sol_types::private::IntoLogData::into_log_data(inner),
                 Self::Upgraded(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/permissionedstaketable.rs
+++ b/contract-bindings-alloy/src/permissionedstaketable.rs
@@ -15,8 +15,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -171,7 +172,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -463,8 +464,9 @@ library EdOnBN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod EdOnBN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct EdOnBN254Point { uint256 x; uint256 y; }
     ```*/
@@ -500,7 +502,7 @@ pub mod EdOnBN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1359,8 +1361,9 @@ interface PermissionedStakeTable {
     clippy::empty_structs_with_brackets
 )]
 pub mod PermissionedStakeTable {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -1420,7 +1423,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1622,7 +1625,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1682,7 +1685,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1745,7 +1748,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1812,7 +1815,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1879,7 +1882,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1945,7 +1948,7 @@ pub mod PermissionedStakeTable {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2330,7 +2333,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2407,7 +2410,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2436,7 +2439,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2517,7 +2520,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2546,7 +2549,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2628,7 +2631,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2657,7 +2660,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2743,7 +2746,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2772,7 +2775,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2856,7 +2859,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2885,7 +2888,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2964,7 +2967,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2993,7 +2996,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3075,7 +3078,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3104,7 +3107,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3202,7 +3205,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3234,7 +3237,7 @@ pub mod PermissionedStakeTable {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3343,15 +3346,15 @@ pub mod PermissionedStakeTable {
                 Self::initialize(_) => <initializeCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::initializedAtBlock(_) => {
                     <initializedAtBlockCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::isStaker(_) => <isStakerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::owner(_) => <ownerCall as alloy_sol_types::SolCall>::SELECTOR,
                 Self::renounceOwnership(_) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::transferOwnership(_) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::SELECTOR
-                }
+                },
                 Self::update(_) => <updateCall as alloy_sol_types::SolCall>::SELECTOR,
             }
         }
@@ -3477,28 +3480,28 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::_hashBlsKey(inner) => {
                     <_hashBlsKeyCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::initializedAtBlock(inner) => {
                     <initializedAtBlockCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::isStaker(inner) => {
                     <isStakerCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::update(inner) => {
                     <updateCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3506,28 +3509,28 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::_hashBlsKey(inner) => {
                     <_hashBlsKeyCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initialize(inner) => {
                     <initializeCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::initializedAtBlock(inner) => {
                     <initializedAtBlockCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::isStaker(inner) => {
                     <isStakerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::owner(inner) => {
                     <ownerCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::renounceOwnership(inner) => {
                     <renounceOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::transferOwnership(inner) => {
                     <transferOwnershipCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::update(inner) => {
                     <updateCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -3573,19 +3576,19 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::InvalidInitialization(_) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::NotInitializing(_) => {
                     <NotInitializing as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableInvalidOwner(_) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::OwnableUnauthorizedAccount(_) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::StakerAlreadyExists(_) => {
                     <StakerAlreadyExists as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::StakerNotFound(_) => <StakerNotFound as alloy_sol_types::SolError>::SELECTOR,
             }
         }
@@ -3695,24 +3698,24 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::InvalidInitialization(inner) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::NotInitializing(inner) => {
                     <NotInitializing as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::OwnableInvalidOwner(inner) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(inner) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::abi_encoded_size(
                         inner,
                     )
-                }
+                },
                 Self::StakerAlreadyExists(inner) => {
                     <StakerAlreadyExists as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::StakerNotFound(inner) => {
                     <StakerNotFound as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3720,24 +3723,24 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::InvalidInitialization(inner) => {
                     <InvalidInitialization as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::NotInitializing(inner) => {
                     <NotInitializing as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::OwnableInvalidOwner(inner) => {
                     <OwnableInvalidOwner as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(inner) => {
                     <OwnableUnauthorizedAccount as alloy_sol_types::SolError>::abi_encode_raw(
                         inner, out,
                     )
-                }
+                },
                 Self::StakerAlreadyExists(inner) => {
                     <StakerAlreadyExists as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::StakerNotFound(inner) => {
                     <StakerNotFound as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -3791,19 +3794,19 @@ pub mod PermissionedStakeTable {
                         topics, data, validate,
                     )
                     .map(Self::Initialized)
-                }
+                },
                 Some(<OwnershipTransferred as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <OwnershipTransferred as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::OwnershipTransferred)
-                }
+                },
                 Some(<StakersUpdated as alloy_sol_types::SolEvent>::SIGNATURE_HASH) => {
                     <StakersUpdated as alloy_sol_types::SolEvent>::decode_raw_log(
                         topics, data, validate,
                     )
                     .map(Self::StakersUpdated)
-                }
+                },
                 _ => alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                     name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                     log: alloy_sol_types::private::Box::new(
@@ -3822,26 +3825,26 @@ pub mod PermissionedStakeTable {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
                 Self::StakersUpdated(inner) => {
                     alloy_sol_types::private::IntoLogData::to_log_data(inner)
-                }
+                },
             }
         }
         fn into_log_data(self) -> alloy_sol_types::private::LogData {
             match self {
                 Self::Initialized(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::OwnershipTransferred(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
                 Self::StakersUpdated(inner) => {
                     alloy_sol_types::private::IntoLogData::into_log_data(inner)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/plonkverifier.rs
+++ b/contract-bindings-alloy/src/plonkverifier.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -563,8 +564,9 @@ library IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct PlonkProof { BN254.G1Point wire0; BN254.G1Point wire1; BN254.G1Point wire2; BN254.G1Point wire3; BN254.G1Point wire4; BN254.G1Point prodPerm; BN254.G1Point split0; BN254.G1Point split1; BN254.G1Point split2; BN254.G1Point split3; BN254.G1Point split4; BN254.G1Point zeta; BN254.G1Point zetaOmega; BN254.ScalarField wireEval0; BN254.ScalarField wireEval1; BN254.ScalarField wireEval2; BN254.ScalarField wireEval3; BN254.ScalarField wireEval4; BN254.ScalarField sigmaEval0; BN254.ScalarField sigmaEval1; BN254.ScalarField sigmaEval2; BN254.ScalarField sigmaEval3; BN254.ScalarField prodPermZetaOmegaEval; }
     ```*/
@@ -684,7 +686,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1250,7 +1252,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2607,8 +2609,9 @@ interface PlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod PlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -2654,7 +2657,7 @@ pub mod PlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2714,7 +2717,7 @@ pub mod PlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2774,7 +2777,7 @@ pub mod PlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2860,7 +2863,7 @@ pub mod PlonkVerifier {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2893,7 +2896,7 @@ pub mod PlonkVerifier {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3026,7 +3029,7 @@ pub mod PlonkVerifier {
             match self {
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3034,7 +3037,7 @@ pub mod PlonkVerifier {
             match self {
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -3071,10 +3074,10 @@ pub mod PlonkVerifier {
             match self {
                 Self::InvalidPlonkArgs(_) => {
                     <InvalidPlonkArgs as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::UnsupportedDegree(_) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
                 Self::WrongPlonkVK(_) => <WrongPlonkVK as alloy_sol_types::SolError>::SELECTOR,
             }
         }
@@ -3146,13 +3149,13 @@ pub mod PlonkVerifier {
             match self {
                 Self::InvalidPlonkArgs(inner) => {
                     <InvalidPlonkArgs as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::UnsupportedDegree(inner) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
                 Self::WrongPlonkVK(inner) => {
                     <WrongPlonkVK as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3160,13 +3163,13 @@ pub mod PlonkVerifier {
             match self {
                 Self::InvalidPlonkArgs(inner) => {
                     <InvalidPlonkArgs as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::UnsupportedDegree(inner) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::WrongPlonkVK(inner) => {
                     <WrongPlonkVK as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-alloy/src/plonkverifier2.rs
+++ b/contract-bindings-alloy/src/plonkverifier2.rs
@@ -16,8 +16,9 @@ library BN254 {
     clippy::empty_structs_with_brackets
 )]
 pub mod BN254 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct BaseField(alloy::sol_types::private::primitives::aliases::U256);
@@ -282,7 +283,7 @@ pub mod BN254 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -563,8 +564,9 @@ library IPlonkVerifier {
     clippy::empty_structs_with_brackets
 )]
 pub mod IPlonkVerifier {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /**```solidity
     struct PlonkProof { BN254.G1Point wire0; BN254.G1Point wire1; BN254.G1Point wire2; BN254.G1Point wire3; BN254.G1Point wire4; BN254.G1Point prodPerm; BN254.G1Point split0; BN254.G1Point split1; BN254.G1Point split2; BN254.G1Point split3; BN254.G1Point split4; BN254.G1Point zeta; BN254.G1Point zetaOmega; BN254.ScalarField wireEval0; BN254.ScalarField wireEval1; BN254.ScalarField wireEval2; BN254.ScalarField wireEval3; BN254.ScalarField wireEval4; BN254.ScalarField sigmaEval0; BN254.ScalarField sigmaEval1; BN254.ScalarField sigmaEval2; BN254.ScalarField sigmaEval3; BN254.ScalarField prodPermZetaOmegaEval; }
     ```*/
@@ -684,7 +686,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -1250,7 +1252,7 @@ pub mod IPlonkVerifier {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2623,8 +2625,9 @@ interface PlonkVerifier2 {
     clippy::empty_structs_with_brackets
 )]
 pub mod PlonkVerifier2 {
-    use super::*;
     use alloy::sol_types as alloy_sol_types;
+
+    use super::*;
     /// The creation / init bytecode of the contract.
     ///
     /// ```text
@@ -2670,7 +2673,7 @@ pub mod PlonkVerifier2 {
             match _t {
                 alloy_sol_types::private::AssertTypeEq::<
                     <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
+                >(_) => {},
             }
         }
         #[automatically_derived]
@@ -2738,7 +2741,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2767,7 +2770,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2849,7 +2852,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2878,7 +2881,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -2978,7 +2981,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3011,7 +3014,7 @@ pub mod PlonkVerifier2 {
                 match _t {
                     alloy_sol_types::private::AssertTypeEq::<
                         <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                    >(_) => {}
+                    >(_) => {},
                 }
             }
             #[automatically_derived]
@@ -3174,13 +3177,13 @@ pub mod PlonkVerifier2 {
             match self {
                 Self::P_MOD(inner) => {
                     <P_MODCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::R_MOD(inner) => {
                     <R_MODCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3188,13 +3191,13 @@ pub mod PlonkVerifier2 {
             match self {
                 Self::P_MOD(inner) => {
                     <P_MODCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::R_MOD(inner) => {
                     <R_MODCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
                 Self::verify(inner) => {
                     <verifyCall as alloy_sol_types::SolCall>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }
@@ -3223,7 +3226,7 @@ pub mod PlonkVerifier2 {
             match self {
                 Self::UnsupportedDegree(_) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::SELECTOR
-                }
+                },
             }
         }
         #[inline]
@@ -3268,7 +3271,7 @@ pub mod PlonkVerifier2 {
             match self {
                 Self::UnsupportedDegree(inner) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::abi_encoded_size(inner)
-                }
+                },
             }
         }
         #[inline]
@@ -3276,7 +3279,7 @@ pub mod PlonkVerifier2 {
             match self {
                 Self::UnsupportedDegree(inner) => {
                     <UnsupportedDegree as alloy_sol_types::SolError>::abi_encode_raw(inner, out)
-                }
+                },
             }
         }
     }

--- a/contract-bindings-ethers/src/erc1967_proxy.rs
+++ b/contract-bindings-ethers/src/erc1967_proxy.rs
@@ -320,7 +320,7 @@ pub mod erc1967_proxy {
                 Self::AddressEmptyCode(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FailedInnerCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
@@ -333,21 +333,21 @@ pub mod erc1967_proxy {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
                 _ if selector == <AddressEmptyCode as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <ERC1967InvalidImplementation as ::ethers::contract::EthError>::selector(
                     ) =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <ERC1967NonPayable as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <FailedInnerCall as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ => false,
             }
         }
@@ -358,7 +358,7 @@ pub mod erc1967_proxy {
                 Self::AddressEmptyCode(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailedInnerCall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),

--- a/contract-bindings-ethers/src/fee_contract.rs
+++ b/contract-bindings-ethers/src/fee_contract.rs
@@ -1071,32 +1071,32 @@ pub mod fee_contract {
                 Self::DepositTooSmall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FailedInnerCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FunctionDoesNotExist(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidInitialization(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidUserAddress(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::NoFunctionCalled(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NotInitializing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OwnableInvalidOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -1107,70 +1107,70 @@ pub mod fee_contract {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
                 _ if selector == <AddressEmptyCode as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector == <DepositTooLarge as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector == <DepositTooSmall as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <ERC1967InvalidImplementation as ::ethers::contract::EthError>::selector(
                     ) =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <ERC1967NonPayable as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <FailedInnerCall as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <FunctionDoesNotExist as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <InvalidInitialization as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <InvalidUserAddress as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <NoFunctionCalled as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector == <NotInitializing as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <OwnableInvalidOwner as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <OwnableUnauthorizedAccount as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <UUPSUnauthorizedCallContext as ::ethers::contract::EthError>::selector(
                     ) =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <UUPSUnsupportedProxiableUUID as ::ethers::contract::EthError>::selector(
                     ) =>
                 {
                     true
-                }
+                },
                 _ => false,
             }
         }
@@ -1183,7 +1183,7 @@ pub mod fee_contract {
                 Self::DepositTooSmall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailedInnerCall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FunctionDoesNotExist(element) => ::core::fmt::Display::fmt(element, f),
@@ -1196,7 +1196,7 @@ pub mod fee_contract {
                 Self::UUPSUnauthorizedCallContext(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),
             }
         }
@@ -1754,7 +1754,7 @@ pub mod fee_contract {
             match self {
                 Self::UpgradeInterfaceVersion(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::Balances(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Deposit(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetVersion(element) => ::ethers::core::abi::AbiEncode::encode(element),

--- a/contract-bindings-ethers/src/light_client.rs
+++ b/contract-bindings-ethers/src/light_client.rs
@@ -1726,45 +1726,45 @@ pub mod light_client {
                 Self::AddressEmptyCode(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FailedInnerCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InsufficientSnapshotHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidAddress(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidArgs(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidInitialization(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidMaxStateHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidProof(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NoChangeRequired(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NotInitializing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OutdatedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OwnableInvalidOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProverNotPermissioned(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -1859,7 +1859,7 @@ pub mod light_client {
                 Self::AddressEmptyCode(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailedInnerCall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InsufficientSnapshotHistory(element) => ::core::fmt::Display::fmt(element, f),
@@ -1867,7 +1867,7 @@ pub mod light_client {
                 Self::InvalidArgs(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::InvalidInitialization(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidMaxStateHistory(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidProof(element) => ::core::fmt::Display::fmt(element, f),
@@ -1880,7 +1880,7 @@ pub mod light_client {
                 Self::UUPSUnauthorizedCallContext(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),
             }
@@ -2176,10 +2176,10 @@ pub mod light_client {
                 Self::OwnershipTransferredFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PermissionedProverNotRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::PermissionedProverRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::UpgradeFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UpgradedFilter(element) => ::core::fmt::Display::fmt(element, f),
             }
@@ -2777,54 +2777,54 @@ pub mod light_client {
             match self {
                 Self::UpgradeInterfaceVersion(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::CurrentBlockNumber(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::DisablePermissionedProverMode(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::FinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GenesisStakeTableState(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GenesisState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetHotShotCommitment(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetStateHistoryCount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetVersion(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Initialize(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::IsPermissionedProverEnabled(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::LagOverEscapeHatchThreshold(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::NewFinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Owner(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::PermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProxiableUUID(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RenounceOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetPermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryCommitments(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryFirstIndex(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::TransferOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::UpgradeToAndCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
@@ -2837,7 +2837,7 @@ pub mod light_client {
                 Self::CurrentBlockNumber(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DisablePermissionedProverMode(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::FinalizedState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisStakeTableState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisState(element) => ::core::fmt::Display::fmt(element, f),
@@ -2855,7 +2855,7 @@ pub mod light_client {
                 Self::SetPermissionedProver(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::StateHistoryCommitments(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryFirstIndex(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryRetentionPeriod(element) => ::core::fmt::Display::fmt(element, f),

--- a/contract-bindings-ethers/src/light_client_arbitrum.rs
+++ b/contract-bindings-ethers/src/light_client_arbitrum.rs
@@ -1726,45 +1726,45 @@ pub mod light_client_arbitrum {
                 Self::AddressEmptyCode(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FailedInnerCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InsufficientSnapshotHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidAddress(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidArgs(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidInitialization(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidMaxStateHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidProof(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NoChangeRequired(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NotInitializing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OutdatedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OwnableInvalidOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProverNotPermissioned(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -1859,7 +1859,7 @@ pub mod light_client_arbitrum {
                 Self::AddressEmptyCode(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailedInnerCall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InsufficientSnapshotHistory(element) => ::core::fmt::Display::fmt(element, f),
@@ -1867,7 +1867,7 @@ pub mod light_client_arbitrum {
                 Self::InvalidArgs(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::InvalidInitialization(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidMaxStateHistory(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidProof(element) => ::core::fmt::Display::fmt(element, f),
@@ -1880,7 +1880,7 @@ pub mod light_client_arbitrum {
                 Self::UUPSUnauthorizedCallContext(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),
             }
@@ -2178,10 +2178,10 @@ pub mod light_client_arbitrum {
                 Self::OwnershipTransferredFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PermissionedProverNotRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::PermissionedProverRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::UpgradeFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UpgradedFilter(element) => ::core::fmt::Display::fmt(element, f),
             }
@@ -2779,54 +2779,54 @@ pub mod light_client_arbitrum {
             match self {
                 Self::UpgradeInterfaceVersion(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::CurrentBlockNumber(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::DisablePermissionedProverMode(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::FinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GenesisStakeTableState(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GenesisState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetHotShotCommitment(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetStateHistoryCount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetVersion(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Initialize(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::IsPermissionedProverEnabled(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::LagOverEscapeHatchThreshold(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::NewFinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Owner(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::PermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProxiableUUID(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RenounceOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetPermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryCommitments(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryFirstIndex(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::TransferOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::UpgradeToAndCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
@@ -2839,7 +2839,7 @@ pub mod light_client_arbitrum {
                 Self::CurrentBlockNumber(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DisablePermissionedProverMode(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::FinalizedState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisStakeTableState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisState(element) => ::core::fmt::Display::fmt(element, f),
@@ -2857,7 +2857,7 @@ pub mod light_client_arbitrum {
                 Self::SetPermissionedProver(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::StateHistoryCommitments(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryFirstIndex(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryRetentionPeriod(element) => ::core::fmt::Display::fmt(element, f),

--- a/contract-bindings-ethers/src/light_client_mock.rs
+++ b/contract-bindings-ethers/src/light_client_mock.rs
@@ -1867,45 +1867,45 @@ pub mod light_client_mock {
                 Self::AddressEmptyCode(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::FailedInnerCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InsufficientSnapshotHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidAddress(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidArgs(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidInitialization(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidMaxStateHistory(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::InvalidProof(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NoChangeRequired(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::NotInitializing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OutdatedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OwnableInvalidOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProverNotPermissioned(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnauthorizedCallContext(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
         }
@@ -2000,7 +2000,7 @@ pub mod light_client_mock {
                 Self::AddressEmptyCode(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ERC1967InvalidImplementation(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::ERC1967NonPayable(element) => ::core::fmt::Display::fmt(element, f),
                 Self::FailedInnerCall(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InsufficientSnapshotHistory(element) => ::core::fmt::Display::fmt(element, f),
@@ -2008,7 +2008,7 @@ pub mod light_client_mock {
                 Self::InvalidArgs(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidHotShotBlockForCommitmentCheck(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::InvalidInitialization(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidMaxStateHistory(element) => ::core::fmt::Display::fmt(element, f),
                 Self::InvalidProof(element) => ::core::fmt::Display::fmt(element, f),
@@ -2021,7 +2021,7 @@ pub mod light_client_mock {
                 Self::UUPSUnauthorizedCallContext(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UUPSUnsupportedProxiableUUID(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::WrongStakeTableUsed(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),
             }
@@ -2319,10 +2319,10 @@ pub mod light_client_mock {
                 Self::OwnershipTransferredFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PermissionedProverNotRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::PermissionedProverRequiredFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::UpgradeFilter(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UpgradedFilter(element) => ::core::fmt::Display::fmt(element, f),
             }
@@ -3015,60 +3015,60 @@ pub mod light_client_mock {
             match self {
                 Self::UpgradeInterfaceVersion(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::CurrentBlockNumber(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::DisablePermissionedProverMode(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::FinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GenesisStakeTableState(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GenesisState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetHotShotCommitment(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetStateHistoryCount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::GetVersion(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Initialize(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::IsPermissionedProverEnabled(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::LagOverEscapeHatchThreshold(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::NewFinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Owner(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::PermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::ProxiableUUID(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RenounceOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetFinalizedState(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetHotShotDownSince(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::SetHotShotUp(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetPermissionedProver(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::SetStateHistory(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryCommitments(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryFirstIndex(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StateHistoryRetentionPeriod(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::TransferOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::UpgradeToAndCall(element) => ::ethers::core::abi::AbiEncode::encode(element),
             }
@@ -3081,7 +3081,7 @@ pub mod light_client_mock {
                 Self::CurrentBlockNumber(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DisablePermissionedProverMode(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::FinalizedState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisStakeTableState(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GenesisState(element) => ::core::fmt::Display::fmt(element, f),
@@ -3103,7 +3103,7 @@ pub mod light_client_mock {
                 Self::SetStateHistory(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetstateHistoryRetentionPeriod(element) => {
                     ::core::fmt::Display::fmt(element, f)
-                }
+                },
                 Self::StateHistoryCommitments(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryFirstIndex(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StateHistoryRetentionPeriod(element) => ::core::fmt::Display::fmt(element, f),

--- a/contract-bindings-ethers/src/permissioned_stake_table.rs
+++ b/contract-bindings-ethers/src/permissioned_stake_table.rs
@@ -763,17 +763,17 @@ pub mod permissioned_stake_table {
             match self {
                 Self::InvalidInitialization(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::NotInitializing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::OwnableInvalidOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::OwnableUnauthorizedAccount(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StakerAlreadyExists(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::StakerNotFound(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RevertString(s) => ::ethers::core::abi::AbiEncode::encode(s),
             }
@@ -787,28 +787,28 @@ pub mod permissioned_stake_table {
                     == <InvalidInitialization as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <NotInitializing as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <OwnableInvalidOwner as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <OwnableUnauthorizedAccount as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector
                     == <StakerAlreadyExists as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <StakerNotFound as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ => false,
             }
         }
@@ -1178,7 +1178,7 @@ pub mod permissioned_stake_table {
                 Self::Initialize(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::InitializedAtBlock(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
-                }
+                },
                 Self::IsStaker(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::Owner(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RenounceOwnership(element) => ::ethers::core::abi::AbiEncode::encode(element),

--- a/contract-bindings-ethers/src/plonk_verifier.rs
+++ b/contract-bindings-ethers/src/plonk_verifier.rs
@@ -442,12 +442,12 @@ pub mod plonk_verifier {
                 [0x08, 0xc3, 0x79, 0xa0] => true,
                 _ if selector == <InvalidPlonkArgs as ::ethers::contract::EthError>::selector() => {
                     true
-                }
+                },
                 _ if selector
                     == <UnsupportedDegree as ::ethers::contract::EthError>::selector() =>
                 {
                     true
-                }
+                },
                 _ if selector == <WrongPlonkVK as ::ethers::contract::EthError>::selector() => true,
                 _ => false,
             }

--- a/contracts/rust/adapter/src/jellyfish.rs
+++ b/contracts/rust/adapter/src/jellyfish.rs
@@ -13,10 +13,12 @@ use ethers::{
     utils::hex::ToHex,
 };
 use jf_pcs::prelude::Commitment;
-use jf_plonk::constants::KECCAK256_STATE_SIZE;
-use jf_plonk::proof_system::structs::{OpenKey, Proof, ProofEvaluations, VerifyingKey};
-use jf_plonk::testing_apis::Challenges;
-use jf_plonk::transcript::SolidityTranscript;
+use jf_plonk::{
+    constants::KECCAK256_STATE_SIZE,
+    proof_system::structs::{OpenKey, Proof, ProofEvaluations, VerifyingKey},
+    testing_apis::Challenges,
+    transcript::SolidityTranscript,
+};
 use jf_utils::to_bytes;
 use num_bigint::BigUint;
 use num_traits::Num;

--- a/contracts/rust/adapter/src/light_client.rs
+++ b/contracts/rust/adapter/src/light_client.rs
@@ -4,9 +4,7 @@ use ark_ff::PrimeField;
 use ark_std::str::FromStr;
 use diff_test_bn254::{field_to_u256, u256_to_field};
 use ethers::{
-    abi::AbiDecode,
-    abi::Token,
-    abi::Tokenize,
+    abi::{AbiDecode, Token, Tokenize},
     prelude::{AbiError, EthAbiCodec, EthAbiType},
     types::U256,
 };

--- a/contracts/rust/adapter/src/stake_table.rs
+++ b/contracts/rust/adapter/src/stake_table.rs
@@ -1,4 +1,5 @@
-use crate::jellyfish::u256_to_field;
+use std::str::FromStr;
+
 use ark_ec::{
     short_weierstrass,
     twisted_edwards::{self, Affine, TECurveConfig},
@@ -29,7 +30,8 @@ use hotshot_types::{
     PeerConfig,
 };
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+
+use crate::jellyfish::u256_to_field;
 
 // TODO: (alex) maybe move these commonly shared util to a crate
 /// convert a field element to U256, panic if field size is larger than 256 bit

--- a/contracts/rust/diff-test/src/main.rs
+++ b/contracts/rust/diff-test/src/main.rs
@@ -2,12 +2,10 @@ use ark_bn254::{Bn254, Fq, Fr, G1Affine, G2Affine};
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ed_on_bn254::{EdwardsConfig as EdOnBn254Config, Fq as FqEd254};
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
-use ark_poly::domain::radix2::Radix2EvaluationDomain;
-use ark_poly::EvaluationDomain;
+use ark_poly::{domain::radix2::Radix2EvaluationDomain, EvaluationDomain};
 use ark_std::rand::{rngs::StdRng, Rng, SeedableRng};
 use clap::{Parser, ValueEnum};
 use diff_test_bn254::ParsedG2Point;
-
 use ethers::{
     abi::{AbiDecode, AbiEncode, Address},
     types::{Bytes, U256},
@@ -17,15 +15,19 @@ use hotshot_state_prover::mock_ledger::{
     gen_plonk_proof_for_test, MockLedger, MockSystemParam, STAKE_TABLE_CAPACITY,
 };
 use jf_pcs::prelude::Commitment;
-use jf_plonk::proof_system::structs::{Proof, VerifyingKey};
-use jf_plonk::proof_system::PlonkKzgSnark;
 use jf_plonk::{
+    proof_system::{
+        structs::{Proof, VerifyingKey},
+        PlonkKzgSnark,
+    },
     testing_apis::Verifier,
     transcript::{PlonkTranscript, SolidityTranscript},
 };
-use jf_signature::bls_over_bn254::{hash_to_curve, KeyPair as BLSKeyPair, Signature};
-use jf_signature::constants::CS_ID_BLS_BN254;
-use jf_signature::schnorr::KeyPair as SchnorrKeyPair;
+use jf_signature::{
+    bls_over_bn254::{hash_to_curve, KeyPair as BLSKeyPair, Signature},
+    constants::CS_ID_BLS_BN254,
+    schnorr::KeyPair as SchnorrKeyPair,
+};
 use sha3::Keccak256;
 
 #[derive(Parser)]
@@ -102,7 +104,7 @@ fn main() {
                 field_to_u256(domain.group_gen),
             );
             println!("{}", res.encode_hex());
-        }
+        },
         Action::EvalDomainElements => {
             if cli.args.len() != 2 {
                 panic!("Should provide arg1=logSize, arg2=length");
@@ -117,7 +119,7 @@ fn main() {
                 .map(field_to_u256)
                 .collect::<Vec<_>>();
             println!("{}", res.encode_hex());
-        }
+        },
         Action::EvalDataGen => {
             if cli.args.len() != 3 {
                 panic!("Should provide arg1=logSize, arg2=zeta, arg3=publicInput");
@@ -138,7 +140,7 @@ fn main() {
                 field_to_u256(pi_eval),
             );
             println!("{}", res.encode_hex());
-        }
+        },
         Action::TranscriptAppendMsg => {
             if cli.args.len() != 2 {
                 panic!("Should provide arg1=transcript, arg2=message");
@@ -153,7 +155,7 @@ fn main() {
             <SolidityTranscript as PlonkTranscript<Fr>>::append_message(&mut t, &[], &msg).unwrap();
             let res: ParsedTranscript = t.into();
             println!("{}", (res,).encode_hex());
-        }
+        },
         Action::TranscriptAppendField => {
             if cli.args.len() != 2 {
                 panic!("Should provide arg1=transcript, arg2=fieldElement");
@@ -165,7 +167,7 @@ fn main() {
             t.append_field_elem::<Bn254>(&[], &field).unwrap();
             let res: ParsedTranscript = t.into();
             println!("{}", (res,).encode_hex());
-        }
+        },
         Action::TranscriptAppendGroup => {
             if cli.args.len() != 2 {
                 panic!("Should provide arg1=transcript, arg2=groupElement");
@@ -179,7 +181,7 @@ fn main() {
                 .unwrap();
             let res: ParsedTranscript = t.into();
             println!("{}", (res,).encode_hex());
-        }
+        },
         Action::TranscriptGetChal => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=transcript");
@@ -193,7 +195,7 @@ fn main() {
             let updated_t: ParsedTranscript = t.into();
             let res = (updated_t, field_to_u256(chal));
             println!("{}", res.encode_hex());
-        }
+        },
         Action::TranscriptAppendVkAndPi => {
             if cli.args.len() != 3 {
                 panic!("Should provide arg1=transcript, arg2=verifyingKey, arg3=publicInput");
@@ -210,7 +212,7 @@ fn main() {
 
             let res: ParsedTranscript = t.into();
             println!("{}", (res,).encode_hex());
-        }
+        },
         Action::TranscriptAppendProofEvals => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=transcript");
@@ -232,7 +234,7 @@ fn main() {
             let t_updated: ParsedTranscript = t.into();
             let res = (t_updated, proof_parsed);
             println!("{}", res.encode_hex());
-        }
+        },
         Action::PlonkConstants => {
             let coset_k = coset_k();
             let open_key = open_key();
@@ -250,7 +252,7 @@ fn main() {
                 field_to_u256::<Fq>(open_key.beta_h.y().unwrap().c0),
             );
             println!("{}", res.encode_hex());
-        }
+        },
         Action::PlonkComputeChal => {
             if cli.args.len() != 4 {
                 panic!("Should provide arg1=verifyingKey, arg2=publicInput, arg3=proof, arg4=extraTranscriptInitMsg");
@@ -275,9 +277,9 @@ fn main() {
                 .unwrap()
                 .into();
             println!("{}", (chal,).encode_hex());
-        }
+        },
         Action::PlonkVerify => {
-            let (proof, vk, public_input, _, _): (
+            let (proof, vk, public_input, ..): (
                 Proof<Bn254>,
                 VerifyingKey<Bn254>,
                 Vec<Fr>,
@@ -304,7 +306,7 @@ fn main() {
 
             let res = (vk_parsed, pi_parsed, proof_parsed);
             println!("{}", res.encode_hex());
-        }
+        },
         Action::DummyProof => {
             let mut rng = jf_utils::test_rng();
             if !cli.args.is_empty() {
@@ -313,10 +315,10 @@ fn main() {
             }
             let proof = ParsedPlonkProof::dummy(&mut rng);
             println!("{}", (proof,).encode_hex());
-        }
+        },
         Action::TestOnly => {
             println!("args: {:?}", cli.args);
-        }
+        },
         Action::GenClientWallet => {
             if cli.args.len() != 2 {
                 panic!("Should provide arg1=senderAddress arg2=seed");
@@ -358,7 +360,7 @@ fn main() {
                 sender_address,
             );
             println!("{}", res.encode_hex());
-        }
+        },
         Action::GenRandomG2Point => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=exponent");
@@ -370,7 +372,7 @@ fn main() {
             let point_parsed: ParsedG2Point = point.into();
             let res = point_parsed;
             println!("{}", (res.encode_hex()));
-        }
+        },
         Action::MockGenesis => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=numInitValidators");
@@ -382,7 +384,7 @@ fn main() {
 
             let res = (ledger.get_state(), ledger.get_stake_table_state());
             println!("{}", res.encode_hex());
-        }
+        },
         Action::MockConsecutiveFinalizedStates => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=numInitValidators");
@@ -413,7 +415,7 @@ fn main() {
 
             let res = (new_states, proofs);
             println!("{}", res.encode_hex());
-        }
+        },
         Action::MockSkipBlocks => {
             if cli.args.is_empty() || cli.args.len() > 2 {
                 panic!("Should provide arg1=numBlockSkipped,arg2(opt)=requireValidProof");
@@ -444,7 +446,7 @@ fn main() {
                 (state_parsed, proof_parsed)
             };
             println!("{}", res.encode_hex());
-        }
+        },
         Action::GenBLSHashes => {
             if cli.args.len() != 1 {
                 panic!("Should provide arg1=message");
@@ -464,7 +466,7 @@ fn main() {
 
             let res = (fq_u256, hash_to_curve_elem_parsed);
             println!("{}", res.encode_hex());
-        }
+        },
         Action::GenBLSSig => {
             let mut rng = jf_utils::test_rng();
 
@@ -486,6 +488,6 @@ fn main() {
 
             let res = (vk_parsed, sig_parsed);
             println!("{}", res.encode_hex());
-        }
+        },
     };
 }

--- a/contracts/rust/gen-vk-contract/src/main.rs
+++ b/contracts/rust/gen-vk-contract/src/main.rs
@@ -5,12 +5,11 @@
 
 use std::{fs::OpenOptions, io::Write, path::PathBuf, process::Command};
 
+use clap::Parser;
 use ethers::core::abi::AbiEncode;
 use hotshot_contract_adapter::jellyfish::ParsedVerifyingKey;
 use hotshot_stake_table::config::STAKE_TABLE_CAPACITY;
 use jf_pcs::prelude::UnivariateUniversalParams;
-
-use clap::Parser;
 
 #[derive(Parser)]
 struct Cli {

--- a/hotshot-builder-api/src/api.rs
+++ b/hotshot-builder-api/src/api.rs
@@ -34,7 +34,7 @@ fn merge_toml(into: &mut Value, from: Value) {
                 Entry::Occupied(mut entry) => merge_toml(entry.get_mut(), value),
                 Entry::Vacant(entry) => {
                     entry.insert(value);
-                }
+                },
             }
         }
     }

--- a/hotshot-builder-core-refactored/src/block_size_limits.rs
+++ b/hotshot-builder-core-refactored/src/block_size_limits.rs
@@ -1,6 +1,7 @@
+use std::sync::atomic::Ordering;
+
 use atomic::Atomic;
 use coarsetime::{Duration, Instant};
-use std::sync::atomic::Ordering;
 
 #[derive(Debug, Clone, Copy, bytemuck::NoUninit)]
 #[repr(C)]

--- a/hotshot-builder-core-refactored/src/block_store.rs
+++ b/hotshot-builder-core-refactored/src/block_store.rs
@@ -2,16 +2,13 @@ use std::marker::PhantomData;
 
 use hotshot::traits::BlockPayload;
 use hotshot_builder_api::v0_1::block_info::AvailableBlockInfo;
-use hotshot_types::traits::signature_key::BuilderSignatureKey;
-use marketplace_builder_shared::error::Error;
-use marketplace_builder_shared::utils::BuilderKeys;
+use hotshot_types::traits::{node_implementation::NodeType, signature_key::BuilderSignatureKey};
 use marketplace_builder_shared::{
-    block::BuilderStateId, coordinator::tiered_view_map::TieredViewMap,
+    block::{BlockId, BuilderStateId},
+    coordinator::tiered_view_map::TieredViewMap,
+    error::Error,
+    utils::BuilderKeys,
 };
-
-use marketplace_builder_shared::block::BlockId;
-
-use hotshot_types::traits::node_implementation::NodeType;
 
 // It holds all the necessary information for a block
 #[derive(Debug, Clone)]

--- a/hotshot-builder-core-refactored/src/service.rs
+++ b/hotshot-builder-core-refactored/src/service.rs
@@ -1,3 +1,21 @@
+use std::{
+    fmt::Display,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+pub use async_broadcast::{broadcast, RecvError, TryRecvError};
+use async_lock::RwLock;
+use async_trait::async_trait;
+use committable::Commitment;
+use futures::{
+    future::BoxFuture,
+    stream::{FuturesOrdered, FuturesUnordered, StreamExt},
+    Stream, TryStreamExt,
+};
 use hotshot::types::Event;
 use hotshot_builder_api::{
     v0_1::{
@@ -9,51 +27,38 @@ use hotshot_builder_api::{
     },
     v0_2::block_info::AvailableBlockHeaderInputV1,
 };
-use hotshot_types::traits::block_contents::Transaction;
-use hotshot_types::traits::EncodeBytes;
 use hotshot_types::{
     data::VidCommitment,
     event::EventType,
     traits::{
-        block_contents::BlockPayload,
+        block_contents::{BlockPayload, Transaction},
         node_implementation::{ConsensusTime, NodeType},
         signature_key::{BuilderSignatureKey, SignatureKey},
+        EncodeBytes,
     },
     utils::BuilderCommitment,
 };
-use marketplace_builder_shared::coordinator::BuilderStateLookup;
-use marketplace_builder_shared::error::Error;
-use marketplace_builder_shared::state::BuilderState;
-use marketplace_builder_shared::utils::BuilderKeys;
 use marketplace_builder_shared::{
     block::{BlockId, BuilderStateId, ReceivedTransaction, TransactionSource},
-    coordinator::BuilderStateCoordinator,
+    coordinator::{BuilderStateCoordinator, BuilderStateLookup},
+    error::Error,
+    state::BuilderState,
+    utils::BuilderKeys,
 };
-use tide_disco::app::AppError;
-use tokio::spawn;
-use tokio::time::{sleep, timeout};
+use tagged_base64::TaggedBase64;
+use tide_disco::{app::AppError, method::ReadState, App};
+use tokio::{
+    spawn,
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
 use tracing::{error, info, instrument, trace, warn};
 use vbs::version::StaticVersion;
 
-use crate::block_size_limits::BlockSizeLimits;
-use crate::block_store::{BlockInfo, BlockStore};
-pub use async_broadcast::{broadcast, RecvError, TryRecvError};
-use async_lock::RwLock;
-use async_trait::async_trait;
-use committable::Commitment;
-use futures::{future::BoxFuture, Stream};
-use futures::{
-    stream::{FuturesOrdered, FuturesUnordered, StreamExt},
-    TryStreamExt,
+use crate::{
+    block_size_limits::BlockSizeLimits,
+    block_store::{BlockInfo, BlockStore},
 };
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::time::Duration;
-use std::{fmt::Display, time::Instant};
-use tagged_base64::TaggedBase64;
-use tide_disco::{method::ReadState, App};
-use tokio::task::JoinHandle;
 
 /// Proportion of overall allotted time to wait for optimal builder state
 /// to appear before resorting to highest view builder state
@@ -201,7 +206,7 @@ where
             match event.event {
                 EventType::Error { error } => {
                     error!("Error event in HotShot: {:?}", error);
-                }
+                },
                 EventType::Transactions { transactions } => {
                     let this = Arc::clone(&self);
                     spawn(async move {
@@ -217,7 +222,7 @@ where
                             .collect::<Vec<_>>()
                             .await;
                     });
-                }
+                },
                 EventType::Decide { leaf_chain, .. } => {
                     let prune_cutoff = leaf_chain[0].leaf.view_number();
 
@@ -226,16 +231,16 @@ where
 
                     let this = Arc::clone(&self);
                     spawn(async move { this.block_store.write().await.prune(prune_cutoff) });
-                }
+                },
                 EventType::DaProposal { proposal, .. } => {
                     let coordinator = Arc::clone(&self.coordinator);
                     spawn(async move { coordinator.handle_da_proposal(proposal.data).await });
-                }
+                },
                 EventType::QuorumProposal { proposal, .. } => {
                     let coordinator = Arc::clone(&self.coordinator);
                     spawn(async move { coordinator.handle_quorum_proposal(proposal.data).await });
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
     }
@@ -287,10 +292,10 @@ where
                 BuilderStateLookup::Found(builder) => break Ok(builder),
                 BuilderStateLookup::Decided => {
                     return Err(Error::AlreadyDecided);
-                }
+                },
                 BuilderStateLookup::NotFound => {
                     sleep(check_period).await;
-                }
+                },
             };
         }
     }
@@ -374,7 +379,7 @@ where
                 Err(error) => {
                     warn!(?error, "Failed to build block payload");
                     return Err(Error::BuildBlock(error));
-                }
+                },
             };
 
         // count the number of txns
@@ -442,7 +447,7 @@ where
                 // Timeout waiting for ideal state, get the highest view builder instead
                 warn!("Couldn't find the ideal builder state");
                 self.coordinator.highest_view_builder().await
-            }
+            },
             Ok(Err(e)) => {
                 // State already decided
                 let lowest_view = self.coordinator.lowest_view().await;
@@ -451,7 +456,7 @@ where
                     "get_available_blocks request for decided view"
                 );
                 return Err(e);
-            }
+            },
         };
 
         let Some(builder) = builder else {
@@ -485,7 +490,7 @@ where
                 }
 
                 Ok(vec![response])
-            }
+            },
             // Success, but no block: we don't have transactions and aren't prioritizing finalization
             Ok(Ok(None)) => Ok(vec![]),
             // Error building block, try to respond with a cached one as last-ditch attempt
@@ -495,7 +500,7 @@ where
                 } else {
                     Err(e)
                 }
-            }
+            },
         }
     }
 

--- a/hotshot-builder-core-refactored/src/testing/basic.rs
+++ b/hotshot-builder-core-refactored/src/testing/basic.rs
@@ -1,29 +1,37 @@
+use std::{sync::Arc, time::Duration};
+
 use async_broadcast::broadcast;
 use hotshot::types::{EventType, SignatureKey};
-
 use hotshot_builder_api::v0_1::data_source::BuilderDataSource;
-use hotshot_example_types::block_types::{TestBlockHeader, TestMetadata, TestTransaction};
-use hotshot_example_types::node_types::{TestTypes, TestVersions};
-use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
-use hotshot_types::data::VidCommitment;
-use hotshot_types::data::{Leaf2, QuorumProposal2, QuorumProposalWrapper, ViewNumber};
-use hotshot_types::event::LeafInfo;
-use hotshot_types::simple_certificate::QuorumCertificate2;
-use hotshot_types::traits::block_contents::BlockHeader;
-use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
-use hotshot_types::utils::BuilderCommitment;
-use marketplace_builder_shared::error::Error;
-use marketplace_builder_shared::testing::consensus::SimulatedChainState;
-use marketplace_builder_shared::testing::constants::{
-    TEST_NUM_NODES_IN_VID_COMPUTATION, TEST_PROTOCOL_MAX_BLOCK_SIZE,
+use hotshot_example_types::{
+    block_types::{TestBlockHeader, TestMetadata, TestTransaction},
+    node_types::{TestTypes, TestVersions},
+    state_types::{TestInstanceState, TestValidatedState},
+};
+use hotshot_types::{
+    data::{Leaf2, QuorumProposal2, QuorumProposalWrapper, VidCommitment, ViewNumber},
+    event::LeafInfo,
+    simple_certificate::QuorumCertificate2,
+    traits::{
+        block_contents::BlockHeader,
+        node_implementation::{ConsensusTime, NodeType},
+    },
+    utils::BuilderCommitment,
+};
+use marketplace_builder_shared::{
+    error::Error,
+    testing::{
+        consensus::SimulatedChainState,
+        constants::{TEST_NUM_NODES_IN_VID_COMPUTATION, TEST_PROTOCOL_MAX_BLOCK_SIZE},
+    },
 };
 use tokio::time::sleep;
 use tracing_test::traced_test;
 
-use crate::service::{BuilderConfig, GlobalState, ProxyGlobalState};
-use crate::testing::{assert_eq_generic_err, sign, TestServiceWrapper, MOCK_LEADER_KEYS};
-use std::sync::Arc;
-use std::time::Duration;
+use crate::{
+    service::{BuilderConfig, GlobalState, ProxyGlobalState},
+    testing::{assert_eq_generic_err, sign, TestServiceWrapper, MOCK_LEADER_KEYS},
+};
 
 /// This test simulates consensus performing as expected and builder processing a number
 /// of transactions

--- a/hotshot-builder-core-refactored/src/testing/block_size.rs
+++ b/hotshot-builder-core-refactored/src/testing/block_size.rs
@@ -1,22 +1,27 @@
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::Duration,
+};
+
 use async_broadcast::broadcast;
 use committable::Committable;
 use hotshot_builder_api::v0_1::builder::TransactionStatus;
-use hotshot_example_types::block_types::TestTransaction;
-use hotshot_example_types::state_types::TestInstanceState;
-use hotshot_types::data::VidCommitment;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::traits::node_implementation::ConsensusTime;
-use marketplace_builder_shared::block::{BlockId, BuilderStateId};
-use marketplace_builder_shared::testing::consensus::SimulatedChainState;
-use marketplace_builder_shared::testing::constants::TEST_NUM_NODES_IN_VID_COMPUTATION;
+use hotshot_example_types::{block_types::TestTransaction, state_types::TestInstanceState};
+use hotshot_types::{
+    data::{VidCommitment, ViewNumber},
+    traits::node_implementation::ConsensusTime,
+};
+use marketplace_builder_shared::{
+    block::{BlockId, BuilderStateId},
+    testing::{consensus::SimulatedChainState, constants::TEST_NUM_NODES_IN_VID_COMPUTATION},
+};
 use tracing_test::traced_test;
 
-use crate::block_size_limits::BlockSizeLimits;
-use crate::service::{BuilderConfig, GlobalState};
-use crate::testing::TestServiceWrapper;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::time::Duration;
+use crate::{
+    block_size_limits::BlockSizeLimits,
+    service::{BuilderConfig, GlobalState},
+    testing::TestServiceWrapper,
+};
 
 /// This tests simulates size limits being decreased lower than our capacity
 /// and then checks that size limits return to protocol maximum over time

--- a/hotshot-builder-core-refactored/src/testing/finalization.rs
+++ b/hotshot-builder-core-refactored/src/testing/finalization.rs
@@ -1,16 +1,17 @@
+use std::sync::Arc;
+
 use async_broadcast::broadcast;
+use hotshot_example_types::{block_types::TestTransaction, state_types::TestInstanceState};
+use marketplace_builder_shared::testing::{
+    consensus::SimulatedChainState,
+    constants::{TEST_NUM_NODES_IN_VID_COMPUTATION, TEST_PROTOCOL_MAX_BLOCK_SIZE},
+};
 use tracing_test::traced_test;
 
-use hotshot_example_types::block_types::TestTransaction;
-use hotshot_example_types::state_types::TestInstanceState;
-use marketplace_builder_shared::testing::consensus::SimulatedChainState;
-use marketplace_builder_shared::testing::constants::{
-    TEST_NUM_NODES_IN_VID_COMPUTATION, TEST_PROTOCOL_MAX_BLOCK_SIZE,
+use crate::{
+    service::{BuilderConfig, GlobalState, ALLOW_EMPTY_BLOCK_PERIOD},
+    testing::TestServiceWrapper,
 };
-
-use crate::service::{BuilderConfig, GlobalState, ALLOW_EMPTY_BLOCK_PERIOD};
-use crate::testing::TestServiceWrapper;
-use std::sync::Arc;
 
 // How many times consensus will re-try getting available blocks
 const NUM_RETRIES: usize = 5;

--- a/hotshot-builder-core-refactored/src/testing/integration.rs
+++ b/hotshot-builder-core-refactored/src/testing/integration.rs
@@ -118,21 +118,20 @@ where
 mod tests {
     use std::time::Duration;
 
-    use crate::testing::integration::LegacyBuilderImpl;
-    use marketplace_builder_shared::testing::{
-        generation::{self, TransactionGenerationConfig},
-        run_test,
-        validation::BuilderValidationConfig,
-    };
-
-    use hotshot_example_types::node_types::TestVersions;
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MemoryImpl, TestTypes, TestVersions};
     use hotshot_macros::cross_tests;
     use hotshot_testing::{
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         overall_safety_task::OverallSafetyPropertiesDescription,
         test_builder::TestDescription,
     };
+    use marketplace_builder_shared::testing::{
+        generation::{self, TransactionGenerationConfig},
+        run_test,
+        validation::BuilderValidationConfig,
+    };
+
+    use crate::testing::integration::LegacyBuilderImpl;
 
     #[tokio::test(flavor = "multi_thread")]
     #[tracing::instrument]

--- a/hotshot-builder-core-refactored/src/testing/mod.rs
+++ b/hotshot-builder-core-refactored/src/testing/mod.rs
@@ -2,26 +2,30 @@
 #![allow(clippy::declare_interior_mutable_const)]
 #![allow(clippy::borrow_interior_mutable_const)]
 
-use std::cell::LazyCell;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{cell::LazyCell, sync::Arc, time::Duration};
 
 use async_broadcast::Sender;
 use committable::Commitment;
-use hotshot::rand::{thread_rng, Rng};
-use hotshot::types::{BLSPubKey, Event, EventType, SignatureKey};
-use hotshot_builder_api::v0_1::block_info::AvailableBlockHeaderInputV1;
-use hotshot_builder_api::v0_1::builder::BuildError;
-use hotshot_builder_api::v0_1::data_source::AcceptsTxnSubmits;
-use hotshot_builder_api::v0_1::{block_info::AvailableBlockInfo, data_source::BuilderDataSource};
-use hotshot_example_types::block_types::TestTransaction;
-use hotshot_example_types::node_types::TestTypes;
+use hotshot::{
+    rand::{thread_rng, Rng},
+    types::{BLSPubKey, Event, EventType, SignatureKey},
+};
+use hotshot_builder_api::v0_1::{
+    block_info::{AvailableBlockHeaderInputV1, AvailableBlockInfo},
+    builder::BuildError,
+    data_source::{AcceptsTxnSubmits, BuilderDataSource},
+};
+use hotshot_example_types::{block_types::TestTransaction, node_types::TestTypes};
 use hotshot_task_impls::builder::v0_1::BuilderClient;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
-use marketplace_builder_shared::block::{BlockId, BuilderStateId};
-use marketplace_builder_shared::error::Error;
-use marketplace_builder_shared::utils::BuilderKeys;
+use hotshot_types::{
+    data::ViewNumber,
+    traits::node_implementation::{ConsensusTime, NodeType},
+};
+use marketplace_builder_shared::{
+    block::{BlockId, BuilderStateId},
+    error::Error,
+    utils::BuilderKeys,
+};
 use tokio::spawn;
 use url::Url;
 use vbs::version::StaticVersion;

--- a/hotshot-builder-core/src/builder_state.rs
+++ b/hotshot-builder-core/src/builder_state.rs
@@ -1,3 +1,17 @@
+use core::panic;
+use std::{
+    cmp::PartialEq,
+    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    fmt::Debug,
+    marker::PhantomData,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use async_broadcast::{broadcast, Receiver as BroadcastReceiver, Sender as BroadcastSender};
+use async_lock::RwLock;
+use committable::{Commitment, Committable};
+use futures::StreamExt;
 use hotshot_types::{
     data::{DaProposal2, Leaf2, QuorumProposalWrapper},
     message::Proposal,
@@ -9,29 +23,13 @@ use hotshot_types::{
     utils::BuilderCommitment,
 };
 use marketplace_builder_shared::block::{BlockId, BuilderStateId, ParentBlockReferences};
-
-use committable::{Commitment, Committable};
-
-use crate::service::{GlobalState, ReceivedTransaction};
-use async_broadcast::broadcast;
-use async_broadcast::Receiver as BroadcastReceiver;
-use async_broadcast::Sender as BroadcastSender;
-use async_lock::RwLock;
-use core::panic;
-use futures::StreamExt;
-
 use tokio::{
     spawn,
     sync::{mpsc::UnboundedSender, oneshot},
     time::sleep,
 };
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::Debug;
-use std::sync::Arc;
-use std::time::Instant;
-use std::{cmp::PartialEq, marker::PhantomData};
-use std::{collections::hash_map::Entry, time::Duration};
+use crate::service::{GlobalState, ReceivedTransaction};
 
 pub type TxTimeStamp = u128;
 
@@ -295,7 +293,7 @@ async fn best_builder_states_to_extend<Types: NodeType>(
                 Some(parent_block_references) => {
                     parent_block_references.leaf_commit == justify_qc.data.leaf_commit
                         && parent_block_references.view_number == justify_qc.view_number
-                }
+                },
             },
         )
         .map(|(builder_state_id, _)| builder_state_id.clone())
@@ -1102,15 +1100,15 @@ impl<Types: NodeType, V: Versions> BuilderState<Types, V> {
                     }
                     self.txns_in_queue.insert(tx.commit);
                     self.tx_queue.push_back(tx);
-                }
+                },
                 Err(async_broadcast::TryRecvError::Empty)
                 | Err(async_broadcast::TryRecvError::Closed) => {
                     break;
-                }
+                },
                 Err(async_broadcast::TryRecvError::Overflowed(lost)) => {
                     tracing::warn!("Missed {lost} transactions due to backlog");
                     continue;
-                }
+                },
             }
         }
     }
@@ -1122,20 +1120,19 @@ mod test {
 
     use async_broadcast::broadcast;
     use committable::RawCommitmentBuilder;
-    use hotshot_example_types::block_types::TestTransaction;
-    use hotshot_example_types::node_types::TestTypes;
-    use hotshot_example_types::node_types::TestVersions;
-    use hotshot_types::data::Leaf2;
-    use hotshot_types::data::QuorumProposalWrapper;
-    use hotshot_types::data::ViewNumber;
-    use hotshot_types::traits::node_implementation::{ConsensusTime, NodeType};
-    use hotshot_types::utils::BuilderCommitment;
+    use hotshot_example_types::{
+        block_types::TestTransaction,
+        node_types::{TestTypes, TestVersions},
+    };
+    use hotshot_types::{
+        data::{Leaf2, QuorumProposalWrapper, ViewNumber},
+        traits::node_implementation::{ConsensusTime, NodeType},
+        utils::BuilderCommitment,
+    };
     use marketplace_builder_shared::testing::constants::TEST_NUM_NODES_IN_VID_COMPUTATION;
     use tracing_subscriber::EnvFilter;
 
-    use super::DAProposalInfo;
-    use super::MessageType;
-    use super::ParentBlockReferences;
+    use super::{DAProposalInfo, MessageType, ParentBlockReferences};
     use crate::testing::{calc_builder_commitment, calc_proposal_msg, create_builder_state};
 
     /// This test the function `process_da_proposal`.

--- a/hotshot-builder-core/src/testing/basic_test.rs
+++ b/hotshot-builder-core/src/testing/basic_test.rs
@@ -1,4 +1,3 @@
-pub use crate::builder_state::{BuilderState, MessageType};
 pub use async_broadcast::broadcast;
 pub use hotshot::traits::election::static_committee::StaticCommittee;
 pub use hotshot_types::{
@@ -12,51 +11,49 @@ pub use hotshot_types::{
     },
 };
 use vbs::version::StaticVersionType;
+
+pub use crate::builder_state::{BuilderState, MessageType};
 /// The following tests are performed:
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::collections::VecDeque;
-    use std::{hash::Hash, marker::PhantomData};
+    use std::{collections::VecDeque, hash::Hash, marker::PhantomData, sync::Arc, time::Duration};
 
-    use hotshot::types::SignatureKey;
-    use hotshot_builder_api::v0_2::data_source::BuilderDataSource;
-    use hotshot_example_types::auction_results_provider_types::TestAuctionResult;
-    use hotshot_example_types::node_types::TestVersions;
-    use hotshot_types::data::{DaProposal2, Leaf2, QuorumProposal2, QuorumProposalWrapper};
-    use hotshot_types::simple_vote::QuorumData2;
-    use hotshot_types::traits::node_implementation::Versions;
-    use hotshot_types::{
-        data::vid_commitment, signature_key::BuilderKey, traits::block_contents::BlockHeader,
-        traits::EncodeBytes, utils::BuilderCommitment,
-    };
-
-    use hotshot_example_types::{
-        block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
-        state_types::{TestInstanceState, TestValidatedState},
-    };
-    use marketplace_builder_shared::block::ParentBlockReferences;
-    use marketplace_builder_shared::testing::constants::{
-        TEST_MAX_BLOCK_SIZE_INCREMENT_PERIOD, TEST_MAX_TX_NUM, TEST_NUM_NODES_IN_VID_COMPUTATION,
-        TEST_PROTOCOL_MAX_BLOCK_SIZE,
-    };
-    use tokio::time::error::Elapsed;
-    use tokio::time::timeout;
-    use tracing_subscriber::EnvFilter;
-
-    use crate::builder_state::{
-        DaProposalMessage, DecideMessage, QuorumProposalMessage, TransactionSource,
-    };
-    use crate::service::{
-        handle_received_txns, GlobalState, ProxyGlobalState, ReceivedTransaction,
-    };
     use async_lock::RwLock;
     use committable::{Commitment, CommitmentBoundsArkless, Committable};
-    use sha2::{Digest, Sha256};
-    use std::sync::Arc;
-    use std::time::Duration;
-
+    use hotshot::types::SignatureKey;
+    use hotshot_builder_api::v0_2::data_source::BuilderDataSource;
+    use hotshot_example_types::{
+        auction_results_provider_types::TestAuctionResult,
+        block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
+        node_types::TestVersions,
+        state_types::{TestInstanceState, TestValidatedState},
+    };
+    use hotshot_types::{
+        data::{vid_commitment, DaProposal2, Leaf2, QuorumProposal2, QuorumProposalWrapper},
+        signature_key::BuilderKey,
+        simple_vote::QuorumData2,
+        traits::{block_contents::BlockHeader, node_implementation::Versions, EncodeBytes},
+        utils::BuilderCommitment,
+    };
+    use marketplace_builder_shared::{
+        block::ParentBlockReferences,
+        testing::constants::{
+            TEST_MAX_BLOCK_SIZE_INCREMENT_PERIOD, TEST_MAX_TX_NUM,
+            TEST_NUM_NODES_IN_VID_COMPUTATION, TEST_PROTOCOL_MAX_BLOCK_SIZE,
+        },
+    };
     use serde::{Deserialize, Serialize};
+    use sha2::{Digest, Sha256};
+    use tokio::time::{error::Elapsed, timeout};
+    use tracing_subscriber::EnvFilter;
+
+    use super::*;
+    use crate::{
+        builder_state::{
+            DaProposalMessage, DecideMessage, QuorumProposalMessage, TransactionSource,
+        },
+        service::{handle_received_txns, GlobalState, ProxyGlobalState, ReceivedTransaction},
+    };
     /// This test simulates multiple builder states receiving messages from the channels and processing them
     #[tokio::test]
     //#[instrument]
@@ -461,7 +458,7 @@ mod tests {
                                 )
                                 .unwrap();
                             current_leaf
-                        }
+                        },
                     };
 
                     DecideMessage::<TestTypes> {

--- a/hotshot-builder-core/src/testing/finalization_test.rs
+++ b/hotshot-builder-core/src/testing/finalization_test.rs
@@ -1,10 +1,5 @@
 use std::{sync::Arc, time::Duration};
 
-use super::basic_test::{BuilderState, MessageType};
-use crate::{
-    builder_state::{DaProposalMessage, QuorumProposalMessage, ALLOW_EMPTY_BLOCK_PERIOD},
-    service::{GlobalState, ProxyGlobalState, ReceivedTransaction},
-};
 use async_broadcast::{broadcast, Sender};
 use async_lock::RwLock;
 use committable::Commitment;
@@ -12,19 +7,20 @@ use hotshot::{
     traits::BlockPayload,
     types::{BLSPubKey, SignatureKey},
 };
-use hotshot_builder_api::{
-    v0_1::{block_info::AvailableBlockInfo, data_source::BuilderDataSource},
-    v0_1::{builder::BuildError, data_source::AcceptsTxnSubmits},
+use hotshot_builder_api::v0_1::{
+    block_info::AvailableBlockInfo,
+    builder::BuildError,
+    data_source::{AcceptsTxnSubmits, BuilderDataSource},
 };
 use hotshot_example_types::{
     block_types::{TestBlockHeader, TestBlockPayload, TestMetadata, TestTransaction},
     node_types::{TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
-use hotshot_types::simple_certificate::QuorumCertificate2;
 use hotshot_types::{
     data::{vid_commitment, DaProposal2, QuorumProposal2, QuorumProposalWrapper, ViewNumber},
     message::Proposal,
+    simple_certificate::QuorumCertificate2,
     traits::{
         block_contents::BlockHeader,
         node_implementation::{ConsensusTime, Versions},
@@ -32,18 +28,22 @@ use hotshot_types::{
     },
     utils::BuilderCommitment,
 };
-use marketplace_builder_shared::testing::constants::{
-    TEST_CHANNEL_BUFFER_SIZE, TEST_MAX_TX_NUM, TEST_NUM_CONSENSUS_RETRIES,
-    TEST_NUM_NODES_IN_VID_COMPUTATION,
-};
 use marketplace_builder_shared::{
-    block::BuilderStateId, testing::constants::TEST_MAX_BLOCK_SIZE_INCREMENT_PERIOD,
-};
-use marketplace_builder_shared::{
-    block::ParentBlockReferences, testing::constants::TEST_PROTOCOL_MAX_BLOCK_SIZE,
+    block::{BuilderStateId, ParentBlockReferences},
+    testing::constants::{
+        TEST_CHANNEL_BUFFER_SIZE, TEST_MAX_BLOCK_SIZE_INCREMENT_PERIOD, TEST_MAX_TX_NUM,
+        TEST_NUM_CONSENSUS_RETRIES, TEST_NUM_NODES_IN_VID_COMPUTATION,
+        TEST_PROTOCOL_MAX_BLOCK_SIZE,
+    },
 };
 use sha2::{Digest, Sha256};
 use vbs::version::StaticVersionType;
+
+use super::basic_test::{BuilderState, MessageType};
+use crate::{
+    builder_state::{DaProposalMessage, QuorumProposalMessage, ALLOW_EMPTY_BLOCK_PERIOD},
+    service::{GlobalState, ProxyGlobalState, ReceivedTransaction},
+};
 
 type TestSetup = (
     ProxyGlobalState<TestTypes>,

--- a/hotshot-events-service/src/api.rs
+++ b/hotshot-events-service/src/api.rs
@@ -40,7 +40,7 @@ fn merge_toml(into: &mut Value, from: Value) {
                 Entry::Occupied(mut entry) => merge_toml(entry.get_mut(), value),
                 Entry::Vacant(entry) => {
                     entry.insert(value);
-                }
+                },
             }
         }
     }

--- a/hotshot-events-service/src/events.rs
+++ b/hotshot-events-service/src/events.rs
@@ -1,10 +1,11 @@
+use std::path::PathBuf;
+
 use clap::Args;
 use derive_more::From;
 use futures::{FutureExt, StreamExt, TryFutureExt};
 use hotshot_types::traits::node_implementation::NodeType;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::path::PathBuf;
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
 use vbs::version::StaticVersionType;
 

--- a/hotshot-events-service/src/events_source.rs
+++ b/hotshot-events-service/src/events_source.rs
@@ -99,7 +99,7 @@ impl<Types: NodeType> EventFilterSet<Types> {
             EventType::Decide { .. } => filter.contains(&EventFilter::Decide),
             EventType::ReplicaViewTimeout { .. } => {
                 filter.contains(&EventFilter::ReplicaViewTimeout)
-            }
+            },
             EventType::ViewFinished { .. } => filter.contains(&EventFilter::ViewFinished),
             EventType::ViewTimeout { .. } => filter.contains(&EventFilter::ViewTimeout),
             EventType::Transactions { .. } => filter.contains(&EventFilter::Transactions),

--- a/hotshot-example-types/src/block_types.rs
+++ b/hotshot-example-types/src/block_types.rs
@@ -13,8 +13,7 @@ use std::{
 use async_trait::async_trait;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use hotshot_types::{
-    data::VidCommitment,
-    data::{BlockError, Leaf2},
+    data::{BlockError, Leaf2, VidCommitment},
     traits::{
         block_contents::{BlockHeader, BuilderFee, EncodeBytes, TestableBlock, Transaction},
         node_implementation::NodeType,

--- a/hotshot-example-types/src/storage_types.rs
+++ b/hotshot-example-types/src/storage_types.rs
@@ -12,7 +12,6 @@ use std::{
 use anyhow::{bail, Result};
 use async_lock::RwLock;
 use async_trait::async_trait;
-use hotshot_types::drb::DrbResult;
 use hotshot_types::{
     consensus::CommitmentMap,
     data::{
@@ -20,6 +19,7 @@ use hotshot_types::{
         DaProposal, DaProposal2, Leaf, Leaf2, QuorumProposal, QuorumProposal2,
         QuorumProposalWrapper, VidCommitment,
     },
+    drb::DrbResult,
     event::HotShotAction,
     message::{convert_proposal, Proposal},
     simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2, UpgradeCertificate},

--- a/hotshot-example-types/src/testable_delay.rs
+++ b/hotshot-example-types/src/testable_delay.rs
@@ -85,16 +85,16 @@ pub trait TestableDelay {
     /// Add a delay from settings
     async fn handle_async_delay(settings: &DelaySettings) {
         match settings.delay_option {
-            DelayOptions::None => {}
+            DelayOptions::None => {},
             DelayOptions::Fixed => {
                 sleep(Duration::from_millis(settings.fixed_time_in_milliseconds)).await;
-            }
+            },
             DelayOptions::Random => {
                 let sleep_in_millis = rand::thread_rng().gen_range(
                     settings.min_time_in_milliseconds..=settings.max_time_in_milliseconds,
                 );
                 sleep(Duration::from_millis(sleep_in_millis)).await;
-            }
+            },
         }
     }
 
@@ -124,7 +124,7 @@ impl Iterator for SupportedTraitTypesForAsyncDelayIterator {
             _ => {
                 assert_eq!(self.index, 3, "Need to ensure that newly added or removed `SupportedTraitTypesForAsyncDelay` enum is handled in iterator");
                 return None;
-            }
+            },
         };
         self.index += 1;
         supported_type

--- a/hotshot-examples/infra/mod.rs
+++ b/hotshot-examples/infra/mod.rs
@@ -441,13 +441,13 @@ pub trait RunDa<
             match event_stream.next().await {
                 None => {
                     panic!("Error! Event stream completed before consensus ended.");
-                }
+                },
                 Some(Event { event, .. }) => {
                     match event {
                         EventType::Error { error } => {
                             error!("Error in consensus: {:?}", error);
                             // TODO what to do here
-                        }
+                        },
                         EventType::Decide {
                             leaf_chain,
                             qc: _,
@@ -514,16 +514,16 @@ pub trait RunDa<
                                 warn!("Leaf chain is greater than 1 with len {}", leaf_chain.len());
                             }
                             // when we make progress, submit new events
-                        }
+                        },
                         EventType::ReplicaViewTimeout { view_number } => {
                             warn!("Timed out as a replicas in view {:?}", view_number);
-                        }
+                        },
                         EventType::ViewTimeout { view_number } => {
                             warn!("Timed out in view {:?}", view_number);
-                        }
-                        _ => {} // mostly DA proposal
+                        },
+                        _ => {}, // mostly DA proposal
                     }
-                }
+                },
             }
         }
         // Panic if we don't have the genesis epoch, there is no recovery from that
@@ -1092,11 +1092,11 @@ where
                 })
                 .collect();
             bind_address = Url::parse(&format!("http://0.0.0.0:{port}")).unwrap();
-        }
+        },
         Some(ref addr) => {
             bind_address = Url::parse(&format!("http://{addr}")).expect("Valid URL");
             advertise_urls = vec![bind_address.clone()];
-        }
+        },
     }
 
     match run_config.builder {
@@ -1116,7 +1116,7 @@ where
                 .await;
 
             Some(builder_task)
-        }
+        },
         BuilderType::Simple => {
             let builder_task =
                 <SimpleBuilderImplementation as TestBuilderImplementation<TYPES>>::start(
@@ -1132,7 +1132,7 @@ where
                 .await;
 
             Some(builder_task)
-        }
+        },
     }
 }
 

--- a/hotshot-fakeapi/src/fake_solver.rs
+++ b/hotshot-fakeapi/src/fake_solver.rs
@@ -91,11 +91,11 @@ impl FakeSolverState {
                         status: tide_disco::StatusCode::INTERNAL_SERVER_ERROR,
                         message: "Internal Server Error".to_string(),
                     });
-                }
+                },
                 FakeSolverFaultType::TimeoutFault => {
                     // Sleep for the preconfigured 1 second timeout interval
                     tokio::time::sleep(SOLVER_MAX_TIMEOUT_S).await;
-                }
+                },
             }
         }
 

--- a/hotshot-libp2p-networking/src/network/behaviours/dht/bootstrap.rs
+++ b/hotshot-libp2p-networking/src/network/behaviours/dht/bootstrap.rs
@@ -50,19 +50,19 @@ impl DHTBootstrapTask {
                     Some(InputEvent::BootstrapFinished) => {
                         tracing::debug!("Bootstrap finished");
                         self.in_progress = false;
-                    }
+                    },
                     Some(InputEvent::ShutdownBootstrap) => {
                         tracing::info!("ShutdownBootstrap received, shutting down");
                         break;
-                    }
+                    },
                     Some(InputEvent::StartBootstrap) => {
                         tracing::warn!("Trying to start bootstrap that's already in progress");
                         continue;
-                    }
+                    },
                     None => {
                         tracing::debug!("Bootstrap channel closed, exiting loop");
                         break;
-                    }
+                    },
                 }
             } else if let Ok(maybe_event) = timeout(Duration::from_secs(120), self.rx.next()).await
             {
@@ -70,18 +70,18 @@ impl DHTBootstrapTask {
                     Some(InputEvent::StartBootstrap) => {
                         tracing::debug!("Start bootstrap in bootstrap task");
                         self.bootstrap();
-                    }
+                    },
                     Some(InputEvent::ShutdownBootstrap) => {
                         tracing::debug!("ShutdownBootstrap received, shutting down");
                         break;
-                    }
+                    },
                     Some(InputEvent::BootstrapFinished) => {
                         tracing::debug!("not in progress got bootstrap finished");
-                    }
+                    },
                     None => {
                         tracing::debug!("Bootstrap channel closed, exiting loop");
                         break;
-                    }
+                    },
                 }
             } else {
                 tracing::debug!("Start bootstrap in bootstrap task after timeout");

--- a/hotshot-libp2p-networking/src/network/behaviours/dht/mod.rs
+++ b/hotshot-libp2p-networking/src/network/behaviours/dht/mod.rs
@@ -274,31 +274,31 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                                 let num_entries = o.get_mut();
                                 *num_entries += 1;
                                 *num_entries
-                            }
+                            },
                             std::collections::hash_map::Entry::Vacant(v) => {
                                 v.insert(1);
                                 1
-                            }
+                            },
                         }
-                    }
+                    },
                     GetRecordOk::FinishedWithNoAdditionalRecord {
                         cache_candidates: _,
                     } => {
                         tracing::debug!("GetRecord Finished with No Additional Record");
                         last = true;
                         0
-                    }
+                    },
                 },
                 Err(err) => {
                     warn!("Error in Kademlia query: {:?}", err);
                     0
-                }
+                },
             },
             None => {
                 // We already finished the query (or it's been cancelled). Do nothing and exit the
                 // function.
                 return;
-            }
+            },
         };
 
         // if the query has completed and we need to retry
@@ -398,7 +398,7 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                     if query.notify.send(()).is_err() {
                         warn!("Put DHT: client channel closed before put record request could be sent");
                     }
-                }
+                },
                 Err(e) => {
                     query.progress = DHTProgress::NotStarted;
                     query.backoff.start_next(false);
@@ -409,7 +409,7 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                     );
                     // push back onto the queue
                     self.retry_put(query);
-                }
+                },
             }
         } else {
             warn!("Put DHT: completed DHT query that is no longer tracked.");
@@ -439,7 +439,7 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                 if last {
                     self.handle_put_query(record_results, id);
                 }
-            }
+            },
             KademliaEvent::OutboundQueryProgressed {
                 result: QueryResult::GetClosestPeers(r),
                 id: query_id,
@@ -454,13 +454,13 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                         };
                     };
                     debug!("Successfully got closest peers for key {:?}", key);
-                }
+                },
                 Err(e) => {
                     if let Some(chan) = self.in_progress_get_closest_peers.remove(&query_id) {
                         let _: Result<_, _> = chan.send(());
                     };
                     warn!("Failed to get closest peers: {:?}", e);
-                }
+                },
             },
             KademliaEvent::OutboundQueryProgressed {
                 result: QueryResult::GetRecord(record_results),
@@ -469,7 +469,7 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                 ..
             } => {
                 self.handle_get_query(store, record_results, id, last);
-            }
+            },
             KademliaEvent::OutboundQueryProgressed {
                 result:
                     QueryResult::Bootstrap(Ok(BootstrapOk {
@@ -485,7 +485,7 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                     debug!("Bootstrap in progress, {} nodes remaining", num_remaining);
                 }
                 return Some(NetworkEvent::IsBootstrapped);
-            }
+            },
             KademliaEvent::OutboundQueryProgressed {
                 result: QueryResult::Bootstrap(Err(e)),
                 ..
@@ -495,16 +495,16 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                     error!("Failed to bootstrap: {:?}", e);
                 }
                 self.finish_bootstrap();
-            }
+            },
             KademliaEvent::RoutablePeer { peer, address: _ } => {
                 debug!("Found routable peer {:?}", peer);
-            }
+            },
             KademliaEvent::PendingRoutablePeer { peer, address: _ } => {
                 debug!("Found pending routable peer {:?}", peer);
-            }
+            },
             KademliaEvent::UnroutablePeer { peer } => {
                 debug!("Found unroutable peer {:?}", peer);
-            }
+            },
             KademliaEvent::RoutingUpdated {
                 peer: _,
                 is_new_peer: _,
@@ -513,13 +513,13 @@ impl<K: SignatureKey + 'static, D: DhtPersistentStorage> DHTBehaviour<K, D> {
                 old_peer: _,
             } => {
                 debug!("Routing table updated");
-            }
+            },
             e @ KademliaEvent::OutboundQueryProgressed { .. } => {
                 debug!("Not handling dht event {:?}", e);
-            }
+            },
             e => {
                 debug!("New unhandled swarm event: {e:?}");
-            }
+            },
         }
         None
     }

--- a/hotshot-libp2p-networking/src/network/behaviours/dht/store/persistent.rs
+++ b/hotshot-libp2p-networking/src/network/behaviours/dht/store/persistent.rs
@@ -281,10 +281,10 @@ impl<R: RecordStore, D: DhtPersistentStorage> PersistentStore<R, D> {
             .await
             .map_err(|_| anyhow::anyhow!("save operation timed out"))
             {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {},
                 Ok(Err(error)) | Err(error) => {
                     warn!("Failed to save DHT to persistent storage: {error}");
-                }
+                },
             };
 
             // Reset the record delta
@@ -324,10 +324,10 @@ impl<R: RecordStore, D: DhtPersistentStorage> PersistentStore<R, D> {
                             err
                         );
                     }
-                }
+                },
                 Err(err) => {
                     warn!("Failed to parse record from persistent storage: {:?}", err);
-                }
+                },
             };
         }
 

--- a/hotshot-libp2p-networking/src/network/behaviours/direct_message.rs
+++ b/hotshot-libp2p-networking/src/network/behaviours/direct_message.rs
@@ -59,7 +59,7 @@ impl DMBehaviour {
             } => {
                 error!("Inbound message failure from {:?}: {:?}", peer, error);
                 None
-            }
+            },
             Event::OutboundFailure {
                 peer,
                 request_id,
@@ -83,7 +83,7 @@ impl DMBehaviour {
                     }
                 }
                 None
-            }
+            },
             Event::Message { message, peer, .. } => match message {
                 Message::Request {
                     request: msg,
@@ -94,7 +94,7 @@ impl DMBehaviour {
                     // receiver, not initiator.
                     // don't track. If we are disconnected, sender will reinitiate
                     Some(NetworkEvent::DirectRequest(msg, peer, channel))
-                }
+                },
                 Message::Response {
                     request_id,
                     response: msg,
@@ -107,12 +107,12 @@ impl DMBehaviour {
                         warn!("Received response for unknown request id {:?}", request_id);
                         None
                     }
-                }
+                },
             },
             e @ Event::ResponseSent { .. } => {
                 debug!("Response sent {:?}", e);
                 None
-            }
+            },
         }
     }
 }

--- a/hotshot-libp2p-networking/src/network/cbor.rs
+++ b/hotshot-libp2p-networking/src/network/cbor.rs
@@ -126,19 +126,19 @@ fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Err
     match err {
         cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
             io::Error::new(io::ErrorKind::Other, e.to_string())
-        }
+        },
         cbor4ii::serde::DecodeError::Core(e @ DecodeError::Unsupported { .. }) => {
             io::Error::new(io::ErrorKind::Unsupported, e.to_string())
-        }
+        },
         cbor4ii::serde::DecodeError::Core(e @ DecodeError::Eof { .. }) => {
             io::Error::new(io::ErrorKind::UnexpectedEof, e.to_string())
-        }
+        },
         cbor4ii::serde::DecodeError::Core(e) => {
             io::Error::new(io::ErrorKind::InvalidData, e.to_string())
-        }
+        },
         cbor4ii::serde::DecodeError::Custom(e) => {
             io::Error::new(io::ErrorKind::Other, e.to_string())
-        }
+        },
     }
 }
 

--- a/hotshot-libp2p-networking/src/network/node.rs
+++ b/hotshot-libp2p-networking/src/network/node.rs
@@ -360,7 +360,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 query.progress = DHTProgress::NotStarted;
                 query.backoff.start_next(false);
                 error!("Error publishing to DHT: {e:?} for peer {:?}", self.peer_id);
-            }
+            },
             Ok(qid) => {
                 debug!("Published record to DHT with qid {:?}", qid);
                 let query = KadPutQuery {
@@ -368,7 +368,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                     ..query
                 };
                 self.dht_handler.put_record(qid, query);
-            }
+            },
         }
     }
 
@@ -392,20 +392,20 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                     ClientRequest::BeginBootstrap => {
                         debug!("Beginning Libp2p bootstrap");
                         let _ = self.swarm.behaviour_mut().dht.bootstrap();
-                    }
+                    },
                     ClientRequest::LookupPeer(pid, chan) => {
                         let id = self.swarm.behaviour_mut().dht.get_closest_peers(pid);
                         self.dht_handler
                             .in_progress_get_closest_peers
                             .insert(id, chan);
-                    }
+                    },
                     ClientRequest::GetRoutingTable(chan) => {
                         self.dht_handler
                             .print_routing_table(&mut self.swarm.behaviour_mut().dht);
                         if chan.send(()).is_err() {
                             warn!("Tried to notify client but client not tracking anymore");
                         }
-                    }
+                    },
                     ClientRequest::PutDHT { key, value, notify } => {
                         let query = KadPutQuery {
                             progress: DHTProgress::NotStarted,
@@ -415,17 +415,17 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                             backoff: ExponentialBackoff::default(),
                         };
                         self.put_record(query);
-                    }
+                    },
                     ClientRequest::GetConnectedPeerNum(s) => {
                         if s.send(self.num_connected()).is_err() {
                             error!("error sending peer number to client");
                         }
-                    }
+                    },
                     ClientRequest::GetConnectedPeers(s) => {
                         if s.send(self.connected_pids()).is_err() {
                             error!("error sending peer set to client");
                         }
-                    }
+                    },
                     ClientRequest::GetDHT {
                         key,
                         notify,
@@ -439,20 +439,20 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                             retry_count,
                             &mut self.swarm.behaviour_mut().dht,
                         );
-                    }
+                    },
                     ClientRequest::IgnorePeers(_peers) => {
                         // NOTE used by test with conductor only
-                    }
+                    },
                     ClientRequest::Shutdown => {
                         if let Some(listener_id) = self.listener_id {
                             self.swarm.remove_listener(listener_id);
                         }
 
                         return Ok(true);
-                    }
+                    },
                     ClientRequest::GossipMsg(topic, contents) => {
                         behaviour.publish_gossip(Topic::new(topic.clone()), contents.clone());
-                    }
+                    },
                     ClientRequest::Subscribe(t, chan) => {
                         behaviour.subscribe_gossip(&t);
                         if let Some(chan) = chan {
@@ -460,7 +460,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                                 error!("finished subscribing but response channel dropped");
                             }
                         }
-                    }
+                    },
                     ClientRequest::Unsubscribe(t, chan) => {
                         behaviour.unsubscribe_gossip(&t);
                         if let Some(chan) = chan {
@@ -468,7 +468,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                                 error!("finished unsubscribing but response channel dropped");
                             }
                         }
-                    }
+                    },
                     ClientRequest::DirectRequest {
                         pid,
                         contents,
@@ -483,23 +483,23 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                             retry_count,
                         };
                         self.direct_message_state.add_direct_request(req, id);
-                    }
+                    },
                     ClientRequest::DirectResponse(chan, msg) => {
                         behaviour.add_direct_response(chan, msg);
-                    }
+                    },
                     ClientRequest::AddKnownPeers(peers) => {
                         self.add_known_peers(&peers);
-                    }
+                    },
                     ClientRequest::Prune(pid) => {
                         if self.swarm.disconnect_peer_id(pid).is_err() {
                             warn!("Could not disconnect from {:?}", pid);
                         }
-                    }
+                    },
                 }
-            }
+            },
             None => {
                 error!("Error receiving msg in main behaviour loop: channel closed");
-            }
+            },
         }
         Ok(false)
     }
@@ -541,7 +541,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 send_to_client
                     .send(NetworkEvent::ConnectedPeersUpdate(self.num_connected()))
                     .map_err(|err| NetworkError::ChannelSendError(err.to_string()))?;
-            }
+            },
             SwarmEvent::ConnectionClosed {
                 connection_id: _,
                 peer_id,
@@ -565,13 +565,13 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 send_to_client
                     .send(NetworkEvent::ConnectedPeersUpdate(self.num_connected()))
                     .map_err(|err| NetworkError::ChannelSendError(err.to_string()))?;
-            }
+            },
             SwarmEvent::Dialing {
                 peer_id,
                 connection_id: _,
             } => {
                 debug!("Attempting to dial {:?}", peer_id);
-            }
+            },
             SwarmEvent::ListenerClosed {
                 listener_id: _,
                 addresses: _,
@@ -591,7 +591,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 connection_id: _,
                 local_addr: _,
                 send_back_addr: _,
-            } => {}
+            } => {},
             SwarmEvent::Behaviour(b) => {
                 let maybe_event = match b {
                     NetworkEventInternal::DHTEvent(e) => self
@@ -621,7 +621,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                             }
                         }
                         None
-                    }
+                    },
                     NetworkEventInternal::GossipEvent(e) => match *e {
                         GossipEvent::Message {
                             propagation_source: _peer_id,
@@ -631,25 +631,25 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                         GossipEvent::Subscribed { peer_id, topic } => {
                             debug!("Peer {:?} subscribed to topic {:?}", peer_id, topic);
                             None
-                        }
+                        },
                         GossipEvent::Unsubscribed { peer_id, topic } => {
                             debug!("Peer {:?} unsubscribed from topic {:?}", peer_id, topic);
                             None
-                        }
+                        },
                         GossipEvent::GossipsubNotSupported { peer_id } => {
                             warn!("Peer {:?} does not support gossipsub", peer_id);
                             None
-                        }
+                        },
                     },
                     NetworkEventInternal::DMEvent(e) => self
                         .direct_message_state
                         .handle_dm_event(e, self.resend_tx.clone()),
                     NetworkEventInternal::AutonatEvent(e) => {
                         match e {
-                            autonat::Event::InboundProbe(_) => {}
+                            autonat::Event::InboundProbe(_) => {},
                             autonat::Event::OutboundProbe(e) => match e {
                                 autonat::OutboundProbeEvent::Request { .. }
-                                | autonat::OutboundProbeEvent::Response { .. } => {}
+                                | autonat::OutboundProbeEvent::Response { .. } => {},
                                 autonat::OutboundProbeEvent::Error {
                                     probe_id: _,
                                     peer,
@@ -659,14 +659,14 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                                         "AutoNAT Probe failed to peer {:?} with error: {:?}",
                                         peer, error
                                     );
-                                }
+                                },
                             },
                             autonat::Event::StatusChanged { old, new } => {
                                 debug!("AutoNAT Status changed. Old: {:?}, New: {:?}", old, new);
-                            }
+                            },
                         };
                         None
-                    }
+                    },
                 };
 
                 if let Some(event) = maybe_event {
@@ -675,14 +675,14 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                         .send(event)
                         .map_err(|err| NetworkError::ChannelSendError(err.to_string()))?;
                 }
-            }
+            },
             SwarmEvent::OutgoingConnectionError {
                 connection_id: _,
                 peer_id,
                 error,
             } => {
                 warn!("Outgoing connection error to {:?}: {:?}", peer_id, error);
-            }
+            },
             SwarmEvent::IncomingConnectionError {
                 connection_id: _,
                 local_addr: _,
@@ -690,29 +690,29 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                 error,
             } => {
                 warn!("Incoming connection error: {:?}", error);
-            }
+            },
             SwarmEvent::ListenerError {
                 listener_id: _,
                 error,
             } => {
                 warn!("Listener error: {:?}", error);
-            }
+            },
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 let my_id = *self.swarm.local_peer_id();
                 self.swarm
                     .behaviour_mut()
                     .dht
                     .add_address(&my_id, address.clone());
-            }
+            },
             SwarmEvent::NewExternalAddrOfPeer { peer_id, address } => {
                 self.swarm
                     .behaviour_mut()
                     .dht
                     .add_address(&peer_id, address.clone());
-            }
+            },
             _ => {
                 debug!("Unhandled swarm event {:?}", event);
-            }
+            },
         }
         Ok(())
     }

--- a/hotshot-libp2p-networking/src/network/transport.rs
+++ b/hotshot-libp2p-networking/src/network/transport.rs
@@ -358,7 +358,7 @@ where
                         local_addr,
                         send_back_addr,
                     }
-                }
+                },
 
                 // We need to re-map the other events because we changed the type of the upgrade
                 TransportEvent::AddressExpired {
@@ -377,7 +377,7 @@ where
                 },
                 TransportEvent::ListenerError { listener_id, error } => {
                     TransportEvent::ListenerError { listener_id, error }
-                }
+                },
                 TransportEvent::NewAddress {
                     listener_id,
                     listen_addr,

--- a/hotshot-macros/src/lib.rs
+++ b/hotshot-macros/src/lib.rs
@@ -118,7 +118,7 @@ impl ToLowerSnakeStr for syn::GenericArgument {
                 syn::Type::Path(p) => p.to_lower_snake_str(),
                 _ => {
                     panic!("Unexpected type for GenericArgument::Type: {t:?}");
-                }
+                },
             },
             syn::GenericArgument::Const(c) => match c {
                 syn::Expr::Lit(l) => match &l.lit {
@@ -126,15 +126,15 @@ impl ToLowerSnakeStr for syn::GenericArgument {
                     syn::Lit::Int(v) => format!("{}_", v.base10_digits()),
                     _ => {
                         panic!("Unexpected type for GenericArgument::Const::Lit: {l:?}");
-                    }
+                    },
                 },
                 _ => {
                     panic!("Unexpected type for GenericArgument::Const: {c:?}");
-                }
+                },
             },
             _ => {
                 panic!("Unexpected type for GenericArgument: {self:?}");
-            }
+            },
         }
     }
 }

--- a/hotshot-orchestrator/src/client.rs
+++ b/hotshot-orchestrator/src/client.rs
@@ -515,7 +515,7 @@ impl OrchestratorClient {
                 Err(err) => {
                     tracing::info!("{err}");
                     sleep(Duration::from_millis(250)).await;
-                }
+                },
             }
         }
     }

--- a/hotshot-query-service/examples/simple-server.rs
+++ b/hotshot-query-service/examples/simple-server.rs
@@ -16,6 +16,8 @@
 //! consensus network with two nodes and connects a query service to each node. It runs each query
 //! server on local host. The program continues until it is manually killed.
 
+use std::{num::NonZeroUsize, str::FromStr, sync::Arc, time::Duration};
+
 use async_lock::RwLock;
 use clap::Parser;
 use futures::future::{join_all, try_join_all};
@@ -48,7 +50,6 @@ use hotshot_types::{
     traits::{election::Membership, network::Topic},
     HotShotConfig, PeerConfig,
 };
-use std::{num::NonZeroUsize, str::FromStr, sync::Arc, time::Duration};
 use tracing_subscriber::EnvFilter;
 use url::Url;
 use vbs::version::StaticVersionType;

--- a/hotshot-query-service/src/api.rs
+++ b/hotshot-query-service/src/api.rs
@@ -10,8 +10,8 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
+
 use tide_disco::api::{Api, ApiError};
 use toml::{map::Entry, Value};
 use vbs::version::StaticVersionType;
@@ -40,7 +40,7 @@ fn merge_toml(into: &mut Value, from: Value) {
                 Entry::Occupied(mut entry) => merge_toml(entry.get_mut(), value),
                 Entry::Vacant(entry) => {
                     entry.insert(value);
-                }
+                },
             }
         }
     }

--- a/hotshot-query-service/src/availability/data_source.rs
+++ b/hotshot-query-service/src/availability/data_source.rs
@@ -10,15 +10,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::{
-    fetch::Fetch,
-    query_data::{
-        BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadMetadata, PayloadQueryData,
-        QueryablePayload, TransactionHash, TransactionQueryData, VidCommonMetadata,
-        VidCommonQueryData,
-    },
+use std::{
+    cmp::Ordering,
+    ops::{Bound, RangeBounds},
 };
-use crate::{types::HeightIndexed, Header, Payload};
+
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::{Display, From};
@@ -30,10 +26,16 @@ use hotshot_types::{
     data::{VidCommitment, VidShare},
     traits::node_implementation::NodeType,
 };
-use std::{
-    cmp::Ordering,
-    ops::{Bound, RangeBounds},
+
+use super::{
+    fetch::Fetch,
+    query_data::{
+        BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadMetadata, PayloadQueryData,
+        QueryablePayload, TransactionHash, TransactionQueryData, VidCommonMetadata,
+        VidCommonQueryData,
+    },
 };
+use crate::{types::HeightIndexed, Header, Payload};
 
 #[derive(Derivative, From, Display)]
 #[derivative(Ord = "feature_allow_slow_enum")]

--- a/hotshot-query-service/src/availability/fetch.rs
+++ b/hotshot-query-service/src/availability/fetch.rs
@@ -10,9 +10,10 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::{future::IntoFuture, time::Duration};
+
 use futures::future::{BoxFuture, FutureExt};
 use snafu::{Error, ErrorCompat, IntoError, NoneError, OptionExt};
-use std::{future::IntoFuture, time::Duration};
 use tokio::time::timeout;
 
 /// An in-progress request to fetch some data.

--- a/hotshot-query-service/src/availability/query_data.rs
+++ b/hotshot-query-service/src/availability/query_data.rs
@@ -10,7 +10,8 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::{types::HeightIndexed, Header, Metadata, Payload, Transaction, VidCommon};
+use std::fmt::Debug;
+
 use committable::{Commitment, Committable};
 use hotshot_types::{
     data::{Leaf, Leaf2, VidCommitment, VidShare},
@@ -26,7 +27,8 @@ use hotshot_types::{
 use jf_vid::VidScheme;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use snafu::{ensure, Snafu};
-use std::fmt::Debug;
+
+use crate::{types::HeightIndexed, Header, Metadata, Payload, Transaction, VidCommon};
 
 pub type LeafHash<Types> = Commitment<Leaf2<Types>>;
 pub type QcHash<Types> = Commitment<QuorumCertificate2<Types>>;

--- a/hotshot-query-service/src/data_source.rs
+++ b/hotshot-query-service/src/data_source.rs
@@ -47,16 +47,18 @@ pub use update::{Transaction, UpdateDataSource, VersionedDataSource};
 
 #[cfg(any(test, feature = "testing"))]
 mod test_helpers {
+    use std::ops::{Bound, RangeBounds};
+
+    use futures::{
+        future,
+        stream::{BoxStream, StreamExt},
+    };
+
     use crate::{
         availability::{BlockQueryData, Fetch, LeafQueryData},
         node::NodeDataSource,
         testing::{consensus::TestableDataSource, mocks::MockTypes},
     };
-    use futures::{
-        future,
-        stream::{BoxStream, StreamExt},
-    };
-    use std::ops::{Bound, RangeBounds};
 
     /// Apply an upper bound to a range based on the currently available block height.
     async fn bound_range<R, D>(ds: &D, range: R) -> impl RangeBounds<usize>
@@ -119,6 +121,16 @@ mod test_helpers {
 #[cfg(any(test, feature = "testing"))]
 #[espresso_macros::generic_tests]
 pub mod availability_tests {
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Bound, RangeBounds},
+    };
+
+    use committable::Committable;
+    use futures::stream::StreamExt;
+    use hotshot_types::data::Leaf2;
+
     use super::test_helpers::*;
     use crate::{
         availability::{payload_size, BlockId},
@@ -131,12 +143,6 @@ pub mod availability_tests {
         },
         types::HeightIndexed,
     };
-    use committable::Committable;
-    use futures::stream::StreamExt;
-    use hotshot_types::data::Leaf2;
-    use std::collections::HashMap;
-    use std::fmt::Debug;
-    use std::ops::{Bound, RangeBounds};
 
     async fn validate(ds: &impl TestableDataSource) {
         // Check the consistency of every block/leaf pair. Keep track of payloads and transactions
@@ -537,6 +543,10 @@ pub mod availability_tests {
 #[cfg(any(test, feature = "testing"))]
 #[espresso_macros::generic_tests]
 pub mod persistence_tests {
+    use committable::Committable;
+    use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
+    use hotshot_types::simple_certificate::QuorumCertificate2;
+
     use crate::{
         availability::{BlockQueryData, LeafQueryData},
         data_source::{
@@ -552,9 +562,6 @@ pub mod persistence_tests {
         types::HeightIndexed,
         Leaf2,
     };
-    use committable::Committable;
-    use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
-    use hotshot_types::simple_certificate::QuorumCertificate2;
 
     #[tokio::test(flavor = "multi_thread")]
     pub async fn test_revert<D: TestableDataSource>()
@@ -756,6 +763,24 @@ pub mod persistence_tests {
 #[cfg(any(test, feature = "testing"))]
 #[espresso_macros::generic_tests]
 pub mod node_tests {
+    use std::time::Duration;
+
+    use committable::Committable;
+    use futures::{future::join_all, stream::StreamExt};
+    use hotshot::traits::BlockPayload;
+    use hotshot_example_types::{
+        block_types::{TestBlockHeader, TestBlockPayload, TestMetadata},
+        node_types::TestTypes,
+        state_types::{TestInstanceState, TestValidatedState},
+    };
+    use hotshot_types::{
+        data::{vid_commitment, VidCommitment, VidShare},
+        traits::{block_contents::EncodeBytes, node_implementation::Versions},
+        vid::advz::{advz_scheme, ADVZScheme},
+    };
+    use jf_vid::VidScheme;
+    use vbs::version::StaticVersionType;
+
     use crate::{
         availability::{
             BlockInfo, BlockQueryData, LeafQueryData, QueryableHeader, VidCommonQueryData,
@@ -773,24 +798,6 @@ pub mod node_tests {
         types::HeightIndexed,
         Header,
     };
-    use committable::Committable;
-    use futures::{future::join_all, stream::StreamExt};
-    use hotshot::traits::BlockPayload;
-    use hotshot_example_types::{
-        block_types::TestBlockPayload, node_types::TestTypes, state_types::TestValidatedState,
-    };
-    use hotshot_example_types::{
-        block_types::{TestBlockHeader, TestMetadata},
-        state_types::TestInstanceState,
-    };
-    use hotshot_types::{
-        data::{vid_commitment, VidCommitment, VidShare},
-        traits::{block_contents::EncodeBytes, node_implementation::Versions},
-        vid::advz::{advz_scheme, ADVZScheme},
-    };
-    use jf_vid::VidScheme;
-    use std::time::Duration;
-    use vbs::version::StaticVersionType;
 
     #[tokio::test(flavor = "multi_thread")]
     pub async fn test_sync_status<D: TestableDataSource>()
@@ -1387,6 +1394,8 @@ pub mod node_tests {
 #[cfg(any(test, feature = "testing"))]
 #[espresso_macros::generic_tests]
 pub mod status_tests {
+    use std::time::Duration;
+
     use crate::{
         status::StatusDataSource,
         testing::{
@@ -1395,7 +1404,6 @@ pub mod status_tests {
             setup_test, sleep,
         },
     };
-    use std::time::Duration;
 
     #[tokio::test(flavor = "multi_thread")]
     pub async fn test_metrics<D: DataSourceLifeCycle + StatusDataSource>() {

--- a/hotshot-query-service/src/data_source/extension.rs
+++ b/hotshot-query-service/src/data_source/extension.rs
@@ -10,8 +10,14 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::ops::{Bound, RangeBounds};
+
+use async_trait::async_trait;
+use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
+use jf_merkle_tree::prelude::MerkleProof;
+use tagged_base64::TaggedBase64;
+
 use super::VersionedDataSource;
-use crate::data_source::storage::pruning::PrunedHeightDataSource;
 use crate::{
     availability::{
         AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, FetchStream, LeafId,
@@ -19,6 +25,7 @@ use crate::{
         TransactionHash, TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata,
         VidCommonQueryData,
     },
+    data_source::storage::pruning::PrunedHeightDataSource,
     explorer::{self, ExplorerDataSource, ExplorerHeader, ExplorerTransaction},
     merklized_state::{
         MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence, Snapshot,
@@ -29,12 +36,6 @@ use crate::{
     status::{HasMetrics, StatusDataSource},
     Header, Payload, QueryResult, Transaction,
 };
-use async_trait::async_trait;
-use hotshot_types::data::VidShare;
-use hotshot_types::traits::node_implementation::NodeType;
-use jf_merkle_tree::prelude::MerkleProof;
-use std::ops::{Bound, RangeBounds};
-use tagged_base64::TaggedBase64;
 /// Wrapper to add extensibility to an existing data source.
 ///
 /// [`ExtensibleDataSource`] adds app-specific data to any existing data source. It implements all
@@ -500,6 +501,8 @@ where
 
 #[cfg(any(test, feature = "testing"))]
 mod impl_testable_data_source {
+    use hotshot::types::Event;
+
     use super::*;
     use crate::{
         data_source::UpdateDataSource,
@@ -508,7 +511,6 @@ mod impl_testable_data_source {
             mocks::MockTypes,
         },
     };
-    use hotshot::types::Event;
 
     #[async_trait]
     impl<D, U> DataSourceLifeCycle for ExtensibleDataSource<D, U>
@@ -540,7 +542,6 @@ mod impl_testable_data_source {
 mod test {
     use super::ExtensibleDataSource;
     use crate::testing::consensus::MockDataSource;
-
     // For some reason this is the only way to import the macro defined in another module of this
     // crate.
     use crate::*;

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -73,37 +73,16 @@
 //! different request for the same object, one that permitted an active fetch. Or it may have been
 //! fetched [proactively](#proactive-fetching).
 
-use super::{
-    notifier::Notifier,
-    storage::{
-        pruning::{PruneStorage, PrunedHeightDataSource, PrunedHeightStorage},
-        sql::MigrateTypes,
-        Aggregate, AggregatesStorage, AvailabilityStorage, ExplorerStorage,
-        MerklizedStateHeightStorage, MerklizedStateStorage, NodeStorage, UpdateAggregatesStorage,
-        UpdateAvailabilityStorage,
-    },
-    Transaction, VersionedDataSource,
+use std::{
+    cmp::{max, min},
+    fmt::{Debug, Display},
+    iter::repeat_with,
+    marker::PhantomData,
+    ops::{Bound, Range, RangeBounds},
+    sync::Arc,
+    time::Duration,
 };
-use crate::availability::HeaderQueryData;
-use crate::{
-    availability::{
-        AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, FetchStream, LeafId,
-        LeafQueryData, PayloadMetadata, PayloadQueryData, QueryableHeader, QueryablePayload,
-        TransactionHash, TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata,
-        VidCommonQueryData,
-    },
-    explorer::{self, ExplorerDataSource},
-    fetching::{self, request, Provider},
-    merklized_state::{
-        MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence, Snapshot,
-    },
-    metrics::PrometheusMetrics,
-    node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
-    status::{HasMetrics, StatusDataSource},
-    task::BackgroundTask,
-    types::HeightIndexed,
-    Header, Payload, QueryError, QueryResult,
-};
+
 use anyhow::{bail, Context};
 use async_lock::Semaphore;
 use async_trait::async_trait;
@@ -122,18 +101,40 @@ use hotshot_types::{
     },
 };
 use jf_merkle_tree::{prelude::MerkleProof, MerkleTreeScheme};
-use std::sync::Arc;
-use std::{
-    cmp::{max, min},
-    fmt::{Debug, Display},
-    iter::repeat_with,
-    marker::PhantomData,
-    ops::{Bound, Range, RangeBounds},
-    time::Duration,
-};
 use tagged_base64::TaggedBase64;
 use tokio::{spawn, time::sleep};
 use tracing::Instrument;
+
+use super::{
+    notifier::Notifier,
+    storage::{
+        pruning::{PruneStorage, PrunedHeightDataSource, PrunedHeightStorage},
+        sql::MigrateTypes,
+        Aggregate, AggregatesStorage, AvailabilityStorage, ExplorerStorage,
+        MerklizedStateHeightStorage, MerklizedStateStorage, NodeStorage, UpdateAggregatesStorage,
+        UpdateAvailabilityStorage,
+    },
+    Transaction, VersionedDataSource,
+};
+use crate::{
+    availability::{
+        AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, FetchStream,
+        HeaderQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData, QueryableHeader,
+        QueryablePayload, TransactionHash, TransactionQueryData, UpdateAvailabilityData,
+        VidCommonMetadata, VidCommonQueryData,
+    },
+    explorer::{self, ExplorerDataSource},
+    fetching::{self, request, Provider},
+    merklized_state::{
+        MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence, Snapshot,
+    },
+    metrics::PrometheusMetrics,
+    node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
+    status::{HasMetrics, StatusDataSource},
+    task::BackgroundTask,
+    types::HeightIndexed,
+    Header, Payload, QueryError, QueryResult,
+};
 
 mod block;
 mod header;
@@ -467,15 +468,15 @@ where
             match storage.prune(&mut pruner).await {
                 Ok(Some(height)) => {
                     tracing::warn!("Pruned to height {height}");
-                }
+                },
                 Ok(None) => {
                     tracing::warn!("pruner run complete.");
                     break;
-                }
+                },
                 Err(e) => {
                     tracing::error!("pruner run failed: {e:?}");
                     break;
-                }
+                },
             }
         }
     }
@@ -977,7 +978,7 @@ where
                     ?req,
                     "unable to fetch object; spawning a task to retry: {err:#}"
                 );
-            }
+            },
         }
 
         // We'll use this channel to get the object back if we successfully load it on retry.
@@ -1005,14 +1006,14 @@ where
                             tracing::info!(?req, "object was ready after retries");
                             send.send(obj).ok();
                             break;
-                        }
+                        },
                         Ok(None) => {
                             // The object was not immediately available after all, but we have
                             // successfully spawned a fetch for it if possible. The spawned fetch
                             // will notify the original request once it completes.
                             tracing::info!(?req, "spawned fetch after retries");
                             break;
-                        }
+                        },
                         Err(err) => {
                             tracing::warn!(
                                 ?req,
@@ -1023,7 +1024,7 @@ where
                             if let Some(next_delay) = backoff.next_backoff() {
                                 delay = next_delay;
                             }
-                        }
+                        },
                     }
                 }
             }
@@ -1058,12 +1059,12 @@ where
                 tracing::debug!(?req, "object missing from local storage, will try to fetch");
                 self.fetch::<T>(&mut tx, req).await?;
                 Ok(None)
-            }
+            },
             Err(err) => {
                 // An error occurred while querying the database. We don't know if we need to fetch
                 // the object or not. Return an error so we can try again.
                 bail!("failed to fetch resource {req:?} from local storage: {err:#}");
-            }
+            },
         }
     }
 
@@ -1224,13 +1225,13 @@ where
                         None => passive(T::Request::from(chunk.start + i), passive_fetch),
                     })
                     .collect();
-            }
+            },
             Err(err) => {
                 tracing::warn!(
                     ?chunk,
                     "unable to fetch chunk; spawning a task to retry: {err:#}"
                 );
-            }
+            },
         }
 
         // We'll use these channels to get the objects back that we successfully load on retry.
@@ -1272,7 +1273,7 @@ where
                                     }
                                 }
                                 break;
-                            }
+                            },
                             Err(err) => {
                                 tracing::warn!(
                                     ?chunk,
@@ -1283,7 +1284,7 @@ where
                                 if let Some(next_delay) = backoff.next_backoff() {
                                     delay = next_delay;
                                 }
-                            }
+                            },
                         }
                     }
                 }
@@ -1432,7 +1433,7 @@ where
                             backoff = min(2 * backoff, max_backoff);
                             metrics.backoff.set(backoff.as_secs() as usize);
                             continue;
-                        }
+                        },
                     };
                     let heights = match Heights::load(&mut tx).await {
                         Ok(heights) => heights,
@@ -1443,7 +1444,7 @@ where
                             backoff = min(2 * backoff, max_backoff);
                             metrics.backoff.set(backoff.as_secs() as usize);
                             continue;
-                        }
+                        },
                     };
                     metrics.retries.set(0);
                     break heights;
@@ -1577,7 +1578,7 @@ where
                         tracing::error!("unable to open read tx: {err:#}");
                         sleep(Duration::from_secs(5)).await;
                         continue;
-                    }
+                    },
                 };
                 match tx.load_prev_aggregate().await {
                     Ok(agg) => break agg,
@@ -1585,7 +1586,7 @@ where
                         tracing::error!("unable to load previous aggregate: {err:#}");
                         sleep(Duration::from_secs(5)).await;
                         continue;
-                    }
+                    },
                 }
             };
 
@@ -1629,7 +1630,7 @@ where
                     match res {
                         Ok(()) => {
                             break;
-                        }
+                        },
                         Err(err) => {
                             tracing::warn!(
                                 num_blocks,
@@ -1637,7 +1638,7 @@ where
                                 "failed to update aggregates for chunk: {err:#}"
                             );
                             sleep(Duration::from_secs(1)).await;
-                        }
+                        },
                     }
                 }
                 metrics.height.set(height as usize);
@@ -2201,7 +2202,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
                     "error loading resource from local storage, will try to fetch: {err:#}"
                 );
                 None
-            }
+            },
         }
     }
 }
@@ -2320,7 +2321,7 @@ where
                     //   dropped. If this happens, things are very broken in any case, and it is
                     //   better to panic loudly than simply block forever.
                     panic!("notifier dropped without satisfying request {req:?}");
-                }
+                },
             }
         })
         .boxed(),

--- a/hotshot-query-service/src/data_source/fetching/block.rs
+++ b/hotshot-query-service/src/data_source/fetching/block.rs
@@ -12,6 +12,14 @@
 
 //! [`Fetchable`] implementation for [`BlockQueryData`] and [`PayloadQueryData`].
 
+use std::{cmp::Ordering, future::IntoFuture, iter::once, ops::RangeBounds, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use derive_more::From;
+use futures::future::{BoxFuture, FutureExt};
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
+
 use super::{
     header::{fetch_header_and_then, HeaderCallback},
     AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Heights, Notifiers, RangedFetchable,
@@ -34,12 +42,6 @@ use crate::{
     types::HeightIndexed,
     Header, Payload, QueryResult,
 };
-use async_trait::async_trait;
-use derivative::Derivative;
-use derive_more::From;
-use futures::future::{BoxFuture, FutureExt};
-use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
-use std::{cmp::Ordering, future::IntoFuture, iter::once, ops::RangeBounds, sync::Arc};
 pub(super) type PayloadFetcher<Types, S, P> =
     fetching::Fetcher<request::PayloadRequest, PayloadCallback<Types, S, P>>;
 

--- a/hotshot-query-service/src/data_source/fetching/transaction.rs
+++ b/hotshot-query-service/src/data_source/fetching/transaction.rs
@@ -12,6 +12,13 @@
 
 //! Transaction fetching.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use derive_more::From;
+use futures::future::{BoxFuture, FutureExt};
+use hotshot_types::traits::node_implementation::NodeType;
+
 use super::{AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Notifiers};
 use crate::{
     availability::{QueryablePayload, TransactionHash, TransactionQueryData},
@@ -24,11 +31,6 @@ use crate::{
     },
     Payload, QueryResult,
 };
-use async_trait::async_trait;
-use derive_more::From;
-use futures::future::{BoxFuture, FutureExt};
-use hotshot_types::traits::node_implementation::NodeType;
-use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, From)]
 pub(super) struct TransactionRequest<Types: NodeType>(TransactionHash<Types>);

--- a/hotshot-query-service/src/data_source/fetching/vid.rs
+++ b/hotshot-query-service/src/data_source/fetching/vid.rs
@@ -12,6 +12,17 @@
 
 //! [`Fetchable`] implementation for [`VidCommonQueryData`].
 
+use std::{cmp::Ordering, future::IntoFuture, iter::once, ops::RangeBounds, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use derive_more::From;
+use futures::future::{BoxFuture, FutureExt};
+use hotshot_types::{
+    data::VidShare,
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
+
 use super::{
     header::{fetch_header_and_then, HeaderCallback},
     AvailabilityProvider, FetchRequest, Fetchable, Fetcher, Heights, Notifiers, RangedFetchable,
@@ -30,16 +41,6 @@ use crate::{
     types::HeightIndexed,
     Header, Payload, QueryResult,
 };
-use async_trait::async_trait;
-use derivative::Derivative;
-use derive_more::From;
-use futures::future::{BoxFuture, FutureExt};
-use hotshot_types::{
-    data::VidShare,
-    traits::{block_contents::BlockHeader, node_implementation::NodeType},
-};
-use std::sync::Arc;
-use std::{cmp::Ordering, future::IntoFuture, iter::once, ops::RangeBounds};
 
 pub(super) type VidCommonFetcher<Types, S, P> =
     fetching::Fetcher<request::VidCommonRequest, VidCommonCallback<Types, S, P>>;

--- a/hotshot-query-service/src/data_source/fs.rs
+++ b/hotshot-query-service/src/data_source/fs.rs
@@ -12,16 +12,17 @@
 
 #![cfg(feature = "file-system-data-source")]
 
+use std::path::Path;
+
+use atomic_store::AtomicStoreLoader;
+use hotshot_types::traits::node_implementation::NodeType;
+
+pub use super::storage::fs::Transaction;
 use super::{storage::FileSystemStorage, AvailabilityProvider, FetchingDataSource};
 use crate::{
     availability::{query_data::QueryablePayload, QueryableHeader},
     Header, Payload,
 };
-use atomic_store::AtomicStoreLoader;
-use hotshot_types::traits::node_implementation::NodeType;
-use std::path::Path;
-
-pub use super::storage::fs::Transaction;
 
 /// A data source for the APIs provided in this crate, backed by the local file system.
 ///
@@ -239,14 +240,15 @@ where
 
 #[cfg(any(test, feature = "testing"))]
 mod impl_testable_data_source {
+    use async_trait::async_trait;
+    use hotshot::types::Event;
+    use tempfile::TempDir;
+
     use super::*;
     use crate::{
         data_source::UpdateDataSource,
         testing::{consensus::DataSourceLifeCycle, mocks::MockTypes},
     };
-    use async_trait::async_trait;
-    use hotshot::types::Event;
-    use tempfile::TempDir;
 
     #[async_trait]
     impl<P: AvailabilityProvider<MockTypes> + Default> DataSourceLifeCycle
@@ -279,11 +281,10 @@ mod impl_testable_data_source {
 #[cfg(test)]
 mod test {
     use super::FileSystemDataSource;
-    use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
-
     // For some reason this is the only way to import the macro defined in another module of this
     // crate.
     use crate::*;
+    use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
 
     instantiate_data_source_tests!(FileSystemDataSource<MockTypes, NoFetching>);
 }

--- a/hotshot-query-service/src/data_source/metrics.rs
+++ b/hotshot-query-service/src/data_source/metrics.rs
@@ -12,12 +12,13 @@
 
 #![cfg(feature = "metrics-data-source")]
 
+use async_trait::async_trait;
+
 use crate::{
     metrics::PrometheusMetrics,
     status::{HasMetrics, StatusDataSource},
     QueryError, QueryResult,
 };
-use async_trait::async_trait;
 
 /// A minimal data source for the status API provided in this crate, with no persistent storage.
 ///
@@ -82,9 +83,10 @@ impl StatusDataSource for MetricsDataSource {
 
 #[cfg(any(test, feature = "testing"))]
 mod impl_testable_data_source {
+    use hotshot::types::Event;
+
     use super::*;
     use crate::testing::{consensus::DataSourceLifeCycle, mocks::MockTypes};
-    use hotshot::types::Event;
 
     #[async_trait]
     impl DataSourceLifeCycle for MetricsDataSource {
@@ -112,9 +114,7 @@ mod impl_testable_data_source {
 
 #[cfg(test)]
 mod test {
-    use super::super::status_tests;
-    use super::MetricsDataSource;
-
+    use super::{super::status_tests, MetricsDataSource};
     // For some reason this is the only way to import the macro defined in another module of this
     // crate.
     use crate::*;

--- a/hotshot-query-service/src/data_source/sql.rs
+++ b/hotshot-query-service/src/data_source/sql.rs
@@ -12,6 +12,11 @@
 
 #![cfg(feature = "sql-data-source")]
 
+pub use anyhow::Error;
+use hotshot_types::traits::node_implementation::NodeType;
+pub use refinery::Migration;
+pub use sql::Transaction;
+
 use super::{
     fetching::{self},
     storage::sql::{self, SqlStorage},
@@ -22,11 +27,6 @@ use crate::{
     availability::{QueryableHeader, QueryablePayload},
     Header, Payload,
 };
-pub use anyhow::Error;
-use hotshot_types::traits::node_implementation::NodeType;
-pub use refinery::Migration;
-
-pub use sql::Transaction;
 
 pub type Builder<Types, Provider> = fetching::Builder<Types, SqlStorage, Provider>;
 
@@ -318,15 +318,15 @@ where
 // These tests run the `postgres` Docker image, which doesn't work on Windows.
 #[cfg(all(any(test, feature = "testing"), not(target_os = "windows")))]
 pub mod testing {
+    use async_trait::async_trait;
+    use hotshot::types::Event;
+    pub use sql::testing::TmpDb;
+
     use super::*;
     use crate::{
         data_source::UpdateDataSource,
         testing::{consensus::DataSourceLifeCycle, mocks::MockTypes},
     };
-    use async_trait::async_trait;
-    use hotshot::types::Event;
-
-    pub use sql::testing::TmpDb;
 
     #[async_trait]
     impl<P: AvailabilityProvider<MockTypes> + Default> DataSourceLifeCycle
@@ -372,17 +372,20 @@ pub mod testing {
 #[cfg(all(test, not(target_os = "windows")))]
 mod generic_test {
     use super::SqlDataSource;
-    use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
-
     // For some reason this is the only way to import the macro defined in another module of this
     // crate.
     use crate::*;
+    use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
 
     instantiate_data_source_tests!(SqlDataSource<MockTypes, NoFetching>);
 }
 
 #[cfg(all(test, not(target_os = "windows")))]
 mod test {
+    use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
+    use hotshot_types::{data::VidShare, vid::advz::advz_scheme};
+    use jf_vid::VidScheme;
+
     use super::*;
     use crate::{
         availability::{
@@ -396,9 +399,6 @@ mod test {
         fetching::provider::NoFetching,
         testing::{consensus::DataSourceLifeCycle, mocks::MockTypes, setup_test},
     };
-    use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
-    use hotshot_types::{data::VidShare, vid::advz::advz_scheme};
-    use jf_vid::VidScheme;
 
     type D = SqlDataSource<MockTypes, NoFetching>;
 

--- a/hotshot-query-service/src/data_source/storage.rs
+++ b/hotshot-query-service/src/data_source/storage.rs
@@ -56,6 +56,14 @@
 //! [`AvailabilityDataSource`](crate::availability::AvailabilityDataSource) in fallibility.
 //!
 
+use std::ops::RangeBounds;
+
+use async_trait::async_trait;
+use futures::future::Future;
+use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
+use jf_merkle_tree::prelude::MerkleProof;
+use tagged_base64::TaggedBase64;
+
 use crate::{
     availability::{
         BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData,
@@ -76,12 +84,6 @@ use crate::{
     node::{SyncStatus, TimeWindowQueryData, WindowStart},
     Header, Payload, QueryResult, Transaction,
 };
-use async_trait::async_trait;
-use futures::future::Future;
-use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
-use jf_merkle_tree::prelude::MerkleProof;
-use std::ops::RangeBounds;
-use tagged_base64::TaggedBase64;
 
 pub mod fail_storage;
 pub mod fs;

--- a/hotshot-query-service/src/data_source/storage/fail_storage.rs
+++ b/hotshot-query-service/src/data_source/storage/fail_storage.rs
@@ -12,6 +12,13 @@
 
 #![cfg(any(test, feature = "testing"))]
 
+use std::{ops::RangeBounds, sync::Arc};
+
+use async_lock::Mutex;
+use async_trait::async_trait;
+use futures::future::Future;
+use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
+
 use super::{
     pruning::{PruneStorage, PrunedHeightStorage, PrunerCfg, PrunerConfig},
     sql::MigrateTypes,
@@ -32,12 +39,6 @@ use crate::{
     status::HasMetrics,
     Header, Payload, QueryError, QueryResult,
 };
-use async_lock::Mutex;
-use async_trait::async_trait;
-use futures::future::Future;
-use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
-use std::ops::RangeBounds;
-use std::sync::Arc;
 
 /// A specific action that can be targeted to inject an error.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -87,8 +88,8 @@ impl FailureMode {
         match self {
             Self::Once(fail_action) if fail_action.matches(action) => {
                 *self = Self::Never;
-            }
-            Self::Always(fail_action) if fail_action.matches(action) => {}
+            },
+            Self::Always(fail_action) if fail_action.matches(action) => {},
             _ => return Ok(()),
         }
 

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -12,6 +12,28 @@
 
 #![cfg(feature = "file-system-data-source")]
 
+use std::{
+    collections::{
+        hash_map::{Entry, HashMap},
+        BTreeMap,
+    },
+    hash::Hash,
+    ops::{Bound, Deref, RangeBounds},
+    path::Path,
+};
+
+use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use async_trait::async_trait;
+use atomic_store::{AtomicStore, AtomicStoreLoader, PersistenceError};
+use committable::Committable;
+use futures::future::Future;
+use hotshot_types::{
+    data::{VidCommitment, VidShare},
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
+use serde::{de::DeserializeOwned, Serialize};
+use snafu::OptionExt;
+
 use super::{
     ledger_log::{Iter, LedgerLog},
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
@@ -19,7 +41,6 @@ use super::{
     Aggregate, AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata,
     UpdateAggregatesStorage, UpdateAvailabilityStorage, VidCommonMetadata,
 };
-
 use crate::{
     availability::{
         data_source::{BlockId, LeafId},
@@ -35,24 +56,6 @@ use crate::{
     types::HeightIndexed,
     ErrorSnafu, Header, MissingSnafu, NotFoundSnafu, Payload, QueryError, QueryResult,
 };
-use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use async_trait::async_trait;
-use atomic_store::{AtomicStore, AtomicStoreLoader, PersistenceError};
-use committable::Committable;
-use futures::future::Future;
-use hotshot_types::{
-    data::{VidCommitment, VidShare},
-    traits::{block_contents::BlockHeader, node_implementation::NodeType},
-};
-use serde::{de::DeserializeOwned, Serialize};
-use snafu::OptionExt;
-use std::collections::{
-    hash_map::{Entry, HashMap},
-    BTreeMap,
-};
-use std::hash::Hash;
-use std::ops::{Bound, Deref, RangeBounds};
-use std::path::Path;
 
 const CACHED_LEAVES_COUNT: usize = 100;
 const CACHED_BLOCKS_COUNT: usize = 100;
@@ -88,10 +91,10 @@ where
             BlockId::Number(n) => Ok(n),
             BlockId::Hash(h) => {
                 Ok(*self.index_by_block_hash.get(&h).context(NotFoundSnafu)? as usize)
-            }
+            },
             BlockId::PayloadHash(h) => {
                 Ok(*self.index_by_payload_hash.get(&h).context(NotFoundSnafu)? as usize)
-            }
+            },
         }
     }
 
@@ -405,11 +408,11 @@ where
                 iter.nth(n - 1);
             }
             n
-        }
+        },
         Bound::Excluded(n) => {
             iter.nth(n);
             n + 1
-        }
+        },
         Bound::Unbounded => 0,
     };
 
@@ -662,10 +665,10 @@ fn update_index_by_hash<H: Eq + Hash, P: Ord>(index: &mut HashMap<H, P>, hash: H
                 // Overwrite the existing entry if the new object was sequenced first.
                 e.insert(pos);
             }
-        }
+        },
         Entry::Vacant(e) => {
             e.insert(pos);
-        }
+        },
     }
 }
 
@@ -772,7 +775,7 @@ where
                 // entry in `index_by_time` has a non-empty list associated with it, so this
                 // indexing is safe.
                 blocks[0]
-            }
+            },
         } as usize;
 
         let mut res = TimeWindowQueryData::default();

--- a/hotshot-query-service/src/data_source/storage/ledger_log.rs
+++ b/hotshot-query-service/src/data_source/storage/ledger_log.rs
@@ -12,12 +12,12 @@
 
 #![cfg(feature = "file-system-data-source")]
 
+use std::{collections::VecDeque, fmt::Debug};
+
 use atomic_store::{
     append_log, load_store::BincodeLoadStore, AppendLog, AtomicStoreLoader, PersistenceError,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use std::collections::VecDeque;
-use std::fmt::Debug;
 use tracing::{debug, warn};
 
 /// A caching append log for ledger objects.
@@ -262,10 +262,11 @@ impl<T: Serialize + DeserializeOwned + Clone> ExactSizeIterator for Iter<'_, T> 
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::testing::setup_test;
     use atomic_store::AtomicStore;
     use tempfile::TempDir;
+
+    use super::*;
+    use crate::testing::setup_test;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_ledger_log_creation() {

--- a/hotshot-query-service/src/data_source/storage/pruning.rs
+++ b/hotshot-query-service/src/data_source/storage/pruning.rs
@@ -10,9 +10,10 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::{fmt::Debug, time::Duration};
+
 use anyhow::bail;
 use async_trait::async_trait;
-use std::{fmt::Debug, time::Duration};
 
 #[derive(Clone, Debug)]
 pub struct PrunerCfg {

--- a/hotshot-query-service/src/data_source/storage/sql/migrate.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/migrate.rs
@@ -1,4 +1,3 @@
-use super::{queries::DecodeError, Db};
 use async_trait::async_trait;
 use derive_more::From;
 use futures::stream::StreamExt;
@@ -8,6 +7,8 @@ use refinery_core::{
 };
 use sqlx::{pool::PoolConnection, Acquire, Executor, Row};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use super::{queries::DecodeError, Db};
 
 /// Run migrations using a sqlx connection.
 ///

--- a/hotshot-query-service/src/data_source/storage/sql/queries.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries.rs
@@ -13,27 +13,30 @@
 
 //! Immutable query functionality of a SQL database.
 
+use std::{
+    fmt::Display,
+    ops::{Bound, RangeBounds},
+};
+
+use anyhow::Context;
+use derivative::Derivative;
+use hotshot_types::{
+    simple_certificate::QuorumCertificate2,
+    traits::{
+        block_contents::{BlockHeader, BlockPayload},
+        node_implementation::NodeType,
+    },
+};
+use sqlx::{Arguments, FromRow, Row};
+
 use super::{Database, Db, Query, QueryAs, Transaction};
-use crate::Leaf2;
 use crate::{
     availability::{
         BlockId, BlockQueryData, LeafQueryData, PayloadQueryData, QueryablePayload,
         VidCommonQueryData,
     },
     data_source::storage::{PayloadMetadata, VidCommonMetadata},
-    Header, Payload, QueryError, QueryResult,
-};
-use anyhow::Context;
-use derivative::Derivative;
-use hotshot_types::simple_certificate::QuorumCertificate2;
-use hotshot_types::traits::{
-    block_contents::{BlockHeader, BlockPayload},
-    node_implementation::NodeType,
-};
-use sqlx::{Arguments, FromRow, Row};
-use std::{
-    fmt::Display,
-    ops::{Bound, RangeBounds},
+    Header, Leaf2, Payload, QueryError, QueryResult,
 };
 
 pub(super) mod availability;
@@ -137,20 +140,20 @@ impl QueryBuilder<'_> {
         match range.start_bound() {
             Bound::Included(n) => {
                 bounds.push(format!("{column} >= {}", self.bind(*n as i64)?));
-            }
+            },
             Bound::Excluded(n) => {
                 bounds.push(format!("{column} > {}", self.bind(*n as i64)?));
-            }
-            Bound::Unbounded => {}
+            },
+            Bound::Unbounded => {},
         }
         match range.end_bound() {
             Bound::Included(n) => {
                 bounds.push(format!("{column} <= {}", self.bind(*n as i64)?));
-            }
+            },
             Bound::Excluded(n) => {
                 bounds.push(format!("{column} < {}", self.bind(*n as i64)?));
-            }
-            Bound::Unbounded => {}
+            },
+            Bound::Unbounded => {},
         }
 
         let mut where_clause = bounds.join(" AND ");

--- a/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
@@ -12,27 +12,30 @@
 
 //! Availability storage implementation for a database query engine.
 
-use super::{
-    super::transaction::{query, Transaction, TransactionMode},
-    QueryBuilder, BLOCK_COLUMNS, LEAF_COLUMNS, PAYLOAD_COLUMNS, PAYLOAD_METADATA_COLUMNS,
-    VID_COMMON_COLUMNS, VID_COMMON_METADATA_COLUMNS,
-};
-use crate::data_source::storage::sql::sqlx::Row;
-use crate::{
-    availability::{
-        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryableHeader,
-        QueryablePayload, TransactionHash, TransactionQueryData, VidCommonQueryData,
-    },
-    data_source::storage::{AvailabilityStorage, PayloadMetadata, VidCommonMetadata},
-    types::HeightIndexed,
-    ErrorSnafu, Header, MissingSnafu, Payload, QueryError, QueryResult,
-};
+use std::ops::RangeBounds;
+
 use async_trait::async_trait;
 use futures::stream::{StreamExt, TryStreamExt};
 use hotshot_types::traits::node_implementation::NodeType;
 use snafu::OptionExt;
 use sqlx::FromRow;
-use std::ops::RangeBounds;
+
+use super::{
+    super::transaction::{query, Transaction, TransactionMode},
+    QueryBuilder, BLOCK_COLUMNS, LEAF_COLUMNS, PAYLOAD_COLUMNS, PAYLOAD_METADATA_COLUMNS,
+    VID_COMMON_COLUMNS, VID_COMMON_METADATA_COLUMNS,
+};
+use crate::{
+    availability::{
+        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryableHeader,
+        QueryablePayload, TransactionHash, TransactionQueryData, VidCommonQueryData,
+    },
+    data_source::storage::{
+        sql::sqlx::Row, AvailabilityStorage, PayloadMetadata, VidCommonMetadata,
+    },
+    types::HeightIndexed,
+    ErrorSnafu, Header, MissingSnafu, Payload, QueryError, QueryResult,
+};
 
 #[async_trait]
 impl<Mode, Types> AvailabilityStorage<Types> for Transaction<Mode>

--- a/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
@@ -12,6 +12,18 @@
 
 //! Node storage implementation for a database query engine.
 
+use std::ops::{Bound, RangeBounds};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use futures::stream::{StreamExt, TryStreamExt};
+use hotshot_types::{
+    data::VidShare,
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
+use snafu::OptionExt;
+use sqlx::Row;
+
 use super::{
     super::transaction::{query, query_as, Transaction, TransactionMode, Write},
     parse_header, DecodeError, QueryBuilder, HEADER_COLUMNS,
@@ -24,16 +36,6 @@ use crate::{
     types::HeightIndexed,
     Header, MissingSnafu, NotFoundSnafu, QueryError, QueryResult,
 };
-use anyhow::anyhow;
-use async_trait::async_trait;
-use futures::stream::{StreamExt, TryStreamExt};
-use hotshot_types::{
-    data::VidShare,
-    traits::{block_contents::BlockHeader, node_implementation::NodeType},
-};
-use snafu::OptionExt;
-use sqlx::Row;
-use std::ops::{Bound, RangeBounds};
 
 #[async_trait]
 impl<Mode, Types> NodeStorage<Types> for Transaction<Mode>
@@ -50,11 +52,11 @@ where
                 // The height of the block is the number of blocks below it, so the total number of
                 // blocks is one more than the height of the highest block.
                 Ok(height as usize + 1)
-            }
+            },
             (None,) => {
                 // If there are no blocks yet, the height is 0.
                 Ok(0)
-            }
+            },
         }
     }
 
@@ -174,11 +176,11 @@ where
                 // The height of the block is the number of blocks below it, so the total number of
                 // blocks is one more than the height of the highest block.
                 height as usize + 1
-            }
+            },
             None => {
                 // If there are no blocks yet, the height is 0.
                 0
-            }
+            },
         };
         let total_leaves = row.get::<i64, _>("total_leaves") as usize;
         let null_payloads = row.get::<i64, _>("null_payloads") as usize;
@@ -216,7 +218,7 @@ where
                 // sufficient data to answer the query is not as simple as just trying `load_header`
                 // for a specific block ID.
                 return self.time_window::<Types>(t, end, limit).await;
-            }
+            },
             WindowStart::Height(h) => h,
             WindowStart::Hash(h) => self.load_header::<Types>(h).await?.block_number(),
         };
@@ -479,7 +481,7 @@ async fn aggregate_range_bounds(
                 return Ok(None);
             }
             height - 1
-        }
+        },
     };
     Ok(Some((from, to)))
 }

--- a/hotshot-query-service/src/data_source/update.rs
+++ b/hotshot-query-service/src/data_source/update.rs
@@ -11,6 +11,26 @@
 // see <https://www.gnu.org/licenses/>.
 
 //! A generic algorithm for updating a HotShot Query Service data source with new data.
+use std::iter::once;
+
+use anyhow::{ensure, Context};
+use async_trait::async_trait;
+use futures::future::Future;
+use hotshot::types::{Event, EventType};
+use hotshot_types::{
+    data::{ns_table::parse_ns_table, Leaf2, VidCommitment, VidDisperseShare, VidShare},
+    event::LeafInfo,
+    traits::{
+        block_contents::{BlockHeader, BlockPayload, EncodeBytes, GENESIS_VID_NUM_STORAGE_NODES},
+        node_implementation::{ConsensusTime, NodeType},
+    },
+    vid::{
+        advz::advz_scheme,
+        avidm::{init_avidm_param, AvidMScheme},
+    },
+};
+use jf_vid::VidScheme;
+
 use crate::{
     availability::{
         BlockInfo, BlockQueryData, LeafQueryData, QueryablePayload, UpdateAvailabilityData,
@@ -18,25 +38,6 @@ use crate::{
     },
     Payload,
 };
-use anyhow::{ensure, Context};
-use async_trait::async_trait;
-use futures::future::Future;
-use hotshot::types::{Event, EventType};
-use hotshot_types::{data::VidCommitment, event::LeafInfo};
-use hotshot_types::{
-    data::{ns_table::parse_ns_table, Leaf2},
-    traits::{
-        block_contents::{BlockHeader, BlockPayload, EncodeBytes, GENESIS_VID_NUM_STORAGE_NODES},
-        node_implementation::{ConsensusTime, NodeType},
-    },
-    vid::advz::advz_scheme,
-};
-use hotshot_types::{
-    data::{VidDisperseShare, VidShare},
-    vid::avidm::{init_avidm_param, AvidMScheme},
-};
-use jf_vid::VidScheme;
-use std::iter::once;
 
 /// An extension trait for types which implement the update trait for each API module.
 ///
@@ -109,7 +110,7 @@ where
                             "inconsistent leaf; cannot append leaf information: {err:#}"
                         );
                         return Err(leaf2.block_header().block_number());
-                    }
+                    },
                 };
                 let block_data = leaf2
                     .block_payload()
@@ -141,12 +142,12 @@ where
                                 Err(err) => {
                                     tracing::warn!("failed to compute genesis VID: {err:#}");
                                     (None, None)
-                                }
+                                },
                             }
                         } else {
                             (None, None)
                         }
-                    }
+                    },
                 };
 
                 if vid_common.is_none() {
@@ -188,7 +189,7 @@ fn genesis_vid<Types: NodeType>(
                 VidCommonQueryData::new(leaf.block_header().clone(), Some(disperse.common)),
                 VidShare::V0(disperse.shares.remove(0)),
             ))
-        }
+        },
         VidCommitment::V1(commit) => {
             let avidm_param = init_avidm_param(GENESIS_VID_NUM_STORAGE_NODES)?;
             let weights = vec![1; GENESIS_VID_NUM_STORAGE_NODES];
@@ -208,7 +209,7 @@ fn genesis_vid<Types: NodeType>(
                 VidCommonQueryData::new(leaf.block_header().clone(), None),
                 VidShare::V1(shares.remove(0)),
             ))
-        }
+        },
     }
 }
 

--- a/hotshot-query-service/src/error.rs
+++ b/hotshot-query-service/src/error.rs
@@ -10,12 +10,14 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::{availability, explorer, merklized_state, node, status};
+use std::fmt::Display;
+
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::fmt::Display;
 use tide_disco::StatusCode;
+
+use crate::{availability, explorer, merklized_state, node, status};
 
 #[derive(Clone, Debug, From, Snafu, Deserialize, Serialize)]
 pub enum Error {

--- a/hotshot-query-service/src/explorer/currency.rs
+++ b/hotshot-query-service/src/explorer/currency.rs
@@ -10,10 +10,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::errors::ExplorerAPIError;
-use serde::ser::SerializeStruct;
-use serde::{Deserialize, Serialize, Serializer};
 use std::fmt::Display;
+
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+
+use super::errors::ExplorerAPIError;
 
 /// CurrencyMismatchError is an error that occurs when two different currencies
 /// are attempted to be combined in any way that would result in an invalid

--- a/hotshot-query-service/src/explorer/data_source.rs
+++ b/hotshot-query-service/src/explorer/data_source.rs
@@ -10,6 +10,10 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use async_trait::async_trait;
+use hotshot_types::traits::node_implementation::NodeType;
+use tagged_base64::TaggedBase64;
+
 use super::{
     query_data::{
         BlockDetail, BlockIdentifier, BlockSummary, ExplorerSummary, GetBlockDetailError,
@@ -24,9 +28,6 @@ use crate::{
     availability::{QueryableHeader, QueryablePayload},
     Header, Payload, Transaction,
 };
-use async_trait::async_trait;
-use hotshot_types::traits::node_implementation::NodeType;
-use tagged_base64::TaggedBase64;
 
 /// An interface for querying Data and Statistics from the HotShot Blockchain.
 ///

--- a/hotshot-query-service/src/explorer/errors.rs
+++ b/hotshot-query-service/src/explorer/errors.rs
@@ -10,9 +10,9 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use serde::ser::SerializeStruct;
-use serde::{Deserialize, Serialize, Serializer};
 use std::fmt::{Debug, Display};
+
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use tide_disco::StatusCode;
 
 /// [ExplorerAPIError] is a trait that represents an error that can be returned
@@ -417,7 +417,7 @@ mod test {
             let want = query_error;
 
             match &have.error {
-                crate::QueryError::NotFound => {}
+                crate::QueryError::NotFound => {},
                 _ => panic!("deserialized QueryError mismatch: have: {have}, want: {want}"),
             }
         }

--- a/hotshot-query-service/src/explorer/monetary_value.rs
+++ b/hotshot-query-service/src/explorer/monetary_value.rs
@@ -10,14 +10,15 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::currency::{CurrencyCode, CurrencyMismatchError};
-use itertools::Itertools;
-use serde::{Deserialize, Serialize, Serializer};
-use std::fmt::Display;
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     ops::{Add, Sub},
 };
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize, Serializer};
+
+use super::currency::{CurrencyCode, CurrencyMismatchError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// [MonetaryValue]s is a struct that paris a [CurrencyCode] with a value.
@@ -195,7 +196,7 @@ where
             return Err(E::custom(
                 "no non-breaking space found in expected MonetaryValue",
             ))
-        }
+        },
     };
 
     let first: String = value.chars().take(index).collect();
@@ -244,7 +245,7 @@ fn determine_pre_and_post_decimal_strings(value: &str) -> (String, Option<String
                 .collect();
 
             (pre_decimal_string, Some(post_decimal_string))
-        }
+        },
     }
 }
 
@@ -289,7 +290,7 @@ where
                     + 10i128.pow(significant_digits - num_digits) * post_decimal_value);
 
             Ok(value)
-        }
+        },
     }
 }
 
@@ -406,7 +407,7 @@ mod test {
                 let result = match result {
                     Err(err) => {
                         panic!("{} failed to parse: {}", value, err);
-                    }
+                    },
                     Ok(result) => result,
                 };
 
@@ -436,7 +437,7 @@ mod test {
                 let result = match result {
                     Err(err) => {
                         panic!("{} failed to parse: {}", value, err);
-                    }
+                    },
                     Ok(result) => result,
                 };
 

--- a/hotshot-query-service/src/explorer/query_data.rs
+++ b/hotshot-query-service/src/explorer/query_data.rs
@@ -10,6 +10,17 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::{
+    collections::VecDeque,
+    fmt::{Debug, Display},
+    num::{NonZeroUsize, TryFromIntError},
+};
+
+use hotshot_types::traits::node_implementation::NodeType;
+use serde::{Deserialize, Serialize};
+use tide_disco::StatusCode;
+use time::format_description::well_known::Rfc3339;
+
 use super::{
     errors::{BadQuery, ExplorerAPIError, InvalidLimit, NotFound, QueryError, Unimplemented},
     monetary_value::MonetaryValue,
@@ -17,18 +28,10 @@ use super::{
 };
 use crate::{
     availability::{BlockQueryData, QueryableHeader, QueryablePayload, TransactionHash},
+    node::BlockHash,
+    types::HeightIndexed,
     Header, Payload, Resolvable, Transaction,
 };
-use crate::{node::BlockHash, types::HeightIndexed};
-use hotshot_types::traits::node_implementation::NodeType;
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::VecDeque,
-    fmt::{Debug, Display},
-    num::{NonZeroUsize, TryFromIntError},
-};
-use tide_disco::StatusCode;
-use time::format_description::well_known::Rfc3339;
 
 /// BlockIdentifier is an enum that represents multiple ways of referring to
 /// a specific Block.  These use cases are specific to a Block Explorer and
@@ -79,7 +82,7 @@ impl<Types: NodeType> Display for TransactionIdentifier<Types> {
             TransactionIdentifier::Latest => write!(f, "latest"),
             TransactionIdentifier::HeightAndOffset(height, offset) => {
                 write!(f, "{} {}", height, offset)
-            }
+            },
             TransactionIdentifier::Hash(hash) => write!(f, "{}", hash),
         }
     }

--- a/hotshot-query-service/src/explorer/traits.rs
+++ b/hotshot-query-service/src/explorer/traits.rs
@@ -10,9 +10,10 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::fmt::Debug;
+
 use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
 
 /// [ExplorerHeader] is a trait that represents certain extensions to the
 /// [BlockHeader] that are specific to the Block Explorer API.  This trait

--- a/hotshot-query-service/src/fetching.rs
+++ b/hotshot-query-service/src/fetching.rs
@@ -21,16 +21,16 @@
 //! implementations of [`Provider`] for various data availability sources.
 //!
 
-use async_lock::Mutex;
-use async_lock::Semaphore;
-use backoff::{backoff::Backoff, ExponentialBackoff};
-use derivative::Derivative;
 use std::{
     collections::{hash_map::Entry, BTreeSet, HashMap},
     fmt::Debug,
     sync::Arc,
     time::Duration,
 };
+
+use async_lock::{Mutex, Semaphore};
+use backoff::{backoff::Backoff, ExponentialBackoff};
+use derivative::Derivative;
 use tokio::{spawn, time::sleep};
 
 pub mod provider;
@@ -122,12 +122,12 @@ impl<T, C> Fetcher<T, C> {
                         e.get_mut().extend(callbacks);
                         tracing::info!(?req, callbacks = ?e.get(), "resource is already being fetched");
                         return;
-                    }
+                    },
                     Entry::Vacant(e) => {
                         // If the object is not being fetched, we will register our own callback and
                         // then fetch it ourselves.
                         e.insert(callbacks.into_iter().collect());
-                    }
+                    },
                 }
             }
 

--- a/hotshot-query-service/src/fetching/provider.rs
+++ b/hotshot-query-service/src/fetching/provider.rs
@@ -35,9 +35,11 @@
 //! * [`TestProvider`]
 //!
 
-use super::Request;
-use async_trait::async_trait;
 use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::Request;
 
 mod any;
 mod query_service;

--- a/hotshot-query-service/src/fetching/provider/any.rs
+++ b/hotshot-query-service/src/fetching/provider/any.rs
@@ -10,6 +10,12 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use hotshot_types::traits::node_implementation::NodeType;
+
 use super::{Provider, Request};
 use crate::{
     availability::LeafQueryData,
@@ -17,11 +23,6 @@ use crate::{
     fetching::request::{LeafRequest, PayloadRequest, VidCommonRequest},
     Payload, VidCommon,
 };
-use async_trait::async_trait;
-use derivative::Derivative;
-use hotshot_types::traits::node_implementation::NodeType;
-use std::fmt::Debug;
-use std::sync::Arc;
 
 /// Blanket trait combining [`Debug`] and [`Provider`].
 ///
@@ -191,7 +192,7 @@ where
                     providers.len()
                 );
                 continue;
-            }
+            },
         }
     }
 
@@ -201,6 +202,11 @@ where
 // These tests run the `postgres` Docker image, which doesn't work on Windows.
 #[cfg(all(test, not(target_os = "windows")))]
 mod test {
+    use futures::stream::StreamExt;
+    use portpicker::pick_unused_port;
+    use tide_disco::App;
+    use vbs::version::StaticVersionType;
+
     use super::*;
     use crate::{
         availability::{define_api, AvailabilityDataSource, UpdateAvailabilityData},
@@ -215,10 +221,6 @@ mod test {
         types::HeightIndexed,
         ApiState, Error,
     };
-    use futures::stream::StreamExt;
-    use portpicker::pick_unused_port;
-    use tide_disco::App;
-    use vbs::version::StaticVersionType;
 
     type Provider = AnyProvider<MockTypes>;
 

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -10,14 +10,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::Provider;
-
-use crate::{
-    availability::{LeafQueryData, PayloadQueryData, VidCommonQueryData},
-    fetching::request::{LeafRequest, PayloadRequest, VidCommonRequest},
-    types::HeightIndexed,
-    Error, Payload, VidCommon,
-};
 use async_trait::async_trait;
 use committable::Committable;
 use futures::try_join;
@@ -29,6 +21,14 @@ use hotshot_types::{
 use jf_vid::VidScheme;
 use surf_disco::{Client, Url};
 use vbs::version::StaticVersionType;
+
+use super::Provider;
+use crate::{
+    availability::{LeafQueryData, PayloadQueryData, VidCommonQueryData},
+    fetching::request::{LeafRequest, PayloadRequest, VidCommonRequest},
+    types::HeightIndexed,
+    Error, Payload, VidCommon,
+};
 
 /// Data availability provider backed by another instance of this query service.
 ///
@@ -79,7 +79,7 @@ where
                             Err(err) => {
                                 tracing::error!(%err, "unable to compute VID commitment");
                                 return None;
-                            }
+                            },
                         },
                     );
                     if commit != req.0 {
@@ -91,11 +91,11 @@ where
                 }
 
                 Some(payload.data)
-            }
+            },
             Err(err) => {
                 tracing::error!("failed to fetch payload {req:?}: {err}");
                 None
-            }
+            },
         }
     }
 }
@@ -134,11 +134,11 @@ where
                 leaf.leaf.unfill_block_payload();
 
                 Some(leaf)
-            }
+            },
             Err(err) => {
                 tracing::error!("failed to fetch leaf {req:?}: {err}");
                 None
-            }
+            },
         }
     }
 }
@@ -171,18 +171,18 @@ where
                         tracing::error!(?req, ?res, "Expect VID common data but found None");
                         None
                     }
-                }
+                },
                 VidCommitment::V1(_) => {
                     if res.common.is_some() {
                         tracing::warn!(?req, ?res, "Expect no VID common data but found some.")
                     }
                     None
-                }
+                },
             },
             Err(err) => {
                 tracing::error!("failed to fetch VID common {req:?}: {err}");
                 None
-            }
+            },
         }
     }
 }
@@ -190,8 +190,20 @@ where
 // These tests run the `postgres` Docker image, which doesn't work on Windows.
 #[cfg(all(test, not(target_os = "windows")))]
 mod test {
-    use super::*;
+    use std::{future::IntoFuture, time::Duration};
 
+    use committable::Committable;
+    use futures::{
+        future::{join, FutureExt},
+        stream::StreamExt,
+    };
+    use generic_array::GenericArray;
+    use hotshot_example_types::node_types::TestVersions;
+    use portpicker::pick_unused_port;
+    use rand::RngCore;
+    use tide_disco::{error::ServerError, App};
+
+    use super::*;
     use crate::{
         api::load_api,
         availability::{
@@ -219,17 +231,6 @@ mod test {
         types::HeightIndexed,
         ApiState,
     };
-    use committable::Committable;
-    use futures::{
-        future::{join, FutureExt},
-        stream::StreamExt,
-    };
-    use generic_array::GenericArray;
-    use hotshot_example_types::node_types::TestVersions;
-    use portpicker::pick_unused_port;
-    use rand::RngCore;
-    use std::{future::IntoFuture, time::Duration};
-    use tide_disco::{error::ServerError, App};
 
     type Provider = TestProvider<QueryServiceProvider<MockBase>>;
 
@@ -1201,7 +1202,7 @@ mod test {
                     .as_ref()
                     .fail_begins_writable(FailableAction::Any)
                     .await
-            }
+            },
             FailureType::Write => data_source.as_ref().fail_writes(FailableAction::Any).await,
             FailureType::Commit => data_source.as_ref().fail_commits(FailableAction::Any).await,
         }
@@ -1304,19 +1305,19 @@ mod test {
                     .as_ref()
                     .fail_one_begin_writable(FailableAction::Any)
                     .await
-            }
+            },
             FailureType::Write => {
                 data_source
                     .as_ref()
                     .fail_one_write(FailableAction::Any)
                     .await
-            }
+            },
             FailureType::Commit => {
                 data_source
                     .as_ref()
                     .fail_one_commit(FailableAction::Any)
                     .await
-            }
+            },
         }
         assert_eq!(leaves[0], data_source.get_leaf(1).await.await);
 
@@ -1882,7 +1883,7 @@ mod test {
                 for (leaf, payload) in leaves.iter().zip(payloads) {
                     assert_eq!(payload.block_hash, leaf.block_hash());
                 }
-            }
+            },
             MetadataType::Vid => {
                 let vids = data_source.subscribe_vid_common_metadata(1).await.take(3);
 
@@ -1895,7 +1896,7 @@ mod test {
                 for (leaf, vid) in leaves.iter().zip(vids) {
                     assert_eq!(vid.block_hash, leaf.block_hash());
                 }
-            }
+            },
         }
     }
 

--- a/hotshot-query-service/src/fetching/provider/testing.rs
+++ b/hotshot-query-service/src/fetching/provider/testing.rs
@@ -12,18 +12,22 @@
 
 #![cfg(any(test, feature = "testing"))]
 
-use super::Provider;
-use crate::fetching::Request;
+use std::{
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
 use async_lock::RwLock;
 use async_trait::async_trait;
 use derivative::Derivative;
 use hotshot_types::traits::node_implementation::NodeType;
-use std::sync::Arc;
-use std::{
-    fmt::Debug,
-    sync::atomic::{AtomicBool, Ordering},
-};
 use tokio::sync::broadcast;
+
+use super::Provider;
+use crate::fetching::Request;
 
 /// Adaptor to add test-only functionality to an existing [`Provider`].
 ///

--- a/hotshot-query-service/src/fetching/request.rs
+++ b/hotshot-query-service/src/fetching/request.rs
@@ -12,15 +12,15 @@
 
 //! Requests for fetching resources.
 
+use std::{fmt::Debug, hash::Hash};
+
+use derive_more::{From, Into};
+use hotshot_types::{data::VidCommitment, traits::node_implementation::NodeType};
+
 use crate::{
     availability::{LeafHash, LeafQueryData, QcHash},
     Payload,
 };
-use derive_more::{From, Into};
-use hotshot_types::{data::VidCommitment, traits::node_implementation::NodeType};
-
-use std::fmt::Debug;
-use std::hash::Hash;
 
 /// A request for a resource.
 pub trait Request<Types>: Copy + Debug + Eq + Hash + Send {

--- a/hotshot-query-service/src/lib.rs
+++ b/hotshot-query-service/src/lib.rs
@@ -428,25 +428,24 @@ pub mod task;
 pub mod testing;
 pub mod types;
 
-pub use error::Error;
-pub use resolvable::Resolvable;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use derive_more::{Deref, From, Into};
+pub use error::Error;
 use futures::{future::BoxFuture, stream::StreamExt};
 use hotshot::types::SystemContextHandle;
 use hotshot_types::traits::{
     node_implementation::{NodeImplementation, NodeType, Versions},
     BlockPayload,
 };
+pub use hotshot_types::{data::Leaf2, simple_certificate::QuorumCertificate};
+pub use resolvable::Resolvable;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::sync::Arc;
 use task::BackgroundTask;
 use tide_disco::{method::ReadState, App, StatusCode};
 use vbs::version::StaticVersionType;
-
-pub use hotshot_types::{data::Leaf2, simple_certificate::QuorumCertificate};
 
 pub type VidCommon = Option<hotshot_types::vid::advz::ADVZCommon>;
 
@@ -589,6 +588,23 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::{
+        ops::{Bound, RangeBounds},
+        time::Duration,
+    };
+
+    use async_lock::RwLock;
+    use async_trait::async_trait;
+    use atomic_store::{load_store::BincodeLoadStore, AtomicStore, AtomicStoreLoader, RollingLog};
+    use futures::future::FutureExt;
+    use hotshot_types::{data::VidShare, simple_certificate::QuorumCertificate2};
+    use portpicker::pick_unused_port;
+    use surf_disco::Client;
+    use tempfile::TempDir;
+    use testing::mocks::MockBase;
+    use tide_disco::App;
+    use toml::toml;
+
     use super::*;
     use crate::{
         availability::{
@@ -604,19 +620,6 @@ mod test {
             mocks::{MockHeader, MockPayload, MockTypes},
         },
     };
-    use async_lock::RwLock;
-    use async_trait::async_trait;
-    use atomic_store::{load_store::BincodeLoadStore, AtomicStore, AtomicStoreLoader, RollingLog};
-    use futures::future::FutureExt;
-    use hotshot_types::{data::VidShare, simple_certificate::QuorumCertificate2};
-    use portpicker::pick_unused_port;
-    use std::ops::{Bound, RangeBounds};
-    use std::time::Duration;
-    use surf_disco::Client;
-    use tempfile::TempDir;
-    use testing::mocks::MockBase;
-    use tide_disco::App;
-    use toml::toml;
 
     struct CompositeState {
         store: AtomicStore,

--- a/hotshot-query-service/src/merklized_state.rs
+++ b/hotshot-query-service/src/merklized_state.rs
@@ -15,14 +15,16 @@
 //! The state API provides an interface for serving queries against arbitrarily old snapshots of the state.
 //! This allows a full Merkle tree to be reconstructed from storage.
 //! If any parent state is missing then the partial snapshot can not be queried.
-use std::{fmt::Display, path::PathBuf};
+use std::{
+    fmt::{Debug, Display},
+    path::PathBuf,
+};
 
 use derive_more::From;
 use futures::FutureExt;
 use hotshot_types::traits::node_implementation::NodeType;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::fmt::Debug;
 use tagged_base64::TaggedBase64;
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
 use vbs::version::StaticVersionType;

--- a/hotshot-query-service/src/merklized_state/data_source.rs
+++ b/hotshot-query-service/src/merklized_state/data_source.rs
@@ -16,21 +16,19 @@
 //! and provides methods for querying and reconstructing the snapshot.
 //!
 
+use std::{cmp::Ordering, fmt::Debug, str::FromStr};
+
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::Display;
 use hotshot_types::traits::node_implementation::NodeType;
-
 use jf_merkle_tree::{
     prelude::MerkleProof, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     MerkleCommitment, NodeValue, ToTraversalPath,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use std::{fmt::Debug, str::FromStr};
 use tagged_base64::TaggedBase64;
-
-use std::cmp::Ordering;
 
 use crate::QueryResult;
 

--- a/hotshot-query-service/src/metrics.rs
+++ b/hotshot-query-service/src/metrics.rs
@@ -12,6 +12,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
 use hotshot_types::traits::metrics;
 use itertools::Itertools;
 use prometheus::{
@@ -19,8 +24,6 @@ use prometheus::{
     Encoder, HistogramVec, Opts, Registry, TextEncoder,
 };
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Snafu)]
 pub enum MetricsError {
@@ -444,10 +447,11 @@ impl metrics::MetricsFamily<()> for TextFamily {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::testing::setup_test;
     use metrics::Metrics;
     use tide_disco::metrics::Metrics as _;
+
+    use super::*;
+    use crate::testing::setup_test;
 
     #[test]
     fn test_prometheus_metrics() {

--- a/hotshot-query-service/src/node.rs
+++ b/hotshot-query-service/src/node.rs
@@ -20,15 +20,17 @@
 //! fully synced with the entire history of the chain. However, the node will _eventually_ sync and
 //! return the expected counts.
 
-use crate::{api::load_api, QueryError};
+use std::{fmt::Display, ops::Bound, path::PathBuf};
+
 use derive_more::From;
 use futures::FutureExt;
 use hotshot_types::traits::node_implementation::NodeType;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::{fmt::Display, ops::Bound, path::PathBuf};
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
 use vbs::version::StaticVersionType;
+
+use crate::{api::load_api, QueryError};
 
 pub(crate) mod data_source;
 pub(crate) mod query_data;
@@ -201,17 +203,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::{
-        data_source::ExtensibleDataSource,
-        task::BackgroundTask,
-        testing::{
-            consensus::{MockDataSource, MockNetwork, MockSqlDataSource},
-            mocks::{mock_transaction, MockBase, MockTypes},
-            setup_test,
-        },
-        ApiState, Error, Header,
-    };
+    use std::time::Duration;
+
     use async_lock::RwLock;
     use committable::Committable;
     use futures::{FutureExt, StreamExt};
@@ -224,12 +217,23 @@ mod test {
         },
     };
     use portpicker::pick_unused_port;
-    use std::time::Duration;
     use surf_disco::Client;
     use tempfile::TempDir;
     use tide_disco::{App, Error as _};
     use tokio::time::sleep;
     use toml::toml;
+
+    use super::*;
+    use crate::{
+        data_source::ExtensibleDataSource,
+        task::BackgroundTask,
+        testing::{
+            consensus::{MockDataSource, MockNetwork, MockSqlDataSource},
+            mocks::{mock_transaction, MockBase, MockTypes},
+            setup_test,
+        },
+        ApiState, Error, Header,
+    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_api() {

--- a/hotshot-query-service/src/node/data_source.rs
+++ b/hotshot-query-service/src/node/data_source.rs
@@ -24,13 +24,15 @@
 //! updated implicitly via the [availability API update
 //! trait](crate::availability::UpdateAvailabilityData).
 
-use super::query_data::{BlockHash, BlockId, SyncStatus, TimeWindowQueryData};
-use crate::{Header, QueryResult};
+use std::ops::RangeBounds;
+
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::From;
 use hotshot_types::{data::VidShare, traits::node_implementation::NodeType};
-use std::ops::RangeBounds;
+
+use super::query_data::{BlockHash, BlockId, SyncStatus, TimeWindowQueryData};
+use crate::{Header, QueryResult};
 
 #[derive(Derivative, From)]
 #[derivative(Copy(bound = ""), Debug(bound = ""))]

--- a/hotshot-query-service/src/node/query_data.rs
+++ b/hotshot-query-service/src/node/query_data.rs
@@ -10,11 +10,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::types::HeightIndexed;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 pub use crate::availability::{BlockHash, BlockId};
+use crate::types::HeightIndexed;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct SyncStatus {

--- a/hotshot-query-service/src/status.rs
+++ b/hotshot-query-service/src/status.rs
@@ -23,16 +23,16 @@
 //! * snapshots of the state right now, with no way to query historical snapshots
 //! * summary statistics
 
-use crate::api::load_api;
+use std::{borrow::Cow, fmt::Display, path::PathBuf};
+
 use derive_more::From;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::borrow::Cow;
-use std::fmt::Display;
-use std::path::PathBuf;
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
 use vbs::version::StaticVersionType;
+
+use crate::api::load_api;
 
 pub(crate) mod data_source;
 
@@ -107,6 +107,17 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::{str::FromStr, time::Duration};
+
+    use async_lock::RwLock;
+    use futures::FutureExt;
+    use portpicker::pick_unused_port;
+    use reqwest::redirect::Policy;
+    use surf_disco::Client;
+    use tempfile::TempDir;
+    use tide_disco::{App, Url};
+    use toml::toml;
+
     use super::*;
     use crate::{
         data_source::ExtensibleDataSource,
@@ -118,16 +129,6 @@ mod test {
         },
         ApiState, Error,
     };
-    use async_lock::RwLock;
-    use futures::FutureExt;
-    use portpicker::pick_unused_port;
-    use reqwest::redirect::Policy;
-    use std::str::FromStr;
-    use std::time::Duration;
-    use surf_disco::Client;
-    use tempfile::TempDir;
-    use tide_disco::{App, Url};
-    use toml::toml;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_api() {

--- a/hotshot-query-service/src/status/data_source.rs
+++ b/hotshot-query-service/src/status/data_source.rs
@@ -10,14 +10,14 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use async_trait::async_trait;
+use chrono::Utc;
+use hotshot_types::traits::metrics::Metrics;
+
 use crate::{
     metrics::{MetricsError, PrometheusMetrics},
     QueryError, QueryResult,
 };
-
-use async_trait::async_trait;
-use chrono::Utc;
-use hotshot_types::traits::metrics::Metrics;
 
 pub trait HasMetrics {
     fn metrics(&self) -> &PrometheusMetrics;

--- a/hotshot-query-service/src/task.rs
+++ b/hotshot-query-service/src/task.rs
@@ -12,10 +12,10 @@
 
 //! Async task utilities.
 
+use std::{fmt::Display, sync::Arc};
+
 use derivative::Derivative;
 use futures::future::Future;
-use std::fmt::Display;
-use std::sync::Arc;
 use tokio::{
     spawn,
     task::{JoinError, JoinHandle},

--- a/hotshot-query-service/src/testing/consensus.rs
+++ b/hotshot-query-service/src/testing/consensus.rs
@@ -10,16 +10,8 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::mocks::{MockMembership, MockNodeImpl, MockTransaction, MockTypes, MockVersions};
-use crate::{
-    availability::{AvailabilityDataSource, UpdateAvailabilityData},
-    data_source::{FileSystemDataSource, SqlDataSource, VersionedDataSource},
-    fetching::provider::NoFetching,
-    node::NodeDataSource,
-    status::{StatusDataSource, UpdateStatusData},
-    task::BackgroundTask,
-    SignatureKey,
-};
+use std::{fmt::Display, num::NonZeroUsize, str::FromStr, sync::Arc, time::Duration};
+
 use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::{
@@ -44,16 +36,23 @@ use hotshot_types::{
     traits::{election::Membership, network::Topic, signature_key::SignatureKey as _},
     HotShotConfig, PeerConfig,
 };
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-use std::time::Duration;
-use std::{fmt::Display, str::FromStr};
 use tokio::{
     runtime::Handle,
     task::{block_in_place, yield_now},
 };
 use tracing::{info_span, Instrument};
 use url::Url;
+
+use super::mocks::{MockMembership, MockNodeImpl, MockTransaction, MockTypes, MockVersions};
+use crate::{
+    availability::{AvailabilityDataSource, UpdateAvailabilityData},
+    data_source::{FileSystemDataSource, SqlDataSource, VersionedDataSource},
+    fetching::provider::NoFetching,
+    node::NodeDataSource,
+    status::{StatusDataSource, UpdateStatusData},
+    task::BackgroundTask,
+    SignatureKey,
+};
 
 struct MockNode<D: DataSourceLifeCycle> {
     hotshot: SystemContextHandle<MockTypes, MockNodeImpl, MockVersions>,

--- a/hotshot-query-service/src/testing/mocks.rs
+++ b/hotshot-query-service/src/testing/mocks.rs
@@ -10,12 +10,8 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::explorer::traits::{ExplorerHeader, ExplorerTransaction};
-use crate::merklized_state::MerklizedState;
-use crate::{
-    availability::{QueryableHeader, QueryablePayload},
-    types::HeightIndexed,
-};
+use std::ops::Range;
+
 use hotshot::traits::{
     election::static_committee::StaticCommittee, implementations::MemoryNetwork, NodeImplementation,
 };
@@ -25,21 +21,25 @@ use hotshot_example_types::{
     state_types::{TestInstanceState, TestValidatedState},
     storage_types::TestStorage,
 };
-use hotshot_types::traits::node_implementation::Versions;
 use hotshot_types::{
     data::{QuorumProposal, ViewNumber},
     signature_key::BLSPubKey,
-    traits::node_implementation::NodeType,
+    traits::node_implementation::{NodeType, Versions},
 };
-
 use jf_merkle_tree::{
     prelude::{MerkleProof, Sha3Digest, Sha3Node},
     universal_merkle_tree::UniversalMerkleTree,
     ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
 };
 use serde::{Deserialize, Serialize};
-use std::ops::Range;
 use vbs::version::StaticVersion;
+
+use crate::{
+    availability::{QueryableHeader, QueryablePayload},
+    explorer::traits::{ExplorerHeader, ExplorerTransaction},
+    merklized_state::MerklizedState,
+    types::HeightIndexed,
+};
 
 pub type MockHeader = TestBlockHeader;
 pub type MockPayload = TestBlockPayload;

--- a/hotshot-stake-table/src/mt_based.rs
+++ b/hotshot-stake-table/src/mt_based.rs
@@ -100,7 +100,7 @@ impl<K: Key> StakeTableScheme for StakeTable<K> {
             Some(index) => {
                 let branches = to_merkle_path(*index, self.height);
                 root.simple_lookup(self.height, &branches)
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }
     }
@@ -116,7 +116,7 @@ impl<K: Key> StakeTableScheme for StakeTable<K> {
             Some(index) => {
                 let branches = to_merkle_path(*index, self.height);
                 root.lookup(self.height, &branches)
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }?;
         let amount = *proof.value().ok_or(StakeTableError::KeyNotFound)?;
@@ -149,7 +149,7 @@ impl<K: Key> StakeTableScheme for StakeTable<K> {
                     negative,
                 )?;
                 Ok(value)
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }
     }
@@ -221,7 +221,7 @@ impl<K: Key> StakeTable<K> {
                     value,
                 )?;
                 Ok(old_value)
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }
     }

--- a/hotshot-stake-table/src/mt_based/internal.rs
+++ b/hotshot-stake-table/src/mt_based/internal.rs
@@ -155,10 +155,10 @@ impl<K: Key> MerkleProof<K> {
                             let comm = Digest::evaluate(input)
                                 .map_err(|_| StakeTableError::RescueError)?[0];
                             Ok(comm)
-                        }
+                        },
                         MerklePathEntry::Leaf { .. } => Err(StakeTableError::MalformedProof),
                     })
-            }
+            },
             _ => Err(StakeTableError::MalformedProof),
         }
     }
@@ -305,7 +305,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                     siblings: siblings.try_into().unwrap(),
                 });
                 Ok(proof)
-            }
+            },
             PersistentMerkleNode::Leaf {
                 comm: _,
                 key,
@@ -341,7 +341,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                         ptr += 1;
                     }
                     children[ptr].key_by_stake(stake_number)
-                }
+                },
                 PersistentMerkleNode::Leaf {
                     comm: _,
                     key,
@@ -441,7 +441,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                     }),
                     value,
                 ))
-            }
+            },
             PersistentMerkleNode::Leaf {
                 comm: _,
                 key: node_key,
@@ -473,7 +473,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                 } else {
                     Err(StakeTableError::MismatchedKey)
                 }
-            }
+            },
         }
     }
 
@@ -518,7 +518,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                         old_value,
                     ))
                 }
-            }
+            },
             PersistentMerkleNode::Leaf {
                 comm: _,
                 key: cur_key,
@@ -541,7 +541,7 @@ impl<K: Key> PersistentMerkleNode<K> {
                 } else {
                     Err(StakeTableError::MismatchedKey)
                 }
-            }
+            },
         }
     }
 }
@@ -584,7 +584,7 @@ impl<K: Key> Iterator for IntoIter<K> {
                 // put the left-most child to the last, so it is visited first.
                 self.unvisited.extend(children.into_iter().rev());
                 self.next()
-            }
+            },
             PersistentMerkleNode::Leaf {
                 comm: _,
                 key,

--- a/hotshot-stake-table/src/vec_based.rs
+++ b/hotshot-stake-table/src/vec_based.rs
@@ -126,7 +126,7 @@ where
                 self.head_total_stake -= self.head.stake_amount[*pos];
                 self.head.stake_amount[*pos] = U256::zero();
                 Ok(())
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }
     }
@@ -306,7 +306,7 @@ where
                 self.head_total_stake -= old_value;
                 self.head_total_stake += value;
                 Ok(old_value)
-            }
+            },
             None => Err(StakeTableError::KeyNotFound),
         }
     }

--- a/hotshot-stake-table/src/vec_based/config.rs
+++ b/hotshot-stake-table/src/vec_based/config.rs
@@ -41,7 +41,7 @@ impl ToFields<FieldType> for QCVerKey {
                     FieldType::from_le_bytes_mod_order(&bytes[31..62]),
                     FieldType::from_le_bytes_mod_order(&bytes[62..]),
                 ]
-            }
+            },
             Err(_) => unreachable!(),
         }
     }

--- a/hotshot-state-prover/src/circuit.rs
+++ b/hotshot-state-prover/src/circuit.rs
@@ -331,8 +331,10 @@ where
 #[cfg(test)]
 mod tests {
     use ark_ed_on_bn254::EdwardsConfig as Config;
-    use hotshot_types::light_client::LightClientState;
-    use hotshot_types::traits::stake_table::{SnapshotVersion, StakeTableScheme};
+    use hotshot_types::{
+        light_client::LightClientState,
+        traits::stake_table::{SnapshotVersion, StakeTableScheme},
+    };
     use jf_crhf::CRHF;
     use jf_relation::Circuit;
     use jf_rescue::crhf::VariableLengthRescueCRHF;

--- a/hotshot-state-prover/src/service.rs
+++ b/hotshot-state-prover/src/service.rs
@@ -9,13 +9,13 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use contract_bindings_ethers::light_client::{LightClient, LightClientErrors};
 use displaydoc::Display;
-use ethers::middleware::{
-    gas_oracle::{GasCategory, GasOracle},
-    signer::SignerMiddlewareError,
-};
 use ethers::{
     core::k256::ecdsa::SigningKey,
-    middleware::SignerMiddleware,
+    middleware::{
+        gas_oracle::{GasCategory, GasOracle},
+        signer::SignerMiddlewareError,
+        SignerMiddleware,
+    },
     providers::{Http, Middleware, Provider, ProviderError},
     signers::{LocalWallet, Signer, Wallet},
     types::{transaction::eip2718::TypedTransaction, Address, U256},
@@ -42,8 +42,7 @@ use jf_pcs::prelude::UnivariateUniversalParams;
 use jf_plonk::errors::PlonkError;
 use jf_relation::Circuit as _;
 use jf_signature::constants::CS_ID_SCHNORR;
-use sequencer_utils::blocknative::BlockNative;
-use sequencer_utils::deployer::is_proxy_contract;
+use sequencer_utils::{blocknative::BlockNative, deployer::is_proxy_contract};
 use serde::Deserialize;
 use surf_disco::Client;
 use tide_disco::{error::ServerError, Api};
@@ -155,12 +154,12 @@ async fn init_stake_table_from_sequencer(
                 Err(e) => {
                     tracing::error!("Failed to parse the network config: {e}");
                     sleep(Duration::from_secs(5)).await;
-                }
+                },
             },
             Err(e) => {
                 tracing::error!("Failed to fetch the network config: {e}");
                 sleep(Duration::from_secs(5)).await;
-            }
+            },
         }
     };
 
@@ -288,7 +287,7 @@ pub async fn read_contract_state(
         Err(e) => {
             tracing::error!("unable to read finalized_state from contract: {}", e);
             return Err(ProverError::ContractError(e.into()));
-        }
+        },
     };
     let st_state: ParsedStakeTableState = match contract.genesis_stake_table_state().call().await {
         Ok(s) => s.into(),
@@ -298,7 +297,7 @@ pub async fn read_contract_state(
                 e
             );
             return Err(ProverError::ContractError(e.into()));
-        }
+        },
     };
 
     Ok((state.into(), st_state.into()))
@@ -330,10 +329,10 @@ pub async fn submit_state_and_proof(
                         priority_fee
                     );
                 }
-            }
+            },
             Err(e) => {
                 tracing::warn!("!! BlockNative Price Oracle failed: {}", e);
-            }
+            },
         }
     }
 

--- a/hotshot-task-impls/src/builder.rs
+++ b/hotshot-task-impls/src/builder.rs
@@ -43,10 +43,10 @@ impl From<BuilderApiError> for BuilderClientError {
         match value {
             BuilderApiError::Request(source) | BuilderApiError::TxnUnpack(source) => {
                 Self::Api(source.to_string())
-            }
+            },
             BuilderApiError::TxnSubmit(source) | BuilderApiError::BuilderAddress(source) => {
                 Self::Api(source.to_string())
-            }
+            },
             BuilderApiError::Custom { message, .. } => Self::Api(message),
             BuilderApiError::BlockAvailable { source, .. }
             | BuilderApiError::BlockClaim { source, .. } => match source {

--- a/hotshot-task-impls/src/consensus/mod.rs
+++ b/hotshot-task-impls/src/consensus/mod.rs
@@ -4,6 +4,8 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::{sync::Arc, time::Instant};
+
 use async_broadcast::{Receiver, Sender};
 use async_trait::async_trait;
 use hotshot_task::task::TaskState;
@@ -22,7 +24,6 @@ use hotshot_types::{
     vote::HasViewNumber,
 };
 use hotshot_utils::anytrace::*;
-use std::{sync::Arc, time::Instant};
 use tokio::task::JoinHandle;
 use tracing::instrument;
 
@@ -120,14 +121,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                 {
                     tracing::debug!("Failed to handle QuorumVoteRecv event; error = {e}");
                 }
-            }
+            },
             HotShotEvent::TimeoutVoteRecv(ref vote) => {
                 if let Err(e) =
                     handle_timeout_vote_recv(vote, Arc::clone(&event), &sender, self).await
                 {
                     tracing::debug!("Failed to handle TimeoutVoteRecv event; error = {e}");
                 }
-            }
+            },
             HotShotEvent::ViewChange(new_view_number, epoch_number) => {
                 if let Err(e) =
                     handle_view_change(*new_view_number, *epoch_number, &sender, &receiver, self)
@@ -136,12 +137,12 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                     tracing::trace!("Failed to handle ViewChange event; error = {e}");
                 }
                 self.view_start_time = Instant::now();
-            }
+            },
             HotShotEvent::Timeout(view_number, epoch) => {
                 if let Err(e) = handle_timeout(*view_number, *epoch, &sender, self).await {
                     tracing::debug!("Failed to handle Timeout event; error = {e}");
                 }
-            }
+            },
             HotShotEvent::ExtendedQc2Formed(eqc) => {
                 let cert_view = eqc.view_number();
                 let cert_block_number = self
@@ -168,7 +169,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                     &sender,
                 )
                 .await;
-            }
+            },
             HotShotEvent::ExtendedQcRecv(high_qc, next_epoch_high_qc, _) => {
                 if !self
                     .consensus
@@ -217,8 +218,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
                     )
                     .await;
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         Ok(())

--- a/hotshot-task-impls/src/da.rs
+++ b/hotshot-task-impls/src/da.rs
@@ -10,10 +10,10 @@ use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_task::task::TaskState;
-use hotshot_types::epoch_membership::EpochMembershipCoordinator;
 use hotshot_types::{
     consensus::{Consensus, OuterConsensus, PayloadWithMetadata},
     data::{vid_commitment, DaProposal2, PackedBundle},
+    epoch_membership::EpochMembershipCoordinator,
     event::{Event, EventType},
     message::{Proposal, UpgradeLock},
     simple_certificate::DaCertificate2,
@@ -141,7 +141,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                     &event_stream,
                 )
                 .await;
-            }
+            },
             HotShotEvent::DaProposalValidated(proposal, sender) => {
                 let cur_view = self.consensus.read().await.cur_view();
                 let view_number = proposal.data.view_number();
@@ -315,7 +315,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                         }
                     });
                 }
-            }
+            },
             HotShotEvent::DaVoteRecv(ref vote) => {
                 tracing::debug!("DA vote recv, Main Task {:?}", vote.view_number());
                 // Check if we are the leader and the vote is from the sender.
@@ -348,7 +348,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                     EpochTransitionIndicator::NotInTransition,
                 )
                 .await?;
-            }
+            },
             HotShotEvent::ViewChange(view, epoch) => {
                 if *epoch > self.cur_epoch {
                     self.cur_epoch = *epoch;
@@ -364,7 +364,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                     tracing::info!("View changed by more than 1 going to view {:?}", view);
                 }
                 self.cur_view = view;
-            }
+            },
             HotShotEvent::BlockRecv(packed_bundle) => {
                 let PackedBundle::<TYPES> {
                     encoded_transactions,
@@ -434,8 +434,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> DaTaskState<TYP
                 {
                     tracing::trace!("{e:?}");
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
         Ok(())
     }

--- a/hotshot-task-impls/src/events.rs
+++ b/hotshot-task-impls/src/events.rs
@@ -10,10 +10,9 @@ use async_broadcast::Sender;
 use either::Either;
 use hotshot_task::task::TaskEvent;
 use hotshot_types::{
-    data::VidCommitment,
     data::{
         DaProposal2, Leaf2, PackedBundle, QuorumProposal2, QuorumProposalWrapper, UpgradeProposal,
-        VidDisperse, VidDisperseShare,
+        VidCommitment, VidDisperse, VidDisperseShare,
     },
     message::Proposal,
     request_response::ProposalRequestPayload,
@@ -284,7 +283,7 @@ impl<TYPES: NodeType> HotShotEvent<TYPES> {
             HotShotEvent::QuorumVoteRecv(v) => Some(v.view_number()),
             HotShotEvent::TimeoutVoteRecv(v) | HotShotEvent::TimeoutVoteSend(v) => {
                 Some(v.view_number())
-            }
+            },
             HotShotEvent::QuorumProposalRecv(proposal, _)
             | HotShotEvent::QuorumProposalSend(proposal, _)
             | HotShotEvent::QuorumProposalValidated(proposal, _)
@@ -292,16 +291,16 @@ impl<TYPES: NodeType> HotShotEvent<TYPES> {
             | HotShotEvent::QuorumProposalResponseSend(_, proposal)
             | HotShotEvent::QuorumProposalPreliminarilyValidated(proposal) => {
                 Some(proposal.data.view_number())
-            }
+            },
             HotShotEvent::QuorumVoteSend(vote) | HotShotEvent::ExtendedQuorumVoteSend(vote) => {
                 Some(vote.view_number())
-            }
+            },
             HotShotEvent::DaProposalRecv(proposal, _)
             | HotShotEvent::DaProposalValidated(proposal, _)
             | HotShotEvent::DaProposalSend(proposal, _) => Some(proposal.data.view_number()),
             HotShotEvent::DaVoteRecv(vote) | HotShotEvent::DaVoteSend(vote) => {
                 Some(vote.view_number())
-            }
+            },
             HotShotEvent::QcFormed(cert) => match cert {
                 either::Left(qc) => Some(qc.view_number()),
                 either::Right(tc) => Some(tc.view_number()),
@@ -327,41 +326,41 @@ impl<TYPES: NodeType> HotShotEvent<TYPES> {
             | HotShotEvent::ViewSyncCommitCertificateSend(cert, _) => Some(cert.view_number()),
             HotShotEvent::ViewSyncFinalizeCertificateRecv(cert)
             | HotShotEvent::ViewSyncFinalizeCertificateSend(cert, _) => Some(cert.view_number()),
-            HotShotEvent::SendPayloadCommitmentAndMetadata(_, _, _, view_number, _, _) => {
+            HotShotEvent::SendPayloadCommitmentAndMetadata(_, _, _, view_number, ..) => {
                 Some(*view_number)
-            }
+            },
             HotShotEvent::BlockRecv(packed_bundle) => Some(packed_bundle.view_number),
             HotShotEvent::Shutdown
-            | HotShotEvent::TransactionSend(_, _)
+            | HotShotEvent::TransactionSend(..)
             | HotShotEvent::TransactionsRecv(_) => None,
             HotShotEvent::VidDisperseSend(proposal, _) => Some(proposal.data.view_number()),
             HotShotEvent::VidShareRecv(_, proposal) | HotShotEvent::VidShareValidated(proposal) => {
                 Some(proposal.data.view_number())
-            }
+            },
             HotShotEvent::UpgradeProposalRecv(proposal, _)
             | HotShotEvent::UpgradeProposalSend(proposal, _) => Some(proposal.data.view_number()),
             HotShotEvent::UpgradeVoteRecv(vote) | HotShotEvent::UpgradeVoteSend(vote) => {
                 Some(vote.view_number())
-            }
+            },
             HotShotEvent::QuorumProposalRequestSend(req, _)
             | HotShotEvent::QuorumProposalRequestRecv(req, _) => Some(req.view_number),
             HotShotEvent::ViewChange(view_number, _)
-            | HotShotEvent::ViewSyncTimeout(view_number, _, _)
+            | HotShotEvent::ViewSyncTimeout(view_number, ..)
             | HotShotEvent::ViewSyncTrigger(view_number)
             | HotShotEvent::Timeout(view_number, ..) => Some(*view_number),
             HotShotEvent::DaCertificateRecv(cert) | HotShotEvent::DacSend(cert, _) => {
                 Some(cert.view_number())
-            }
+            },
             HotShotEvent::DaCertificateValidated(cert) => Some(cert.view_number),
             HotShotEvent::UpgradeCertificateFormed(cert) => Some(cert.view_number()),
-            HotShotEvent::VidRequestSend(request, _, _)
+            HotShotEvent::VidRequestSend(request, ..)
             | HotShotEvent::VidRequestRecv(request, _) => Some(request.view),
             HotShotEvent::VidResponseSend(_, _, proposal)
             | HotShotEvent::VidResponseRecv(_, proposal) => Some(proposal.data.view_number()),
             HotShotEvent::HighQcRecv(qc, _)
             | HotShotEvent::HighQcSend(qc, ..)
-            | HotShotEvent::ExtendedQcRecv(qc, _, _)
-            | HotShotEvent::ExtendedQcSend(qc, _, _) => Some(qc.view_number()),
+            | HotShotEvent::ExtendedQcRecv(qc, ..)
+            | HotShotEvent::ExtendedQcSend(qc, ..) => Some(qc.view_number()),
         }
     }
 }
@@ -378,20 +377,20 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::QuorumVoteRecv(v) => {
                 write!(f, "QuorumVoteRecv(view_number={:?})", v.view_number())
-            }
+            },
             HotShotEvent::ExtendedQuorumVoteSend(v) => {
                 write!(
                     f,
                     "ExtendedQuorumVoteSend(view_number={:?})",
                     v.view_number()
                 )
-            }
+            },
             HotShotEvent::TimeoutVoteRecv(v) => {
                 write!(f, "TimeoutVoteRecv(view_number={:?})", v.view_number())
-            }
+            },
             HotShotEvent::TimeoutVoteSend(v) => {
                 write!(f, "TimeoutVoteSend(view_number={:?})", v.view_number())
-            }
+            },
             HotShotEvent::DaProposalRecv(proposal, _) => write!(
                 f,
                 "DaProposalRecv(view_number={:?})",
@@ -404,10 +403,10 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::DaVoteRecv(vote) => {
                 write!(f, "DaVoteRecv(view_number={:?})", vote.view_number())
-            }
+            },
             HotShotEvent::DaCertificateRecv(cert) => {
                 write!(f, "DaCertificateRecv(view_number={:?})", cert.view_number())
-            }
+            },
             HotShotEvent::DaCertificateValidated(cert) => write!(
                 f,
                 "DaCertificateValidated(view_number={:?})",
@@ -420,7 +419,7 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::QuorumVoteSend(vote) => {
                 write!(f, "QuorumVoteSend(view_number={:?})", vote.view_number())
-            }
+            },
             HotShotEvent::QuorumProposalValidated(proposal, _) => write!(
                 f,
                 "QuorumProposalValidated(view_number={:?})",
@@ -433,7 +432,7 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::DaVoteSend(vote) => {
                 write!(f, "DaVoteSend(view_number={:?})", vote.view_number())
-            }
+            },
             HotShotEvent::QcFormed(cert) => match cert {
                 either::Left(qc) => write!(f, "QcFormed(view_number={:?})", qc.view_number()),
                 either::Right(tc) => write!(f, "QcFormed(view_number={:?})", tc.view_number()),
@@ -445,26 +444,26 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             HotShotEvent::NextEpochQc2Formed(cert) => match cert {
                 either::Left(qc) => {
                     write!(f, "NextEpochQc2Formed(view_number={:?})", qc.view_number())
-                }
+                },
                 either::Right(tc) => {
                     write!(f, "NextEpochQc2Formed(view_number={:?})", tc.view_number())
-                }
+                },
             },
             HotShotEvent::ExtendedQc2Formed(cert) => {
                 write!(f, "ExtendedQc2Formed(view_number={:?})", cert.view_number())
-            }
+            },
             HotShotEvent::DacSend(cert, _) => {
                 write!(f, "DacSend(view_number={:?})", cert.view_number())
-            }
+            },
             HotShotEvent::ViewChange(view_number, epoch_number) => {
                 write!(
                     f,
                     "ViewChange(view_number={view_number:?}, epoch_number={epoch_number:?})"
                 )
-            }
-            HotShotEvent::ViewSyncTimeout(view_number, _, _) => {
+            },
+            HotShotEvent::ViewSyncTimeout(view_number, ..) => {
                 write!(f, "ViewSyncTimeout(view_number={view_number:?})")
-            }
+            },
             HotShotEvent::ViewSyncPreCommitVoteRecv(vote) => write!(
                 f,
                 "ViewSyncPreCommitVoteRecv(view_number={:?})",
@@ -501,59 +500,59 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
                     "ViewSyncPreCommitCertificateRecv(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncCommitCertificateRecv(cert) => {
                 write!(
                     f,
                     "ViewSyncCommitCertificateRecv(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncFinalizeCertificateRecv(cert) => {
                 write!(
                     f,
                     "ViewSyncFinalizeCertificateRecv(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncPreCommitCertificateSend(cert, _) => {
                 write!(
                     f,
                     "ViewSyncPreCommitCertificateSend(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncCommitCertificateSend(cert, _) => {
                 write!(
                     f,
                     "ViewSyncCommitCertificateSend(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncFinalizeCertificateSend(cert, _) => {
                 write!(
                     f,
                     "ViewSyncFinalizeCertificateSend(view_number={:?})",
                     cert.view_number()
                 )
-            }
+            },
             HotShotEvent::ViewSyncTrigger(view_number) => {
                 write!(f, "ViewSyncTrigger(view_number={view_number:?})")
-            }
+            },
             HotShotEvent::Timeout(view_number, epoch) => {
                 write!(f, "Timeout(view_number={view_number:?}, epoch={epoch:?})")
-            }
+            },
             HotShotEvent::TransactionsRecv(_) => write!(f, "TransactionsRecv"),
-            HotShotEvent::TransactionSend(_, _) => write!(f, "TransactionSend"),
-            HotShotEvent::SendPayloadCommitmentAndMetadata(_, _, _, view_number, _, _) => {
+            HotShotEvent::TransactionSend(..) => write!(f, "TransactionSend"),
+            HotShotEvent::SendPayloadCommitmentAndMetadata(_, _, _, view_number, ..) => {
                 write!(
                     f,
                     "SendPayloadCommitmentAndMetadata(view_number={view_number:?})"
                 )
-            }
+            },
             HotShotEvent::BlockRecv(packed_bundle) => {
                 write!(f, "BlockRecv(view_number={:?})", packed_bundle.view_number)
-            }
+            },
             HotShotEvent::VidDisperseSend(proposal, _) => write!(
                 f,
                 "VidDisperseSend(view_number={:?})",
@@ -581,10 +580,10 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::UpgradeVoteRecv(vote) => {
                 write!(f, "UpgradeVoteRecv(view_number={:?})", vote.view_number())
-            }
+            },
             HotShotEvent::UpgradeVoteSend(vote) => {
                 write!(f, "UpgradeVoteSend(view_number={:?})", vote.view_number())
-            }
+            },
             HotShotEvent::UpgradeCertificateFormed(cert) => write!(
                 f,
                 "UpgradeCertificateFormed(view_number={:?})",
@@ -592,63 +591,63 @@ impl<TYPES: NodeType> Display for HotShotEvent<TYPES> {
             ),
             HotShotEvent::QuorumProposalRequestSend(view_number, _) => {
                 write!(f, "QuorumProposalRequestSend(view_number={view_number:?})")
-            }
+            },
             HotShotEvent::QuorumProposalRequestRecv(view_number, _) => {
                 write!(f, "QuorumProposalRequestRecv(view_number={view_number:?})")
-            }
+            },
             HotShotEvent::QuorumProposalResponseSend(_, proposal) => {
                 write!(
                     f,
                     "QuorumProposalResponseSend(view_number={:?})",
                     proposal.data.view_number()
                 )
-            }
+            },
             HotShotEvent::QuorumProposalResponseRecv(proposal) => {
                 write!(
                     f,
                     "QuorumProposalResponseRecv(view_number={:?})",
                     proposal.data.view_number()
                 )
-            }
+            },
             HotShotEvent::QuorumProposalPreliminarilyValidated(proposal) => {
                 write!(
                     f,
                     "QuorumProposalPreliminarilyValidated(view_number={:?}",
                     proposal.data.view_number()
                 )
-            }
-            HotShotEvent::VidRequestSend(request, _, _) => {
+            },
+            HotShotEvent::VidRequestSend(request, ..) => {
                 write!(f, "VidRequestSend(view_number={:?}", request.view)
-            }
+            },
             HotShotEvent::VidRequestRecv(request, _) => {
                 write!(f, "VidRequestRecv(view_number={:?}", request.view)
-            }
+            },
             HotShotEvent::VidResponseSend(_, _, proposal) => {
                 write!(
                     f,
                     "VidResponseSend(view_number={:?}",
                     proposal.data.view_number()
                 )
-            }
+            },
             HotShotEvent::VidResponseRecv(_, proposal) => {
                 write!(
                     f,
                     "VidResponseRecv(view_number={:?}",
                     proposal.data.view_number()
                 )
-            }
+            },
             HotShotEvent::HighQcRecv(qc, _) => {
                 write!(f, "HighQcRecv(view_number={:?}", qc.view_number())
-            }
+            },
             HotShotEvent::HighQcSend(qc, ..) => {
                 write!(f, "HighQcSend(view_number={:?}", qc.view_number())
-            }
+            },
             HotShotEvent::ExtendedQcRecv(qc, ..) => {
                 write!(f, "ExtendedQcRecv(view_number={:?}", qc.view_number())
-            }
+            },
             HotShotEvent::ExtendedQcSend(qc, ..) => {
                 write!(f, "ExtendedQcSend(view_number={:?}", qc.view_number())
-            }
+            },
         }
     }
 }

--- a/hotshot-task-impls/src/helpers.rs
+++ b/hotshot-task-impls/src/helpers.rs
@@ -4,12 +4,17 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use async_broadcast::{Receiver, SendError, Sender};
 use async_lock::RwLock;
 use committable::{Commitment, Committable};
 use either::Either;
 use hotshot_task::dependency::{Dependency, EventDependency};
-use hotshot_types::traits::storage::Storage;
 use hotshot_types::{
     consensus::OuterConsensus,
     data::{Leaf2, QuorumProposalWrapper, ViewChangeEvidence2},
@@ -24,6 +29,7 @@ use hotshot_types::{
         election::Membership,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
+        storage::Storage,
         BlockPayload, ValidatedState,
     },
     utils::{
@@ -34,11 +40,6 @@ use hotshot_types::{
     StakeTableEntries,
 };
 use hotshot_utils::anytrace::*;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::{Duration, Instant},
-};
 use tokio::time::timeout;
 use tracing::instrument;
 
@@ -814,7 +815,7 @@ pub(crate) async fn validate_proposal_view_and_certs<
                             *view_number, e
                         )
                     })?;
-            }
+            },
             ViewChangeEvidence2::ViewSync(view_sync_cert) => {
                 ensure!(
                     view_sync_cert.view_number == view_number,
@@ -838,7 +839,7 @@ pub(crate) async fn validate_proposal_view_and_certs<
                     )
                     .await
                     .context(|e| warn!("Invalid view sync finalize cert provided: {}", e))?;
-            }
+            },
         }
     }
 
@@ -871,13 +872,13 @@ pub async fn broadcast_event<E: Clone + std::fmt::Debug>(event: E, sender: &Send
                 "Event sender queue overflow, Oldest event removed form queue: {:?}",
                 overflowed
             );
-        }
+        },
         Err(SendError(e)) => {
             tracing::warn!(
                 "Event: {:?}\n Sending failed, event stream probably shutdown",
                 e
             );
-        }
+        },
     }
 }
 

--- a/hotshot-task-impls/src/network.rs
+++ b/hotshot-task-impls/src/network.rs
@@ -85,7 +85,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::QuorumProposalRecv(convert_proposal(proposal), sender)
-                        }
+                        },
                         GeneralConsensusMessage::Proposal2(proposal) => {
                             if !self
                                 .upgrade_lock
@@ -96,10 +96,10 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::QuorumProposalRecv(convert_proposal(proposal), sender)
-                        }
+                        },
                         GeneralConsensusMessage::ProposalRequested(req, sig) => {
                             HotShotEvent::QuorumProposalRequestRecv(req, sig)
-                        }
+                        },
                         GeneralConsensusMessage::ProposalResponse(proposal) => {
                             if self
                                 .upgrade_lock
@@ -110,7 +110,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::QuorumProposalResponseRecv(convert_proposal(proposal))
-                        }
+                        },
                         GeneralConsensusMessage::ProposalResponse2(proposal) => {
                             if !self
                                 .upgrade_lock
@@ -121,21 +121,21 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::QuorumProposalResponseRecv(convert_proposal(proposal))
-                        }
+                        },
                         GeneralConsensusMessage::Vote(vote) => {
                             if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                                 tracing::warn!("received GeneralConsensusMessage::Vote for view {} but epochs are enabled for that view", vote.view_number());
                                 return;
                             }
                             HotShotEvent::QuorumVoteRecv(vote.to_vote2())
-                        }
+                        },
                         GeneralConsensusMessage::Vote2(vote) => {
                             if !self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                                 tracing::warn!("received GeneralConsensusMessage::Vote2 for view {} but epochs are not enabled for that view", vote.view_number());
                                 return;
                             }
                             HotShotEvent::QuorumVoteRecv(vote)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncPreCommitVote(view_sync_message) => {
                             if self
                                 .upgrade_lock
@@ -146,7 +146,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncPreCommitVoteRecv(view_sync_message.to_vote2())
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncPreCommitVote2(view_sync_message) => {
                             if !self
                                 .upgrade_lock
@@ -157,7 +157,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncPreCommitVoteRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncPreCommitCertificate(
                             view_sync_message,
                         ) => {
@@ -172,7 +172,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                             HotShotEvent::ViewSyncPreCommitCertificateRecv(
                                 view_sync_message.to_vsc2(),
                             )
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncPreCommitCertificate2(
                             view_sync_message,
                         ) => {
@@ -185,7 +185,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncPreCommitCertificateRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncCommitVote(view_sync_message) => {
                             if self
                                 .upgrade_lock
@@ -196,7 +196,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncCommitVoteRecv(view_sync_message.to_vote2())
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncCommitVote2(view_sync_message) => {
                             if !self
                                 .upgrade_lock
@@ -207,7 +207,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncCommitVoteRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncCommitCertificate(view_sync_message) => {
                             if self
                                 .upgrade_lock
@@ -218,7 +218,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncCommitCertificateRecv(view_sync_message.to_vsc2())
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncCommitCertificate2(view_sync_message) => {
                             if !self
                                 .upgrade_lock
@@ -229,7 +229,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncCommitCertificateRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncFinalizeVote(view_sync_message) => {
                             if self
                                 .upgrade_lock
@@ -240,7 +240,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncFinalizeVoteRecv(view_sync_message.to_vote2())
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncFinalizeVote2(view_sync_message) => {
                             if !self
                                 .upgrade_lock
@@ -251,7 +251,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncFinalizeVoteRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncFinalizeCertificate(view_sync_message) => {
                             if self
                                 .upgrade_lock
@@ -264,7 +264,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                             HotShotEvent::ViewSyncFinalizeCertificateRecv(
                                 view_sync_message.to_vsc2(),
                             )
-                        }
+                        },
                         GeneralConsensusMessage::ViewSyncFinalizeCertificate2(
                             view_sync_message,
                         ) => {
@@ -277,7 +277,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::ViewSyncFinalizeCertificateRecv(view_sync_message)
-                        }
+                        },
                         GeneralConsensusMessage::TimeoutVote(message) => {
                             if self
                                 .upgrade_lock
@@ -288,7 +288,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::TimeoutVoteRecv(message.to_vote2())
-                        }
+                        },
                         GeneralConsensusMessage::TimeoutVote2(message) => {
                             if !self
                                 .upgrade_lock
@@ -299,18 +299,18 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::TimeoutVoteRecv(message)
-                        }
+                        },
                         GeneralConsensusMessage::UpgradeProposal(message) => {
                             HotShotEvent::UpgradeProposalRecv(message, sender)
-                        }
+                        },
                         GeneralConsensusMessage::UpgradeVote(message) => {
                             tracing::error!("Received upgrade vote!");
                             HotShotEvent::UpgradeVoteRecv(message)
-                        }
+                        },
                         GeneralConsensusMessage::HighQc(qc) => HotShotEvent::HighQcRecv(qc, sender),
                         GeneralConsensusMessage::ExtendedQc(qc, next_epoch_qc) => {
                             HotShotEvent::ExtendedQcRecv(qc, next_epoch_qc, sender)
-                        }
+                        },
                     },
                     SequencingMessage::Da(da_message) => match da_message {
                         DaConsensusMessage::DaProposal(proposal) => {
@@ -323,7 +323,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::DaProposalRecv(convert_proposal(proposal), sender)
-                        }
+                        },
                         DaConsensusMessage::DaProposal2(proposal) => {
                             if !self
                                 .upgrade_lock
@@ -334,35 +334,35 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::DaProposalRecv(proposal, sender)
-                        }
+                        },
                         DaConsensusMessage::DaVote(vote) => {
                             if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                                 tracing::warn!("received DaConsensusMessage::DaVote for view {} but epochs are enabled for that view", vote.view_number());
                                 return;
                             }
                             HotShotEvent::DaVoteRecv(vote.clone().to_vote2())
-                        }
+                        },
                         DaConsensusMessage::DaVote2(vote) => {
                             if !self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                                 tracing::warn!("received DaConsensusMessage::DaVote2 for view {} but epochs are not enabled for that view", vote.view_number());
                                 return;
                             }
                             HotShotEvent::DaVoteRecv(vote.clone())
-                        }
+                        },
                         DaConsensusMessage::DaCertificate(cert) => {
                             if self.upgrade_lock.epochs_enabled(cert.view_number()).await {
                                 tracing::warn!("received DaConsensusMessage::DaCertificate for view {} but epochs are enabled for that view", cert.view_number());
                                 return;
                             }
                             HotShotEvent::DaCertificateRecv(cert.to_dac2())
-                        }
+                        },
                         DaConsensusMessage::DaCertificate2(cert) => {
                             if !self.upgrade_lock.epochs_enabled(cert.view_number()).await {
                                 tracing::warn!("received DaConsensusMessage::DaCertificate2 for view {} but epochs are not enabled for that view", cert.view_number());
                                 return;
                             }
                             HotShotEvent::DaCertificateRecv(cert)
-                        }
+                        },
                         DaConsensusMessage::VidDisperseMsg(proposal) => {
                             if self
                                 .upgrade_lock
@@ -373,7 +373,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::VidShareRecv(sender, convert_proposal(proposal))
-                        }
+                        },
                         DaConsensusMessage::VidDisperseMsg2(proposal) => {
                             if !self
                                 .upgrade_lock
@@ -384,11 +384,11 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                 return;
                             }
                             HotShotEvent::VidShareRecv(sender, convert_proposal(proposal))
-                        }
+                        },
                     },
                 };
                 broadcast_event(Arc::new(event), &self.internal_event_stream).await;
-            }
+            },
 
             // Handle data messages
             MessageKind::Data(message) => match message {
@@ -403,7 +403,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                         &self.internal_event_stream,
                     )
                     .await;
-                }
+                },
                 DataMessage::DataResponse(response) => {
                     if let ResponseMessage::Found(message) = response {
                         match message {
@@ -416,7 +416,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                     &self.internal_event_stream,
                                 )
                                 .await;
-                            }
+                            },
                             SequencingMessage::Da(DaConsensusMessage::VidDisperseMsg2(
                                 proposal,
                             )) => {
@@ -428,11 +428,11 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                                     &self.internal_event_stream,
                                 )
                                 .await;
-                            }
-                            _ => {}
+                            },
+                            _ => {},
                         }
                     }
-                }
+                },
                 DataMessage::RequestData(data) => {
                     let req_data = data.clone();
                     if let RequestKind::Vid(_view_number, _key) = req_data.request {
@@ -442,7 +442,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                         )
                         .await;
                     }
-                }
+                },
             },
 
             // Handle external messages
@@ -459,7 +459,7 @@ impl<TYPES: NodeType, V: Versions> NetworkMessageTaskState<TYPES, V> {
                     &self.external_event_stream,
                 )
                 .await;
-            }
+            },
         }
     }
 }
@@ -607,7 +607,7 @@ impl<
                 Err(e) => {
                     tracing::error!("Failed to serialize message: {}", e);
                     continue;
-                }
+                },
             };
 
             messages.insert(recipient, serialized_message);
@@ -630,7 +630,7 @@ impl<
                 return;
             }
             match net.vid_broadcast_message(messages).await {
-                Ok(()) => {}
+                Ok(()) => {},
                 Err(e) => tracing::warn!("Failed to send message from network task: {:?}", e),
             }
         });
@@ -665,7 +665,7 @@ impl<
                 Err(e) => {
                     tracing::warn!("Not Sending {:?} because of storage error: {:?}", action, e);
                     Err(())
-                }
+                },
             }
         } else {
             Ok(())
@@ -718,7 +718,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::Broadcast))
-            }
+            },
 
             // ED Each network task is subscribed to all these message types.  Need filters per network task
             HotShotEvent::QuorumVoteSend(vote) => {
@@ -740,7 +740,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
 
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
@@ -754,7 +754,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::ExtendedQuorumVoteSend(vote) => {
                 *maybe_action = Some(HotShotAction::Vote);
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
@@ -768,7 +768,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Broadcast))
-            }
+            },
             HotShotEvent::QuorumProposalRequestSend(req, signature) => Some((
                 req.key.clone(),
                 MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -796,11 +796,11 @@ impl<
                     message,
                     TransmitType::Direct(sender_key),
                 ))
-            }
+            },
             HotShotEvent::VidDisperseSend(proposal, sender) => {
                 self.handle_vid_disperse_proposal(proposal, &sender).await;
                 None
-            }
+            },
             HotShotEvent::DaProposalSend(proposal, sender) => {
                 *maybe_action = Some(HotShotAction::DaPropose);
 
@@ -819,7 +819,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::DaCommitteeBroadcast))
-            }
+            },
             HotShotEvent::DaVoteSend(vote) => {
                 *maybe_action = Some(HotShotAction::DaVote);
                 let view_number = vote.view_number();
@@ -839,7 +839,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
 
                 let message = if self.upgrade_lock.epochs_enabled(view_number).await {
@@ -853,7 +853,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::DacSend(certificate, sender) => {
                 *maybe_action = Some(HotShotAction::DaCert);
                 let message = if self
@@ -871,7 +871,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::Broadcast))
-            }
+            },
             HotShotEvent::ViewSyncPreCommitVoteSend(vote) => {
                 let view_number = vote.view_number() + vote.date().relay;
                 let leader = match self
@@ -890,7 +890,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -903,7 +903,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::ViewSyncCommitVoteSend(vote) => {
                 *maybe_action = Some(HotShotAction::ViewSyncVote);
                 let view_number = vote.view_number() + vote.date().relay;
@@ -923,7 +923,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -936,7 +936,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::ViewSyncFinalizeVoteSend(vote) => {
                 *maybe_action = Some(HotShotAction::ViewSyncVote);
                 let view_number = vote.view_number() + vote.date().relay;
@@ -956,7 +956,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -969,7 +969,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::ViewSyncPreCommitCertificateSend(certificate, sender) => {
                 let view_number = certificate.view_number();
                 let message = if self.upgrade_lock.epochs_enabled(view_number).await {
@@ -983,7 +983,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::Broadcast))
-            }
+            },
             HotShotEvent::ViewSyncCommitCertificateSend(certificate, sender) => {
                 let view_number = certificate.view_number();
                 let message = if self.upgrade_lock.epochs_enabled(view_number).await {
@@ -997,7 +997,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::Broadcast))
-            }
+            },
             HotShotEvent::ViewSyncFinalizeCertificateSend(certificate, sender) => {
                 let view_number = certificate.view_number();
                 let message = if self.upgrade_lock.epochs_enabled(view_number).await {
@@ -1011,7 +1011,7 @@ impl<
                 };
 
                 Some((sender, message, TransmitType::Broadcast))
-            }
+            },
             HotShotEvent::TimeoutVoteSend(vote) => {
                 *maybe_action = Some(HotShotAction::Vote);
                 let view_number = vote.view_number() + 1;
@@ -1031,7 +1031,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
                 let message = if self.upgrade_lock.epochs_enabled(vote.view_number()).await {
                     MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -1044,7 +1044,7 @@ impl<
                 };
 
                 Some((vote.signing_key(), message, TransmitType::Direct(leader)))
-            }
+            },
             HotShotEvent::UpgradeProposalSend(proposal, sender) => Some((
                 sender,
                 MessageKind::<TYPES>::from_consensus_message(SequencingMessage::General(
@@ -1071,7 +1071,7 @@ impl<
                             e
                         );
                         return None;
-                    }
+                    },
                 };
                 Some((
                     vote.signing_key(),
@@ -1080,7 +1080,7 @@ impl<
                     )),
                     TransmitType::Direct(leader),
                 ))
-            }
+            },
             HotShotEvent::ViewChange(view, epoch) => {
                 self.view = view;
                 if epoch > self.epoch {
@@ -1096,7 +1096,7 @@ impl<
                         .await;
                 });
                 None
-            }
+            },
             HotShotEvent::VidRequestSend(req, sender, to) => Some((
                 sender,
                 MessageKind::Data(DataMessage::RequestData(req)),
@@ -1126,7 +1126,7 @@ impl<
                                 vid_share_proposal,
                             )),
                         )))
-                    }
+                    },
                     VidDisperseShare::V1(data) => {
                         if !epochs_enabled {
                             tracing::warn!(
@@ -1145,10 +1145,10 @@ impl<
                                 vid_share_proposal,
                             )),
                         )))
-                    }
+                    },
                 };
                 Some((sender, message, TransmitType::Direct(to)))
-            }
+            },
             HotShotEvent::HighQcSend(quorum_cert, leader, sender) => Some((
                 sender,
                 MessageKind::Consensus(SequencingMessage::General(
@@ -1234,18 +1234,18 @@ impl<
                 Err(e) => {
                     tracing::error!("Failed to serialize message: {}", e);
                     return;
-                }
+                },
             };
 
             let transmit_result = match transmit {
                 TransmitType::Direct(recipient) => {
                     network.direct_message(serialized_message, recipient).await
-                }
+                },
                 TransmitType::Broadcast => {
                     network
                         .broadcast_message(serialized_message, committee_topic, broadcast_delay)
                         .await
-                }
+                },
                 TransmitType::DaCommitteeBroadcast => {
                     network
                         .da_broadcast_message(
@@ -1254,11 +1254,11 @@ impl<
                             broadcast_delay,
                         )
                         .await
-                }
+                },
             };
 
             match transmit_result {
-                Ok(()) => {}
+                Ok(()) => {},
                 Err(e) => tracing::warn!("Failed to send message task: {:?}", e),
             }
         });

--- a/hotshot-task-impls/src/quorum_proposal/handlers.rs
+++ b/hotshot-task-impls/src/quorum_proposal/handlers.rs
@@ -13,11 +13,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    events::HotShotEvent,
-    helpers::{broadcast_event, parent_leaf_and_state, wait_for_next_epoch_qc},
-    quorum_proposal::{QuorumProposalTaskState, UpgradeLock, Versions},
-};
 use anyhow::{ensure, Context, Result};
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
@@ -41,6 +36,12 @@ use hotshot_types::{
 use hotshot_utils::anytrace::*;
 use tracing::instrument;
 use vbs::version::StaticVersionType;
+
+use crate::{
+    events::HotShotEvent,
+    helpers::{broadcast_event, parent_leaf_and_state, wait_for_next_epoch_qc},
+    quorum_proposal::{QuorumProposalTaskState, UpgradeLock, Versions},
+};
 
 /// Proposal dependency types. These types represent events that precipitate a proposal.
 #[derive(PartialEq, Debug)]
@@ -431,22 +432,22 @@ impl<TYPES: NodeType, V: Versions> HandleDepOutput for ProposalDependencyHandle<
                         block_view: *view,
                         auction_result: auction_result.clone(),
                     });
-                }
+                },
                 HotShotEvent::Qc2Formed(cert) => match cert {
                     either::Right(timeout) => {
                         timeout_certificate = Some(timeout.clone());
-                    }
+                    },
                     either::Left(qc) => {
                         parent_qc = Some(qc.clone());
-                    }
+                    },
                 },
                 HotShotEvent::ViewSyncFinalizeCertificateRecv(cert) => {
                     view_sync_finalize_cert = Some(cert.clone());
-                }
+                },
                 HotShotEvent::VidDisperseSend(share, _) => {
                     vid_share = Some(share.clone());
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
 

--- a/hotshot-task-impls/src/quorum_proposal_recv/handlers.rs
+++ b/hotshot-task-impls/src/quorum_proposal_recv/handlers.rs
@@ -221,7 +221,7 @@ pub(crate) async fn handle_quorum_proposal_recv<
             } else {
                 bail!("Parent state not found! Consensus internally inconsistent");
             }
-        }
+        },
         None => None,
     };
 

--- a/hotshot-task-impls/src/quorum_proposal_recv/mod.rs
+++ b/hotshot-task-impls/src/quorum_proposal_recv/mod.rs
@@ -22,8 +22,8 @@ use hotshot_types::{
     message::UpgradeLock,
     simple_certificate::UpgradeCertificate,
     simple_vote::HasEpoch,
-    traits::block_contents::BlockHeader,
     traits::{
+        block_contents::BlockHeader,
         node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
         signature_key::SignatureKey,
     },
@@ -180,10 +180,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                 )
                 .await
                 {
-                    Ok(()) => {}
+                    Ok(()) => {},
                     Err(e) => error!(?e, "Failed to validate the proposal"),
                 }
-            }
+            },
             HotShotEvent::ViewChange(view, epoch) => {
                 if *epoch > self.cur_epoch {
                     self.cur_epoch = *epoch;
@@ -198,8 +198,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                 // to enter view V + 1.
                 let oldest_view_to_keep = TYPES::View::new(view.saturating_sub(1));
                 self.cancel_tasks(oldest_view_to_keep);
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 }

--- a/hotshot-task-impls/src/quorum_vote/handlers.rs
+++ b/hotshot-task-impls/src/quorum_vote/handlers.rs
@@ -10,12 +10,11 @@ use async_broadcast::{InactiveReceiver, Sender};
 use async_lock::RwLock;
 use chrono::Utc;
 use committable::Committable;
-use hotshot_types::epoch_membership::EpochMembership;
 use hotshot_types::{
     consensus::OuterConsensus,
     data::{Leaf2, QuorumProposalWrapper, VidDisperseShare},
     drb::{compute_drb_result, DrbResult, INITIAL_DRB_RESULT},
-    epoch_membership::EpochMembershipCoordinator,
+    epoch_membership::{EpochMembership, EpochMembershipCoordinator},
     event::{Event, EventType},
     message::{Proposal, UpgradeLock},
     simple_vote::{HasEpoch, QuorumData2, QuorumVote2},
@@ -126,7 +125,7 @@ async fn store_and_get_computed_drb_result<
             .await;
             task_state.drb_computation = None;
             Ok(result)
-        }
+        },
         Err(e) => Err(warn!("Error in DRB calculation: {:?}.", e)),
     }
 }
@@ -243,10 +242,10 @@ async fn start_drb_task<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versio
                         )
                         .await;
                         task_state.drb_computation = None;
-                    }
+                    },
                     Err(e) => {
                         tracing::error!("error joining DRB computation task: {e:?}");
-                    }
+                    },
                 }
             } else if *task_epoch == new_epoch_number {
                 return;
@@ -606,10 +605,10 @@ pub(crate) async fn update_shared_state<
                 Some((leaf, view)) => {
                     maybe_validated_view = Some(view);
                     Some(leaf)
-                }
+                },
                 None => None,
             }
-        }
+        },
     };
 
     let parent = maybe_parent.context(info!(

--- a/hotshot-task-impls/src/quorum_vote/mod.rs
+++ b/hotshot-task-impls/src/quorum_vote/mod.rs
@@ -15,7 +15,6 @@ use hotshot_task::{
     dependency_task::{DependencyTask, HandleDepOutput},
     task::TaskState,
 };
-use hotshot_types::StakeTableEntries;
 use hotshot_types::{
     consensus::{ConsensusMetricsValue, OuterConsensus},
     data::{Leaf2, QuorumProposalWrapper},
@@ -33,6 +32,7 @@ use hotshot_types::{
     },
     utils::{epoch_from_block_number, option_epoch_from_block_number},
     vote::{Certificate, HasViewNumber},
+    StakeTableEntries,
 };
 use hotshot_utils::anytrace::*;
 use tokio::task::JoinHandle;
@@ -123,7 +123,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                         Err(e) => {
                             tracing::error!("{e:#}");
                             return;
-                        }
+                        },
                     };
                     let proposal_payload_comm = proposal.data.block_header().payload_commitment();
                     let parent_commitment = parent_leaf.commit();
@@ -165,7 +165,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                     }
                     leaf = Some(proposed_leaf);
                     parent_view_number = Some(parent_leaf.view_number());
-                }
+                },
                 HotShotEvent::DaCertificateValidated(cert) => {
                     let cert_payload_comm = &cert.data().payload_commit;
                     let next_epoch_cert_payload_comm = cert.data().next_epoch_payload_commit;
@@ -187,7 +187,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                     } else {
                         next_epoch_payload_commitment = next_epoch_cert_payload_comm;
                     }
-                }
+                },
                 HotShotEvent::VidShareValidated(share) => {
                     let vid_payload_commitment = &share.data.payload_commitment();
                     vid_share = Some(share.clone());
@@ -211,8 +211,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
                     } else {
                         payload_commitment = Some(*vid_payload_commitment);
                     }
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
 
@@ -269,7 +269,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions> Handl
             Err(e) => {
                 tracing::warn!("{:?}", e);
                 return;
-            }
+            },
         };
 
         tracing::trace!(
@@ -380,21 +380,21 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                         } else {
                             return false;
                         }
-                    }
+                    },
                     VoteDependency::Dac => {
                         if let HotShotEvent::DaCertificateValidated(cert) = event {
                             cert.view_number
                         } else {
                             return false;
                         }
-                    }
+                    },
                     VoteDependency::Vid => {
                         if let HotShotEvent::VidShareValidated(disperse) = event {
                             disperse.data.view_number()
                         } else {
                             return false;
                         }
-                    }
+                    },
                 };
                 if event_view == view_number {
                     tracing::trace!(
@@ -552,7 +552,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                         Arc::clone(&event),
                     );
                 }
-            }
+            },
             HotShotEvent::DaCertificateRecv(cert) => {
                 let view = cert.view_number;
 
@@ -595,7 +595,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                     &event_sender,
                     Arc::clone(&event),
                 );
-            }
+            },
             HotShotEvent::VidShareRecv(sender, share) => {
                 let view = share.data.view_number();
                 // Do nothing if the VID share is old
@@ -659,7 +659,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                     &event_sender,
                     Arc::clone(&event),
                 );
-            }
+            },
             HotShotEvent::Timeout(view, ..) => {
                 let view = TYPES::View::new(view.saturating_sub(1));
                 // cancel old tasks
@@ -668,7 +668,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                     task.abort();
                 }
                 self.vote_dependencies = current_tasks;
-            }
+            },
             HotShotEvent::ViewChange(mut view, _) => {
                 view = TYPES::View::new(view.saturating_sub(1));
                 if !self.update_latest_voted_view(view).await {
@@ -680,8 +680,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> QuorumVoteTaskS
                     task.abort();
                 }
                 self.vote_dependencies = current_tasks;
-            }
-            _ => {}
+            },
+            _ => {},
         }
         Ok(())
     }

--- a/hotshot-task-impls/src/request.rs
+++ b/hotshot-task-impls/src/request.rs
@@ -147,14 +147,14 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> TaskState for NetworkRequest
                         .await;
                 }
                 Ok(())
-            }
+            },
             HotShotEvent::ViewChange(view, _) => {
                 let view = *view;
                 if view > self.view {
                     self.view = view;
                 }
                 Ok(())
-            }
+            },
             _ => Ok(()),
         }
     }
@@ -226,7 +226,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> NetworkRequestState<TYPES, I
             Err(e) => {
                 tracing::warn!(e.message);
                 return;
-            }
+            },
         };
         let mut da_committee_for_view = membership_reader.da_committee_members(view).await;
         if let Ok(leader) = membership_reader.leader(view).await {

--- a/hotshot-task-impls/src/response.rs
+++ b/hotshot-task-impls/src/response.rs
@@ -111,7 +111,7 @@ impl<TYPES: NodeType, V: Versions> NetworkResponseState<TYPES, V> {
                                 )
                                 .await;
                             }
-                        }
+                        },
                         HotShotEvent::QuorumProposalRequestRecv(req, signature) => {
                             // Make sure that this request came from who we think it did
                             if !req.key.validate(signature, req.commit().as_ref()) {
@@ -137,16 +137,16 @@ impl<TYPES: NodeType, V: Versions> NetworkResponseState<TYPES, V> {
                                 )
                                 .await;
                             }
-                        }
+                        },
                         HotShotEvent::Shutdown => {
                             return;
-                        }
-                        _ => {}
+                        },
+                        _ => {},
                     }
-                }
+                },
                 Err(e) => {
                     tracing::error!("Failed to receive event. {:?}", e);
-                }
+                },
             }
         }
     }

--- a/hotshot-task-impls/src/rewind.rs
+++ b/hotshot-task-impls/src/rewind.rs
@@ -58,7 +58,7 @@ impl<TYPES: NodeType> TaskState for RewindTaskState<TYPES> {
             Err(e) => {
                 tracing::error!("Failed to write file {}; error = {}", filename, e);
                 return;
-            }
+            },
         };
 
         for (event_number, event) in self.events.iter().enumerate() {

--- a/hotshot-task-impls/src/transactions.rs
+++ b/hotshot-task-impls/src/transactions.rs
@@ -16,8 +16,7 @@ use hotshot_builder_api::v0_1::block_info::AvailableBlockInfo;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
     consensus::OuterConsensus,
-    data::VidCommitment,
-    data::{null_block, PackedBundle},
+    data::{null_block, PackedBundle, VidCommitment},
     epoch_membership::EpochMembershipCoordinator,
     event::{Event, EventType},
     message::UpgradeLock,
@@ -134,7 +133,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             Err(e) => {
                 tracing::error!("Failed to calculate version: {:?}", e);
                 return None;
-            }
+            },
         };
 
         if version < V::Marketplace::VERSION {
@@ -159,7 +158,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             Err(err) => {
                 tracing::error!("Upgrade certificate requires unsupported version, refusing to request blocks: {}", err);
                 return None;
-            }
+            },
         };
 
         // Request a block from the builder unless we are between versions.
@@ -303,11 +302,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 Ok(Err(e)) => {
                     tracing::debug!("Failed to retrieve bundle: {e}");
                     continue;
-                }
+                },
                 Err(e) => {
                     tracing::debug!("Failed to retrieve bundle: {e}");
                     continue;
-                }
+                },
             }
         }
 
@@ -384,7 +383,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             Err(err) => {
                 tracing::error!("Upgrade certificate requires unsupported version, refusing to request blocks: {}", err);
                 return None;
-            }
+            },
         };
 
         let packed_bundle = match self
@@ -410,7 +409,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     .add(1);
 
                 null_block
-            }
+            },
         };
 
         broadcast_event(
@@ -458,7 +457,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     &self.output_event_stream,
                 )
                 .await;
-            }
+            },
             HotShotEvent::ViewChange(view, epoch) => {
                 let view = TYPES::View::new(std::cmp::max(1, **view));
                 let epoch = if self.upgrade_lock.epochs_enabled(view).await {
@@ -491,8 +490,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     self.handle_view_change(&event_stream, view, epoch).await;
                     return Ok(());
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
         Ok(())
     }
@@ -513,7 +512,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     // We still have time, will re-try in a bit
                     sleep(RETRY_DELAY).await;
                     continue;
-                }
+                },
             }
         }
     }
@@ -547,13 +546,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     let leaf = consensus_reader.saved_leaves().get(leaf_commitment).context
                         (info!("Missing leaf with commitment {leaf_commitment} for view {target_view} in saved_leaves"))?;
                     return Ok((target_view, leaf.payload_commitment()));
-                }
+                },
                 ViewInner::Failed => {
                     // For failed views, backtrack
                     target_view =
                         TYPES::View::new(target_view.checked_sub(1).context(warn!("Reached genesis. Something is wrong -- have we not decided any blocks since genesis?"))?);
                     continue;
-                }
+                },
             }
         }
     }
@@ -571,7 +570,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             Err(e) => {
                 tracing::warn!("Failed to find last vid commitment in time: {e}");
                 return None;
-            }
+            },
         };
 
         let parent_comm_sig = match <<TYPES as NodeType>::SignatureKey as SignatureKey>::sign(
@@ -582,7 +581,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
             Err(err) => {
                 tracing::error!(%err, "Failed to sign block hash");
                 return None;
-            }
+            },
         };
 
         while task_start_time.elapsed() < self.builder_timeout {
@@ -596,7 +595,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 // We got a block
                 Ok(Ok(block)) => {
                     return Some(block);
-                }
+                },
 
                 // We failed to get a block
                 Ok(Err(err)) => {
@@ -604,13 +603,13 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     // pause a bit
                     sleep(RETRY_DELAY).await;
                     continue;
-                }
+                },
 
                 // We timed out while getting available blocks
                 Err(err) => {
                     tracing::info!(%err, "Timeout while getting available blocks");
                     return None;
-                }
+                },
             }
         }
 
@@ -675,7 +674,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 Err(err) => {
                     tracing::warn!(%err,"Error getting available blocks");
                     None
-                }
+                },
             })
             .flatten()
             .collect::<Vec<_>>()
@@ -735,7 +734,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                 Err(err) => {
                     tracing::error!(%err, "Failed to sign block hash");
                     continue;
-                }
+                },
             };
 
             let response = {
@@ -751,7 +750,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     Err(err) => {
                         tracing::warn!(%err, "Error claiming block data");
                         continue;
-                    }
+                    },
                 };
 
                 let header_input = match header_input {
@@ -759,7 +758,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> TransactionTask
                     Err(err) => {
                         tracing::warn!(%err, "Error claiming header input");
                         continue;
-                    }
+                    },
                 };
 
                 // verify the signature over the message

--- a/hotshot-task-impls/src/upgrade.rs
+++ b/hotshot-task-impls/src/upgrade.rs
@@ -217,7 +217,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeTaskState<TYPES, V> {
 
                 tracing::debug!("Sending upgrade vote {:?}", vote.view_number());
                 broadcast_event(Arc::new(HotShotEvent::UpgradeVoteSend(vote)), &tx).await;
-            }
+            },
             HotShotEvent::UpgradeVoteRecv(ref vote) => {
                 tracing::debug!("Upgrade vote recv, Main Task {:?}", vote.view_number());
 
@@ -248,7 +248,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeTaskState<TYPES, V> {
                     EpochTransitionIndicator::NotInTransition,
                 )
                 .await?;
-            }
+            },
             HotShotEvent::ViewChange(new_view, epoch_number) => {
                 if *epoch_number > self.cur_epoch {
                     self.cur_epoch = *epoch_number;
@@ -328,8 +328,8 @@ impl<TYPES: NodeType, V: Versions> UpgradeTaskState<TYPES, V> {
                     )
                     .await;
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
         Ok(())
     }

--- a/hotshot-task-impls/src/vid.rs
+++ b/hotshot-task-impls/src/vid.rs
@@ -160,7 +160,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> VidTaskState<TY
                     &event_stream,
                 )
                 .await;
-            }
+            },
 
             HotShotEvent::ViewChange(view, epoch) => {
                 if *epoch > self.cur_epoch {
@@ -178,7 +178,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> VidTaskState<TY
                 self.cur_view = view;
 
                 return None;
-            }
+            },
 
             HotShotEvent::QuorumProposalSend(proposal, _) => {
                 let proposed_block_number = proposal.data.block_header().block_number();
@@ -243,11 +243,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> VidTaskState<TY
                     &event_stream,
                 )
                 .await;
-            }
+            },
             HotShotEvent::Shutdown => {
                 return Some(HotShotTaskCompleted);
-            }
-            _ => {}
+            },
+            _ => {},
         }
         None
     }

--- a/hotshot-task-impls/src/view_sync.rs
+++ b/hotshot-task-impls/src/view_sync.rs
@@ -233,7 +233,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
             Err(e) => {
                 tracing::warn!(e.message);
                 return;
-            }
+            },
         };
 
         // We do not have a replica task already running, so start one
@@ -278,25 +278,25 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                 let view = certificate.view_number();
                 self.send_to_or_create_replica(event, view, &event_stream)
                     .await;
-            }
+            },
             HotShotEvent::ViewSyncCommitCertificateRecv(certificate) => {
                 tracing::debug!("Received view sync cert for phase {:?}", certificate);
                 let view = certificate.view_number();
                 self.send_to_or_create_replica(event, view, &event_stream)
                     .await;
-            }
+            },
             HotShotEvent::ViewSyncFinalizeCertificateRecv(certificate) => {
                 tracing::debug!("Received view sync cert for phase {:?}", certificate);
                 let view = certificate.view_number();
                 self.send_to_or_create_replica(event, view, &event_stream)
                     .await;
-            }
-            HotShotEvent::ViewSyncTimeout(view, _, _) => {
+            },
+            HotShotEvent::ViewSyncTimeout(view, ..) => {
                 tracing::debug!("view sync timeout in main task {:?}", view);
                 let view = *view;
                 self.send_to_or_create_replica(event, view, &event_stream)
                     .await;
-            }
+            },
 
             HotShotEvent::ViewSyncPreCommitVoteRecv(ref vote) => {
                 let mut map = self.pre_commit_relay_map.write().await;
@@ -344,7 +344,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                 .await?;
 
                 relay_map.insert(relay, vote_collector);
-            }
+            },
 
             HotShotEvent::ViewSyncCommitVoteRecv(ref vote) => {
                 let mut map = self.commit_relay_map.write().await;
@@ -392,7 +392,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                 )
                 .await?;
                 relay_map.insert(relay, vote_collector);
-            }
+            },
 
             HotShotEvent::ViewSyncFinalizeVoteRecv(vote) => {
                 let mut map = self.finalize_relay_map.write().await;
@@ -441,7 +441,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                 if let Ok(vote_task) = vote_collector {
                     relay_map.insert(relay, vote_task);
                 }
-            }
+            },
 
             &HotShotEvent::ViewChange(new_view, epoch) => {
                 if epoch > self.cur_epoch {
@@ -483,7 +483,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
 
                     self.last_garbage_collected_view = self.cur_view - 1;
                 }
-            }
+            },
             &HotShotEvent::Timeout(view_number, ..) => {
                 // This is an old timeout and we can ignore it
                 ensure!(
@@ -528,9 +528,9 @@ impl<TYPES: NodeType, V: Versions> ViewSyncTaskState<TYPES, V> {
                     )
                     .await;
                 }
-            }
+            },
 
-            _ => {}
+            _ => {},
         }
         Ok(())
     }
@@ -634,7 +634,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                         .await;
                     }
                 }));
-            }
+            },
 
             HotShotEvent::ViewSyncCommitCertificateRecv(certificate) => {
                 let last_seen_certificate = ViewSyncPhase::Commit;
@@ -741,7 +741,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                         .await;
                     }
                 }));
-            }
+            },
 
             HotShotEvent::ViewSyncFinalizeCertificateRecv(certificate) => {
                 // Ignore certificate if it is for an older round
@@ -796,7 +796,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 )
                 .await;
                 return Some(HotShotTaskCompleted);
-            }
+            },
 
             HotShotEvent::ViewSyncTrigger(view_number) => {
                 let view_number = *view_number;
@@ -850,7 +850,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                 }));
 
                 return None;
-            }
+            },
 
             HotShotEvent::ViewSyncTimeout(round, relay, last_seen_certificate) => {
                 let round = *round;
@@ -884,11 +884,11 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
                                 &event_stream,
                             )
                             .await;
-                        }
+                        },
                         ViewSyncPhase::Finalize => {
                             // This should never occur
                             unimplemented!()
-                        }
+                        },
                     }
 
                     self.timeout_task = Some(spawn({
@@ -917,7 +917,7 @@ impl<TYPES: NodeType, V: Versions> ViewSyncReplicaTaskState<TYPES, V> {
 
                     return None;
                 }
-            }
+            },
             _ => return None,
         }
         None

--- a/hotshot-task-impls/src/vote_collection.rs
+++ b/hotshot-task-impls/src/vote_collection.rs
@@ -138,7 +138,7 @@ impl<
                 self.accumulator = None;
 
                 Ok(Some(cert))
-            }
+            },
         }
     }
 }
@@ -279,7 +279,7 @@ where
             entry.insert(collector);
 
             Ok(())
-        }
+        },
         Entry::Occupied(mut entry) => {
             // handle the vote, and garbage collect if the vote collector is finished
             if entry
@@ -293,7 +293,7 @@ where
             }
 
             Ok(())
-        }
+        },
     }
 }
 
@@ -517,7 +517,7 @@ impl<TYPES: NodeType, V: Versions>
             HotShotEvent::QuorumVoteRecv(vote) => {
                 // #3967 REVIEW NOTE: Should we error if self.epoch is None?
                 self.accumulate_vote(&vote.clone().into(), sender).await
-            }
+            },
             _ => Ok(None),
         }
     }
@@ -599,7 +599,7 @@ impl<TYPES: NodeType, V: Versions>
         match event.as_ref() {
             HotShotEvent::ViewSyncPreCommitVoteRecv(vote) => {
                 self.accumulate_vote(vote, sender).await
-            }
+            },
             _ => Ok(None),
         }
     }
@@ -641,7 +641,7 @@ impl<TYPES: NodeType, V: Versions>
         match event.as_ref() {
             HotShotEvent::ViewSyncFinalizeVoteRecv(vote) => {
                 self.accumulate_vote(vote, sender).await
-            }
+            },
             _ => Ok(None),
         }
     }

--- a/hotshot-task/src/dependency.rs
+++ b/hotshot-task/src/dependency.rs
@@ -163,13 +163,13 @@ impl<T: Clone + Send + Sync + 'static> Dependency<T> for EventDependency<T> {
                     if (self.match_fn)(&event) {
                         return Some(event);
                     }
-                }
+                },
                 Err(RecvError::Overflowed(n)) => {
                     tracing::error!("Dependency Task overloaded, skipping {} events", n);
-                }
+                },
                 Err(RecvError::Closed) => {
                     return None;
-                }
+                },
             }
         }
     }

--- a/hotshot-task/src/task.rs
+++ b/hotshot-task/src/task.rs
@@ -86,13 +86,13 @@ impl<S: TaskState + Send + 'static> Task<S> {
                             S::handle_event(&mut self.state, input, &self.sender, &self.receiver)
                                 .await
                                 .inspect_err(|e| tracing::debug!("{e}"));
-                    }
+                    },
                     Err(RecvError::Closed) => {
                         break self.boxed_state();
-                    }
+                    },
                     Err(e) => {
                         tracing::error!("Failed to receive from event stream Error: {}", e);
-                    }
+                    },
                 }
             }
         })

--- a/hotshot-testing/src/block_builder/mod.rs
+++ b/hotshot-testing/src/block_builder/mod.rs
@@ -109,13 +109,13 @@ pub fn run_builder_source<TYPES, Source>(
             match event {
                 BuilderChange::Up if handle.is_none() => {
                     handle = Some(start_builder(url.clone(), source.clone()));
-                }
+                },
                 BuilderChange::Down => {
                     if let Some(handle) = handle.take() {
                         handle.abort();
                     }
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
     });
@@ -153,13 +153,13 @@ pub fn run_builder_source_0_1<TYPES, Source>(
             match event {
                 BuilderChange::Up if handle.is_none() => {
                     handle = Some(start_builder(url.clone(), source.clone()));
-                }
+                },
                 BuilderChange::Down => {
                     if let Some(handle) = handle.take() {
                         handle.abort();
                     }
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
     });

--- a/hotshot-testing/src/block_builder/random.rs
+++ b/hotshot-testing/src/block_builder/random.rs
@@ -178,7 +178,7 @@ where
                 match stream.next().await {
                     None => {
                         break;
-                    }
+                    },
                     Some(evt) => {
                         if let EventType::ViewFinished { view_number } = evt.event {
                             if let Some(change) = self.changes.remove(&view_number) {
@@ -192,18 +192,18 @@ where
                                                 self.blocks.clone(),
                                             )))
                                         }
-                                    }
+                                    },
                                     BuilderChange::Down => {
                                         if let Some(handle) = task.take() {
                                             handle.abort();
                                         }
-                                    }
-                                    BuilderChange::FailClaims(_) => {}
+                                    },
+                                    BuilderChange::FailClaims(_) => {},
                                 }
                                 let _ = self.change_sender.broadcast(change).await;
                             }
                         }
-                    }
+                    },
                 }
             }
         });

--- a/hotshot-testing/src/block_builder/simple.rs
+++ b/hotshot-testing/src/block_builder/simple.rs
@@ -382,7 +382,7 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                 match stream.next().await {
                     None => {
                         break;
-                    }
+                    },
                     Some(evt) => match evt.event {
                         EventType::ViewFinished { view_number } => {
                             if let Some(change) = self.changes.remove(&view_number) {
@@ -392,14 +392,14 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                                         should_build_blocks = false;
                                         self.transactions.write().await.clear();
                                         self.blocks.write().await.clear();
-                                    }
+                                    },
                                     BuilderChange::FailClaims(value) => {
                                         self.should_fail_claims.store(value, Ordering::Relaxed);
-                                    }
+                                    },
                                 }
                                 let _ = self.change_sender.broadcast(change).await;
                             }
-                        }
+                        },
                         EventType::Decide { leaf_chain, .. } if should_build_blocks => {
                             let mut queue = self.transactions.write().await;
                             for leaf_info in leaf_chain.iter() {
@@ -413,7 +413,7 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                                 }
                             }
                             self.blocks.write().await.clear();
-                        }
+                        },
                         EventType::DaProposal { proposal, .. } if should_build_blocks => {
                             let payload = TYPES::BlockPayload::from_bytes(
                                 &proposal.data.encoded_transactions,
@@ -429,7 +429,7 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                                     txn.claimed = Some(now);
                                 }
                             }
-                        }
+                        },
                         EventType::Transactions { transactions } if should_build_blocks => {
                             let mut queue = self.transactions.write().await;
                             for transaction in transactions {
@@ -443,8 +443,8 @@ impl<TYPES: NodeType> BuilderTask<TYPES> for SimpleBuilderTask<TYPES> {
                                     );
                                 }
                             }
-                        }
-                        _ => {}
+                        },
+                        _ => {},
                     },
                 }
             }

--- a/hotshot-testing/src/byzantine/byzantine_behaviour.rs
+++ b/hotshot-testing/src/byzantine/byzantine_behaviour.rs
@@ -67,7 +67,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> EventTransforme
 
                 consensus.write().await.reset_actions();
                 result
-            }
+            },
             _ => vec![event.clone()],
         }
     }
@@ -94,9 +94,9 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> EventTransforme
         _consensus: Arc<RwLock<Consensus<TYPES>>>,
     ) -> Vec<HotShotEvent<TYPES>> {
         match event {
-            HotShotEvent::QuorumProposalSend(_, _) | HotShotEvent::QuorumVoteSend(_) => {
+            HotShotEvent::QuorumProposalSend(..) | HotShotEvent::QuorumVoteSend(_) => {
                 vec![event.clone(), event.clone()]
-            }
+            },
             _ => vec![event.clone()],
         }
     }
@@ -182,11 +182,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
                     self.handle_proposal_send_event(event, proposal, sender)
                         .await,
                 ];
-            }
+            },
             HotShotEvent::QuorumProposalValidated(proposal, _) => {
                 self.validated_proposals.push(proposal.data.clone());
-            }
-            _ => {}
+            },
+            _ => {},
         }
         vec![event.clone()]
     }
@@ -412,7 +412,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
                     .unwrap();
                     return vec![HotShotEvent::QuorumVoteSend(vote)];
                 }
-            }
+            },
             HotShotEvent::TimeoutVoteSend(vote) => {
                 // Check if this view was a dishonest proposal view, if true dont send timeout
                 let dishonest_proposals = self.dishonest_proposal_view_numbers.read().await;
@@ -421,11 +421,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + std::fmt::Debug, V: Version
                     // So, dont send the timeout to the next leader from this byzantine replica
                     return vec![];
                 }
-            }
+            },
             HotShotEvent::QuorumVoteSend(vote) => {
                 self.votes_sent.push(vote.clone());
-            }
-            _ => {}
+            },
+            _ => {},
         }
         vec![event.clone()]
     }

--- a/hotshot-testing/src/consistency_task.rs
+++ b/hotshot-testing/src/consistency_task.rs
@@ -44,15 +44,15 @@ fn sanitize_node_map<TYPES: NodeType>(
         reduced.dedup();
 
         match reduced.len() {
-            0 => {}
+            0 => {},
             1 => {
                 result.insert(*view, reduced[0].clone());
-            }
+            },
             _ => {
                 bail!(
                     "We have received inconsistent leaves for view {view:?}. Leaves:\n\n{leaves:?}"
                 );
-            }
+            },
         }
     }
 
@@ -300,12 +300,12 @@ impl<TYPES: NodeType<BlockHeader = TestBlockHeader>, V: Versions> ConsistencyTas
         match result {
             Ok(TestProgress::Finished) => {
                 let _ = self.test_sender.broadcast(TestEvent::Shutdown).await;
-            }
+            },
             Err(e) => {
                 self.add_error(e);
                 let _ = self.test_sender.broadcast(TestEvent::Shutdown).await;
-            }
-            Ok(TestProgress::Incomplete) => {}
+            },
+            Ok(TestProgress::Incomplete) => {},
         }
     }
 

--- a/hotshot-testing/src/helpers.rs
+++ b/hotshot-testing/src/helpers.rs
@@ -5,6 +5,8 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 #![allow(clippy::panic)]
+use std::{collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+
 use async_broadcast::{Receiver, Sender};
 use async_lock::RwLock;
 use bitvec::bitvec;
@@ -22,7 +24,6 @@ use hotshot_example_types::{
     storage_types::TestStorage,
 };
 use hotshot_task_impls::events::HotShotEvent;
-use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
     data::{vid_commitment, Leaf2, VidCommitment, VidDisperse, VidDisperseShare},
@@ -33,7 +34,7 @@ use hotshot_types::{
     simple_vote::{DaData2, DaVote2, SimpleVote, VersionedVoteData},
     traits::{
         election::Membership,
-        node_implementation::{NodeType, Versions},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         EncodeBytes,
     },
     utils::{option_epoch_from_block_number, View, ViewInner},
@@ -42,7 +43,6 @@ use hotshot_types::{
 };
 use primitive_types::U256;
 use serde::Serialize;
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 use vbs::version::Version;
 
 use crate::{test_builder::TestDescription, test_launcher::TestLauncher};

--- a/hotshot-testing/src/predicates/event.rs
+++ b/hotshot-testing/src/predicates/event.rs
@@ -217,7 +217,7 @@ where
             QuorumProposalSend(proposal, _) => {
                 Some(proposal.data.block_header().payload_commitment())
                     == null_block::commitment::<V>(num_storage_nodes)
-            }
+            },
             _ => false,
         });
     Box::new(EventPredicate { check, info })

--- a/hotshot-testing/src/script.rs
+++ b/hotshot-testing/src/script.rs
@@ -121,6 +121,6 @@ pub async fn validate_output_or_panic_in_script<S: std::fmt::Debug>(
                 "Stage {} | Output in {} failed to satisfy: {:?}.\n\nReceived:\n\n{:?}",
                 stage_number, script_name, assert, output
             )
-        }
+        },
     }
 }

--- a/hotshot-testing/src/spinning_task.rs
+++ b/hotshot-testing/src/spinning_task.rs
@@ -199,10 +199,10 @@ where
                                             marketplace_config,
                                         )
                                         .await
-                                    }
+                                    },
                                     LateNodeContext::Restart => {
                                         panic!("Cannot spin up a node with Restart context")
-                                    }
+                                    },
                                 };
 
                                 let handle = context.run_tasks().await;
@@ -219,13 +219,13 @@ where
 
                                 self.handles.write().await.push(node);
                             }
-                        }
+                        },
                         NodeAction::Down => {
                             if let Some(node) = self.handles.write().await.get_mut(idx) {
                                 tracing::error!("Node {} shutting down", idx);
                                 node.handle.shut_down().await;
                             }
-                        }
+                        },
                         NodeAction::RestartDown(delay_views) => {
                             let node_id = idx.try_into().unwrap();
                             if let Some(node) = self.handles.write().await.get_mut(idx) {
@@ -327,25 +327,25 @@ where
                                     self.restart_contexts.insert(idx, new_ctx);
                                 }
                             }
-                        }
+                        },
                         NodeAction::RestartUp => {
                             if let Some(ctx) = self.restart_contexts.remove(&idx) {
                                 new_nodes.push((ctx.context, idx));
                                 new_networks.push(ctx.network.clone());
                             }
-                        }
+                        },
                         NodeAction::NetworkUp => {
                             if let Some(handle) = self.handles.write().await.get(idx) {
                                 tracing::error!("Node {} networks resuming", idx);
                                 handle.network.resume();
                             }
-                        }
+                        },
                         NodeAction::NetworkDown => {
                             if let Some(handle) = self.handles.write().await.get(idx) {
                                 tracing::error!("Node {} networks pausing", idx);
                                 handle.network.pause();
                             }
-                        }
+                        },
                     }
                 }
             }

--- a/hotshot-testing/src/test_builder.rs
+++ b/hotshot-testing/src/test_builder.rs
@@ -4,6 +4,8 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::{collections::HashMap, num::NonZeroUsize, rc::Rc, sync::Arc, time::Duration};
+
 use async_lock::RwLock;
 use hotshot::{
     tasks::EventTransformerState,
@@ -15,16 +17,14 @@ use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider, node_types::TestTypes,
     state_types::TestInstanceState, storage_types::TestStorage, testable_delay::DelayConfig,
 };
-use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
     drb::INITIAL_DRB_RESULT,
     epoch_membership::EpochMembershipCoordinator,
-    traits::node_implementation::{NodeType, Versions},
+    traits::node_implementation::{ConsensusTime, NodeType, Versions},
     HotShotConfig, PeerConfig, ValidatorConfig,
 };
 use hotshot_utils::anytrace::*;
-use std::{collections::HashMap, num::NonZeroUsize, rc::Rc, sync::Arc, time::Duration};
 use tide_disco::Url;
 use vec1::Vec1;
 
@@ -283,7 +283,7 @@ pub async fn create_test_handle<
                 .await;
 
             left_handle
-        }
+        },
         Behaviour::Byzantine(state) => {
             let state = Box::leak(state);
             state
@@ -300,7 +300,7 @@ pub async fn create_test_handle<
                     marketplace_config,
                 )
                 .await
-        }
+        },
         Behaviour::Standard => {
             let hotshot = SystemContext::<TYPES, I, V>::new(
                 public_key,
@@ -317,7 +317,7 @@ pub async fn create_test_handle<
             .await;
 
             hotshot.run_tasks().await
-        }
+        },
     }
 }
 

--- a/hotshot-testing/src/test_runner.rs
+++ b/hotshot-testing/src/test_runner.rs
@@ -5,14 +5,19 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 #![allow(clippy::panic)]
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    marker::PhantomData,
+    sync::Arc,
+};
+
 use async_broadcast::{broadcast, Receiver, Sender};
 use async_lock::RwLock;
 use futures::future::join_all;
-use hotshot::InitializerEpochInfo;
 use hotshot::{
     traits::TestableNodeImplementation,
     types::{Event, SystemContextHandle},
-    HotShotInitializer, MarketplaceConfig, SystemContext,
+    HotShotInitializer, InitializerEpochInfo, MarketplaceConfig, SystemContext,
 };
 use hotshot_example_types::{
     auction_results_provider_types::TestAuctionResultsProvider,
@@ -22,11 +27,11 @@ use hotshot_example_types::{
 };
 use hotshot_fakeapi::fake_solver::FakeSolverState;
 use hotshot_task_impls::events::HotShotEvent;
-use hotshot_types::drb::INITIAL_DRB_RESULT;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
     constants::EVENT_CHANNEL_SIZE,
     data::Leaf2,
+    drb::INITIAL_DRB_RESULT,
     epoch_membership::EpochMembershipCoordinator,
     simple_certificate::QuorumCertificate2,
     traits::{
@@ -35,11 +40,6 @@ use hotshot_types::{
         node_implementation::{ConsensusTime, NodeImplementation, NodeType, Versions},
     },
     HotShotConfig, ValidatorConfig,
-};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    marker::PhantomData,
-    sync::Arc,
 };
 use tide_disco::Url;
 use tokio::{spawn, task::JoinHandle};
@@ -281,12 +281,12 @@ where
                 Ok(res) => match res {
                     TestResult::Pass => {
                         info!("Task shut down successfully");
-                    }
+                    },
                     TestResult::Fail(e) => error_list.push(e),
                 },
                 Err(e) => {
                     tracing::error!("Error Joining the test task {:?}", e);
-                }
+                },
             }
         }
 
@@ -560,14 +560,14 @@ where
                     if let Some(task) = builder_tasks.pop() {
                         task.start(Box::new(handle.event_stream()))
                     }
-                }
+                },
                 std::cmp::Ordering::Equal => {
                     // If we have more builder tasks than DA nodes, pin them all on the last node.
                     while let Some(task) = builder_tasks.pop() {
                         task.start(Box::new(handle.event_stream()))
                     }
-                }
-                std::cmp::Ordering::Greater => {}
+                },
+                std::cmp::Ordering::Greater => {},
             }
 
             self.nodes.push(Node {

--- a/hotshot-testing/src/test_task.rs
+++ b/hotshot-testing/src/test_task.rs
@@ -158,12 +158,12 @@ impl<S: TestTaskState + Send + 'static> TestTask<S> {
                         let _ = S::handle_event(&mut self.state, (input, id))
                             .await
                             .inspect_err(|e| tracing::error!("{e}"));
-                    }
+                    },
                     Ok((Err(e), _id, _)) => {
                         error!("Error from one channel in test task {:?}", e);
                         sleep(Duration::from_millis(4000)).await;
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 };
             }
         })
@@ -202,7 +202,7 @@ pub async fn add_network_message_test_task<
                 Err(e) => {
                     error!("Failed to receive message: {:?}", e);
                     continue;
-                }
+                },
             };
 
             // Deserialize the message
@@ -212,7 +212,7 @@ pub async fn add_network_message_test_task<
                     Err(e) => {
                         tracing::error!("Failed to deserialize message: {:?}", e);
                         continue;
-                    }
+                    },
                 };
 
             // Handle the message

--- a/hotshot-testing/src/txn_task.rs
+++ b/hotshot-testing/src/txn_task.rs
@@ -52,7 +52,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TxnTask
             match handles.get(idx) {
                 None => {
                     tracing::error!("couldn't get node in txn task");
-                }
+                },
                 Some(node) => {
                     // use rand::seq::IteratorRandom;
                     // we're assuming all nodes have the same leaf.
@@ -64,7 +64,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>, V: Versions> TxnTask
                         .submit_transaction(txn.clone())
                         .await
                         .expect("Could not send transaction");
-                }
+                },
             }
         }
     }

--- a/hotshot-testing/src/view_generator.rs
+++ b/hotshot-testing/src/view_generator.rs
@@ -675,7 +675,7 @@ impl<V: Versions> Stream for TestViewGenerator<V> {
             Poll::Ready(test_view) => {
                 self.current_view = Some(test_view.clone());
                 Poll::Ready(Some(test_view))
-            }
+            },
             Poll::Pending => Poll::Pending,
         }
     }

--- a/hotshot-testing/src/view_sync_task.rs
+++ b/hotshot-testing/src/view_sync_task.rs
@@ -42,7 +42,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
     async fn handle_event(&mut self, (event, id): (Self::Event, usize)) -> Result<()> {
         match event.as_ref() {
             // all the view sync events
-            HotShotEvent::ViewSyncTimeout(_, _, _)
+            HotShotEvent::ViewSyncTimeout(..)
             | HotShotEvent::ViewSyncPreCommitVoteRecv(_)
             | HotShotEvent::ViewSyncCommitVoteRecv(_)
             | HotShotEvent::ViewSyncFinalizeVoteRecv(_)
@@ -52,12 +52,12 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
             | HotShotEvent::ViewSyncPreCommitCertificateRecv(_)
             | HotShotEvent::ViewSyncCommitCertificateRecv(_)
             | HotShotEvent::ViewSyncFinalizeCertificateRecv(_)
-            | HotShotEvent::ViewSyncPreCommitCertificateSend(_, _)
-            | HotShotEvent::ViewSyncCommitCertificateSend(_, _)
-            | HotShotEvent::ViewSyncFinalizeCertificateSend(_, _)
+            | HotShotEvent::ViewSyncPreCommitCertificateSend(..)
+            | HotShotEvent::ViewSyncCommitCertificateSend(..)
+            | HotShotEvent::ViewSyncFinalizeCertificateSend(..)
             | HotShotEvent::ViewSyncTrigger(_) => {
                 self.hit_view_sync.insert(id);
-            }
+            },
             _ => (),
         }
 
@@ -75,7 +75,7 @@ impl<TYPES: NodeType, I: TestableNodeImplementation<TYPES>> TestTaskState
                         hit_view_sync: self.hit_view_sync.clone(),
                     }))
                 }
-            }
+            },
         }
     }
 }

--- a/hotshot-testing/tests/tests_6/test_epochs.rs
+++ b/hotshot-testing/tests/tests_6/test_epochs.rs
@@ -4,6 +4,8 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::time::Duration;
+
 use hotshot_example_types::{
     node_types::{
         CombinedImpl, EpochUpgradeTestVersions, EpochsTestVersions, Libp2pImpl, MemoryImpl,
@@ -22,7 +24,6 @@ use hotshot_testing::{
     test_builder::{TestDescription, TimingData},
     view_sync_task::ViewSyncTaskDescription,
 };
-use std::time::Duration;
 
 cross_tests!(
     TestName: test_success_with_epochs,

--- a/hotshot-types/src/consensus.rs
+++ b/hotshot-types/src/consensus.rs
@@ -589,7 +589,7 @@ impl<TYPES: NodeType> Consensus<TYPES> {
                 // because the leader of view n + 1 may propose to the DA (and we would vote)
                 // before the leader of view n.
                 return true;
-            }
+            },
             _ => return true,
         };
         if view > *old_view {

--- a/hotshot-types/src/data.rs
+++ b/hotshot-types/src/data.rs
@@ -505,13 +505,13 @@ impl<TYPES: NodeType> VidDisperseShare<TYPES> {
                     .into_iter()
                     .map(|share| Self::V0(share))
                     .collect()
-            }
+            },
             VidDisperse::V1(vid_disperse) => {
                 VidDisperseShare2::<TYPES>::from_vid_disperse(vid_disperse)
                     .into_iter()
                     .map(|share| Self::V1(share))
                     .collect()
-            }
+            },
         }
     }
 
@@ -672,10 +672,10 @@ impl<TYPES: NodeType> ViewChangeEvidence<TYPES> {
         match self {
             ViewChangeEvidence::Timeout(timeout_cert) => {
                 ViewChangeEvidence2::Timeout(timeout_cert.to_tc2())
-            }
+            },
             ViewChangeEvidence::ViewSync(view_sync_cert) => {
                 ViewChangeEvidence2::ViewSync(view_sync_cert.to_vsc2())
-            }
+            },
         }
     }
 }
@@ -705,10 +705,10 @@ impl<TYPES: NodeType> ViewChangeEvidence2<TYPES> {
         match self {
             ViewChangeEvidence2::Timeout(timeout_cert) => {
                 ViewChangeEvidence::Timeout(timeout_cert.to_tc())
-            }
+            },
             ViewChangeEvidence2::ViewSync(view_sync_cert) => {
                 ViewChangeEvidence::ViewSync(view_sync_cert.to_vsc())
-            }
+            },
         }
     }
 }
@@ -1242,7 +1242,7 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
             // Easiest cases are:
             //   - no upgrade certificate on either: this is the most common case, and is always fine.
             //   - if the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade: again, this is always fine.
-            (None | Some(_), None) => {}
+            (None | Some(_), None) => {},
             // If we no longer see a cert, we have to make sure that we either:
             //    - no longer care because we have passed new_version_first_view, or
             //    - no longer care because we have passed `decide_by` without deciding the certificate.
@@ -1252,13 +1252,13 @@ impl<TYPES: NodeType> Leaf2<TYPES> {
                     || (self.view_number() > parent_cert.data.decide_by && decided_upgrade_certificate_read.is_none()),
                        "The new leaf is missing an upgrade certificate that was present in its parent, and should still be live."
                 );
-            }
+            },
             // If we both have a certificate, they should be identical.
             // Technically, this prevents us from initiating a new upgrade in the view immediately following an upgrade.
             // I think this is a fairly lax restriction.
             (Some(cert), Some(parent_cert)) => {
                 ensure!(cert == parent_cert, "The new leaf does not extend the parent leaf, because it has attached a different upgrade certificate.");
-            }
+            },
         }
 
         // This check should be added once we sort out the genesis leaf/justify_qc issue.
@@ -1621,7 +1621,7 @@ impl<TYPES: NodeType> Leaf<TYPES> {
             // Easiest cases are:
             //   - no upgrade certificate on either: this is the most common case, and is always fine.
             //   - if the parent didn't have a certificate, but we see one now, it just means that we have begun an upgrade: again, this is always fine.
-            (None | Some(_), None) => {}
+            (None | Some(_), None) => {},
             // If we no longer see a cert, we have to make sure that we either:
             //    - no longer care because we have passed new_version_first_view, or
             //    - no longer care because we have passed `decide_by` without deciding the certificate.
@@ -1631,13 +1631,13 @@ impl<TYPES: NodeType> Leaf<TYPES> {
                     || (self.view_number() > parent_cert.data.decide_by && decided_upgrade_certificate_read.is_none()),
                        "The new leaf is missing an upgrade certificate that was present in its parent, and should still be live."
                 );
-            }
+            },
             // If we both have a certificate, they should be identical.
             // Technically, this prevents us from initiating a new upgrade in the view immediately following an upgrade.
             // I think this is a fairly lax restriction.
             (Some(cert), Some(parent_cert)) => {
                 ensure!(cert == parent_cert, "The new leaf does not extend the parent leaf, because it has attached a different upgrade certificate.");
-            }
+            },
         }
 
         // This check should be added once we sort out the genesis leaf/justify_qc issue.

--- a/hotshot-types/src/data/vid_disperse.rs
+++ b/hotshot-types/src/data/vid_disperse.rs
@@ -13,6 +13,7 @@ use jf_vid::{VidDisperse as JfVidDisperse, VidScheme};
 use serde::{Deserialize, Serialize};
 use tokio::task::spawn_blocking;
 
+use super::ns_table::parse_ns_table;
 use crate::{
     epoch_membership::{EpochMembership, EpochMembershipCoordinator},
     impl_has_epoch,
@@ -28,8 +29,6 @@ use crate::{
     },
     vote::HasViewNumber,
 };
-
-use super::ns_table::parse_ns_table;
 
 impl_has_epoch!(
     ADVZDisperse<TYPES>,

--- a/hotshot-types/src/epoch_membership.rs
+++ b/hotshot-types/src/epoch_membership.rs
@@ -1,17 +1,25 @@
-use std::collections::BTreeSet;
-use std::num::NonZeroU64;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    num::NonZeroU64,
+    sync::Arc,
+};
 
 use async_broadcast::{broadcast, InactiveReceiver};
 use async_lock::{Mutex, RwLock};
-use hotshot_utils::anytrace::{self, Error, Level, Result, DEFAULT_LOG_LEVEL};
-use hotshot_utils::{ensure, line_info, log, warn};
+use hotshot_utils::{
+    anytrace::{self, Error, Level, Result, DEFAULT_LOG_LEVEL},
+    ensure, line_info, log, warn,
+};
 
-use crate::drb::DrbResult;
-use crate::traits::election::Membership;
-use crate::traits::node_implementation::{ConsensusTime, NodeType};
-use crate::utils::root_block_in_epoch;
-use crate::PeerConfig;
+use crate::{
+    drb::DrbResult,
+    traits::{
+        election::Membership,
+        node_implementation::{ConsensusTime, NodeType},
+    },
+    utils::root_block_in_epoch,
+    PeerConfig,
+};
 
 type EpochMap<TYPES> =
     HashMap<<TYPES as NodeType>::Epoch, InactiveReceiver<Result<EpochMembership<TYPES>>>>;

--- a/hotshot-types/src/lib.rs
+++ b/hotshot-types/src/lib.rs
@@ -134,7 +134,7 @@ impl<KEY: SignatureKey> PeerConfig<KEY> {
             Err(e) => {
                 error!(?e, "Failed to serialize public key");
                 vec![]
-            }
+            },
         }
     }
 
@@ -148,7 +148,7 @@ impl<KEY: SignatureKey> PeerConfig<KEY> {
             Err(e) => {
                 error!(?e, "Failed to deserialize public key");
                 None
-            }
+            },
         }
     }
 }

--- a/hotshot-types/src/message.rs
+++ b/hotshot-types/src/message.rs
@@ -173,9 +173,7 @@ impl<TYPES: NodeType> HasEpoch<TYPES> for MessageKind<TYPES> {
     fn epoch(&self) -> Option<TYPES::Epoch> {
         match &self {
             MessageKind::Consensus(message) => message.epoch_number(),
-            MessageKind::Data(
-                DataMessage::SubmitTransaction(_, _) | DataMessage::RequestData(_),
-            )
+            MessageKind::Data(DataMessage::SubmitTransaction(..) | DataMessage::RequestData(_))
             | MessageKind::External(_) => None,
             MessageKind::Data(DataMessage::DataResponse(msg)) => match msg {
                 ResponseMessage::Found(m) => m.epoch_number(),
@@ -325,66 +323,66 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::Proposal2(p) => {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ProposalRequested(req, _) => req.view_number,
                     GeneralConsensusMessage::ProposalResponse(proposal) => {
                         proposal.data.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ProposalResponse2(proposal) => {
                         proposal.data.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::Vote(vote_message) => vote_message.view_number(),
                     GeneralConsensusMessage::Vote2(vote_message) => vote_message.view_number(),
                     GeneralConsensusMessage::TimeoutVote(message) => message.view_number(),
                     GeneralConsensusMessage::ViewSyncPreCommitVote(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitVote(message) => message.view_number(),
                     GeneralConsensusMessage::ViewSyncFinalizeVote(message) => message.view_number(),
                     GeneralConsensusMessage::ViewSyncPreCommitCertificate(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitCertificate(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::TimeoutVote2(message) => message.view_number(),
                     GeneralConsensusMessage::ViewSyncPreCommitVote2(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitVote2(message) => message.view_number(),
                     GeneralConsensusMessage::ViewSyncFinalizeVote2(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncPreCommitCertificate2(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitCertificate2(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate2(message) => {
                         message.view_number()
-                    }
+                    },
                     GeneralConsensusMessage::UpgradeProposal(message) => message.data.view_number(),
                     GeneralConsensusMessage::UpgradeVote(message) => message.view_number(),
                     GeneralConsensusMessage::HighQc(qc)
                     | GeneralConsensusMessage::ExtendedQc(qc, _) => qc.view_number(),
                 }
-            }
+            },
             SequencingMessage::Da(da_message) => {
                 match da_message {
                     DaConsensusMessage::DaProposal(p) => {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.view_number()
-                    }
+                    },
                     DaConsensusMessage::DaVote(vote_message) => vote_message.view_number(),
                     DaConsensusMessage::DaCertificate(cert) => cert.view_number,
                     DaConsensusMessage::VidDisperseMsg(disperse) => disperse.data.view_number(),
@@ -392,12 +390,12 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.view_number()
-                    }
+                    },
                     DaConsensusMessage::DaVote2(vote_message) => vote_message.view_number(),
                     DaConsensusMessage::DaCertificate2(cert) => cert.view_number,
                     DaConsensusMessage::VidDisperseMsg2(disperse) => disperse.data.view_number(),
                 }
-            }
+            },
         }
     }
 
@@ -410,13 +408,13 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.epoch()
-                    }
+                    },
                     GeneralConsensusMessage::Proposal2(p) => {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.epoch()
-                    }
-                    GeneralConsensusMessage::ProposalRequested(_, _) => None,
+                    },
+                    GeneralConsensusMessage::ProposalRequested(..) => None,
                     GeneralConsensusMessage::ProposalResponse(proposal) => proposal.data.epoch(),
                     GeneralConsensusMessage::ProposalResponse2(proposal) => proposal.data.epoch(),
                     GeneralConsensusMessage::Vote(vote_message) => vote_message.epoch(),
@@ -427,35 +425,35 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     GeneralConsensusMessage::ViewSyncFinalizeVote(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncPreCommitCertificate(message) => {
                         message.epoch()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitCertificate(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate(message) => {
                         message.epoch()
-                    }
+                    },
                     GeneralConsensusMessage::TimeoutVote2(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncPreCommitVote2(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncCommitVote2(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncFinalizeVote2(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncPreCommitCertificate2(message) => {
                         message.epoch()
-                    }
+                    },
                     GeneralConsensusMessage::ViewSyncCommitCertificate2(message) => message.epoch(),
                     GeneralConsensusMessage::ViewSyncFinalizeCertificate2(message) => {
                         message.epoch()
-                    }
+                    },
                     GeneralConsensusMessage::UpgradeProposal(message) => message.data.epoch(),
                     GeneralConsensusMessage::UpgradeVote(message) => message.epoch(),
                     GeneralConsensusMessage::HighQc(qc)
                     | GeneralConsensusMessage::ExtendedQc(qc, _) => qc.epoch(),
                 }
-            }
+            },
             SequencingMessage::Da(da_message) => {
                 match da_message {
                     DaConsensusMessage::DaProposal(p) => {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.epoch()
-                    }
+                    },
                     DaConsensusMessage::DaVote(vote_message) => vote_message.epoch(),
                     DaConsensusMessage::DaCertificate(cert) => cert.epoch(),
                     DaConsensusMessage::VidDisperseMsg(disperse) => disperse.data.epoch(),
@@ -464,11 +462,11 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                         // view of leader in the leaf when proposal
                         // this should match replica upon receipt
                         p.data.epoch()
-                    }
+                    },
                     DaConsensusMessage::DaVote2(vote_message) => vote_message.epoch(),
                     DaConsensusMessage::DaCertificate2(cert) => cert.epoch(),
                 }
-            }
+            },
         }
     }
 }
@@ -649,7 +647,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
                 } else {
                     V::Base::VERSION
                 }
-            }
+            },
             None => V::Base::VERSION,
         };
 
@@ -669,7 +667,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
                 } else {
                     cert.data.old_version
                 }
-            }
+            },
             None => V::Base::VERSION,
         }
     }
@@ -698,7 +696,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
             v if v == V::Upgrade::VERSION => Serializer::<V::Upgrade>::serialize(&message),
             v => {
                 bail!("Attempted to serialize with version {}, which is incompatible. This should be impossible.", v);
-            }
+            },
         };
 
         serialized_message
@@ -725,7 +723,7 @@ impl<TYPES: NodeType, V: Versions> UpgradeLock<TYPES, V> {
             v if v == V::Upgrade::VERSION => Serializer::<V::Upgrade>::deserialize(message),
             v => {
                 bail!("Cannot deserialize message with stated version {}", v);
-            }
+            },
         }
         .wrap()
         .context(info!("Failed to deserialize message!"))?;

--- a/hotshot-types/src/network.rs
+++ b/hotshot-types/src/network.rs
@@ -209,7 +209,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
             Ok(data) => data,
             Err(e) => {
                 return Err(NetworkConfigError::ReadFromFileError(e));
-            }
+            },
         };
 
         // deserialize
@@ -256,7 +256,7 @@ impl<K: SignatureKey> NetworkConfig<K> {
             Ok(data) => data,
             Err(e) => {
                 return Err(NetworkConfigError::SerializeError(e));
-            }
+            },
         };
 
         // write to file

--- a/hotshot-types/src/simple_vote.rs
+++ b/hotshot-types/src/simple_vote.rs
@@ -19,8 +19,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use vbs::version::Version;
 
 use crate::{
-    data::VidCommitment,
-    data::{Leaf, Leaf2},
+    data::{Leaf, Leaf2, VidCommitment},
     message::UpgradeLock,
     traits::{
         node_implementation::{NodeType, Versions},

--- a/hotshot-types/src/traits/storage.rs
+++ b/hotshot-types/src/traits/storage.rs
@@ -18,11 +18,10 @@ use committable::Commitment;
 use super::node_implementation::NodeType;
 use crate::{
     consensus::{CommitmentMap, View},
-    data::VidCommitment,
     data::{
         vid_disperse::{ADVZDisperseShare, VidDisperseShare2},
         DaProposal, DaProposal2, Leaf, Leaf2, QuorumProposal, QuorumProposal2,
-        QuorumProposalWrapper, VidDisperseShare,
+        QuorumProposalWrapper, VidCommitment, VidDisperseShare,
     },
     drb::DrbResult,
     event::HotShotAction,
@@ -55,7 +54,7 @@ pub trait Storage<TYPES: NodeType>: Send + Sync + Clone {
                     _pd: std::marker::PhantomData,
                 })
                 .await
-            }
+            },
             VidDisperseShare::V1(share) => {
                 self.append_vid2(&Proposal {
                     data: share.clone(),
@@ -63,7 +62,7 @@ pub trait Storage<TYPES: NodeType>: Send + Sync + Clone {
                     _pd: std::marker::PhantomData,
                 })
                 .await
-            }
+            },
         }
     }
     /// Add a proposal to the stored DA proposals.

--- a/hotshot-types/src/utils.rs
+++ b/hotshot-types/src/utils.rs
@@ -6,6 +6,12 @@
 
 //! Utility functions, type aliases, helper structs and enum definitions.
 
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::Arc,
+};
+
 use anyhow::{anyhow, ensure};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bincode::{
@@ -19,11 +25,6 @@ use committable::{Commitment, Committable};
 use digest::OutputSizeUser;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
-use std::{
-    hash::{Hash, Hasher},
-    ops::Deref,
-    sync::Arc,
-};
 use tagged_base64::tagged;
 use typenum::Unsigned;
 use vbs::version::StaticVersionType;

--- a/hotshot-types/src/vote.rs
+++ b/hotshot-types/src/vote.rs
@@ -170,7 +170,7 @@ impl<
             Err(e) => {
                 tracing::warn!("Failed to generate versioned vote data: {e}");
                 return None;
-            }
+            },
         };
 
         if !key.validate(&vote.signature(), vote_commitment.as_ref()) {

--- a/hotshot-utils/src/anytrace.rs
+++ b/hotshot-utils/src/anytrace.rs
@@ -24,21 +24,21 @@ impl Log for Error {
         match error_level {
             Level::Trace => {
                 tracing::trace!("{}", self.message);
-            }
+            },
             Level::Debug => {
                 tracing::debug!("{}", self.message);
-            }
+            },
             Level::Info => {
                 tracing::info!("{}", self.message);
-            }
+            },
             Level::Warn => {
                 tracing::warn!("{}", self.message);
-            }
+            },
             Level::Error => {
                 tracing::error!("{}", self.message);
-            }
+            },
             // impossible
-            Level::Unspecified => {}
+            Level::Unspecified => {},
         }
     }
 }
@@ -48,7 +48,7 @@ impl<T> Log for Result<T> {
         let error = match self {
             Ok(_) => {
                 return;
-            }
+            },
             Err(e) => e,
         };
 
@@ -60,21 +60,21 @@ impl<T> Log for Result<T> {
         match error_level {
             Level::Trace => {
                 tracing::trace!("{}", error.message);
-            }
+            },
             Level::Debug => {
                 tracing::debug!("{}", error.message);
-            }
+            },
             Level::Info => {
                 tracing::info!("{}", error.message);
-            }
+            },
             Level::Warn => {
                 tracing::warn!("{}", error.message);
-            }
+            },
             Level::Error => {
                 tracing::error!("{}", error.message);
-            }
+            },
             // impossible
-            Level::Unspecified => {}
+            Level::Unspecified => {},
         }
     }
 }

--- a/hotshot-utils/src/anytrace/macros.rs
+++ b/hotshot-utils/src/anytrace/macros.rs
@@ -167,21 +167,21 @@ macro_rules! log {
             match error_level {
                 Level::Trace => {
                     tracing::trace!("{}", error.message);
-                }
+                },
                 Level::Debug => {
                     tracing::debug!("{}", error.message);
-                }
+                },
                 Level::Info => {
                     tracing::info!("{}", error.message);
-                }
+                },
                 Level::Warn => {
                     tracing::warn!("{}", error.message);
-                }
+                },
                 Level::Error => {
                     tracing::error!("{}", error.message);
-                }
+                },
                 // impossible
-                Level::Unspecified => {}
+                Level::Unspecified => {},
             }
         }
     };

--- a/hotshot/src/lib.rs
+++ b/hotshot/src/lib.rs
@@ -215,10 +215,10 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> SystemContext<T
     ) -> Arc<Self> {
         #[allow(clippy::panic)]
         match storage.migrate_consensus().await {
-            Ok(()) => {}
+            Ok(()) => {},
             Err(e) => {
                 panic!("Failed to migrate consensus storage: {e}");
-            }
+            },
         }
 
         let internal_chan = broadcast(EVENT_CHANNEL_SIZE);
@@ -767,10 +767,10 @@ where
                         match event {
                             Either::Left(msg) => {
                                 let _ = left_sender.broadcast(msg.into()).await;
-                            }
+                            },
                             Either::Right(msg) => {
                                 let _ = right_sender.broadcast(msg.into()).await;
-                            }
+                            },
                         }
                     }
                 }

--- a/hotshot/src/tasks/mod.rs
+++ b/hotshot/src/tasks/mod.rs
@@ -10,7 +10,6 @@
 pub mod task_state;
 use std::{collections::BTreeMap, fmt::Debug, num::NonZeroUsize, sync::Arc, time::Duration};
 
-use crate::EpochMembershipCoordinator;
 use async_broadcast::{broadcast, RecvError};
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -46,8 +45,9 @@ use vbs::version::StaticVersionType;
 
 use crate::{
     genesis_epoch_from_version, tasks::task_state::CreateTaskState, types::SystemContextHandle,
-    ConsensusApi, ConsensusMetricsValue, ConsensusTaskRegistry, HotShotConfig, HotShotInitializer,
-    MarketplaceConfig, NetworkTaskRegistry, SignatureKey, SystemContext, Versions,
+    ConsensusApi, ConsensusMetricsValue, ConsensusTaskRegistry, EpochMembershipCoordinator,
+    HotShotConfig, HotShotInitializer, MarketplaceConfig, NetworkTaskRegistry, SignatureKey,
+    SystemContext, Versions,
 };
 
 /// event for global event stream
@@ -280,13 +280,13 @@ pub fn create_shutdown_event_monitor<TYPES: NodeType, I: NodeImplementation<TYPE
                     if matches!(event.as_ref(), HotShotEvent::Shutdown) {
                         return;
                     }
-                }
+                },
                 Err(RecvError::Closed) => {
                     return;
-                }
+                },
                 Err(e) => {
                     tracing::error!("Shutdown event monitor channel recv error: {}", e);
-                }
+                },
             }
         }
     }

--- a/hotshot/src/traits/election/static_committee_leader_two_views.rs
+++ b/hotshot/src/traits/election/static_committee_leader_two_views.rs
@@ -4,6 +4,11 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU64,
+};
+
 use hotshot_types::{
     drb::DrbResult,
     traits::{
@@ -15,10 +20,6 @@ use hotshot_types::{
 };
 use hotshot_utils::anytrace::Result;
 use primitive_types::U256;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    num::NonZeroU64,
-};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 

--- a/hotshot/src/traits/election/two_static_committees.rs
+++ b/hotshot/src/traits/election/two_static_committees.rs
@@ -4,6 +4,12 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
+use std::{
+    cmp::max,
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU64,
+};
+
 use hotshot_types::{
     drb::DrbResult,
     traits::{
@@ -15,11 +21,6 @@ use hotshot_types::{
 };
 use hotshot_utils::anytrace::Result;
 use primitive_types::U256;
-use std::{
-    cmp::max,
-    collections::{BTreeMap, BTreeSet},
-    num::NonZeroU64,
-};
 
 /// Tuple type for eligible leaders
 type EligibleLeaders<T> = (

--- a/hotshot/src/traits/networking/combined_network.rs
+++ b/hotshot/src/traits/networking/combined_network.rs
@@ -185,12 +185,12 @@ impl<TYPES: NodeType> CombinedNetworks<TYPES> {
                             // The primary fail counter reached 0, the primary is now considered up
                             primary_down.store(false, Ordering::Relaxed);
                             debug!("primary_fail_counter reached zero, primary_down set to false");
-                        }
+                        },
                         c => {
                             // Decrement the primary fail counter
                             primary_fail_counter.store(c - 1, Ordering::Relaxed);
                             debug!("primary_fail_counter set to {:?}", c - 1);
-                        }
+                        },
                     }
                     return Ok(());
                 }
@@ -211,7 +211,7 @@ impl<TYPES: NodeType> CombinedNetworks<TYPES> {
                     c if c < COMBINED_NETWORK_PRIMARY_CHECK_INTERVAL => {
                         // Just increment the 'no delay counter'
                         self.no_delay_counter.store(c + 1, Ordering::Relaxed);
-                    }
+                    },
                     _ => {
                         // The 'no delay counter' reached the threshold
                         debug!(
@@ -226,7 +226,7 @@ impl<TYPES: NodeType> CombinedNetworks<TYPES> {
                         // The primary fail counter is set just below the threshold to delay the next message
                         self.primary_fail_counter
                             .store(COMBINED_NETWORK_MIN_PRIMARY_FAILURES, Ordering::Relaxed);
-                    }
+                    },
                 }
             }
             // Send the message

--- a/hotshot/src/traits/networking/memory_network.rs
+++ b/hotshot/src/traits/networking/memory_network.rs
@@ -282,10 +282,10 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
                 match res {
                     Ok(()) => {
                         trace!(?key, "Delivered message to remote");
-                    }
+                    },
                     Err(e) => {
                         warn!(?e, ?key, "Error sending broadcast message to node");
-                    }
+                    },
                 }
             }
         }
@@ -336,10 +336,10 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
                 match res {
                     Ok(()) => {
                         trace!(?key, "Delivered message to remote");
-                    }
+                    },
                     Err(e) => {
                         warn!(?e, ?key, "Error sending broadcast message to node");
-                    }
+                    },
                 }
             }
         }
@@ -375,7 +375,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for MemoryNetwork<K> {
                     Ok(()) => {
                         trace!(?recipient, "Delivered message to remote");
                         Ok(())
-                    }
+                    },
                     Err(e) => Err(NetworkError::MessageSendError(format!(
                         "error sending direct message to node: {e}",
                     ))),

--- a/hotshot/src/traits/networking/push_cdn_network.rs
+++ b/hotshot/src/traits/networking/push_cdn_network.rs
@@ -591,7 +591,7 @@ impl<K: SignatureKey + 'static> ConnectedNetwork<K> for PushCdnNetwork<K> {
                 return Err(NetworkError::MessageReceiveError(format!(
                     "failed to receive message: {error}"
                 )));
-            }
+            },
         };
 
         // Extract the underlying message

--- a/hotshot/src/types/handle.rs
+++ b/hotshot/src/types/handle.rs
@@ -6,6 +6,8 @@
 
 //! Provides an event-streaming handle for a [`SystemContext`] running in the background
 
+use std::sync::Arc;
+
 use anyhow::{anyhow, Context, Ok, Result};
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
 use async_lock::RwLock;
@@ -32,7 +34,6 @@ use hotshot_types::{
     },
     utils::option_epoch_from_block_number,
 };
-use std::sync::Arc;
 use tracing::instrument;
 
 use crate::{traits::NodeImplementation, types::Event, SystemContext, Versions};
@@ -116,17 +117,17 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
                 self.network
                     .broadcast_message(serialized_message, Topic::Global, BroadcastDelay::None)
                     .await?;
-            }
+            },
             RecipientList::Direct(recipient) => {
                 self.network
                     .direct_message(serialized_message, recipient)
                     .await?;
-            }
+            },
             RecipientList::Many(recipients) => {
                 self.network
                     .da_broadcast_message(serialized_message, recipients, BroadcastDelay::None)
                     .await?;
-            }
+            },
         }
         Ok(())
     }
@@ -199,7 +200,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static, V: Versions>
                         Err(e) => {
                             tracing::warn!(e.message);
                             continue;
-                        }
+                        },
                     };
                     // Make sure that the quorum_proposal is valid
                     if let Err(err) = quorum_proposal.validate_signature(&membership).await {

--- a/marketplace-builder-core/src/testing/basic_test.rs
+++ b/marketplace-builder-core/src/testing/basic_test.rs
@@ -1,14 +1,15 @@
+use std::{marker::PhantomData, sync::Arc};
+
 use async_broadcast::broadcast;
 use hotshot_builder_api::v0_99::data_source::{AcceptsTxnSubmits, BuilderDataSource};
-
 use hotshot_example_types::block_types::TestTransaction;
+use marketplace_builder_shared::testing::consensus::SimulatedChainState;
 use tracing_test::traced_test;
 
-use crate::hooks::NoHooks;
-use crate::service::{BuilderConfig, GlobalState, ProxyGlobalState};
-use marketplace_builder_shared::testing::consensus::SimulatedChainState;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use crate::{
+    hooks::NoHooks,
+    service::{BuilderConfig, GlobalState, ProxyGlobalState},
+};
 
 /// This test simulates multiple builder states receiving messages from the channels and processing them
 #[tokio::test]

--- a/marketplace-builder-core/src/testing/integration.rs
+++ b/marketplace-builder-core/src/testing/integration.rs
@@ -118,21 +118,20 @@ where
 mod tests {
     use std::time::Duration;
 
-    use crate::testing::integration::MarketplaceBuilderImpl;
-    use marketplace_builder_shared::testing::{
-        generation::{self, TransactionGenerationConfig},
-        run_test,
-        validation::BuilderValidationConfig,
-    };
-
-    use hotshot_example_types::node_types::MarketplaceTestVersions;
-    use hotshot_example_types::node_types::{MemoryImpl, TestTypes};
+    use hotshot_example_types::node_types::{MarketplaceTestVersions, MemoryImpl, TestTypes};
     use hotshot_macros::cross_tests;
     use hotshot_testing::{
         completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
         overall_safety_task::OverallSafetyPropertiesDescription,
         test_builder::TestDescription,
     };
+    use marketplace_builder_shared::testing::{
+        generation::{self, TransactionGenerationConfig},
+        run_test,
+        validation::BuilderValidationConfig,
+    };
+
+    use crate::testing::integration::MarketplaceBuilderImpl;
 
     #[tokio::test(flavor = "multi_thread")]
     #[tracing::instrument]

--- a/marketplace-builder-core/src/testing/order_test.rs
+++ b/marketplace-builder-core/src/testing/order_test.rs
@@ -1,5 +1,9 @@
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
 use async_broadcast::broadcast;
+use hotshot::rand::{self, seq::SliceRandom, thread_rng};
 use hotshot_builder_api::v0_99::data_source::{AcceptsTxnSubmits, BuilderDataSource};
+use hotshot_example_types::block_types::TestTransaction;
 use hotshot_types::{bundle::Bundle, traits::node_implementation::ConsensusTime};
 use marketplace_builder_shared::{block::BuilderStateId, testing::consensus::SimulatedChainState};
 use tracing_test::traced_test;
@@ -8,12 +12,6 @@ use crate::{
     hooks::NoHooks,
     service::{BuilderConfig, GlobalState, ProxyGlobalState},
 };
-
-use std::{fmt::Debug, marker::PhantomData, sync::Arc};
-
-use hotshot_example_types::block_types::TestTransaction;
-
-use hotshot::rand::{self, seq::SliceRandom, thread_rng};
 
 /// [`RoundTransactionBehavior`] is an enum that is used to represent different
 /// behaviors that we may want to simulate during a round.  This applies to
@@ -64,12 +62,12 @@ impl RoundTransactionBehavior {
                     ]),
                 );
                 transactions
-            }
+            },
             RoundTransactionBehavior::AdjustRemoveTail => {
                 let mut transactions = transactions.clone();
                 transactions.pop();
                 transactions
-            }
+            },
             RoundTransactionBehavior::ProposeInAdvance(propose_in_advance_round) => {
                 let mut transactions = transactions.clone();
                 transactions.push(TestTransaction::new(vec![
@@ -77,12 +75,12 @@ impl RoundTransactionBehavior {
                     0_u8,
                 ]));
                 transactions
-            }
+            },
             RoundTransactionBehavior::AdjustRemove => {
                 let mut transactions = transactions.clone();
                 transactions.remove(rand::random::<usize>() % (transactions.len() - 1));
                 transactions
-            }
+            },
         }
     }
 }

--- a/marketplace-builder-shared/src/block.rs
+++ b/marketplace-builder-shared/src/block.rs
@@ -3,11 +3,12 @@
 use std::time::Instant;
 
 use committable::{Commitment, Committable};
-use hotshot_types::data::{fake_commitment, Leaf2};
-use hotshot_types::traits::node_implementation::ConsensusTime;
 use hotshot_types::{
-    data::VidCommitment,
-    traits::{block_contents::Transaction, node_implementation::NodeType},
+    data::{fake_commitment, Leaf2, VidCommitment},
+    traits::{
+        block_contents::Transaction,
+        node_implementation::{ConsensusTime, NodeType},
+    },
     utils::BuilderCommitment,
 };
 

--- a/marketplace-builder-shared/src/coordinator/mod.rs
+++ b/marketplace-builder-shared/src/coordinator/mod.rs
@@ -195,7 +195,7 @@ where
                     },
                 );
                 return Err(Error::TxnSender(err));
-            }
+            },
         };
 
         self.update_txn_status(&commit, TransactionStatus::Pending);
@@ -251,15 +251,15 @@ where
                     (Either::Right(da_proposal), Either::Left(quorum_proposal))
                     | (Either::Left(quorum_proposal), Either::Right(da_proposal)) => {
                         self.spawn_builder_state(quorum_proposal, da_proposal).await
-                    }
+                    },
                     _ => {
                         unreachable!()
-                    }
+                    },
                 }
-            }
+            },
             Entry::Vacant(entry) => {
                 entry.insert(proposal);
-            }
+            },
         }
     }
 
@@ -499,10 +499,10 @@ where
                         "Not changing status of rejected/sequenced transaction",
                     );
                     return;
-                }
+                },
                 _ => {
                     tracing::debug!(?old_status, ?new_status, "Changing status of transaction",);
-                }
+                },
             }
         }
         self.tx_status.insert(*txn_hash, new_status);
@@ -525,6 +525,7 @@ mod tests {
     use hotshot_types::data::ViewNumber;
     use tracing_test::traced_test;
 
+    use super::*;
     use crate::{
         block::TransactionSource,
         testing::{
@@ -534,8 +535,6 @@ mod tests {
             mock,
         },
     };
-
-    use super::*;
 
     type BuilderStateCoordinator = super::BuilderStateCoordinator<TestTypes>;
 

--- a/marketplace-builder-shared/src/coordinator/tiered_view_map.rs
+++ b/marketplace-builder-shared/src/coordinator/tiered_view_map.rs
@@ -143,10 +143,10 @@ where
         match self.0.entry(*key.view()) {
             Entry::Vacant(entry) => {
                 entry.insert(nem![key.into_subkey() => value]);
-            }
+            },
             Entry::Occupied(mut entry) => {
                 entry.get_mut().insert(key.into_subkey(), value);
-            }
+            },
         }
     }
 
@@ -181,13 +181,13 @@ where
 mod tests {
     use std::{cmp::Ordering, ops::Bound, sync::Arc};
 
-    use crate::{state::BuilderState, testing::mock};
-
-    use super::*;
     use hotshot_example_types::node_types::TestTypes;
     use hotshot_types::{data::ViewNumber, traits::node_implementation::ConsensusTime};
     use rand::{distributions::Standard, thread_rng, Rng};
     use tracing_test::traced_test;
+
+    use super::*;
+    use crate::{state::BuilderState, testing::mock};
 
     type View = ViewNumber;
     type BuilderStateMap =

--- a/marketplace-builder-shared/src/error.rs
+++ b/marketplace-builder-shared/src/error.rs
@@ -33,18 +33,18 @@ impl<Types: NodeType> From<Error<Types>> for BuildError {
         match value {
             Error::SignatureValidation => {
                 BuildError::Error("Signature validation failed".to_owned())
-            }
+            },
             Error::Signing(_) => BuildError::Error("Failed to sign response".to_owned()),
             Error::ApiTimeout => BuildError::Error("Timeout".to_owned()),
             Error::NotFound => BuildError::NotFound,
             Error::AlreadyDecided => {
                 BuildError::Error("Request for an already decided view".to_owned())
-            }
+            },
             Error::BuildBlock(_) => BuildError::Error("Failed to build block".to_owned()),
             Error::TxnSender(_) => BuildError::Error("Transaction channel error".to_owned()),
             Error::TxTooBig { len, max_tx_len } => {
                 BuildError::Error(format!("Transaction too big ({len}/{max_tx_len}"))
-            }
+            },
         }
     }
 }

--- a/marketplace-builder-shared/src/state.rs
+++ b/marketplace-builder-shared/src/state.rs
@@ -4,10 +4,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    block::{BuilderStateId, ParentBlockReferences, ReceivedTransaction},
-    utils::RotatingSet,
-};
 use async_broadcast::Receiver;
 use async_lock::{Mutex, RwLock};
 use committable::{Commitment, Committable};
@@ -15,6 +11,11 @@ use hotshot::traits::{BlockPayload, ValidatedState};
 use hotshot_types::{
     data::{DaProposal2, Leaf2, QuorumProposalWrapper},
     traits::{block_contents::BlockHeader, node_implementation::NodeType},
+};
+
+use crate::{
+    block::{BuilderStateId, ParentBlockReferences, ReceivedTransaction},
+    utils::RotatingSet,
 };
 
 #[derive(derive_more::Debug, Clone)]
@@ -208,7 +209,7 @@ where
 
                     self.txn_queue.write().await.insert(txn);
                     queue_empty = false;
-                }
+                },
 
                 Err(async_broadcast::TryRecvError::Empty)
                 | Err(async_broadcast::TryRecvError::Closed) => {
@@ -216,12 +217,12 @@ where
                     // If it's closed that's a big problem and we should
                     // probably indicate it as such.
                     break;
-                }
+                },
 
                 Err(async_broadcast::TryRecvError::Overflowed(lost)) => {
                     tracing::warn!("Missed {lost} transactions due to backlog");
                     continue;
-                }
+                },
             }
         }
         queue_empty

--- a/marketplace-builder-shared/src/testing/consensus.rs
+++ b/marketplace-builder-shared/src/testing/consensus.rs
@@ -2,8 +2,6 @@
 
 use std::marker::PhantomData;
 
-use crate::block::BuilderStateId;
-use crate::testing::constants::TEST_NUM_NODES_IN_VID_COMPUTATION;
 use async_broadcast::Sender;
 use committable::Committable;
 use hotshot::{
@@ -17,8 +15,10 @@ use hotshot_example_types::{
     state_types::{TestInstanceState, TestValidatedState},
 };
 use hotshot_types::{
-    data::vid_commitment,
-    data::{DaProposal2, EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, ViewNumber},
+    data::{
+        vid_commitment, DaProposal2, EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper,
+        ViewNumber,
+    },
     message::Proposal,
     simple_certificate::{QuorumCertificate2, SimpleCertificate, SuccessThreshold},
     simple_vote::QuorumData2,
@@ -29,6 +29,8 @@ use hotshot_types::{
 };
 use sha2::{Digest, Sha256};
 use vbs::version::StaticVersionType;
+
+use crate::{block::BuilderStateId, testing::constants::TEST_NUM_NODES_IN_VID_COMPUTATION};
 
 pub struct SimulatedChainState {
     epoch: Option<EpochNumber>,
@@ -108,7 +110,7 @@ impl SimulatedChainState {
                     &TestInstanceState::default(),
                 )
                 .await
-            }
+            },
             Some(prev_proposal) => {
                 let prev_justify_qc = &prev_proposal.justify_qc();
                 let quorum_data = QuorumData2::<TestTypes> {
@@ -124,7 +126,7 @@ impl SimulatedChainState {
                     prev_justify_qc.signatures.clone(),
                     PhantomData,
                 )
-            }
+            },
         };
 
         tracing::debug!("Iteration: {} justify_qc: {:?}", self.round, justify_qc);

--- a/marketplace-builder-shared/src/testing/generation.rs
+++ b/marketplace-builder-shared/src/testing/generation.rs
@@ -137,7 +137,7 @@ where
                             .map(Result::unwrap),
                     );
                 }
-            }
+            },
             GenerationStrategy::Random {
                 min_per_view,
                 max_per_view,
@@ -164,7 +164,7 @@ where
 
                     self.txn_nonce += 1;
                 }
-            }
+            },
             GenerationStrategy::Flood {
                 min_tx_size,
                 max_tx_size,
@@ -188,7 +188,7 @@ where
 
                     self.txn_nonce += 1;
                 }
-            }
+            },
         };
     }
 }
@@ -235,7 +235,7 @@ where
                             .publish_transaction_async(txn)
                             .await
                             .expect("Failed to submit transaction to public mempool");
-                    }
+                    },
                     SubmissionEndpoint::Private => {
                         if let Err(e) = private_mempool_client
                             .post::<()>("submit")
@@ -248,17 +248,17 @@ where
                                 // If we can't reach the builder altogether, test should fail
                                 builder::Error::Request(request_error) => {
                                     panic!("Builder API not available: {request_error}")
-                                }
+                                },
                                 // If the builder returns an error, we will re-submit this transaction
                                 // on the next view, so we return it to the queue and break
                                 error => {
                                     tracing::warn!(?error, "Builder API error");
                                     self.txn_queue.push_front(txn);
                                     break;
-                                }
+                                },
                             };
                         }
-                    }
+                    },
                 }
             }
         }

--- a/marketplace-builder-shared/src/testing/mock.rs
+++ b/marketplace-builder-shared/src/testing/mock.rs
@@ -2,40 +2,35 @@
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use async_broadcast::broadcast;
-use committable::Commitment;
-use committable::Committable;
-use hotshot_example_types::block_types::{TestBlockHeader, TestBlockPayload, TestTransaction};
+use committable::{Commitment, Committable};
 use hotshot_example_types::{
+    block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
     node_types::{TestTypes, TestVersions},
     state_types::{TestInstanceState, TestValidatedState},
 };
-use hotshot_types::data::DaProposal2;
-use hotshot_types::data::ViewNumber;
-use hotshot_types::data::{QuorumProposal2, QuorumProposalWrapper};
-use hotshot_types::event::LeafInfo;
-use hotshot_types::simple_certificate::QuorumCertificate2;
-use hotshot_types::simple_vote::QuorumData2;
-use hotshot_types::traits::block_contents::GENESIS_VID_NUM_STORAGE_NODES;
-use hotshot_types::traits::node_implementation::Versions;
-use hotshot_types::traits::EncodeBytes;
-use hotshot_types::vid::advz::advz_scheme;
 use hotshot_types::{
-    data::{random_commitment, vid_commitment, Leaf, Leaf2},
+    data::{
+        random_commitment, vid_commitment, DaProposal2, Leaf, Leaf2, QuorumProposal2,
+        QuorumProposalWrapper, ViewNumber,
+    },
+    event::LeafInfo,
     message::UpgradeLock,
-    simple_certificate::QuorumCertificate,
-    simple_vote::VersionedVoteData,
-    traits::node_implementation::{ConsensusTime, NodeType},
-    traits::BlockPayload,
+    simple_certificate::{QuorumCertificate, QuorumCertificate2},
+    simple_vote::{QuorumData2, VersionedVoteData},
+    traits::{
+        block_contents::GENESIS_VID_NUM_STORAGE_NODES,
+        node_implementation::{ConsensusTime, NodeType, Versions},
+        BlockPayload, EncodeBytes,
+    },
     utils::BuilderCommitment,
+    vid::advz::advz_scheme,
 };
 use jf_vid::VidScheme;
 use rand::{distributions::Standard, thread_rng, Rng};
 use vbs::version::StaticVersionType;
 
-use crate::block::ParentBlockReferences;
-use crate::state::BuilderState;
-
 use super::constants::{TEST_CHANNEL_BUFFER_SIZE, TEST_NUM_NODES_IN_VID_COMPUTATION};
+use crate::{block::ParentBlockReferences, state::BuilderState};
 
 pub fn transaction() -> TestTransaction {
     TestTransaction::new(

--- a/marketplace-builder-shared/src/testing/validation.rs
+++ b/marketplace-builder-shared/src/testing/validation.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use super::TransactionPayload;
-
+use anyhow::{bail, Error};
 use async_lock::RwLock;
+use async_trait::async_trait;
+use chrono::{DateTime, Local};
 use hotshot::{
     traits::{BlockPayload, TestableNodeImplementation},
     types::{Event, EventType},
@@ -17,9 +18,7 @@ use hotshot_types::traits::{
     node_implementation::{NodeType, Versions},
 };
 
-use anyhow::{bail, Error};
-use async_trait::async_trait;
-use chrono::{DateTime, Local};
+use super::TransactionPayload;
 
 #[derive(Clone, Debug)]
 pub struct IncludedTransaction {

--- a/marketplace-builder-shared/src/utils/rotating_set.rs
+++ b/marketplace-builder-shared/src/utils/rotating_set.rs
@@ -76,10 +76,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::thread::sleep;
+
     use tracing_test::traced_test;
 
     use super::*;
-    use std::thread::sleep;
 
     #[test]
     #[traced_test]

--- a/marketplace-builder/src/bin/marketplace-builder.rs
+++ b/marketplace-builder/src/bin/marketplace-builder.rs
@@ -129,11 +129,11 @@ async fn main() -> anyhow::Result<()> {
     match (base, upgrade) {
         (FeeVersion::VERSION, MarketplaceVersion::VERSION) => {
             run::<SequencerVersions<FeeVersion, MarketplaceVersion>>(genesis, opt).await
-        }
+        },
         (FeeVersion::VERSION, _) => run::<SequencerVersions<FeeVersion, V0_0>>(genesis, opt).await,
         (MarketplaceVersion::VERSION, _) => {
             run::<SequencerVersions<MarketplaceVersion, V0_0>>(genesis, opt).await
-        }
+        },
         _ => panic!(
             "Invalid base ({base}) and upgrade ({upgrade}) versions specified in the toml file."
         ),

--- a/marketplace-builder/src/hooks.rs
+++ b/marketplace-builder/src/hooks.rs
@@ -1,39 +1,21 @@
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use async_lock::RwLock;
 use async_trait::async_trait;
-use espresso_types::v0_99::BidTxBody;
-use tokio::{spawn, time::sleep};
-
-use espresso_types::v0_99::RollupRegistration;
-
-use espresso_types::MarketplaceVersion;
-use espresso_types::SeqTypes;
-use hotshot::types::EventType;
-
-use hotshot::types::Event;
-
-use hotshot_types::traits::node_implementation::Versions;
+use espresso_types::{
+    eth_signature_key::EthKeyPair,
+    v0_99::{BidTxBody, RollupRegistration},
+    FeeAmount, MarketplaceVersion, NamespaceId, SeqTypes,
+};
+use hotshot::types::{Event, EventType};
+use hotshot_types::traits::node_implementation::{NodeType, Versions};
 use marketplace_builder_core::hooks::BuilderHooks;
-
-use espresso_types::FeeAmount;
-
-use espresso_types::eth_signature_key::EthKeyPair;
-
-use espresso_types::NamespaceId;
-
-use hotshot_types::traits::node_implementation::NodeType;
-
-use marketplace_solver::SolverError;
-use marketplace_solver::SOLVER_API_PATH;
+use marketplace_solver::{SolverError, SOLVER_API_PATH};
 use sequencer::SequencerApiVersion;
 use surf_disco::Client;
-
 use tide_disco::Url;
-use tracing::error;
-use tracing::info;
+use tokio::{spawn, time::sleep};
+use tracing::{error, info};
 
 /// Configurations for bid submission.
 pub struct BidConfig {
@@ -67,11 +49,11 @@ pub async fn fetch_namespaces_to_skip(solver_base_url: Url) -> Option<HashSet<Na
                 }
             }
             Some(namespaces_to_skip)
-        }
+        },
         Err(e) => {
             error!("Failed to get the registered rollups: {:?}.", e);
             None
-        }
+        },
     }
 }
 
@@ -130,7 +112,7 @@ impl BuilderHooks<SeqTypes> for EspressoReserveHooks {
                 Err(e) => {
                     error!("Failed to sign the bid txn: {:?}.", e);
                     return;
-                }
+                },
             };
 
             let solver_client = connect_to_solver(solver_base_url);
@@ -172,12 +154,12 @@ impl BuilderHooks<SeqTypes> for EspressoFallbackHooks {
             Some(namespaces_to_skip) => {
                 transactions.retain(|txn| !namespaces_to_skip.contains(&txn.namespace()));
                 transactions
-            }
+            },
             // Solver connection has failed and we don't have up-to-date information on this
             None => {
                 error!("Not accepting transactions due to outdated information");
                 Vec::new()
-            }
+            },
         }
     }
 

--- a/marketplace-builder/src/lib.rs
+++ b/marketplace-builder/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     marker::PhantomData,
     mem,
     net::{IpAddr, Ipv4Addr},
+    sync::Arc,
     thread::Builder,
 };
 
@@ -35,16 +36,13 @@ use hotshot_builder_api::v0_99::builder::{
     BuildError, Error as BuilderApiError, Options as HotshotBuilderApiOptions,
 };
 use hotshot_orchestrator::client::{OrchestratorClient, ValidatorArgs};
-use hotshot_types::network::NetworkConfig;
-use marketplace_builder_core::service::{GlobalState, ProxyGlobalState};
-use std::sync::Arc;
-use tokio::{spawn, task::JoinHandle};
 // Should move `STAKE_TABLE_CAPACITY` in the sequencer repo when we have variate stake table support
 use hotshot_stake_table::config::STAKE_TABLE_CAPACITY;
 use hotshot_types::{
     consensus::ConsensusMetricsValue,
     event::LeafInfo,
     light_client::StateKeyPair,
+    network::NetworkConfig,
     signature_key::{BLSPrivKey, BLSPubKey},
     traits::{
         block_contents::{BlockHeader, BlockPayload, EncodeBytes, GENESIS_VID_NUM_STORAGE_NODES},
@@ -57,6 +55,7 @@ use hotshot_types::{
 };
 use jf_merkle_tree::{namespaced_merkle_tree::NamespacedMerkleTreeScheme, MerkleTreeScheme};
 use jf_signature::bls_over_bn254::VerKey;
+use marketplace_builder_core::service::{GlobalState, ProxyGlobalState};
 use sequencer::{
     catchup::StatePeers,
     context::{Consensus, SequencerContext},
@@ -66,6 +65,7 @@ use sequencer::{
 };
 use surf_disco::Client;
 use tide_disco::{app, method::ReadState, App, Url};
+use tokio::{spawn, task::JoinHandle};
 use tracing::error;
 use vbs::version::{StaticVersion, StaticVersionType};
 

--- a/marketplace-solver/src/api.rs
+++ b/marketplace-solver/src/api.rs
@@ -164,7 +164,7 @@ fn merge_toml(into: &mut Value, from: Value) {
                 Entry::Occupied(mut entry) => merge_toml(entry.get_mut(), value),
                 Entry::Vacant(entry) => {
                     entry.insert(value);
-                }
+                },
             }
         }
     }

--- a/marketplace-solver/src/database.rs
+++ b/marketplace-solver/src/database.rs
@@ -60,7 +60,7 @@ impl PostgresClient {
                 }
 
                 connect_opts.to_url_lossy()
-            }
+            },
         };
 
         if let Some(max_connections) = max_connections {
@@ -149,8 +149,9 @@ pub mod mock {
 
 #[cfg(all(test, not(target_os = "windows"), not(feature = "embedded-db")))]
 mod test {
-    use crate::database::mock::setup_mock_database;
     use hotshot::helpers::initialize_logging;
+
+    use crate::database::mock::setup_mock_database;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_database_connection() {

--- a/marketplace-solver/src/events.rs
+++ b/marketplace-solver/src/events.rs
@@ -59,7 +59,7 @@ pub async fn handle_events(
         match event.event {
             hotshot::types::EventType::ViewFinished { view_number } => {
                 tracing::debug!("received view finished event {view_number:?}")
-            }
+            },
             _ => (),
         }
     }
@@ -69,6 +69,8 @@ pub async fn handle_events(
 
 #[cfg(any(test, feature = "testing"))]
 pub mod mock {
+    use std::{sync::Arc, time::Duration};
+
     use async_lock::RwLock;
     use espresso_types::SeqTypes;
     use hotshot::rand::{self};
@@ -83,7 +85,6 @@ pub mod mock {
     };
     use portpicker::pick_unused_port;
     use rand::{rngs::OsRng, RngCore};
-    use std::{sync::Arc, time::Duration};
     use tide_disco::{App, Url};
     use tokio::{spawn, task::JoinHandle, time::sleep};
     use vbs::version::{StaticVersion, StaticVersionType};
@@ -184,8 +185,7 @@ pub mod mock {
 mod test {
     use espresso_types::SeqTypes;
     use futures::StreamExt as _;
-    use hotshot::helpers::initialize_logging;
-    use hotshot::types::Event;
+    use hotshot::{helpers::initialize_logging, types::Event};
     use hotshot_events_service::events_source::StartupInfo;
     use surf_disco::Client;
 

--- a/marketplace-solver/src/testing.rs
+++ b/marketplace-solver/src/testing.rs
@@ -122,6 +122,8 @@ impl MockSolver {
 
 #[cfg(all(test, not(feature = "embedded-db")))]
 mod test {
+    use std::{str::FromStr, time::Duration};
+
     use committable::Committable;
     use espresso_types::{
         v0_99::{
@@ -132,7 +134,6 @@ mod test {
     };
     use hotshot::types::{BLSPubKey, SignatureKey};
     use hotshot_types::traits::node_implementation::NodeType;
-    use std::{str::FromStr, time::Duration};
     use tide_disco::Url;
 
     use crate::{testing::MockSolver, SolverError};
@@ -192,7 +193,7 @@ mod test {
         let client = surf_disco::Client::<SolverError, MarketplaceVersion>::new(solver_api);
         client.connect(None).await;
 
-        let (reg_ns_1, _, _) =
+        let (reg_ns_1, ..) =
             register_rollup_helper(1, Some("http://localhost"), 200, true, "test").await;
 
         // registering a rollup
@@ -230,7 +231,7 @@ mod test {
         let client = surf_disco::Client::<SolverError, MarketplaceVersion>::new(solver_api);
         client.connect(None).await;
 
-        let (reg_ns_1, _, _) =
+        let (reg_ns_1, ..) =
             register_rollup_helper(1, Some("http://localhost"), 200, true, "test").await;
 
         // registering a rollup
@@ -268,7 +269,7 @@ mod test {
         // Ensure the error indicates an invalid signature
         match err {
             SolverError::InvalidSignature(signature)
-                if reg_ns_2.signature.to_string() == signature => {}
+                if reg_ns_2.signature.to_string() == signature => {},
             _ => panic!("err {err:?}"),
         }
     }
@@ -375,7 +376,7 @@ mod test {
             .unwrap_err();
 
         match err {
-            SolverError::Database(_) => {}
+            SolverError::Database(_) => {},
             _ => panic!("err {err:?}"),
         }
     }
@@ -532,7 +533,7 @@ mod test {
         client.connect(Some(Duration::from_secs(5))).await;
 
         // Register the first rollup (ns = 1)
-        let (reg_ns_1, _, _) =
+        let (reg_ns_1, ..) =
             register_rollup_helper(1, Some("http://localhost"), 200, true, "test").await;
         let _: RollupRegistration = client
             .post("register_rollup")
@@ -543,7 +544,7 @@ mod test {
             .unwrap();
 
         // Register the second rollup (ns = 2)
-        let (reg_ns_2, _, _) =
+        let (reg_ns_2, ..) =
             register_rollup_helper(2, Some("http://localhost"), 200, true, "test").await;
         let _: RollupRegistration = client
             .post("register_rollup")

--- a/node-metrics/src/api/node_validator/v0/cdn/mod.rs
+++ b/node-metrics/src/api/node_validator/v0/cdn/mod.rs
@@ -1,4 +1,3 @@
-use crate::api::node_validator::v0::create_node_validator_api::ExternalMessage;
 use espresso_types::{PubKey, SeqTypes};
 use futures::{channel::mpsc::SendError, Sink, SinkExt};
 use hotshot::{
@@ -14,6 +13,8 @@ use hotshot_types::{
 };
 use tokio::{spawn, task::JoinHandle};
 use url::Url;
+
+use crate::api::node_validator::v0::create_node_validator_api::ExternalMessage;
 
 /// ConnectedNetworkConsumer represents a trait that splits up a portion of
 /// the ConnectedNetwork trait, so that the consumer only needs to be aware of
@@ -95,7 +96,7 @@ impl CdnReceiveMessagesTask {
                 Err(err) => {
                     tracing::error!("error receiving message: {:?}", err);
                     continue;
-                }
+                },
             };
 
             // We want to try and decode this message.
@@ -106,17 +107,17 @@ impl CdnReceiveMessagesTask {
                 Err(err) => {
                     tracing::error!("error deserializing message: {:?}", err);
                     continue;
-                }
+                },
             };
 
             let external_message_deserialize_result = match message.kind {
                 MessageKind::External(external_message) => {
                     bincode::deserialize::<ExternalMessage>(&external_message)
-                }
+                },
                 _ => {
                     tracing::error!("unexpected message kind: {:?}", message);
                     continue;
-                }
+                },
             };
 
             let external_message = match external_message_deserialize_result {
@@ -124,7 +125,7 @@ impl CdnReceiveMessagesTask {
                 Err(err) => {
                     tracing::error!("error deserializing message: {:?}", err);
                     continue;
-                }
+                },
             };
 
             match external_message {
@@ -137,11 +138,11 @@ impl CdnReceiveMessagesTask {
                         tracing::error!("error sending public api url: {:?}", err);
                         return;
                     }
-                }
+                },
 
                 _ => {
                     // We're not concerned about other message types
-                }
+                },
             }
         }
     }
@@ -237,7 +238,7 @@ impl BroadcastRollCallTask {
             Err(err) => {
                 tracing::error!("error serializing rollcall request: {:?}", err);
                 return;
-            }
+            },
         };
 
         let hotshot_message = Message::<SeqTypes> {
@@ -250,7 +251,7 @@ impl BroadcastRollCallTask {
             Err(err) => {
                 tracing::error!("error serializing hotshot message: {:?}", err);
                 return;
-            }
+            },
         };
 
         let broadcast_result = network
@@ -278,30 +279,32 @@ impl Drop for BroadcastRollCallTask {
 
 #[cfg(test)]
 mod test {
-    use super::{BroadcastRollCallTask, ConnectedNetworkConsumer, ConnectedNetworkPublisher};
-    use crate::api::node_validator::v0::create_node_validator_api::ExternalMessage;
-    use crate::api::node_validator::v0::{
-        cdn::CdnReceiveMessagesTask, create_node_validator_api::RollCallInfo,
-    };
     use core::panic;
+    use std::time::Duration;
+
     use espresso_types::SeqTypes;
-    use futures::channel::mpsc::Sender;
-    use futures::SinkExt;
     use futures::{
-        channel::mpsc::{self},
-        StreamExt,
+        channel::mpsc::{
+            Sender, {self},
+        },
+        SinkExt, StreamExt,
     };
-    use hotshot::types::SignatureKey;
     use hotshot::{
         traits::NetworkError,
-        types::{BLSPubKey, Message},
+        types::{BLSPubKey, Message, SignatureKey},
     };
-    use hotshot_types::message::{DataMessage, MessageKind};
-    use hotshot_types::traits::network::{BroadcastDelay, ResponseMessage};
-    use std::time::Duration;
-    use tokio::time::error::Elapsed;
-    use tokio::time::{sleep, timeout};
+    use hotshot_types::{
+        message::{DataMessage, MessageKind},
+        traits::network::{BroadcastDelay, ResponseMessage},
+    };
+    use tokio::time::{error::Elapsed, sleep, timeout};
     use url::Url;
+
+    use super::{BroadcastRollCallTask, ConnectedNetworkConsumer, ConnectedNetworkPublisher};
+    use crate::api::node_validator::v0::{
+        cdn::CdnReceiveMessagesTask,
+        create_node_validator_api::{ExternalMessage, RollCallInfo},
+    };
 
     /// [TestConnectedNetworkConsumer] is a test implementation of the
     /// [ConnectedNetworkConsumer] trait that allows for the simulation of
@@ -564,7 +567,7 @@ mod test {
                     public_key,
                     BLSPubKey::generated_from_seed_indexed([0; 32], 0).0
                 );
-            }
+            },
             _ => panic!("unexpected external message"),
         }
 

--- a/node-metrics/src/api/node_validator/v0/mod.rs
+++ b/node-metrics/src/api/node_validator/v0/mod.rs
@@ -1,37 +1,34 @@
 pub mod cdn;
 pub mod create_node_validator_api;
 
-use crate::service::client_message::{ClientMessage, InternalClientMessage};
-use crate::service::data_state::{LocationDetails, NodeIdentity};
-use crate::service::server_message::ServerMessage;
+use std::{fmt, future::Future, io::BufRead, pin::Pin, str::FromStr, time::Duration};
+
 use espresso_types::{BackoffParams, SeqTypes};
-use futures::channel::mpsc::SendError;
-use futures::future::Either;
 use futures::{
-    channel::mpsc::{self, Sender},
+    channel::mpsc::{self, SendError, Sender},
+    future::Either,
     FutureExt, Sink, SinkExt, Stream, StreamExt,
 };
 use hotshot_query_service::Leaf2;
 use hotshot_stake_table::vec_based::StakeTable;
-use hotshot_types::light_client::{CircuitField, StateVerKey};
-use hotshot_types::signature_key::BLSPubKey;
-use hotshot_types::traits::{signature_key::StakeTableEntryType, stake_table::StakeTableScheme};
-use hotshot_types::PeerConfig;
+use hotshot_types::{
+    light_client::{CircuitField, StateVerKey},
+    signature_key::BLSPubKey,
+    traits::{signature_key::StakeTableEntryType, stake_table::StakeTableScheme},
+    PeerConfig,
+};
 use prometheus_parse::{Sample, Scrape};
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::future::Future;
-use std::io::BufRead;
-use std::pin::Pin;
-use std::str::FromStr;
-use std::time::Duration;
-use tide_disco::socket::Connection;
-use tide_disco::{api::ApiError, Api};
-use tokio::spawn;
-use tokio::task::JoinHandle;
-use tokio::time::sleep;
+use tide_disco::{api::ApiError, socket::Connection, Api};
+use tokio::{spawn, task::JoinHandle, time::sleep};
 use url::Url;
 use vbs::version::{StaticVersion, StaticVersionType, Version};
+
+use crate::service::{
+    client_message::{ClientMessage, InternalClientMessage},
+    data_state::{LocationDetails, NodeIdentity},
+    server_message::ServerMessage,
+};
 
 /// CONSTANT for protocol major version
 pub const VERSION_MAJ: u16 = 0;
@@ -64,11 +61,11 @@ impl fmt::Display for Error {
         match self {
             Self::UnhandledSurfDisco(status, msg) => {
                 write!(f, "Unhandled Surf Disco Error: {} - {}", status, msg)
-            }
+            },
 
             Self::UnhandledTideDisco(status, msg) => {
                 write!(f, "Unhandled Tide Disco Error: {} - {}", status, msg)
-            }
+            },
         }
     }
 }
@@ -255,7 +252,7 @@ where
                             // let's queue up the next client message to receive
                             next_client_message = socket_stream.next();
                             next_server_message = remaining_server_message;
-                        }
+                        },
                         Either::Right((server_message, remaining_client_message)) => {
                             // Alright, we have a server message, we want to forward it
                             // to the down-stream client.
@@ -277,7 +274,7 @@ where
                             // let's queue up the next server message to receive
                             next_server_message = server_message_receiver.next();
                             next_client_message = remaining_client_message;
-                        }
+                        },
                     }
                 }
 
@@ -327,7 +324,7 @@ pub async fn get_stake_table_from_sequencer(
         Err(err) => {
             tracing::info!("retrieve stake table request failed: {}", err);
             return Err(err);
-        }
+        },
     };
 
     let public_hot_shot_config = sequencer_config.config;
@@ -481,7 +478,7 @@ impl LeafStreamRetriever for HotshotQueryServiceLeafStreamRetriever {
                 Err(err) => {
                     tracing::info!("retrieve block height request failed: {}", err);
                     return Err(err);
-                }
+                },
             };
 
             let latest_block_start = block_height.saturating_sub(50);
@@ -504,7 +501,7 @@ impl LeafStreamRetriever for HotshotQueryServiceLeafStreamRetriever {
                 Err(err) => {
                     tracing::info!("retrieve leaves stream failed: {}", err);
                     return Err(err);
-                }
+                },
             };
 
             Ok(leaves_stream)
@@ -621,7 +618,7 @@ impl ProcessProduceLeafStreamTask {
                     delay = backoff_params.backoff(delay);
                     sleep(delay).await;
                     continue;
-                }
+                },
 
                 Ok(leaves_stream) => leaves_stream,
             };
@@ -795,7 +792,7 @@ pub fn populate_node_identity_from_scrape(node_identity: &mut NodeIdentity, scra
                     // We couldn't parse the public key, so we can't create a NodeIdentity.
                     tracing::info!("parsing public key failed: {}", err);
                     return;
-                }
+                },
             }
         } else {
             // We were unable to find the public key in the scrape result.
@@ -878,7 +875,7 @@ pub fn node_identity_from_scrape(scrape: Scrape) -> Option<NodeIdentity> {
         Err(err) => {
             tracing::info!("parsing public key failed: {}", err);
             return None;
-        }
+        },
     };
 
     let mut node_identity = NodeIdentity::from_public_key(public_key);
@@ -937,7 +934,7 @@ impl ProcessNodeIdentityUrlStreamTask {
                 None => {
                     tracing::info!("node identity url stream closed");
                     return;
-                }
+                },
             };
 
             // Alright we have a new Url to try and scrape for a Node Identity.
@@ -949,7 +946,7 @@ impl ProcessNodeIdentityUrlStreamTask {
                 Err(err) => {
                     tracing::warn!("get node identity from url failed.  bad base url?: {}", err);
                     continue;
-                }
+                },
             };
 
             let send_result = node_identity_sender.send(node_identity).await;

--- a/node-metrics/src/lib.rs
+++ b/node-metrics/src/lib.rs
@@ -99,15 +99,6 @@
 pub mod api;
 pub mod service;
 
-use crate::{
-    api::node_validator::v0::{
-        cdn::{BroadcastRollCallTask, CdnReceiveMessagesTask},
-        create_node_validator_api::{create_node_validator_processing, NodeValidatorConfig},
-        HotshotQueryServiceLeafStreamRetriever, ProcessProduceLeafStreamTask,
-        StateClientMessageSender, STATIC_VER_0_1,
-    },
-    service::{client_message::InternalClientMessage, server_message::ServerMessage},
-};
 use clap::Parser;
 use espresso_types::{PubKey, SeqTypes};
 use futures::channel::mpsc::{self, Sender};
@@ -119,6 +110,16 @@ use hotshot_types::traits::{node_implementation::NodeType, signature_key::Builde
 use tide_disco::App;
 use tokio::spawn;
 use url::Url;
+
+use crate::{
+    api::node_validator::v0::{
+        cdn::{BroadcastRollCallTask, CdnReceiveMessagesTask},
+        create_node_validator_api::{create_node_validator_processing, NodeValidatorConfig},
+        HotshotQueryServiceLeafStreamRetriever, ProcessProduceLeafStreamTask,
+        StateClientMessageSender, STATIC_VER_0_1,
+    },
+    service::{client_message::InternalClientMessage, server_message::ServerMessage},
+};
 
 /// Options represents the configuration options that are available for running
 /// the node validator service via the [run_standalone_service] function.
@@ -233,10 +234,10 @@ pub async fn run_standalone_service(options: Options) {
         api::node_validator::v0::define_api().expect("error defining node validator api");
 
     match app.register_module("node-validator", node_validator_api) {
-        Ok(_) => {}
+        Ok(_) => {},
         Err(err) => {
             panic!("error registering node validator api: {:?}", err);
-        }
+        },
     }
 
     let (leaf_sender, leaf_receiver) = mpsc::channel(10);
@@ -260,7 +261,7 @@ pub async fn run_standalone_service(options: Options) {
 
         Err(err) => {
             panic!("error defining node validator api: {:?}", err);
-        }
+        },
     };
 
     let _cdn_tasks = if let Some(cdn_broker_url_string) = options.cdn_marshal_endpoint() {
@@ -278,7 +279,7 @@ pub async fn run_standalone_service(options: Options) {
             Ok(cdn_network) => cdn_network,
             Err(err) => {
                 panic!("error creating cdn network: {:?}", err);
-            }
+            },
         };
 
         let url_sender = node_validator_task_state.url_sender.clone();

--- a/node-metrics/src/service/client_id/mod.rs
+++ b/node-metrics/src/service/client_id/mod.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign};
+
+use serde::{Deserialize, Serialize};
 
 /// [ClientId] represents the unique identifier for a client that is connected
 /// to the server.
@@ -108,8 +109,10 @@ mod tests {
 
     #[test]
     fn test_hash() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         let hash_1 = {
             let client_id = ClientId::from_count(1);

--- a/node-metrics/src/service/client_message/mod.rs
+++ b/node-metrics/src/service/client_message/mod.rs
@@ -1,5 +1,6 @@
-use super::client_id::ClientId;
 use serde::{Deserialize, Serialize};
+
+use super::client_id::ClientId;
 
 /// [ClientMessage] represents the messages that the client can send to the
 /// server for a request.
@@ -38,11 +39,12 @@ impl ClientMessage {
 
 #[cfg(test)]
 mod tests {
-    use super::InternalClientMessage;
-    use super::*;
-    use crate::service::server_message::ServerMessage;
-    use futures::channel::mpsc::Sender;
     use std::iter::zip;
+
+    use futures::channel::mpsc::Sender;
+
+    use super::{InternalClientMessage, *};
+    use crate::service::server_message::ServerMessage;
 
     impl<K> PartialEq for InternalClientMessage<K> {
         fn eq(&self, other: &Self) -> bool {
@@ -141,7 +143,7 @@ mod tests {
                 match internal_client_message {
                     InternalClientMessage::Request(id, _) => {
                         assert_eq!(id, client_id);
-                    }
+                    },
                     _ => panic!("Unexpected InternalClientMessage"),
                 }
             }

--- a/node-metrics/src/service/data_state/node_identity.rs
+++ b/node-metrics/src/service/data_state/node_identity.rs
@@ -1,7 +1,8 @@
-use super::LocationDetails;
 use hotshot_types::signature_key::BLSPubKey;
 use serde::{Deserialize, Serialize};
 use surf_disco::Url;
+
+use super::LocationDetails;
 
 /// [NodeIdentity] represents the identity of the node that is participating
 /// in the network.
@@ -126,10 +127,9 @@ impl NodeIdentity {
 
 #[cfg(test)]
 pub mod tests {
-    use super::LocationDetails;
-    use super::NodeIdentity;
-    use hotshot_types::signature_key::BLSPubKey;
-    use hotshot_types::traits::signature_key::SignatureKey;
+    use hotshot_types::{signature_key::BLSPubKey, traits::signature_key::SignatureKey};
+
+    use super::{LocationDetails, NodeIdentity};
 
     pub fn create_test_node(index: u64) -> NodeIdentity {
         let (pub_key, _) = BLSPubKey::generated_from_seed_indexed([0; 32], index);

--- a/node-metrics/src/service/server_message/mod.rs
+++ b/node-metrics/src/service/server_message/mod.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
-use super::{client_id::ClientId, data_state::NodeIdentity};
 use bitvec::vec::BitVec;
 use espresso_types::SeqTypes;
 use hotshot_query_service::explorer::{BlockDetail, ExplorerHistograms};
 use serde::{Deserialize, Serialize};
+
+use super::{client_id::ClientId, data_state::NodeIdentity};
 
 /// [ServerMessage] represents the messages that the server can send to the
 /// client for a response.

--- a/request-response/src/lib.rs
+++ b/request-response/src/lib.rs
@@ -406,24 +406,24 @@ impl<
                         Err(e) => {
                             warn!("Received invalid message: {e}");
                             continue;
-                        }
+                        },
                     };
 
                     // Handle the message based on its type
                     match message {
                         Message::Request(request_message) => {
                             self.handle_request(request_message, &mut outgoing_responses);
-                        }
+                        },
                         Message::Response(response_message) => {
                             self.handle_response(response_message, &mut incoming_responses);
-                        }
+                        },
                     }
-                }
+                },
                 // An error here means the receiver will _NEVER_ receive any more messages
                 Err(e) => {
                     error!("Request/response receive task exited: {e}");
                     return;
-                }
+                },
             }
         }
     }

--- a/request-response/src/message.rs
+++ b/request-response/src/message.rs
@@ -140,14 +140,14 @@ impl<R: Request, K: SignatureKey> Serializable for Message<R, K> {
 
                 // Write the request content
                 bytes.extend_from_slice(request_message.to_bytes()?.as_slice());
-            }
+            },
             Message::Response(response_message) => {
                 // Write the type (response)
                 bytes.push(1);
 
                 // Write the response content
                 bytes.extend_from_slice(response_message.to_bytes()?.as_slice());
-            }
+            },
         };
 
         Ok(bytes)
@@ -168,13 +168,13 @@ impl<R: Request, K: SignatureKey> Serializable for Message<R, K> {
                 Ok(Message::Request(RequestMessage::from_bytes(&read_to_end(
                     &mut bytes,
                 )?)?))
-            }
+            },
             1 => {
                 // Read the `ResponseMessage`
                 Ok(Message::Response(ResponseMessage::from_bytes(
                     &read_to_end(&mut bytes)?,
                 )?))
-            }
+            },
             _ => Err(anyhow::anyhow!("invalid message type")),
         }
     }
@@ -353,7 +353,7 @@ mod tests {
 
                     // It should not be valid anymore
                     (false, Duration::from_secs(1))
-                }
+                },
 
                 2 => {
                     // Alter the timestamp
@@ -361,13 +361,13 @@ mod tests {
 
                     // It should not be valid anymore
                     (false, Duration::from_secs(1))
-                }
+                },
 
                 3 => {
                     // Change the request ttl to be 0. This should make the request
                     // invalid immediately
                     (true, Duration::from_secs(0))
-                }
+                },
 
                 _ => unreachable!(),
             };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-components = ["rustfmt", "llvm-tools-preview", "rust-src", "clippy"]
+components = ["llvm-tools-preview", "rust-src", "clippy"]
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,8 @@
 reorder_imports = true
-wrap_comments = true
-normalize_comments = true
 use_try_shorthand = true
 match_block_trailing_comma = true
 use_field_init_shorthand = true
-edition = "2018"
+edition = "2021"
 condense_wildcard_suffixes = true
 imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/sequencer/src/api/data_source.rs
+++ b/sequencer/src/api/data_source.rs
@@ -15,11 +15,13 @@ use hotshot_query_service::{
     node::NodeDataSource,
     status::StatusDataSource,
 };
-use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::{
     data::ViewNumber,
     light_client::StateSignatureRequestBody,
-    traits::{network::ConnectedNetwork, node_implementation::Versions},
+    traits::{
+        network::ConnectedNetwork,
+        node_implementation::{NodeType, Versions},
+    },
     PeerConfig,
 };
 use tide_disco::Url;

--- a/sequencer/src/api/endpoints.rs
+++ b/sequencer/src/api/endpoints.rs
@@ -13,11 +13,12 @@ use hotshot_query_service::{
     availability::{self, AvailabilityDataSource, CustomSnafu, FetchBlockSnafu},
     explorer::{self, ExplorerDataSource},
     merklized_state::{
-        self, MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence,
+        self, MerklizedState, MerklizedStateDataSource, MerklizedStateHeightPersistence, Snapshot,
     },
-    node, ApiState, Error,
+    node,
+    node::NodeDataSource,
+    ApiState, Error,
 };
-use hotshot_query_service::{merklized_state::Snapshot, node::NodeDataSource};
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
     traits::{
@@ -28,7 +29,6 @@ use hotshot_types::{
 use jf_merkle_tree::MerkleTreeScheme;
 use serde::{de::Error as _, Deserialize, Serialize};
 use snafu::OptionExt;
-
 use tagged_base64::TaggedBase64;
 use tide_disco::{method::ReadState, Api, Error as _, StatusCode};
 use vbs::version::{StaticVersion, StaticVersionType};

--- a/sequencer/src/api/options.rs
+++ b/sequencer/src/api/options.rs
@@ -1,5 +1,7 @@
 //! Sequencer-specific API options and initialization.
 
+use std::sync::Arc;
+
 use anyhow::{bail, Context};
 use clap::Parser;
 use espresso_types::{
@@ -22,7 +24,6 @@ use hotshot_types::traits::{
     network::ConnectedNetwork,
     node_implementation::Versions,
 };
-use std::sync::Arc;
 use tide_disco::{listener::RateLimitListener, method::ReadState, App, Url};
 use vbs::version::StaticVersionType;
 

--- a/sequencer/src/api/sql.rs
+++ b/sequencer/src/api/sql.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashSet, VecDeque};
+
 use anyhow::{bail, ensure, Context};
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
@@ -30,7 +32,6 @@ use jf_merkle_tree::{
     LookupResult, MerkleTreeScheme,
 };
 use sqlx::{Encode, Type};
-use std::collections::{HashSet, VecDeque};
 
 use super::{
     data_source::{Provider, SequencerDataSource},
@@ -145,7 +146,7 @@ impl CatchupStorage for SqlStorage {
                 LookupResult::Ok(_, proof) => Ok(proof),
                 _ => {
                     bail!("state snapshot {view:?},{height} was found but does not contain frontier at height {}; this should not be possible", height - 1);
-                }
+                },
             }
         }
     }
@@ -275,13 +276,13 @@ async fn load_accounts<Mode: TransactionMode>(
         ))? {
             MerkleNode::Leaf { pos, elem, .. } => {
                 snapshot.remember(*pos, *elem, proof)?;
-            }
+            },
             MerkleNode::Empty => {
                 snapshot.non_membership_remember(*account, proof)?;
-            }
+            },
             _ => {
                 bail!("Invalid proof");
-            }
+            },
         }
     }
 
@@ -442,7 +443,7 @@ async fn header_dependencies<Mode: TransactionMode>(
                     // so the STF will be able to look it up later.
                     catchup.add_chain_config(cf);
                     cf
-                }
+                },
             }
         };
 

--- a/sequencer/src/api/update.rs
+++ b/sequencer/src/api/update.rs
@@ -1,5 +1,7 @@
 //! Update loop for query API state.
 
+use std::{fmt::Debug, sync::Arc};
+
 use anyhow::bail;
 use async_trait::async_trait;
 use derivative::Derivative;
@@ -8,8 +10,6 @@ use espresso_types::{v0::traits::SequencerPersistence, PubKey};
 use hotshot::types::Event;
 use hotshot_query_service::data_source::UpdateDataSource;
 use hotshot_types::traits::{network::ConnectedNetwork, node_implementation::Versions};
-use std::fmt::Debug;
-use std::sync::Arc;
 
 use super::{data_source::SequencerDataSource, StorageState};
 use crate::{EventConsumer, SeqTypes};

--- a/sequencer/src/bin/cdn-whitelist.rs
+++ b/sequencer/src/bin/cdn-whitelist.rs
@@ -9,8 +9,10 @@ use cdn_broker::reexports::discovery::{DiscoveryClient, Embedded, Redis};
 use clap::Parser;
 use espresso_types::SeqTypes;
 use hotshot_orchestrator::client::OrchestratorClient;
-use hotshot_types::network::NetworkConfig;
-use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
+use hotshot_types::{
+    network::NetworkConfig,
+    traits::{node_implementation::NodeType, signature_key::SignatureKey},
+};
 use surf_disco::Url;
 
 #[derive(Parser, Debug)]

--- a/sequencer/src/bin/dev-rollup.rs
+++ b/sequencer/src/bin/dev-rollup.rs
@@ -10,7 +10,6 @@ use espresso_types::{
 use hotshot::types::BLSPubKey;
 use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
 use marketplace_solver::{SolverError, SOLVER_API_PATH};
-
 use sequencer_utils::logging;
 use tagged_base64::TaggedBase64;
 use url::Url;

--- a/sequencer/src/bin/espresso-bridge.rs
+++ b/sequencer/src/bin/espresso-bridge.rs
@@ -1,3 +1,5 @@
+use std::{sync::Arc, time::Duration};
+
 use anyhow::{bail, ensure, Context};
 use clap::{Parser, Subcommand};
 use client::SequencerClient;
@@ -10,7 +12,6 @@ use ethers::{
 };
 use futures::stream::StreamExt;
 use sequencer_utils::logging;
-use std::{sync::Arc, time::Duration};
 use surf_disco::Url;
 
 /// Command-line utility for working with the Espresso bridge.
@@ -213,7 +214,7 @@ async fn deposit(opt: Deposit) -> anyhow::Result<()> {
             Err(err) => {
                 tracing::warn!("error in header stream: {err:#}");
                 continue;
-            }
+            },
         };
         let Some(l1_finalized) = header.l1_finalized() else {
             continue;

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -559,7 +559,6 @@ struct SetHotshotUpReqBody {
 mod tests {
     use std::{process::Child, sync::Arc, time::Duration};
 
-    use crate::AltChainInfo;
     use committable::{Commitment, Committable};
     use contract_bindings_ethers::light_client::LightClient;
     use escargot::CargoBuild;
@@ -577,11 +576,10 @@ mod tests {
     use surf_disco::Client;
     use tide_disco::error::ServerError;
     use tokio::time::sleep;
-
     use url::Url;
     use vbs::version::StaticVersion;
 
-    use crate::{DevInfo, SetHotshotDownReqBody, SetHotshotUpReqBody};
+    use crate::{AltChainInfo, DevInfo, SetHotshotDownReqBody, SetHotshotUpReqBody};
 
     const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
     const NUM_ALT_CHAIN_PROVIDERS: usize = 1;

--- a/sequencer/src/bin/keygen.rs
+++ b/sequencer/src/bin/keygen.rs
@@ -33,7 +33,7 @@ impl Scheme {
             Self::All => {
                 Self::Bls.gen(seed, index, env_file)?;
                 Self::Schnorr.gen(seed, index, env_file)?;
-            }
+            },
             Self::Bls => {
                 let (pub_key, priv_key) = BLSPubKey::generated_from_seed_indexed(seed, index);
                 let priv_key = priv_key.to_tagged_base64()?;
@@ -43,7 +43,7 @@ impl Scheme {
                     "ESPRESSO_SEQUENCER_PRIVATE_STAKING_KEY={priv_key}"
                 )?;
                 tracing::info!(%pub_key, "generated staking key")
-            }
+            },
             Self::Schnorr => {
                 let key_pair = StateKeyPair::generate_from_seed_indexed(seed, index);
                 let priv_key = key_pair.sign_key_ref().to_tagged_base64()?;
@@ -54,7 +54,7 @@ impl Scheme {
                 )?;
                 writeln!(env_file, "ESPRESSO_SEQUENCER_PRIVATE_STATE_KEY={priv_key}")?;
                 tracing::info!(pub_key = %key_pair.ver_key(), "generated state key");
-            }
+            },
         }
         Ok(())
     }

--- a/sequencer/src/bin/nasty-client.rs
+++ b/sequencer/src/bin/nasty-client.rs
@@ -12,6 +12,16 @@
 //! provides a healthcheck endpoint as well as a prometheus endpoint which provides metrics like the
 //! count of various types of actions performed and the number of open streams.
 
+use std::{
+    borrow::Cow,
+    cmp::max,
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use anyhow::{bail, ensure, Context};
 use async_lock::RwLock;
 use clap::Parser;
@@ -41,15 +51,6 @@ use rand::{seq::SliceRandom, RngCore};
 use sequencer::{api::endpoints::NamespaceProofQueryData, SequencerApiVersion};
 use sequencer_utils::logging;
 use serde::de::DeserializeOwned;
-use std::{
-    borrow::Cow,
-    cmp::max,
-    collections::{BTreeMap, HashMap},
-    fmt::Debug,
-    pin::Pin,
-    sync::Arc,
-    time::{Duration, Instant},
-};
 use strum::{EnumDiscriminants, VariantArray};
 use surf_disco::{error::ClientError, socket, Error, StatusCode, Url};
 use tide_disco::{error::ServerError, App};
@@ -520,7 +521,7 @@ impl<T: Queryable> ResourceManager<T> {
                 Ok(res) if i == 0 => {
                     // Succeeded on the first try, get on with it.
                     return Ok(res);
-                }
+                },
                 Ok(res) => {
                     // Succeeded after at least one failure; retry a number of additional times to
                     // be sure the endpoint is healed.
@@ -531,14 +532,14 @@ impl<T: Queryable> ResourceManager<T> {
                         )?;
                     }
                     return Ok(res);
-                }
+                },
                 Err(err) if i < self.cfg.max_retries => {
                     tracing::warn!("failed, will retry: {err:#}");
                     i += 1;
-                }
+                },
                 Err(err) => {
                     return Err(err).context("failed too many times");
-                }
+                },
             }
         }
     }
@@ -674,7 +675,7 @@ impl<T: Queryable> ResourceManager<T> {
                         obj.height()
                     );
                 }
-            }
+            },
             Err(_) if to - from > limit => {
                 tracing::info!(
                     limit,
@@ -682,10 +683,10 @@ impl<T: Queryable> ResourceManager<T> {
                     to,
                     "range query exceeding limit failed as expected"
                 );
-            }
+            },
             Err(err) => {
                 return Err(err).context("error in range query");
-            }
+            },
         }
 
         self.metrics.query_range_actions[&T::RESOURCE].add(1);
@@ -800,7 +801,7 @@ impl<T: Queryable> ResourceManager<T> {
                             );
                         }
                         break obj;
-                    }
+                    },
                     Err(err) if refreshed.elapsed() >= self.cfg.web_socket_timeout => {
                         // Streams are allowed to fail if the connection is too old. Warn about it,
                         // but refresh the connection and try again.
@@ -818,7 +819,7 @@ impl<T: Queryable> ResourceManager<T> {
                             "{} stream refreshed due to connection reset",
                             Self::singular(),
                         );
-                    }
+                    },
                     Err(err) => {
                         // Errors on a relatively fresh connection are not allowed. Close the stream
                         // since it is apparently in a bad state, and return an error.
@@ -830,7 +831,7 @@ impl<T: Queryable> ResourceManager<T> {
                             Self::singular(),
                             refreshed.elapsed()
                         ));
-                    }
+                    },
                 }
             };
 
@@ -944,11 +945,11 @@ impl ResourceManager<Header> {
                 // The block state at height 0 is empty, so to have a valid query just adjust to
                 // querying at height 1. At height 1, the only valid index to query is 0.
                 (1, 0)
-            }
+            },
             block => {
                 // At any other height, all indices between 0 and `block - 1` are valid to query.
                 (block, index % (block - 1))
-            }
+            },
         };
 
         // Get the header of the state snapshot we're going to query and the block commitment we're
@@ -1344,7 +1345,7 @@ impl Client {
                     Resource::Payloads => self.payloads.close_stream(id).await,
                 };
                 Ok(())
-            }
+            },
             Action::PollStream {
                 resource,
                 id,
@@ -1357,16 +1358,16 @@ impl Client {
             },
             Action::QueryWindow { from, duration } => {
                 self.headers.query_window(from, duration).await
-            }
+            },
             Action::QueryNamespace { block, namespace } => {
                 self.blocks.query_namespace(block, namespace).await
-            }
+            },
             Action::QueryBlockState { block, index } => {
                 self.headers.query_block_state(block, index).await
-            }
+            },
             Action::QueryFeeState { block, builder } => {
                 self.headers.query_fee_state(block, builder).await
-            }
+            },
         }
     }
 }

--- a/sequencer/src/bin/pub-key.rs
+++ b/sequencer/src/bin/pub-key.rs
@@ -49,7 +49,7 @@ fn main() {
         (false, PrivateKey::Bls(key)) => println!("{}", PubKey::from_private(&key)),
         (false, PrivateKey::Schnorr(key)) => {
             println!("{}", StateKeyPair::from_sign_key(key).ver_key())
-        }
+        },
 
         // Libp2p
         (true, PrivateKey::Bls(key)) => {
@@ -57,9 +57,9 @@ fn main() {
                 "{}",
                 derive_libp2p_peer_id::<BLSPubKey>(&key).expect("Failed to derive libp2p peer ID")
             );
-        }
+        },
         (true, _) => {
             eprintln!("Key type unsupported for libp2p peer ID derivation");
-        }
+        },
     }
 }

--- a/sequencer/src/bin/reset-storage.rs
+++ b/sequencer/src/bin/reset-storage.rs
@@ -35,11 +35,11 @@ async fn main() -> anyhow::Result<()> {
         Command::Fs(opt) => {
             tracing::warn!("resetting file system storage {opt:?}");
             reset_storage(opt).await
-        }
+        },
         Command::Sql(opt) => {
             tracing::warn!("resetting SQL storage {opt:?}");
             reset_storage(*opt).await
-        }
+        },
     }
 }
 

--- a/sequencer/src/bin/submit-transactions.rs
+++ b/sequencer/src/bin/submit-transactions.rs
@@ -1,5 +1,9 @@
 //! Utility program to submit random transactions to an Espresso Sequencer.
 
+#[cfg(feature = "benchmarking")]
+use std::fs::OpenOptions;
+#[cfg(feature = "benchmarking")]
+use std::num::NonZeroUsize;
 use std::{
     collections::HashMap,
     time::{Duration, Instant},
@@ -7,6 +11,8 @@ use std::{
 
 use clap::Parser;
 use committable::{Commitment, Committable};
+#[cfg(feature = "benchmarking")]
+use csv::Writer;
 use espresso_types::{parse_duration, parse_size, SeqTypes, Transaction};
 use futures::{
     channel::mpsc::{self, Sender},
@@ -23,13 +29,6 @@ use surf_disco::{Client, Url};
 use tide_disco::{error::ServerError, App};
 use tokio::{task::spawn, time::sleep};
 use vbs::version::StaticVersionType;
-
-#[cfg(feature = "benchmarking")]
-use csv::Writer;
-#[cfg(feature = "benchmarking")]
-use std::fs::OpenOptions;
-#[cfg(feature = "benchmarking")]
-use std::num::NonZeroUsize;
 
 /// Submit random transactions to an Espresso Sequencer.
 #[derive(Clone, Debug, Parser)]
@@ -229,7 +228,7 @@ async fn main() {
             Err(err) => {
                 tracing::warn!("error getting block: {err}");
                 continue;
-            }
+            },
         };
         let received_at = Instant::now();
         tracing::debug!("got block {}", block.height());

--- a/sequencer/src/bin/update-permissioned-stake-table.rs
+++ b/sequencer/src/bin/update-permissioned-stake-table.rs
@@ -1,3 +1,5 @@
+use std::{path::PathBuf, time::Duration};
+
 use anyhow::Result;
 use clap::Parser;
 use espresso_types::parse_duration;
@@ -6,7 +8,6 @@ use sequencer_utils::{
     logging,
     stake_table::{update_stake_table, PermissionedStakeTableUpdate},
 };
-use std::{path::PathBuf, time::Duration};
 use url::Url;
 
 #[derive(Debug, Clone, Parser)]

--- a/sequencer/src/bin/utils/keygen.rs
+++ b/sequencer/src/bin/utils/keygen.rs
@@ -32,7 +32,7 @@ impl Scheme {
             Self::All => {
                 Self::Bls.gen(seed, index, env_file)?;
                 Self::Schnorr.gen(seed, index, env_file)?;
-            }
+            },
             Self::Bls => {
                 let (pub_key, priv_key) = BLSPubKey::generated_from_seed_indexed(seed, index);
                 let priv_key = priv_key.to_tagged_base64()?;
@@ -42,7 +42,7 @@ impl Scheme {
                     "ESPRESSO_SEQUENCER_PRIVATE_STAKING_KEY={priv_key}"
                 )?;
                 tracing::info!(%pub_key, "generated staking key")
-            }
+            },
             Self::Schnorr => {
                 let key_pair = StateKeyPair::generate_from_seed_indexed(seed, index);
                 let priv_key = key_pair.sign_key_ref().to_tagged_base64()?;
@@ -53,7 +53,7 @@ impl Scheme {
                 )?;
                 writeln!(env_file, "ESPRESSO_SEQUENCER_PRIVATE_STATE_KEY={priv_key}")?;
                 tracing::info!(pub_key = %key_pair.ver_key(), "generated state key");
-            }
+            },
         }
         Ok(())
     }

--- a/sequencer/src/bin/utils/main.rs
+++ b/sequencer/src/bin/utils/main.rs
@@ -1,7 +1,6 @@
 //! sequencer utility programs
 
 use clap::{Parser, Subcommand};
-
 use sequencer_utils::logging;
 mod keygen;
 mod pubkey;
@@ -34,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Pubkey(opt) => {
             pubkey::run(opt);
             Ok(())
-        }
+        },
         Command::ResetStorage(opt) => reset_storage::run(opt).await,
     }
 }

--- a/sequencer/src/bin/utils/pubkey.rs
+++ b/sequencer/src/bin/utils/pubkey.rs
@@ -3,10 +3,11 @@ use std::str::FromStr;
 use anyhow::bail;
 use clap::Parser;
 use espresso_types::{PrivKey, PubKey};
-use hotshot::traits::implementations::derive_libp2p_peer_id;
-use hotshot::types::SignatureKey;
-use hotshot_types::light_client::StateSignKey;
-use hotshot_types::{light_client::StateKeyPair, signature_key::BLSPubKey};
+use hotshot::{traits::implementations::derive_libp2p_peer_id, types::SignatureKey};
+use hotshot_types::{
+    light_client::{StateKeyPair, StateSignKey},
+    signature_key::BLSPubKey,
+};
 use tagged_base64::TaggedBase64;
 
 #[derive(Clone, Debug)]
@@ -47,7 +48,7 @@ pub fn run(opt: Options) {
         (false, PrivateKey::Bls(key)) => println!("{}", PubKey::from_private(&key)),
         (false, PrivateKey::Schnorr(key)) => {
             println!("{}", StateKeyPair::from_sign_key(key).ver_key())
-        }
+        },
 
         // Libp2p
         (true, PrivateKey::Bls(key)) => {
@@ -55,9 +56,9 @@ pub fn run(opt: Options) {
                 "{}",
                 derive_libp2p_peer_id::<BLSPubKey>(&key).expect("Failed to derive libp2p peer ID")
             );
-        }
+        },
         (true, _) => {
             eprintln!("Key type unsupported for libp2p peer ID derivation");
-        }
+        },
     }
 }

--- a/sequencer/src/bin/utils/reset_storage.rs
+++ b/sequencer/src/bin/utils/reset_storage.rs
@@ -1,9 +1,8 @@
+use clap::Subcommand;
 use sequencer::{
     api::data_source::{DataSourceOptions, SequencerDataSource},
     persistence,
 };
-
-use clap::Subcommand;
 
 /// Options for resetting persistent storage.
 ///
@@ -32,11 +31,11 @@ pub async fn run(opt: Commands) -> anyhow::Result<()> {
             SequencerStorage::Fs(opt) => {
                 tracing::warn!("resetting sequencer file system storage {opt:?}");
                 reset_storage(opt).await
-            }
+            },
             SequencerStorage::Sql(opt) => {
                 tracing::warn!("resetting sequencer SQL storage {opt:?}");
                 reset_storage(*opt).await
-            }
+            },
         },
 
         Commands::Solver(opt) => {
@@ -45,7 +44,7 @@ pub async fn run(opt: Commands) -> anyhow::Result<()> {
             opts.connect().await?;
 
             Ok(())
-        }
+        },
     }
 }
 

--- a/sequencer/src/bin/verify-headers.rs
+++ b/sequencer/src/bin/verify-headers.rs
@@ -1,6 +1,6 @@
 //! Utility program to verify properties of headers sequenced by HotShot.
 
-use std::{cmp::max, process::exit, time::Duration};
+use std::{cmp::max, process::exit, sync::Arc, time::Duration};
 
 use clap::Parser;
 use espresso_types::{Header, L1BlockInfo};
@@ -9,7 +9,6 @@ use futures::future::join_all;
 use itertools::Itertools;
 use sequencer::SequencerApiVersion;
 use sequencer_utils::logging;
-use std::sync::Arc;
 use surf_disco::Url;
 use tokio::time::sleep;
 use vbs::version::StaticVersionType;
@@ -134,7 +133,7 @@ async fn get_header<ApiVer: StaticVersionType>(
 
                 // Back off a bit and then retry.
                 sleep(Duration::from_millis(100)).await;
-            }
+            },
         }
     }
 }
@@ -147,12 +146,12 @@ async fn get_l1_block(l1: &Provider<Http>, height: u64) -> L1BlockInfo {
                 tracing::warn!("L1 block {height} not yet available");
                 sleep(Duration::from_secs(1)).await;
                 continue;
-            }
+            },
             Err(err) => {
                 tracing::warn!("error fetching L1 block {height}: {err}");
                 sleep(Duration::from_millis(100)).await;
                 continue;
-            }
+            },
         };
 
         let Some(hash) = block.hash else {

--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -1,15 +1,13 @@
-use std::sync::Arc;
+use std::{cmp::Ordering, collections::HashMap, fmt::Display, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Context};
 use async_lock::RwLock;
 use async_trait::async_trait;
-use committable::Commitment;
-use committable::Committable;
-use espresso_types::config::PublicNetworkConfig;
-use espresso_types::traits::SequencerPersistence;
+use committable::{Commitment, Committable};
 use espresso_types::{
-    v0::traits::StateCatchup, v0_99::ChainConfig, BackoffParams, BlockMerkleTree, FeeAccount,
-    FeeAccountProof, FeeMerkleCommitment, FeeMerkleTree, Leaf2, NodeState,
+    config::PublicNetworkConfig, traits::SequencerPersistence, v0::traits::StateCatchup,
+    v0_99::ChainConfig, BackoffParams, BlockMerkleTree, FeeAccount, FeeAccountProof,
+    FeeMerkleCommitment, FeeMerkleTree, Leaf2, NodeState,
 };
 use futures::future::{Future, FutureExt, TryFuture, TryFutureExt};
 use hotshot_types::{
@@ -25,15 +23,13 @@ use itertools::Itertools;
 use jf_merkle_tree::{prelude::MerkleNode, ForgetableMerkleTreeScheme, MerkleTreeScheme};
 use priority_queue::PriorityQueue;
 use serde::de::DeserializeOwned;
-use std::{cmp::Ordering, collections::HashMap, fmt::Display, time::Duration};
 use surf_disco::Request;
 use tide_disco::error::ServerError;
 use tokio::time::timeout;
 use url::Url;
 use vbs::version::StaticVersionType;
 
-use crate::api::BlocksFrontier;
-use crate::PubKey;
+use crate::{api::BlocksFrontier, PubKey};
 
 // This newtype is probably not worth having. It's only used to be able to log
 // URLs before doing requests.
@@ -75,7 +71,7 @@ pub(crate) async fn local_and_remote(
         Err(err) => {
             tracing::warn!("not using local catchup: {err:#}");
             Arc::new(remote)
-        }
+        },
     }
 }
 
@@ -164,15 +160,15 @@ impl<ApiVer: StaticVersionType> StatePeers<ApiVer> {
                     requests.insert(id, true);
                     res = Ok(t);
                     break;
-                }
+                },
                 Ok(Err(err)) => {
                     tracing::warn!(id, ?score, peer = %client.url, "error from peer: {err:#}");
                     requests.insert(id, false);
-                }
+                },
                 Err(_) => {
                     tracing::warn!(id, ?score, peer = %client.url, ?timeout_dur, "request timed out");
                     requests.insert(id, false);
-                }
+                },
             }
         }
 

--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -1,3 +1,9 @@
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+    time::Duration,
+};
+
 use anyhow::Context;
 use async_lock::RwLock;
 use derivative::Derivative;
@@ -29,8 +35,6 @@ use hotshot_types::{
 };
 use parking_lot::Mutex;
 use request_response::{network::Bytes, RequestResponse, RequestResponseConfig};
-use std::{fmt::Debug, time::Duration};
-use std::{fmt::Display, sync::Arc};
 use tokio::{
     spawn,
     sync::mpsc::{channel, Receiver},

--- a/sequencer/src/external_event_handler.rs
+++ b/sequencer/src/external_event_handler.rs
@@ -1,6 +1,7 @@
 //! Should probably rename this to "external" or something
 
-use crate::context::TaskList;
+use std::{marker::PhantomData, sync::Arc};
+
 use anyhow::{Context, Result};
 use espresso_types::{PubKey, SeqTypes};
 use hotshot::types::Message;
@@ -13,8 +14,9 @@ use hotshot_types::{
 };
 use request_response::network::Bytes;
 use serde::{Deserialize, Serialize};
-use std::{marker::PhantomData, sync::Arc};
 use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::context::TaskList;
 
 /// An external message that can be sent to or received from a node
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -83,7 +85,7 @@ impl<V: Versions> ExternalEventHandler<V> {
                 self.request_response_sender
                     .send(request_response.into())
                     .await?;
-            }
+            },
         }
         Ok(())
     }
@@ -111,14 +113,14 @@ impl<V: Versions> ExternalEventHandler<V> {
                         Err(err) => {
                             tracing::warn!("Failed to serialize direct message: {}", err);
                             continue;
-                        }
+                        },
                     };
 
                     // Send the message to the recipient
                     if let Err(err) = network.direct_message(message_bytes, recipient).await {
                         tracing::error!("Failed to send message: {:?}", err);
                     };
-                }
+                },
 
                 OutboundMessage::Broadcast(message) => {
                     // Wrap it in the real message type
@@ -133,7 +135,7 @@ impl<V: Versions> ExternalEventHandler<V> {
                         Err(err) => {
                             tracing::warn!("Failed to serialize broadcast message: {}", err);
                             continue;
-                        }
+                        },
                     };
 
                     // Broadcast the message to the global topic
@@ -143,7 +145,7 @@ impl<V: Versions> ExternalEventHandler<V> {
                     {
                         tracing::error!("Failed to broadcast message: {:?}", err);
                     };
-                }
+                },
             }
         }
     }

--- a/sequencer/src/genesis.rs
+++ b/sequencer/src/genesis.rs
@@ -132,9 +132,8 @@ impl Genesis {
 
 mod version_ser {
 
-    use vbs::version::Version;
-
     use serde::{de, Deserialize, Deserializer, Serializer};
+    use vbs::version::Version;
 
     pub fn serialize<S>(ver: &Version, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -254,12 +253,12 @@ mod upgrade_ser {
                             return Err(de::Error::custom(
                                 "both view and time mode parameters are set",
                             ))
-                        }
+                        },
                         (None, None) => {
                             return Err(de::Error::custom(
                                 "no view or time mode parameters provided",
                             ))
-                        }
+                        },
                         (None, Some(v)) => {
                             if v.start_proposing_view > v.stop_proposing_view {
                                 return Err(de::Error::custom(
@@ -274,7 +273,7 @@ mod upgrade_ser {
                                     upgrade_type: fields.upgrade_type,
                                 },
                             );
-                        }
+                        },
                         (Some(t), None) => {
                             if t.start_proposing_time.unix_timestamp()
                                 > t.stop_proposing_time.unix_timestamp()
@@ -291,7 +290,7 @@ mod upgrade_ser {
                                     upgrade_type: fields.upgrade_type.clone(),
                                 },
                             );
-                        }
+                        },
                     }
                 }
 
@@ -321,25 +320,25 @@ impl Genesis {
 
 #[cfg(test)]
 mod test {
-    use ethers::middleware::Middleware;
-    use ethers::prelude::*;
-    use ethers::signers::Signer;
-    use ethers::utils::{Anvil, AnvilInstance};
-    use sequencer_utils::deployer::test_helpers::{
-        deploy_fee_contract, deploy_fee_contract_as_proxy,
-    };
     use std::sync::Arc;
 
     use anyhow::Result;
-
     use contract_bindings_ethers::fee_contract::FeeContract;
     use espresso_types::{
         L1BlockInfo, TimeBasedUpgrade, Timestamp, UpgradeMode, UpgradeType, ViewBasedUpgrade,
     };
-
-    use sequencer_utils::deployer;
-    use sequencer_utils::ser::FromStringOrInteger;
-    use sequencer_utils::test_utils::setup_test;
+    use ethers::{
+        middleware::Middleware,
+        prelude::*,
+        signers::Signer,
+        utils::{Anvil, AnvilInstance},
+    };
+    use sequencer_utils::{
+        deployer,
+        deployer::test_helpers::{deploy_fee_contract, deploy_fee_contract_as_proxy},
+        ser::FromStringOrInteger,
+        test_utils::setup_test,
+    };
     use toml::toml;
 
     use super::*;

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -13,45 +13,44 @@ mod restart_tests;
 
 mod message_compat_tests;
 
+use std::sync::Arc;
+
 use anyhow::Context;
 use catchup::StatePeers;
 use context::SequencerContext;
-use espresso_types::EpochCommittees;
 use espresso_types::{
-    traits::EventConsumer, BackoffParams, L1ClientOptions, NodeState, PubKey, SeqTypes,
-    SolverAuctionResultsProvider, ValidatedState,
+    traits::EventConsumer, BackoffParams, EpochCommittees, L1ClientOptions, NodeState, PubKey,
+    SeqTypes, SolverAuctionResultsProvider, ValidatedState,
 };
 use ethers_conv::ToAlloy;
 use genesis::L1Finalized;
-use proposal_fetcher::ProposalFetcherConfig;
-use std::sync::Arc;
-use tokio::select;
 // Should move `STAKE_TABLE_CAPACITY` in the sequencer repo when we have variate stake table support
 use hotshot_libp2p_networking::network::behaviours::dht::store::persistent::DhtNoPersistence;
 use libp2p::Multiaddr;
 use network::libp2p::split_off_peer_id;
 use options::Identity;
+use proposal_fetcher::ProposalFetcherConfig;
 use state_signature::static_stake_table_commitment;
+use tokio::select;
 use tracing::info;
 use url::Url;
 pub mod persistence;
 pub mod state;
+use std::{fmt::Debug, marker::PhantomData, time::Duration};
+
 use derivative::Derivative;
 use espresso_types::v0::traits::SequencerPersistence;
 pub use genesis::Genesis;
-use hotshot::traits::implementations::{
-    derive_libp2p_multiaddr, CombinedNetworks, GossipConfig, Libp2pNetwork, RequestResponseConfig,
-};
 use hotshot::{
     traits::implementations::{
-        derive_libp2p_peer_id, CdnMetricsValue, CdnTopic, KeyPair, MemoryNetwork, PushCdnNetwork,
-        WrappedSignatureKey,
+        derive_libp2p_multiaddr, derive_libp2p_peer_id, CdnMetricsValue, CdnTopic,
+        CombinedNetworks, GossipConfig, KeyPair, Libp2pNetwork, MemoryNetwork, PushCdnNetwork,
+        RequestResponseConfig, WrappedSignatureKey,
     },
     types::SignatureKey,
     MarketplaceConfig,
 };
-use hotshot_orchestrator::client::get_complete_config;
-use hotshot_orchestrator::client::OrchestratorClient;
+use hotshot_orchestrator::client::{get_complete_config, OrchestratorClient};
 use hotshot_types::{
     data::ViewNumber,
     light_client::{StateKeyPair, StateSignKey},
@@ -66,8 +65,6 @@ use hotshot_types::{
 };
 pub use options::Options;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
-use std::{fmt::Debug, marker::PhantomData};
 use vbs::version::{StaticVersion, StaticVersionType};
 pub mod network;
 
@@ -312,7 +309,7 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
         (Some(config), _) => {
             tracing::info!("loaded network config from storage, rejoining existing network");
             (config, false)
-        }
+        },
         // If we were told to fetch the config from an already-started peer, do so.
         (None, Some(peers)) => {
             tracing::info!(?peers, "loading network config from peers");
@@ -330,7 +327,7 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
             );
             persistence.save_config(&config).await?;
             (config, false)
-        }
+        },
         // Otherwise, this is a fresh network; load from the orchestrator.
         (None, None) => {
             tracing::info!("loading network config from orchestrator");
@@ -356,7 +353,7 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
             persistence.save_config(&config).await?;
             tracing::error!("all nodes connected");
             (config, true)
-        }
+        },
     };
 
     if let Some(upgrade) = genesis.upgrades.get(&V::Upgrade::VERSION) {
@@ -451,7 +448,7 @@ pub async fn init_node<P: SequencerPersistence, V: Versions>(
                     ethers::types::U256::from(timestamp.unix_timestamp()).to_alloy(),
                 )
                 .await
-        }
+        },
     };
 
     let mut genesis_state = ValidatedState {
@@ -590,20 +587,22 @@ pub mod testing {
     use hotshot_testing::block_builder::{
         BuilderTask, SimpleBuilderImplementation, TestBuilderImplementation,
     };
-    use hotshot_types::traits::network::Topic;
-    use hotshot_types::traits::signature_key::StakeTableEntryType;
     use hotshot_types::{
         event::LeafInfo,
         light_client::{CircuitField, StateKeyPair, StateVerKey},
-        traits::signature_key::BuilderSignatureKey,
-        traits::{block_contents::BlockHeader, metrics::NoMetrics, stake_table::StakeTableScheme},
+        traits::{
+            block_contents::BlockHeader,
+            metrics::NoMetrics,
+            network::Topic,
+            signature_key::{BuilderSignatureKey, StakeTableEntryType},
+            stake_table::StakeTableScheme,
+        },
         HotShotConfig, PeerConfig,
     };
     use marketplace_builder_core::{
         hooks::NoHooks,
         service::{BuilderConfig, GlobalState},
     };
-
     use portpicker::pick_unused_port;
     use tokio::spawn;
     use vbs::version::Version;

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::needless_lifetimes)]
 
 use core::fmt::Display;
-use jf_signature::{bls_over_bn254, schnorr};
-use sequencer_utils::logging;
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
@@ -11,14 +9,16 @@ use std::{
     path::PathBuf,
     time::Duration,
 };
-use tagged_base64::TaggedBase64;
 
 use anyhow::{bail, Context};
 use clap::{error::ErrorKind, Args, FromArgMatches, Parser};
 use derivative::Derivative;
 use espresso_types::{parse_duration, BackoffParams, L1ClientOptions};
 use hotshot_types::{light_client::StateSignKey, signature_key::BLSPrivKey};
+use jf_signature::{bls_over_bn254, schnorr};
 use libp2p::Multiaddr;
+use sequencer_utils::logging;
+use tagged_base64::TaggedBase64;
 use url::Url;
 
 use crate::{api, persistence, proposal_fetcher::ProposalFetcherConfig};
@@ -472,10 +472,10 @@ fn fmt_opt_urls(
             write!(fmt, "Some(")?;
             fmt_urls(urls, fmt)?;
             write!(fmt, ")")?;
-        }
+        },
         None => {
             write!(fmt, "None")?;
-        }
+        },
     }
     Ok(())
 }
@@ -536,13 +536,13 @@ impl ModuleArgs {
             match module {
                 SequencerModule::Storage(m) => {
                     curr = m.add(&mut modules.storage_fs, &mut provided)?
-                }
+                },
                 SequencerModule::StorageFs(m) => {
                     curr = m.add(&mut modules.storage_fs, &mut provided)?
-                }
+                },
                 SequencerModule::StorageSql(m) => {
                     curr = m.add(&mut modules.storage_sql, &mut provided)?
-                }
+                },
                 SequencerModule::Http(m) => curr = m.add(&mut modules.http, &mut provided)?,
                 SequencerModule::Query(m) => curr = m.add(&mut modules.query, &mut provided)?,
                 SequencerModule::Submit(m) => curr = m.add(&mut modules.submit, &mut provided)?,
@@ -551,10 +551,10 @@ impl ModuleArgs {
                 SequencerModule::Config(m) => curr = m.add(&mut modules.config, &mut provided)?,
                 SequencerModule::HotshotEvents(m) => {
                     curr = m.add(&mut modules.hotshot_events, &mut provided)?
-                }
+                },
                 SequencerModule::Explorer(m) => {
                     curr = m.add(&mut modules.explorer, &mut provided)?
-                }
+                },
             }
         }
 

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1,8 +1,18 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs::{self, File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    ops::RangeInclusive,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use anyhow::{anyhow, Context};
 use async_lock::RwLock;
 use async_trait::async_trait;
 use clap::Parser;
 use espresso_types::{
+    upgrade_commitment_map,
     v0::traits::{EventConsumer, PersistenceOptions, SequencerPersistence},
     Leaf, Leaf2, NetworkConfig, Payload, SeqTypes,
 };
@@ -27,18 +37,8 @@ use hotshot_types::{
     utils::View,
     vote::HasViewNumber,
 };
-use std::sync::Arc;
-use std::{
-    collections::{BTreeMap, HashSet},
-    fs::{self, File, OpenOptions},
-    io::{Read, Seek, SeekFrom, Write},
-    ops::RangeInclusive,
-    path::{Path, PathBuf},
-};
 
 use crate::ViewNumber;
-
-use espresso_types::upgrade_commitment_map;
 
 /// Options for file system backed persistence.
 #[derive(Parser, Clone, Debug)]
@@ -606,7 +606,7 @@ impl SequencerPersistence for Persistence {
                 // managed to persist the decided leaves successfully, and the event processing will
                 // just run again at the next decide.
                 tracing::warn!(?view, "event processing failed: {err:#}");
-            }
+            },
             Ok(intervals) => {
                 if let Err(err) = inner.collect_garbage(view, &intervals) {
                     // Similarly, garbage collection is not an error. We have done everything we
@@ -614,7 +614,7 @@ impl SequencerPersistence for Persistence {
                     // error but do not return it.
                     tracing::warn!(?view, "GC failed: {err:#}");
                 }
-            }
+            },
         }
 
         Ok(())
@@ -846,7 +846,7 @@ impl SequencerPersistence for Persistence {
                         // some unintended file whose name happened to match the naming convention.
                         tracing::warn!(?view, "ignoring malformed quorum proposal file: {err:#}");
                         continue;
-                    }
+                    },
                 };
             let proposal2 = convert_proposal(proposal);
 
@@ -1508,32 +1508,27 @@ mod generic_tests {
 
 #[cfg(test)]
 mod test {
-    use espresso_types::{NodeState, PubKey};
+    use std::marker::PhantomData;
+
+    use committable::{Commitment, CommitmentBoundsArkless, Committable};
+    use espresso_types::{Header, Leaf, NodeState, PubKey, ValidatedState};
     use hotshot::types::SignatureKey;
     use hotshot_example_types::node_types::TestVersions;
     use hotshot_query_service::testing::mocks::MockVersions;
-    use hotshot_types::data::{vid_commitment, QuorumProposal2};
-    use hotshot_types::traits::node_implementation::Versions;
-
-    use hotshot_types::vid::advz::advz_scheme;
-    use sequencer_utils::test_utils::setup_test;
-    use vbs::version::StaticVersionType;
-
-    use serde_json::json;
-    use std::marker::PhantomData;
-
-    use super::*;
-    use crate::persistence::testing::TestablePersistence;
-
-    use crate::BLSPubKey;
-    use committable::Committable;
-    use committable::{Commitment, CommitmentBoundsArkless};
-    use espresso_types::{Header, Leaf, ValidatedState};
-
     use hotshot_types::{
-        simple_certificate::QuorumCertificate, simple_vote::QuorumData, traits::EncodeBytes,
+        data::{vid_commitment, QuorumProposal2},
+        simple_certificate::QuorumCertificate,
+        simple_vote::QuorumData,
+        traits::{node_implementation::Versions, EncodeBytes},
+        vid::advz::advz_scheme,
     };
     use jf_vid::VidScheme;
+    use sequencer_utils::test_utils::setup_test;
+    use serde_json::json;
+    use vbs::version::StaticVersionType;
+
+    use super::*;
+    use crate::{persistence::testing::TestablePersistence, BLSPubKey};
 
     #[test]
     fn test_config_migrations_add_builder_urls() {

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -1,6 +1,8 @@
 //! Mock implementation of persistence, for testing.
 #![cfg(any(test, feature = "testing"))]
 
+use std::{collections::BTreeMap, sync::Arc};
+
 use anyhow::bail;
 use async_trait::async_trait;
 use espresso_types::{
@@ -21,8 +23,6 @@ use hotshot_types::{
     simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2, UpgradeCertificate},
     utils::View,
 };
-use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use crate::{NodeType, SeqTypes, ViewNumber};
 

--- a/sequencer/src/proposal_fetcher.rs
+++ b/sequencer/src/proposal_fetcher.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
 use async_channel::{Receiver, Sender};
@@ -19,7 +19,6 @@ use hotshot_types::{
     },
     utils::{View, ViewInner},
 };
-use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::Instrument;
 
@@ -184,10 +183,10 @@ where
                     let leaf = proposal.data.justify_qc().data.leaf_commit;
                     self.request((view, leaf)).await;
                     return Ok(());
-                }
+                },
                 Err(err) => {
                     tracing::info!("proposal missing from storage; fetching from network: {err:#}");
-                }
+                },
             }
 
             let future = self.consensus.read().await.request_proposal(view, leaf)?;

--- a/sequencer/src/request_response/data_source.rs
+++ b/sequencer/src/request_response/data_source.rs
@@ -2,10 +2,11 @@
 //! to calculate/derive a response for a specific request. In the confirmation layer the implementer
 //! would be something like a [`FeeMerkleTree`] for fee catchup
 
-use super::request::{Request, Response};
 use anyhow::Result;
 use async_trait::async_trait;
 use request_response::data_source::DataSource as DataSourceTrait;
+
+use super::request::{Request, Response};
 
 #[derive(Clone, Debug)]
 pub struct DataSource {}

--- a/sequencer/src/request_response/network.rs
+++ b/sequencer/src/request_response/network.rs
@@ -1,13 +1,11 @@
-use crate::external_event_handler::ExternalMessage;
-use crate::external_event_handler::OutboundMessage;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use espresso_types::PubKey;
-use espresso_types::SeqTypes;
+use espresso_types::{PubKey, SeqTypes};
 use hotshot_types::message::MessageKind;
-use request_response::network::Bytes;
-use request_response::network::Sender as SenderTrait;
+use request_response::network::{Bytes, Sender as SenderTrait};
 use tokio::sync::mpsc;
+
+use crate::external_event_handler::{ExternalMessage, OutboundMessage};
 
 /// A wrapper type that we will implement the `Sender` trait for
 #[derive(Clone)]

--- a/sequencer/src/request_response/recipient_source.rs
+++ b/sequencer/src/request_response/recipient_source.rs
@@ -38,7 +38,7 @@ impl RecipientSourceTrait<Request, PubKey> for RecipientSource {
                     .iter()
                     .map(|entry| entry.stake_table_entry.stake_key)
                     .collect()
-            }
+            },
         }
     }
 }

--- a/sequencer/src/restart_tests.rs
+++ b/sequencer/src/restart_tests.rs
@@ -1,13 +1,7 @@
 #![cfg(test)]
 
-use super::*;
-use crate::{
-    api::{self, data_source::testing::TestableSequencerDataSource, options::Query},
-    genesis::{L1Finalized, StakeTableConfig},
-    network::cdn::{TestingDef, WrappedSignatureKey},
-    testing::wait_for_decide_on_handle,
-    SequencerApiVersion,
-};
+use std::{collections::HashSet, path::Path, time::Duration};
+
 use anyhow::bail;
 use cdn_broker::{
     reexports::{crypto::signature::KeyPair, def::hook::NoMessageHook},
@@ -31,10 +25,10 @@ use hotshot_testing::{
     block_builder::{SimpleBuilderImplementation, TestBuilderImplementation},
     test_builder::BuilderChange,
 };
-use hotshot_types::network::{Libp2pConfig, NetworkConfig};
 use hotshot_types::{
     event::{Event, EventType},
     light_client::StateKeyPair,
+    network::{Libp2pConfig, NetworkConfig},
     traits::{node_implementation::ConsensusTime, signature_key::SignatureKey},
 };
 use itertools::Itertools;
@@ -42,16 +36,23 @@ use options::Modules;
 use portpicker::pick_unused_port;
 use run::init_with_storage;
 use sequencer_utils::test_utils::setup_test;
-use std::{collections::HashSet, path::Path, time::Duration};
 use surf_disco::{error::ClientError, Url};
 use tempfile::TempDir;
-use tokio::time::timeout;
 use tokio::{
     task::{spawn, JoinHandle},
-    time::sleep,
+    time::{sleep, timeout},
 };
 use vbs::version::Version;
 use vec1::vec1;
+
+use super::*;
+use crate::{
+    api::{self, data_source::testing::TestableSequencerDataSource, options::Query},
+    genesis::{L1Finalized, StakeTableConfig},
+    network::cdn::{TestingDef, WrappedSignatureKey},
+    testing::wait_for_decide_on_handle,
+    SequencerApiVersion,
+};
 
 async fn test_restart_helper(network: (usize, usize), restart: (usize, usize), cdn: bool) {
     setup_test();
@@ -358,7 +359,7 @@ impl<S: TestableSequencerDataSource> TestNode<S> {
                         sleep(delay).await;
                         delay *= 2;
                         retries -= 1;
-                    }
+                    },
                 }
             };
 

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -1,12 +1,5 @@
 use std::sync::Arc;
 
-use super::{
-    api::{self, data_source::DataSourceOptions},
-    context::SequencerContext,
-    init_node, network,
-    options::{Modules, Options},
-    persistence, Genesis, L1Params, NetworkParams,
-};
 use clap::Parser;
 #[allow(unused_imports)]
 use espresso_types::{
@@ -17,6 +10,14 @@ use futures::future::FutureExt;
 use hotshot::MarketplaceConfig;
 use hotshot_types::traits::{metrics::NoMetrics, node_implementation::Versions};
 use vbs::version::StaticVersionType;
+
+use super::{
+    api::{self, data_source::DataSourceOptions},
+    context::SequencerContext,
+    init_node, network,
+    options::{Modules, Options},
+    persistence, Genesis, L1Params, NetworkParams,
+};
 
 pub async fn main() -> anyhow::Result<()> {
     let opt = Options::parse();
@@ -48,7 +49,7 @@ pub async fn main() -> anyhow::Result<()> {
                 SequencerVersions::<FeeVersion, MarketplaceVersion>::new(),
             )
             .await
-        }
+        },
         #[cfg(feature = "fee")]
         (FeeVersion::VERSION, _) => {
             run(
@@ -58,7 +59,7 @@ pub async fn main() -> anyhow::Result<()> {
                 SequencerVersions::<FeeVersion, V0_0>::new(),
             )
             .await
-        }
+        },
         #[cfg(feature = "marketplace")]
         (MarketplaceVersion::VERSION, _) => {
             run(
@@ -68,7 +69,7 @@ pub async fn main() -> anyhow::Result<()> {
                 SequencerVersions::<MarketplaceVersion, V0_0>::new(),
             )
             .await
-        }
+        },
         _ => panic!(
             "Invalid base ({base}) and upgrade ({upgrade}) versions specified in the toml file."
         ),
@@ -237,7 +238,7 @@ where
                     .boxed()
                 })
                 .await?
-        }
+        },
         None => {
             init_node(
                 genesis,
@@ -253,7 +254,7 @@ where
                 proposal_fetcher_config,
             )
             .await?
-        }
+        },
     };
 
     Ok(ctx)
@@ -263,23 +264,22 @@ where
 mod test {
     use std::time::Duration;
 
-    use tokio::spawn;
-
-    use crate::{
-        api::options::Http,
-        genesis::{L1Finalized, StakeTableConfig},
-        persistence::fs,
-        SequencerApiVersion,
-    };
     use espresso_types::{MockSequencerVersions, PubKey};
     use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey};
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
     use surf_disco::{error::ClientError, Client, Url};
     use tempfile::TempDir;
+    use tokio::spawn;
     use vbs::version::Version;
 
     use super::*;
+    use crate::{
+        api::options::Http,
+        genesis::{L1Finalized, StakeTableConfig},
+        persistence::fs,
+        SequencerApiVersion,
+    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_startup_before_orchestrator() {

--- a/sequencer/src/state.rs
+++ b/sequencer/src/state.rs
@@ -6,8 +6,7 @@ use espresso_types::{
     traits::StateCatchup, v0_99::ChainConfig, BlockMerkleTree, Delta, FeeAccount, FeeMerkleTree,
     Leaf2, ValidatedState,
 };
-use futures::future::Future;
-use futures::StreamExt;
+use futures::{future::Future, StreamExt};
 use hotshot::traits::ValidatedState as HotShotState;
 use hotshot_query_service::{
     availability::{AvailabilityDataSource, LeafQueryData},
@@ -300,12 +299,12 @@ where
                     parent_leaf = leaf;
                     parent_state = state;
                     break;
-                }
+                },
                 Err(err) => {
                     tracing::error!(height = leaf.height(), "failed to updated state: {err:#}");
                     // If we fail, delay for a second and retry.
                     sleep(Duration::from_secs(1)).await;
-                }
+                },
             }
         }
     }

--- a/sequencer/src/state_signature.rs
+++ b/sequencer/src/state_signature.rs
@@ -97,10 +97,10 @@ impl<ApiVer: StaticVersionType> StateSigner<ApiVer> {
                         tracing::warn!("Error posting signature to the relay server: {:?}", error);
                     }
                 }
-            }
+            },
             Err(err) => {
                 tracing::error!("Error generating light client state: {:?}", err)
-            }
+            },
         }
     }
 

--- a/sequencer/src/state_signature/relay_server.rs
+++ b/sequencer/src/state_signature/relay_server.rs
@@ -149,11 +149,11 @@ impl StateRelayServerDataSource for StateRelayServerState {
                     StatusCode::BAD_REQUEST,
                     "A signature of this light client state is already posted at this block height for this key.".to_owned(),
                 ));
-            }
+            },
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(signature);
                 bundle.accumulated_weight += *weight;
-            }
+            },
         }
 
         if bundle.accumulated_weight >= self.threshold {
@@ -204,7 +204,7 @@ where
                 reason: err.to_string(),
             })?;
             Api::<State, Error, ApiVer>::new(toml)?
-        }
+        },
     };
 
     api.get("getlateststate", |_req, state| {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,10 @@
+use std::{fmt, str::FromStr, time::Duration};
+
 use anyhow::{anyhow, Result};
 use client::SequencerClient;
 use espresso_types::{FeeAmount, FeeVersion, MarketplaceVersion};
 use ethers::prelude::*;
 use futures::future::join_all;
-use std::{fmt, str::FromStr, time::Duration};
 use surf_disco::Url;
 use tokio::time::{sleep, timeout};
 use vbs::version::StaticVersionType;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,9 @@
-use crate::common::TestConfig;
+use std::time::Instant;
+
 use anyhow::Result;
 use futures::StreamExt;
-use std::time::Instant;
+
+use crate::common::TestConfig;
 
 /// We allow for no change in state across this many consecutive iterations.
 const MAX_STATE_NOT_INCREMENTING: u8 = 1;

--- a/tests/upgrades.rs
+++ b/tests/upgrades.rs
@@ -1,8 +1,9 @@
-use crate::common::TestConfig;
 use anyhow::Result;
 use espresso_types::{FeeVersion, MarketplaceVersion};
 use futures::{future::join_all, StreamExt};
 use vbs::version::StaticVersionType;
+
+use crate::common::TestConfig;
 
 const SEQUENCER_BLOCKS_TIMEOUT: u64 = 200;
 

--- a/types/src/eth_signature_key.rs
+++ b/types/src/eth_signature_key.rs
@@ -12,8 +12,7 @@ use ethers::{
     types::{Address, Signature},
     utils::public_key_to_address,
 };
-use hotshot_types::traits::signature_key::BuilderSignatureKey;
-use hotshot_types::traits::signature_key::PrivateSignatureKey;
+use hotshot_types::traits::signature_key::{BuilderSignatureKey, PrivateSignatureKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/types/src/v0/config.rs
+++ b/types/src/v0/config.rs
@@ -1,15 +1,17 @@
 use std::{num::NonZeroUsize, time::Duration};
 
 use anyhow::Context;
+use hotshot_types::{
+    network::{
+        BuilderType, CombinedNetworkConfig, Libp2pConfig, NetworkConfig, RandomBuilderConfig,
+    },
+    HotShotConfig, PeerConfig, ValidatorConfig,
+};
+use serde::{Deserialize, Serialize};
+use tide_disco::Url;
 use vec1::Vec1;
 
 use crate::PubKey;
-use hotshot_types::network::{
-    BuilderType, CombinedNetworkConfig, Libp2pConfig, RandomBuilderConfig,
-};
-use hotshot_types::{network::NetworkConfig, HotShotConfig, PeerConfig, ValidatorConfig};
-use serde::{Deserialize, Serialize};
-use tide_disco::Url;
 
 /// This struct defines the public Hotshot validator configuration.
 /// Private key and state key pairs are excluded for security reasons.

--- a/types/src/v0/impls/auction.rs
+++ b/types/src/v0/impls/auction.rs
@@ -1,9 +1,5 @@
-use super::{state::ValidatedState, MarketplaceVersion};
-use crate::{
-    eth_signature_key::{EthKeyPair, SigningError},
-    v0_99::{BidTx, BidTxBody, FullNetworkTx, SolverAuctionResults},
-    FeeAccount, FeeAmount, FeeError, FeeInfo, NamespaceId,
-};
+use std::str::FromStr;
+
 use anyhow::Context;
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
@@ -15,10 +11,16 @@ use hotshot_types::{
         signature_key::BuilderSignatureKey,
     },
 };
-use std::str::FromStr;
 use thiserror::Error;
 use tide_disco::error::ServerError;
 use url::Url;
+
+use super::{state::ValidatedState, MarketplaceVersion};
+use crate::{
+    eth_signature_key::{EthKeyPair, SigningError},
+    v0_99::{BidTx, BidTxBody, FullNetworkTx, SolverAuctionResults},
+    FeeAccount, FeeAmount, FeeError, FeeInfo, NamespaceId,
+};
 
 impl FullNetworkTx {
     /// Proxy for `execute` method of each transaction variant.

--- a/types/src/v0/impls/block/full_payload/ns_proof.rs
+++ b/types/src/v0/impls/block/full_payload/ns_proof.rs
@@ -109,25 +109,25 @@ impl NsProof {
                         )
                         .ok()? // error: internal to payload_verify()
                         .ok()?; // verification failure
-                    }
-                    (None, true) => {} // 0-length namespace, nothing to verify
+                    },
+                    (None, true) => {}, // 0-length namespace, nothing to verify
                     (None, false) => {
                         tracing::error!(
                             "ns verify: missing proof for nonempty ns payload range {:?}",
                             range
                         );
                         return None;
-                    }
+                    },
                     (Some(_), true) => {
                         tracing::error!("ns verify: unexpected proof for empty ns payload range");
                         return None;
-                    }
+                    },
                 }
 
                 // verification succeeded, return some data
                 let ns_id = ns_table.read_ns_id_unchecked(&self.ns_index);
                 Some((self.ns_payload.export_all_txs(&ns_id), ns_id))
-            }
+            },
             VidCommitment::V1(_) => None,
         }
     }

--- a/types/src/v0/impls/block/full_payload/ns_proof/test.rs
+++ b/types/src/v0/impls/block/full_payload/ns_proof/test.rs
@@ -1,6 +1,5 @@
 use futures::future;
-use hotshot::helpers::initialize_logging;
-use hotshot::traits::BlockPayload;
+use hotshot::{helpers::initialize_logging, traits::BlockPayload};
 use hotshot_types::{
     data::VidCommitment,
     traits::EncodeBytes,

--- a/types/src/v0/impls/block/full_payload/payload.rs
+++ b/types/src/v0/impls/block/full_payload/payload.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use async_trait::async_trait;
 use committable::Committable;
 use hotshot_query_service::availability::QueryablePayload;
-use hotshot_types::data::ViewNumber;
 use hotshot_types::{
+    data::ViewNumber,
     traits::{BlockPayload, EncodeBytes},
     utils::BuilderCommitment,
     vid::advz::{ADVZCommon, ADVZScheme},
@@ -13,12 +13,11 @@ use jf_vid::VidScheme;
 use sha2::Digest;
 use thiserror::Error;
 
-use crate::Transaction;
 use crate::{
     v0::impls::{NodeState, ValidatedState},
     v0_1::ChainConfig,
     Index, Iter, NamespaceId, NsIndex, NsPayload, NsPayloadBuilder, NsPayloadRange, NsTable,
-    NsTableBuilder, Payload, PayloadByteLen, SeqTypes, TxProof,
+    NsTableBuilder, Payload, PayloadByteLen, SeqTypes, Transaction, TxProof,
 };
 
 #[derive(serde::Deserialize, serde::Serialize, Error, Debug, Eq, PartialEq)]
@@ -281,7 +280,7 @@ impl PayloadByteLen {
                     ADVZScheme::get_payload_byte_len(common)
                 );
                 return false;
-            }
+            },
         };
 
         self.0 == expected

--- a/types/src/v0/impls/block/namespace_payload/tx_proof.rs
+++ b/types/src/v0/impls/block/namespace_payload/tx_proof.rs
@@ -199,19 +199,19 @@ impl TxProof {
                     {
                         return Some(false);
                     }
-                }
-                (None, true) => {} // 0-length tx, nothing to verify
+                },
+                (None, true) => {}, // 0-length tx, nothing to verify
                 (None, false) => {
                     tracing::error!(
                         "tx verify: missing proof for nonempty tx payload range {:?}",
                         range
                     );
                     return None;
-                }
+                },
                 (Some(_), true) => {
                     tracing::error!("tx verify: unexpected proof for empty tx payload range");
                     return None;
-                }
+                },
             }
         }
 

--- a/types/src/v0/impls/chain_config.rs
+++ b/types/src/v0/impls/chain_config.rs
@@ -1,11 +1,12 @@
-use crate::{BlockSize, ChainId};
+use std::str::FromStr;
+
 use ethers::types::U256;
 use sequencer_utils::{
     impl_serde_from_string_or_integer, impl_to_fixed_bytes, ser::FromStringOrInteger,
 };
-use std::str::FromStr;
 
 use super::parse_size;
+use crate::{BlockSize, ChainId};
 
 impl_serde_from_string_or_integer!(ChainId);
 impl_to_fixed_bytes!(ChainId, U256);
@@ -74,9 +75,8 @@ impl FromStringOrInteger for BlockSize {
 
 #[cfg(test)]
 mod tests {
-    use crate::v0_99::{ChainConfig, ResolvableChainConfig};
-
     use super::*;
+    use crate::v0_99::{ChainConfig, ResolvableChainConfig};
 
     #[test]
     fn test_chainid_serde_json_as_decimal() {

--- a/types/src/v0/impls/fee_info.rs
+++ b/types/src/v0/impls/fee_info.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use anyhow::{bail, ensure, Context};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
@@ -22,7 +24,6 @@ use num_traits::CheckedSub;
 use sequencer_utils::{
     impl_serde_from_string_or_integer, impl_to_fixed_bytes, ser::FromStringOrInteger,
 };
-use std::str::FromStr;
 use thiserror::Error;
 
 use crate::{
@@ -390,7 +391,7 @@ impl FeeAccountProof {
                     .elem()
                     .context("presence proof is missing account balance")?
                     .0)
-            }
+            },
             FeeMerkleProof::Absence(proof) => {
                 let tree = FeeMerkleTree::from_commitment(comm);
                 ensure!(
@@ -398,7 +399,7 @@ impl FeeAccountProof {
                     "invalid proof"
                 );
                 Ok(0.into())
-            }
+            },
         }
     }
 
@@ -413,11 +414,11 @@ impl FeeAccountProof {
                     proof,
                 )?;
                 Ok(())
-            }
+            },
             FeeMerkleProof::Absence(proof) => {
                 tree.non_membership_remember(FeeAccount(self.account), proof)?;
                 Ok(())
-            }
+            },
         }
     }
 }
@@ -442,14 +443,14 @@ pub fn retain_accounts(
                 // This remember cannot fail, since we just constructed a valid proof, and are
                 // remembering into a tree with the same commitment.
                 snapshot.remember(account, *elem, proof).unwrap();
-            }
+            },
             LookupResult::NotFound(proof) => {
                 // Likewise this cannot fail.
                 snapshot.non_membership_remember(account, proof).unwrap()
-            }
+            },
             LookupResult::NotInMemory => {
                 bail!("missing account {account}");
-            }
+            },
         }
     }
 
@@ -460,9 +461,8 @@ pub fn retain_accounts(
 mod test {
     use ethers::abi::Address;
 
-    use crate::{FeeAccount, FeeAmount, FeeInfo};
-
     use super::IterableFeeInfo;
+    use crate::{FeeAccount, FeeAmount, FeeInfo};
 
     #[test]
     fn test_iterable_fee_info() {

--- a/types/src/v0/impls/header.rs
+++ b/types/src/v0/impls/header.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use anyhow::{ensure, Context};
 use ark_serialize::CanonicalSerialize;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
@@ -19,11 +21,11 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use serde_json::{Map, Value};
-use std::fmt;
 use thiserror::Error;
 use time::OffsetDateTime;
 use vbs::version::{StaticVersionType, Version};
 
+use super::{instance_state::NodeState, state::ValidatedState};
 use crate::{
     v0::{
         header::{EitherOrVersion, VersionedHeader},
@@ -34,8 +36,6 @@ use crate::{
     BlockMerkleCommitment, BuilderSignature, FeeAccount, FeeAmount, FeeInfo, FeeMerkleCommitment,
     Header, L1BlockInfo, L1Snapshot, Leaf2, NamespaceId, NsTable, SeqTypes, UpgradeType,
 };
-
-use super::{instance_state::NodeState, state::ValidatedState};
 
 impl v0_1::Header {
     pub(crate) fn commit(&self) -> Commitment<Header> {
@@ -174,7 +174,7 @@ impl<'de> Deserialize<'de> for Header {
                     )),
                     EitherOrVersion::Version(v) => {
                         Err(serde::de::Error::custom(format!("invalid version {v:?}")))
-                    }
+                    },
                 }
             }
 
@@ -211,7 +211,7 @@ impl<'de> Deserialize<'de> for Header {
                         )),
                         EitherOrVersion::Version(v) => {
                             Err(de::Error::custom(format!("invalid version {v:?}")))
-                        }
+                        },
                         chain_config => Err(de::Error::custom(format!(
                             "expected version, found chain_config {chain_config:?}"
                         ))),
@@ -604,7 +604,7 @@ impl Header {
                     .as_ref()
                     .fetch_chain_config(validated_cf.commit())
                     .await
-            }
+            },
         }
     }
 }
@@ -1176,14 +1176,12 @@ mod test_headers {
     use ethers::{types::Address, utils::Anvil};
     use hotshot_query_service::testing::mocks::MockVersions;
     use hotshot_types::traits::signature_key::BuilderSignatureKey;
-
     use sequencer_utils::test_utils::setup_test;
     use v0_1::{BlockMerkleTree, FeeMerkleTree, L1Client};
     use vbs::{bincode_serializer::BincodeSerializer, version::StaticVersion, BinarySerializer};
 
-    use crate::{eth_signature_key::EthKeyPair, mock::MockStateCatchup, Leaf};
-
     use super::*;
+    use crate::{eth_signature_key::EthKeyPair, mock::MockStateCatchup, Leaf};
 
     #[derive(Debug, Default)]
     #[must_use]

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -1,15 +1,15 @@
-use crate::v0::{
-    traits::StateCatchup, v0_99::ChainConfig, GenesisHeader, L1BlockInfo, L1Client, PubKey,
-    Timestamp, Upgrade, UpgradeMode,
-};
-use hotshot_types::traits::states::InstanceState;
-use hotshot_types::HotShotConfig;
 use std::{collections::BTreeMap, sync::Arc};
+
+use hotshot_types::{traits::states::InstanceState, HotShotConfig};
 use vbs::version::Version;
 #[cfg(any(test, feature = "testing"))]
 use vbs::version::{StaticVersion, StaticVersionType};
 
 use super::state::ValidatedState;
+use crate::v0::{
+    traits::StateCatchup, v0_99::ChainConfig, GenesisHeader, L1BlockInfo, L1Client, PubKey,
+    Timestamp, Upgrade, UpgradeMode,
+};
 
 /// Represents the immutable state of a node.
 ///
@@ -174,7 +174,7 @@ impl Upgrade {
                 config.stop_proposing_time = u64::MAX;
                 config.start_voting_time = 0;
                 config.stop_voting_time = u64::MAX;
-            }
+            },
             UpgradeMode::Time(t) => {
                 config.start_proposing_time = t.start_proposing_time.unix_timestamp();
                 config.stop_proposing_time = t.stop_proposing_time.unix_timestamp();
@@ -187,7 +187,7 @@ impl Upgrade {
                 config.stop_proposing_view = u64::MAX;
                 config.start_voting_view = 0;
                 config.stop_voting_view = u64::MAX;
-            }
+            },
         }
     }
 }

--- a/types/src/v0/impls/l1.rs
+++ b/types/src/v0/impls/l1.rs
@@ -1,3 +1,12 @@
+use std::{
+    cmp::{min, Ordering},
+    num::NonZeroUsize,
+    pin::Pin,
+    result::Result as StdResult,
+    sync::Arc,
+    time::Instant,
+};
+
 use alloy::{
     eips::BlockId,
     hex,
@@ -28,14 +37,6 @@ use futures::{
 use hotshot_types::traits::metrics::Metrics;
 use lru::LruCache;
 use parking_lot::RwLock;
-use std::result::Result as StdResult;
-use std::{
-    cmp::{min, Ordering},
-    num::NonZeroUsize,
-    pin::Pin,
-    sync::Arc,
-    time::Instant,
-};
 use tokio::{
     spawn,
     sync::{Mutex, MutexGuard, Notify},
@@ -312,7 +313,7 @@ impl Service<RequestPacket> for SwitchingTransport {
                     // If it's okay, log the success to the status
                     current_transport.status.write().log_success();
                     Ok(res)
-                }
+                },
                 Err(err) => {
                     // Increment the failure metric
                     if let Some(f) = self_clone
@@ -364,7 +365,7 @@ impl Service<RequestPacket> for SwitchingTransport {
                     }
 
                     Err(err)
-                }
+                },
             }
         })
     }
@@ -737,12 +738,12 @@ impl L1Client {
                     );
                     self.retry_delay().await;
                     continue;
-                }
+                },
                 Err(err) => {
                     tracing::warn!(number, "failed to get finalized L1 block: {err:#}");
                     self.retry_delay().await;
                     continue;
-                }
+                },
             };
             break L1BlockInfo {
                 number: block.header.number,
@@ -815,7 +816,7 @@ impl L1Client {
                         Err(err) => {
                             tracing::warn!(from, to, %err, "Fee L1Event Error");
                             sleep(retry_delay).await;
-                        }
+                        },
                     }
                 }
             }
@@ -935,7 +936,7 @@ async fn get_finalized_block(
 
 #[cfg(test)]
 mod test {
-    use std::ops::Add;
+    use std::{ops::Add, time::Duration};
 
     use ethers::{
         middleware::SignerMiddleware,
@@ -948,7 +949,6 @@ mod test {
     use hotshot_contract_adapter::stake_table::NodeInfoJf;
     use portpicker::pick_unused_port;
     use sequencer_utils::test_utils::setup_test;
-    use std::time::Duration;
     use time::OffsetDateTime;
 
     use super::*;

--- a/types/src/v0/impls/mod.rs
+++ b/types/src/v0/impls/mod.rs
@@ -14,12 +14,11 @@ mod transaction;
 
 pub use auction::SolverAuctionResultsProvider;
 pub use fee_info::{retain_accounts, FeeError};
+#[cfg(any(test, feature = "testing"))]
+pub use instance_state::mock;
 pub use instance_state::NodeState;
 pub use stake_table::*;
 pub use state::{
     get_l1_deposits, BuilderValidationError, ProposalValidationError, StateValidationError,
     ValidatedState,
 };
-
-#[cfg(any(test, feature = "testing"))]
-pub use instance_state::mock;

--- a/types/src/v0/impls/solver.rs
+++ b/types/src/v0/impls/solver.rs
@@ -1,10 +1,8 @@
 use committable::{Commitment, Committable};
 use hotshot::types::SignatureKey;
 
-use crate::v0::utils::Update;
-
 use super::v0_99::{RollupRegistrationBody, RollupUpdatebody};
-use crate::v0::utils::Update::Set;
+use crate::v0::utils::{Update, Update::Set};
 
 impl Committable for RollupRegistrationBody {
     fn tag() -> String {
@@ -54,7 +52,7 @@ impl Committable for RollupUpdatebody {
                 comm = comm
                     .u64_field("reserve_url", 2)
                     .var_size_bytes(url.as_str().as_ref())
-            }
+            },
             Set(None) => comm = comm.u64_field("reserve_url", 1),
             Update::Skip => comm = comm.u64_field("reserve_url", 0),
         }

--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -1,7 +1,9 @@
 use std::{
     cmp::max,
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::Debug,
     num::NonZeroU64,
+    sync::Arc,
 };
 
 use anyhow::Context;
@@ -24,9 +26,7 @@ use hotshot_types::{
     },
     PeerConfig,
 };
-
 use itertools::Itertools;
-use std::{fmt::Debug, sync::Arc};
 use thiserror::Error;
 
 use super::{

--- a/types/src/v0/impls/state.rs
+++ b/types/src/v0/impls/state.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 use anyhow::bail;
 use committable::{Commitment, Committable};
 use ethers::types::Address;
@@ -19,7 +21,6 @@ use jf_merkle_tree::{
 };
 use num_traits::CheckedSub;
 use serde::{Deserialize, Serialize};
-use std::ops::Add;
 use thiserror::Error;
 use time::OffsetDateTime;
 use vbs::version::Version;
@@ -1118,7 +1119,7 @@ mod test {
                 }),
                 Header::V99(_) => {
                     panic!("You called `Header.next()` on unimplemented version (v3)")
-                }
+                },
             }
         }
         /// Replaces builder signature w/ invalid one.
@@ -1147,7 +1148,7 @@ mod test {
                 }),
                 Header::V99(_) => {
                     panic!("You called `Header.sign()` on unimplemented version (v3)")
-                }
+                },
             }
         }
 

--- a/types/src/v0/impls/transaction.rs
+++ b/types/src/v0/impls/transaction.rs
@@ -3,9 +3,8 @@ use hotshot_query_service::explorer::ExplorerTransaction;
 use hotshot_types::traits::block_contents::Transaction as HotShotTransaction;
 use serde::{de::Error, Deserialize, Deserializer};
 
-use crate::{NamespaceId, Transaction};
-
 use super::{NsPayloadBuilder, NsTableBuilder};
+use crate::{NamespaceId, Transaction};
 
 impl From<u32> for NamespaceId {
     fn from(value: u32) -> Self {

--- a/types/src/v0/mod.rs
+++ b/types/src/v0/mod.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
     signature_key::BLSPubKey,
@@ -7,7 +9,6 @@ use hotshot_types::{
     },
 };
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
 
 pub mod config;
 mod header;
@@ -15,15 +16,14 @@ mod impls;
 pub mod traits;
 mod utils;
 pub use header::Header;
+#[cfg(any(test, feature = "testing"))]
+pub use impls::mock;
 pub use impls::{
     get_l1_deposits, retain_accounts, BuilderValidationError, EpochCommittees, FeeError,
     ProposalValidationError, StateValidationError,
 };
 pub use utils::*;
 use vbs::version::{StaticVersion, StaticVersionType};
-
-#[cfg(any(test, feature = "testing"))]
-pub use impls::mock;
 
 // This is the single source of truth for minor versions supported by this major version.
 //

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -7,8 +7,6 @@ use async_trait::async_trait;
 use committable::{Commitment, Committable};
 use futures::{FutureExt, TryFutureExt};
 use hotshot::{types::EventType, HotShotInitializer, InitializerEpochInfo};
-use hotshot_types::drb::DrbResult;
-use hotshot_types::traits::node_implementation::NodeType;
 use hotshot_types::{
     consensus::CommitmentMap,
     data::{
@@ -16,13 +14,14 @@ use hotshot_types::{
         DaProposal, DaProposal2, EpochNumber, QuorumProposal, QuorumProposal2,
         QuorumProposalWrapper, VidCommitment, VidDisperseShare, ViewNumber,
     },
+    drb::DrbResult,
     event::{HotShotAction, LeafInfo},
     message::{convert_proposal, Proposal, UpgradeLock},
     simple_certificate::{
         NextEpochQuorumCertificate2, QuorumCertificate, QuorumCertificate2, UpgradeCertificate,
     },
     traits::{
-        node_implementation::{ConsensusTime, Versions},
+        node_implementation::{ConsensusTime, NodeType, Versions},
         storage::Storage,
         ValidatedState as HotShotState,
     },
@@ -31,13 +30,12 @@ use hotshot_types::{
 use itertools::Itertools;
 use serde::{de::DeserializeOwned, Serialize};
 
+use super::{
+    impls::NodeState, utils::BackoffParams, EpochCommittees, EpochVersion, Leaf, SequencerVersions,
+};
 use crate::{
     v0::impls::ValidatedState, v0_99::ChainConfig, BlockMerkleTree, Event, FeeAccount,
     FeeAccountProof, FeeMerkleCommitment, FeeMerkleTree, Leaf2, NetworkConfig, SeqTypes,
-};
-
-use super::{
-    impls::NodeState, utils::BackoffParams, EpochCommittees, EpochVersion, Leaf, SequencerVersions,
 };
 
 #[async_trait]
@@ -381,7 +379,7 @@ impl<T: StateCatchup> StateCatchup for Vec<T> {
                         provider = provider.name(),
                         "failed to fetch leaves: {err:#}"
                     );
-                }
+                },
             }
         }
 
@@ -416,7 +414,7 @@ impl<T: StateCatchup> StateCatchup for Vec<T> {
                         provider = provider.name(),
                         "failed to fetch accounts: {err:#}"
                     );
-                }
+                },
             }
         }
 
@@ -443,7 +441,7 @@ impl<T: StateCatchup> StateCatchup for Vec<T> {
                         provider = provider.name(),
                         "failed to fetch frontier: {err:#}"
                     );
-                }
+                },
             }
         }
 
@@ -463,7 +461,7 @@ impl<T: StateCatchup> StateCatchup for Vec<T> {
                         provider = provider.name(),
                         "failed to fetch chain config: {err:#}"
                     );
-                }
+                },
             }
         }
 
@@ -561,11 +559,11 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
             Some(view) => {
                 tracing::info!(?view, "starting from saved view");
                 view
-            }
+            },
             None => {
                 tracing::info!("no saved view, starting from genesis");
                 ViewNumber::genesis()
-            }
+            },
         };
 
         let next_epoch_high_qc = self
@@ -590,7 +588,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
 
                 let anchor_view = leaf.view_number();
                 (leaf, high_qc, Some(anchor_view))
-            }
+            },
             None => {
                 tracing::info!("no saved leaf, starting from genesis leaf");
                 (
@@ -599,7 +597,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
                     QuorumCertificate2::genesis::<V>(&genesis_validated_state, &state).await,
                     None,
                 )
-            }
+            },
         };
         let validated_state = if leaf.block_header().height() == 0 {
             // If we are starting from genesis, we can provide the full state.

--- a/types/src/v0/utils.rs
+++ b/types/src/v0/utils.rs
@@ -1,3 +1,11 @@
+use std::{
+    cmp::{min, Ordering},
+    fmt::{self, Debug, Display, Formatter},
+    num::ParseIntError,
+    str::FromStr,
+    time::Duration,
+};
+
 use anyhow::Context;
 use bytesize::ByteSize;
 use clap::Parser;
@@ -12,13 +20,6 @@ use hotshot_types::{
 use rand::Rng;
 use sequencer_utils::{impl_serde_from_string_or_integer, ser::FromStringOrInteger};
 use serde::{Deserialize, Serialize};
-use std::{
-    cmp::{min, Ordering},
-    fmt::{self, Debug, Display, Formatter},
-    num::ParseIntError,
-    str::FromStr,
-    time::Duration,
-};
 use thiserror::Error;
 use time::{
     format_description::well_known::Rfc3339 as TimestampFormat, macros::time, Date, OffsetDateTime,
@@ -264,14 +265,14 @@ impl BackoffParams {
                 Ok(res) => return Ok(res),
                 Err(err) if self.disable => {
                     return Err(err.context("Retryable operation failed; retries disabled"));
-                }
+                },
                 Err(err) => {
                     tracing::warn!(
                         "Retryable operation failed, will retry after {delay:?}: {err:#}"
                     );
                     sleep(delay).await;
                     delay = self.backoff(delay);
-                }
+                },
             }
         }
         unreachable!()

--- a/utils/src/deployer.rs
+++ b/utils/src/deployer.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, io::Write, ops::Deref, sync::Arc, time::Duration};
+
 use alloy::{
     contract::RawCallBuilder,
     network::{Ethereum, EthereumWallet},
@@ -24,7 +26,6 @@ use futures::future::{BoxFuture, FutureExt};
 use hotshot_contract_adapter::light_client::{
     LightClientConstructorArgs, ParsedLightClientState, ParsedStakeTableState,
 };
-use std::{collections::HashMap, io::Write, ops::Deref, sync::Arc, time::Duration};
 use url::Url;
 
 /// Set of predeployed contracts.
@@ -548,6 +549,8 @@ fn link_light_client_contract(
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
 
+    use std::sync::Arc;
+
     use anyhow::Context;
     use contract_bindings_ethers::{
         erc1967_proxy::ERC1967Proxy,
@@ -557,11 +560,9 @@ pub mod test_helpers {
     };
     use ethers::prelude::*;
     use hotshot_contract_adapter::light_client::LightClientConstructorArgs;
-    use std::sync::Arc;
-
-    use crate::deployer::link_light_client_contract;
 
     use super::{Contract, Contracts};
+    use crate::deployer::link_light_client_contract;
 
     /// Deployment `LightClientMock.sol` as proxy for testing
     pub async fn deploy_light_client_contract_as_proxy_for_test<M: Middleware + 'static>(

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -257,14 +257,14 @@ pub async fn init_signer(provider: &Url, mnemonic: &str, index: u32) -> Option<S
         Err(err) => {
             tracing::error!("error connecting to RPC {}: {}", provider, err);
             return None;
-        }
+        },
     };
     let chain_id = match provider.get_chainid().await {
         Ok(id) => id.as_u64(),
         Err(err) => {
             tracing::error!("error getting chain ID: {}", err);
             return None;
-        }
+        },
     };
     let mnemonic = match MnemonicBuilder::<English>::default()
         .phrase(mnemonic)
@@ -274,14 +274,14 @@ pub async fn init_signer(provider: &Url, mnemonic: &str, index: u32) -> Option<S
         Err(err) => {
             tracing::error!("error building wallet: {}", err);
             return None;
-        }
+        },
     };
     let wallet = match mnemonic.build() {
         Ok(wallet) => wallet,
         Err(err) => {
             tracing::error!("error opening wallet: {}", err);
             return None;
-        }
+        },
     };
     let wallet = wallet.with_chain_id(chain_id);
     Some(SignerMiddleware::new(provider, wallet))
@@ -367,7 +367,7 @@ where
                 tracing::error!("contract revert: {:?}", e);
             }
             return Err(anyhow!("error sending transaction: {:?}", err));
-        }
+        },
     };
 
     let hash = pending.tx_hash();
@@ -382,12 +382,12 @@ where
         Ok(Some(receipt)) => receipt,
         Ok(None) => {
             return Err(anyhow!("contract call {hash:x}: no receipt"));
-        }
+        },
         Err(err) => {
             return Err(anyhow!(
                 "contract call {hash:x}: error getting transaction receipt: {err}"
             ))
-        }
+        },
     };
     if receipt.status != Some(1.into()) {
         return Err(anyhow!("contract call {hash:x}: transaction reverted"));
@@ -418,19 +418,19 @@ async fn wait_for_transaction_to_be_mined<P: JsonRpcClient>(
                 if i >= log_retries {
                     tracing::warn!("contract call {hash:?} (retry {i}/{retries}): error getting transaction status: {err}");
                 }
-            }
+            },
             Ok(None) => {
                 if i >= log_retries {
                     tracing::warn!(
                         "contract call {hash:?} (retry {i}/{retries}): missing from mempool"
                     );
                 }
-            }
+            },
             Ok(Some(tx)) if tx.block_number.is_none() => {
                 if i >= log_retries {
                     tracing::warn!("contract call {hash:?} (retry {i}/{retries}): pending");
                 }
-            }
+            },
             Ok(Some(_)) => return true,
         }
 

--- a/utils/src/stake_table.rs
+++ b/utils/src/stake_table.rs
@@ -1,3 +1,5 @@
+use std::{fs, path::Path, sync::Arc, time::Duration};
+
 /// Utilities for loading an initial permissioned stake table from a toml file.
 ///
 /// The initial stake table is passed to the permissioned stake table contract
@@ -16,8 +18,6 @@ use hotshot::types::BLSPubKey;
 use hotshot_contract_adapter::stake_table::{bls_jf_to_sol, NodeInfoJf};
 use hotshot_types::network::PeerConfigKeys;
 use url::Url;
-
-use std::{fs, path::Path, sync::Arc, time::Duration};
 
 /// A stake table config stored in a file
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -144,11 +144,14 @@ pub async fn update_stake_table(
 
 #[cfg(test)]
 mod test {
-    use crate::stake_table::{PermissionedStakeTableConfig, PermissionedStakeTableUpdate};
-    use crate::test_utils::setup_test;
     use hotshot::types::{BLSPubKey, SignatureKey};
     use hotshot_types::{light_client::StateKeyPair, network::PeerConfigKeys};
     use toml::toml;
+
+    use crate::{
+        stake_table::{PermissionedStakeTableConfig, PermissionedStakeTableUpdate},
+        test_utils::setup_test,
+    };
 
     fn assert_peer_config_eq(p1: &PeerConfigKeys<BLSPubKey>, p2: &PeerConfigKeys<BLSPubKey>) {
         assert_eq!(p1.stake_table_key, p2.stake_table_key);

--- a/vid/src/avid_m.rs
+++ b/vid/src/avid_m.rs
@@ -11,10 +11,8 @@
 //! vectors. And for dispersal, each storage node gets some vectors and their
 //! Merkle proofs according to its weight.
 
-use crate::{
-    utils::bytes_to_field::{self, bytes_to_field, field_to_bytes},
-    VidError, VidResult, VidScheme,
-};
+use std::ops::Range;
+
 use ark_ff::PrimeField;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -26,8 +24,12 @@ use p3_maybe_rayon::prelude::{
     IntoParallelIterator, IntoParallelRefIterator, ParallelIterator, ParallelSlice,
 };
 use serde::{Deserialize, Serialize};
-use std::ops::Range;
 use tagged_base64::tagged;
+
+use crate::{
+    utils::bytes_to_field::{self, bytes_to_field, field_to_bytes},
+    VidError, VidResult, VidScheme,
+};
 
 mod config;
 
@@ -401,8 +403,9 @@ impl VidScheme for AvidMScheme {
 /// Unit tests
 #[cfg(test)]
 pub mod tests {
-    use crate::{avid_m::AvidMScheme, VidScheme};
     use rand::{seq::SliceRandom, RngCore};
+
+    use crate::{avid_m::AvidMScheme, VidScheme};
 
     #[test]
     fn round_trip() {

--- a/vid/src/avid_m/namespaced.rs
+++ b/vid/src/avid_m/namespaced.rs
@@ -1,13 +1,15 @@
 //! This file implements the namespaced AvidM scheme.
 
+use std::ops::Range;
+
+use jf_merkle_tree::MerkleTreeScheme;
+use serde::{Deserialize, Serialize};
+
 use super::{AvidMCommit, AvidMShare, RawAvidMShare};
 use crate::{
     avid_m::{AvidMScheme, MerkleTree},
     VidError, VidResult, VidScheme,
 };
-use jf_merkle_tree::MerkleTreeScheme;
-use serde::{Deserialize, Serialize};
-use std::ops::Range;
 
 /// Dummy struct for namespaced AvidM scheme
 pub struct NsAvidMScheme;

--- a/vid/src/utils/bytes_to_field.rs
+++ b/vid/src/utils/bytes_to_field.rs
@@ -1,10 +1,11 @@
-use ark_ff::{BigInteger, PrimeField};
 use std::{
     borrow::Borrow,
     iter::Take,
     marker::PhantomData,
     vec::{IntoIter, Vec},
 };
+
+use ark_ff::{BigInteger, PrimeField};
 
 /// Deterministic, infallible, invertible iterator adaptor to convert from
 /// arbitrary bytes to field elements.
@@ -178,10 +179,11 @@ pub fn elem_byte_capacity<F: PrimeField>() -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{bytes_to_field, field_to_bytes, PrimeField, Vec};
     use ark_bls12_381::Fr as Fr381;
     use ark_bn254::Fr as Fr254;
     use rand::RngCore;
+
+    use super::{bytes_to_field, field_to_bytes, PrimeField, Vec};
 
     fn bytes_to_field_iter<F: PrimeField>() {
         let byte_lens = [0, 1, 2, 16, 31, 32, 33, 48, 65, 100, 200, 5000];


### PR DESCRIPTION
Old HS repo used to have nightly rustfmt. After some discussion in the monorepo channel, I figured we'd try nightly rustfmt to get better grouping of dependencies. This gets rid of the mess of redundant "use hotshot_types::a::b::some thing".

Tested locally with nix/direnv. Not sure if I got other peoples' use cases.

The main changes are to the following files:
- flake.nix
- rust-toolchain.toml
- rustfmt.toml

The rest of the changes were done by rustfmt picking up the new config.