### PR TITLE
dev: remove cargo clippy pre-commit hook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,13 +120,6 @@
               types_or = [ "toml" ];
               pass_filenames = false;
             };
-            cargo-clippy = {
-              enable = true;
-              description = "Run clippy";
-              entry = "just clippy";
-              types_or = [ "rust" "toml" ];
-              pass_filenames = false;
-            };
             cargo-lock = {
               enable = true;
               description = "Ensure Cargo.lock is compatible with Cargo.toml";


### PR DESCRIPTION
Developers can run `just lint` to check for clippy errors in all crates.

The project has grown very large and as a result running cargo clippy can take several minutes and that's annoying. It's especially bad when an editor IDE is used to commit that doesn't show what's going in pre-commit hooks. Developers are tempted to run with `--no-verify` which disables all checks. And may then require multiple fixup commits to get CI to pass. The other checks however are all pretty fast or only run when rarely modified files are modified. Therefore I think removing cargo clippy will make the pre-commit hooks more usable again.