### PR TITLE
Add revert logic when array is empty in PermissionedStakeTable.sol

### DIFF
--- a/contracts/src/PermissionedStakeTable.sol
+++ b/contracts/src/PermissionedStakeTable.sol
@@ -32,8 +32,6 @@ contract PermissionedStakeTable is Ownable, InitializedAt {
         insert(initialStakers);
     }
 
-    // public methods
-
     function update(BN254.G2Point[] memory stakersToRemove, NodeInfo[] memory newStakers)
         public
         onlyOwner
@@ -43,10 +41,8 @@ contract PermissionedStakeTable is Ownable, InitializedAt {
         emit StakersUpdated(stakersToRemove, newStakers);
     }
 
-    // internal methods
-
     function insert(NodeInfo[] memory newStakers) internal {
-        // TODO: revert if array empty
+        require(newStakers.length > 0, "No stakers to insert");
         for (uint256 i = 0; i < newStakers.length; i++) {
             bytes32 stakerID = _hashBlsKey(newStakers[i].blsVK);
             if (stakers[stakerID]) {
@@ -57,7 +53,7 @@ contract PermissionedStakeTable is Ownable, InitializedAt {
     }
 
     function remove(BN254.G2Point[] memory stakersToRemove) internal {
-        // TODO: revert if array empty
+        require(stakersToRemove.length > 0, "No stakers to remove");
         for (uint256 i = 0; i < stakersToRemove.length; i++) {
             bytes32 stakerID = _hashBlsKey(stakersToRemove[i]);
             if (!stakers[stakerID]) {
@@ -66,8 +62,6 @@ contract PermissionedStakeTable is Ownable, InitializedAt {
             stakers[stakerID] = false;
         }
     }
-
-    // view methods
 
     function isStaker(BN254.G2Point memory staker) external view returns (bool) {
         return stakers[_hashBlsKey(staker)];


### PR DESCRIPTION
### This PR
- Removes the "TODO: revert if array empty" by adding a `require` statement in the `insert` and `remove` functions of `PermissionedStakeTable.sol`.

### This PR does not
- Change or introduce any other functionality.

### Key places to review
- `PermissionedStakeTable.sol`: lines where the `require` statements were added.