### PR TITLE
upgrade geth to v1.15

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,8 @@ networks:
 
 services:
   demo-l1-network:
-    image: ghcr.io/espressosystems/geth-l1:main
+    # image: ghcr.io/espressosystems/geth-l1:main
+    image: ghcr.io/espressosystems/geth-l1-staging:bab-v1.15.5
     command: --dev --dev.period=1
     ports:
       - $ESPRESSO_SEQUENCER_L1_PORT:8545


### PR DESCRIPTION
I can't test locally. One layer of the block explorer image takes ages to pull. So just putting this CI job out to see if it breaks anything.

If this works we can finally upgrade solc because it should support all the latest and greatest opcode.

cc and thanks @babdor 