### PR TITLE
Fix for using wrong path for block headers in load_start_epoch_info f…

### DIFF
--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1380,15 +1380,15 @@ impl SequencerPersistence for Persistence {
                     .join(epoch.to_string())
                     .with_extension("txt");
                 let block_header = if block_header_path.is_file() {
-                    let bytes = fs::read(&path).context(format!(
+                    let bytes = fs::read(&block_header_path).context(format!(
                         "reading epoch root block header {}",
-                        path.display()
+                        block_header_path.display()
                     ))?;
                     Some(
                         bincode::deserialize::<<SeqTypes as NodeType>::BlockHeader>(&bytes)
                             .context(format!(
                                 "parsing epoch root block header {}",
-                                path.display()
+                                block_header_path.display()
                             ))?,
                     )
                 } else {


### PR DESCRIPTION
…s implementation.

Mistakenly was loading the epoch root block header from the drb result file.