### PR TITLE
skip sepolia fork test unless RPC url provided

### DIFF
--- a/contracts/test/LightClientV2.t.sol
+++ b/contracts/test/LightClientV2.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Unlicensed
 
-/* solhint-disable contract-name-camelcase, func-name-mixedcase, one-contract-per-file */
+/* solhint-disable contract-name-camelcase, func-name-mixedcase, one-contract-per-file, no-console */
 
 pragma solidity ^0.8.0;
 


### PR DESCRIPTION
The tests needs an archive node and I couldn't find a free RPC url. We should set it via a github secret. Until we get around to to that the test will be skipped if the URL isn't provided via env var.
