### PR TITLE
rename add-epoch-root to store-epoch-root in storage

### DIFF
--- a/crates/hotshot/example-types/src/storage_types.rs
+++ b/crates/hotshot/example-types/src/storage_types.rs
@@ -397,7 +397,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
         Ok(())
     }
 
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: TYPES::Epoch,
         block_header: TYPES::BlockHeader,

--- a/crates/hotshot/task-impls/src/helpers.rs
+++ b/crates/hotshot/task-impls/src/helpers.rs
@@ -212,7 +212,7 @@ async fn decide_epoch_root<TYPES: NodeType, I: NodeImplementation<TYPES>>(
 
         let mut start = Instant::now();
         if let Err(e) = storage
-            .add_epoch_root(next_epoch_number, decided_leaf.block_header().clone())
+            .store_epoch_root(next_epoch_number, decided_leaf.block_header().clone())
             .await
         {
             tracing::error!("Failed to store epoch root for epoch {next_epoch_number}: {e}");

--- a/crates/hotshot/types/src/traits/storage.rs
+++ b/crates/hotshot/types/src/traits/storage.rs
@@ -145,7 +145,7 @@ pub trait Storage<TYPES: NodeType>: Send + Sync + Clone + 'static {
     /// Add a drb result
     async fn store_drb_result(&self, epoch: TYPES::Epoch, drb_result: DrbResult) -> Result<()>;
     /// Add an epoch block header
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: TYPES::Epoch,
         block_header: TYPES::BlockHeader,

--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -290,7 +290,7 @@ mod persistence_tests {
 
         // Test storing the header
         storage
-            .add_epoch_root(EpochNumber::new(1), header.clone())
+            .store_epoch_root(EpochNumber::new(1), header.clone())
             .await
             .unwrap();
         assert_eq!(

--- a/sequencer/src/persistence/fs.rs
+++ b/sequencer/src/persistence/fs.rs
@@ -1303,7 +1303,7 @@ impl SequencerPersistence for Persistence {
         Ok(())
     }
 
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: EpochNumber,
         block_header: <SeqTypes as NodeType>::BlockHeader,

--- a/sequencer/src/persistence/no_storage.rs
+++ b/sequencer/src/persistence/no_storage.rs
@@ -225,7 +225,7 @@ impl SequencerPersistence for NoStorage {
         bail!("Cannot load from NoStorage")
     }
 
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         _epoch: EpochNumber,
         _block_header: <SeqTypes as NodeType>::BlockHeader,

--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -1921,7 +1921,7 @@ impl SequencerPersistence for Persistence {
         tx.commit().await
     }
 
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: EpochNumber,
         block_header: <SeqTypes as NodeType>::BlockHeader,

--- a/types/src/v0/traits.rs
+++ b/types/src/v0/traits.rs
@@ -759,7 +759,7 @@ pub trait SequencerPersistence: Sized + Send + Sync + Clone + 'static {
     ) -> anyhow::Result<()>;
     async fn store_drb_input(&self, drb_input: DrbInput) -> anyhow::Result<()>;
     async fn load_drb_input(&self, epoch: u64) -> anyhow::Result<DrbInput>;
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: <SeqTypes as NodeType>::Epoch,
         block_header: <SeqTypes as NodeType>::BlockHeader,
@@ -879,12 +879,12 @@ impl<P: SequencerPersistence> Storage<SeqTypes> for Arc<P> {
         (**self).store_drb_result(epoch, drb_result).await
     }
 
-    async fn add_epoch_root(
+    async fn store_epoch_root(
         &self,
         epoch: <SeqTypes as NodeType>::Epoch,
         block_header: <SeqTypes as NodeType>::BlockHeader,
     ) -> anyhow::Result<()> {
-        (**self).add_epoch_root(epoch, block_header).await
+        (**self).store_epoch_root(epoch, block_header).await
     }
 
     async fn store_drb_input(&self, drb_input: DrbInput) -> anyhow::Result<()> {


### PR DESCRIPTION
Quick PR to rename Storage::add_epoch_root to Storage::store_epoch_root, following the pattern of other methods in Storage.