### PR TITLE
Make dev node respect L1 client options

### DIFF
--- a/sequencer-sqlite/Cargo.lock
+++ b/sequencer-sqlite/Cargo.lock
@@ -4740,24 +4740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hotshot-fakeapi"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-lock 3.4.0",
- "async-trait",
- "futures",
- "hotshot-example-types",
- "hotshot-types",
- "rand 0.8.5",
- "tide-disco",
- "tokio",
- "toml",
- "vbs",
- "workspace-hack",
-]
-
-[[package]]
 name = "hotshot-libp2p-networking"
 version = "0.1.0"
 dependencies = [
@@ -4978,7 +4960,6 @@ dependencies = [
  "hotshot",
  "hotshot-builder-api",
  "hotshot-example-types",
- "hotshot-fakeapi",
  "hotshot-macros",
  "hotshot-task",
  "hotshot-task-impls",

--- a/sequencer/src/bin/espresso-dev-node.rs
+++ b/sequencer/src/bin/espresso-dev-node.rs
@@ -23,7 +23,8 @@ use espresso_contract_deployer::{
     DeployedContracts, HttpProviderWithWallet,
 };
 use espresso_types::{
-    parse_duration, v0_3::ChainConfig, EpochVersion, SeqTypes, SequencerVersions, ValidatedState,
+    parse_duration, v0_3::ChainConfig, EpochVersion, L1ClientOptions, SeqTypes, SequencerVersions,
+    ValidatedState,
 };
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use hotshot_contract_adapter::sol_types::LightClientV2Mock::{self, LightClientV2MockInstance};
@@ -76,15 +77,8 @@ struct Args {
     #[clap(short, long, env = "ESPRESSO_SEQUENCER_L1_PROVIDER")]
     rpc_url: Option<Url>,
 
-    /// Request rate when polling L1.
-    #[clap(
-        short,
-        long,
-        env = "ESPRESSO_SEQUENCER_L1_POLLING_INTERVAL",
-        default_value = "200ms",
-        value_parser = parse_duration
-    )]
-    l1_interval: Duration,
+    #[clap(flatten)]
+    l1_opt: L1ClientOptions,
 
     /// Mnemonic for an L1 wallet.
     ///
@@ -261,7 +255,7 @@ async fn main() -> anyhow::Result<()> {
         retry_interval,
         alt_prover_retry_intervals,
         alt_prover_update_intervals: _,
-        l1_interval: _,
+        l1_opt,
         max_block_size,
         epoch_height,
         contracts,
@@ -312,6 +306,7 @@ async fn main() -> anyhow::Result<()> {
         .builder_port(builder_port)
         .state_relay_url(relay_server_url.clone())
         .l1_url(l1_url.clone())
+        .l1_opt(l1_opt)
         .build();
     let blocks_per_epoch = network_config.hotshot_config().epoch_height;
     let epoch_start_block = network_config.hotshot_config().epoch_start_block;

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -796,6 +796,7 @@ pub mod testing {
         state_key_pairs: Vec<StateKeyPair>,
         master_map: Arc<MasterMap<PubKey>>,
         l1_url: Url,
+        l1_opt: L1ClientOptions,
         anvil_provider: Option<AnvilFillProvider>,
         signer: LocalSigner<SigningKey>,
         state_relay_url: Option<Url>,
@@ -848,6 +849,12 @@ pub mod testing {
             self.l1_url = l1_url;
             self
         }
+
+        pub fn l1_opt(mut self, opt: L1ClientOptions) -> Self {
+            self.l1_opt = opt;
+            self
+        }
+
         pub fn signer(mut self, signer: LocalSigner<SigningKey>) -> Self {
             self.signer = signer;
             self
@@ -943,6 +950,7 @@ pub mod testing {
                 state_key_pairs: self.state_key_pairs,
                 master_map: self.master_map,
                 l1_url: self.l1_url,
+                l1_opt: self.l1_opt,
                 signer: self.signer,
                 state_relay_url: self.state_relay_url,
                 builder_port: self.builder_port,
@@ -1022,6 +1030,13 @@ pub mod testing {
                 state_key_pairs,
                 master_map,
                 l1_url: anvil_provider.anvil().endpoint().parse().unwrap(),
+                l1_opt: L1ClientOptions {
+                    stake_table_update_interval: Duration::from_secs(5),
+                    l1_events_max_block_range: 1000,
+                    l1_polling_interval: Duration::from_secs(1),
+                    subscription_timeout: Duration::from_secs(5),
+                    ..Default::default()
+                },
                 anvil_provider: Some(anvil_provider),
                 signer,
                 state_relay_url: None,
@@ -1038,6 +1053,7 @@ pub mod testing {
         state_key_pairs: Vec<StateKeyPair>,
         master_map: Arc<MasterMap<PubKey>>,
         l1_url: Url,
+        l1_opt: L1ClientOptions,
         anvil_provider: Option<AnvilFillProvider>,
         signer: LocalSigner<SigningKey>,
         state_relay_url: Option<Url>,
@@ -1184,14 +1200,9 @@ pub mod testing {
                 },
             };
 
-            let l1_opt = L1ClientOptions {
-                stake_table_update_interval: Duration::from_secs(5),
-                l1_events_max_block_range: 1000,
-                l1_polling_interval: Duration::from_secs(1),
-                subscription_timeout: Duration::from_secs(5),
-                ..Default::default()
-            };
-            let l1_client = l1_opt
+            let l1_client = self
+                .l1_opt
+                .clone()
                 .connect(vec![self.l1_url.clone()])
                 .expect("failed to create L1 client");
             l1_client.spawn_tasks().await;


### PR DESCRIPTION
Request from Cartesi

### This PR:
* Makes the L1 client options in `TestConfig` configurable
* Makes the dev node accept the same command line/env vars as the normal node for configuring the L1, passing those options through to the `TestConfigBuilder`
