### PR TITLE
Remove ignored/duplicated epoch catchup test

### DIFF
--- a/sequencer/src/api.rs
+++ b/sequencer/src/api.rs
@@ -2021,7 +2021,6 @@ mod test {
         stream::{StreamExt, TryStreamExt},
     };
     use hotshot::types::EventType;
-    use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
     use hotshot_example_types::node_types::EpochsTestVersions;
     use hotshot_query_service::{
         availability::{BlockQueryData, LeafQueryData, VidCommonQueryData},


### PR DESCRIPTION
The original intention was to fix this test and remove the `[ignore]`. But this test was actually added under a different name in #3239. So the PR was changed to remove this duplicated and ignored test. 