### PR TITLE
Fix postgres migration

### DIFF
--- a/hotshot-query-service/migrations/postgres/V900__tx_separate_index.sql
+++ b/hotshot-query-service/migrations/postgres/V900__tx_separate_index.sql
@@ -4,7 +4,7 @@ CREATE FUNCTION json_4byte_le_to_integer(j JSONB)
     IMMUTABLE
 AS $$
 DECLARE
-    len INT := json_array_length(j::json);
+    len INT := jsonb_array_length(j);
 BEGIN
     IF len <> 4 THEN
         RAISE 'expected JSON array of 4 bytes, got (%) instead', len;


### PR DESCRIPTION
While working on #3365 I got a migration error

```
2025-06-05T11:31:54.588710Z  INFO sqlx::postgres::notice: ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "leaf2_height_idx" to "leaf2_pk"
2025-06-05T11:31:54.593013Z ERROR hotshot_query_service::data_source::storage::sql: DB migrations failed: None
Error: `error applying migrations`, `error returned from database: function json_array_length(jsonb) does not exist`

Caused by:
    0: error returned from database: function json_array_length(jsonb) does not exist
    1: function json_array_length(jsonb) does not exist
```

I'm a bit confused as to why this only failed when trying to upgrade the binary but not in other cases.

cc @imabdulbasit @jbearer 