### PR TITLE
debug format of structures as tagged base64

### DIFF
--- a/crates/hotshot/types/src/data.rs
+++ b/crates/hotshot/types/src/data.rs
@@ -206,7 +206,7 @@ where
 }
 
 /// VID Commitment type
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 #[serde(
     try_from = "tagged_base64::TaggedBase64",
     into = "tagged_base64::TaggedBase64"
@@ -225,6 +225,12 @@ impl Default for VidCommitment {
 impl Display for VidCommitment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::write!(f, "{}", TaggedBase64::from(self))
+    }
+}
+
+impl Debug for VidCommitment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
     }
 }
 
@@ -1927,5 +1933,35 @@ impl<TYPES: NodeType> PackedBundle<TYPES> {
             epoch_number,
             sequencing_fees,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_vid_commitment_display() {
+        let vc = VidCommitment::V0(ADVZCommitment::default());
+        assert_eq!(
+            format!("{vc}"),
+            "HASH~AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI"
+        );
+        assert_eq!(
+            format!("{vc:?}"),
+            "HASH~AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI"
+        );
+
+        let vc = VidCommitment::V1(AvidMCommitment {
+            commit: Default::default(),
+        });
+        assert_eq!(
+            format!("{vc}"),
+            "AvidMCommit~AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADr"
+        );
+        assert_eq!(
+            format!("{vc:?}"),
+            "AvidMCommit~AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADr"
+        );
     }
 }

--- a/crates/hotshot/types/src/lib.rs
+++ b/crates/hotshot/types/src/lib.rs
@@ -124,7 +124,7 @@ impl<TYPES: NodeType> Default for ValidatorConfig<TYPES> {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Display, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Display, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 /// structure of peers' config, including public key, stake value, and state key.
 pub struct PeerConfig<TYPES: NodeType> {
@@ -168,6 +168,15 @@ impl<TYPES: NodeType> Default for PeerConfig<TYPES> {
     fn default() -> Self {
         let default_validator_config = ValidatorConfig::<TYPES>::default();
         default_validator_config.public_config()
+    }
+}
+
+impl<TYPES: NodeType> Debug for PeerConfig<TYPES> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeerConfig")
+            .field("stake_table_entry", &self.stake_table_entry)
+            .field("state_ver_key", &format_args!("{}", self.state_ver_key))
+            .finish()
     }
 }
 

--- a/crates/hotshot/types/src/stake_table.rs
+++ b/crates/hotshot/types/src/stake_table.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Stake table entry
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Hash, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Hash, Eq)]
 #[serde(bound(deserialize = ""))]
 pub struct StakeTableEntry<K: SignatureKey> {
     /// The public key
@@ -45,6 +45,15 @@ impl<K: SignatureKey> StakeTableEntry<K> {
     /// Get the public key
     pub fn key(&self) -> &K {
         &self.stake_key
+    }
+}
+
+impl<K: SignatureKey> std::fmt::Debug for StakeTableEntry<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StakeTableEntry")
+            .field("stake_key", &format_args!("{}", self.stake_key))
+            .field("stake_amount", &self.stake_amount)
+            .finish()
     }
 }
 


### PR DESCRIPTION
Makes the debug formatting output of several structures use tagged base64.

~~Take note that for PeerConfig and StakeTableEntry I elected to manually implement Debug for the containing struct instead of changing the Debug formatter in the jellyfish repo. This seemed to make sense for the case where other users of the jellyfish repo might want the original Debug behavior.~~

For the changes to PeerConfig and StakeTableEntry, this serves to get the same behavior for the time being. The jellyfish repo main modifies VerKey to also exhibit this behavior, but that hasn't been pulled into espresso-network yet. Those changes should be backed out once jellyfish is updated.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210186607314342