### PR TITLE
Add unrecognized request handling to node-metrics

### DIFF
--- a/node-metrics/Cargo.toml
+++ b/node-metrics/Cargo.toml
@@ -6,7 +6,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [features]
-testing = ["serde_json", "espresso-types/testing", "hotshot-query-service/testing"]
+testing = ["espresso-types/testing", "hotshot-query-service/testing"]
 
 [dev-dependencies]
 node-metrics = { path = ".", features = [ "testing" ] }
@@ -25,14 +25,14 @@ hotshot = { workspace = true }
 hotshot-example-types = { workspace = true }
 hotshot-query-service = { workspace = true }
 indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { version = "^1.0.113" }
 tokio = { workspace = true }
 
 # Dependencies for feature `testing`
 hotshot-types = { workspace = true }
 prometheus-parse = { version = "^0.2.5" }
 reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { version = "^1.0.113", optional = true }
 surf-disco = { workspace = true }
 tide-disco = { workspace = true }
 time = { workspace = true }

--- a/node-metrics/src/service/server_message/mod.rs
+++ b/node-metrics/src/service/server_message/mod.rs
@@ -63,6 +63,11 @@ pub enum ServerMessage {
     /// StakeTableSnapshot is a message that is sent in response to a request
     /// for the snapshot of the current stake table information.
     StakeTableSnapshot(Arc<Vec<PeerConfig<SeqTypes>>>),
+
+    // UnrecognizedRequest is a message that is sent when the server receives
+    // a request that it does not recognize. This is useful for debugging and
+    // for ensuring that the client is sending valid requests.
+    UnrecognizedRequest(serde_json::Value),
 }
 
 impl PartialEq for ServerMessage {
@@ -80,6 +85,7 @@ impl PartialEq for ServerMessage {
             (Self::VotersSnapshot(lhs), Self::VotersSnapshot(rhs)) => lhs == rhs,
             (Self::ValidatorsSnapshot(lhs), Self::ValidatorsSnapshot(rhs)) => lhs == rhs,
             (Self::StakeTableSnapshot(lhs), Self::StakeTableSnapshot(rhs)) => lhs == rhs,
+            (Self::UnrecognizedRequest(lhs), Self::UnrecognizedRequest(rhs)) => lhs == rhs,
             _ => false,
         }
     }


### PR DESCRIPTION
<!-- Closes #<ISSUE_NUMBER> -->
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Adds unrecognized Client Message Handling

As we start to expand the functionality that the `node-metrics` service is capable of, we may run into the issue of there being a mismatch between the node-metrics service and the UI that is consuming it.  This may lead to the situation where the client might make a request that the server does not recognized.  In the current version of the application, due to the implementation of `tide_disco`, these will result in deserialization failures that will be handled by tide_disco silently, and will lead to the underlying websocket connection being dropped.

This aims to handle, at least part, of these errors by capturing all valid content-type encoded requests that do not match the expected commands.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Modify any of the other behavior of the `node-metrics` service, and as such it should continue to operate as it does today.

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
