### PR TITLE
Add get L1 finalized to the go sdk header

### DIFF
--- a/sdks/go/types/header.go
+++ b/sdks/go/types/header.go
@@ -52,6 +52,7 @@ type HeaderInterface interface {
 	Version() common_types.Version
 	GetBlockHeight() uint64
 	GetL1Head() uint64
+	GetL1Finalized() *common_types.L1BlockInfo
 	GetTimestamp() uint64
 	GetPayloadCommitment() *common_types.TaggedBase64
 	GetBuilderCommitment() *common_types.TaggedBase64

--- a/sdks/go/types/v0/v0_1/header.go
+++ b/sdks/go/types/v0/v0_1/header.go
@@ -35,6 +35,9 @@ func (h *Header) GetPayloadCommitment() *common_types.TaggedBase64 {
 func (h *Header) GetL1Head() uint64 {
 	return h.L1Head
 }
+func (h *Header) GetL1Finalized() *common_types.L1BlockInfo {
+	return h.L1Finalized
+}
 func (h *Header) GetTimestamp() uint64 {
 	return h.Timestamp
 }

--- a/sdks/go/types/v0/v0_2/header.go
+++ b/sdks/go/types/v0/v0_2/header.go
@@ -38,6 +38,10 @@ func (h *Header) GetBuilderSignature() *common.Signature {
 	return h.BuilderSignature
 }
 
+func (h *Header) GetL1Finalized() *common.L1BlockInfo {
+	return h.L1Finalized
+}
+
 func (h *Header) UnmarshalJSON(b []byte) error {
 	var header v01.Header
 	err := json.Unmarshal(b, &header)

--- a/sdks/go/types/v0/v0_3/header.go
+++ b/sdks/go/types/v0/v0_3/header.go
@@ -37,6 +37,9 @@ func (h *Header) GetPayloadCommitment() *common_types.TaggedBase64 {
 func (h *Header) GetL1Head() uint64 {
 	return h.L1Head
 }
+func (h *Header) GetL1Finalized() *common_types.L1BlockInfo {
+	return h.L1Finalized
+}
 func (h *Header) GetTimestamp() uint64 {
 	return h.Timestamp
 }


### PR DESCRIPTION
### This PR:
Supports getL1Finalized in go header

### This PR does not:
Change any logic