### PR TITLE
fix: check merkle proof heights

### DIFF
--- a/sequencer/src/catchup.rs
+++ b/sequencer/src/catchup.rs
@@ -22,6 +22,7 @@ use espresso_types::{
     v0_4::{RewardAccountProofV2, RewardAccountV2, RewardMerkleCommitmentV2, RewardMerkleTreeV2},
     BackoffParams, BlockMerkleTree, EpochVersion, FeeAccount, FeeAccountProof, FeeMerkleCommitment,
     FeeMerkleTree, Leaf2, NodeState, PubKey, SeqTypes, SequencerVersions, ValidatedState,
+    BLOCK_MERKLE_TREE_HEIGHT,
 };
 use futures::{
     future::{Future, FutureExt, TryFuture, TryFutureExt},
@@ -313,6 +314,10 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                     let elem = frontier
                         .elem()
                         .context("provided frontier is missing leaf element")?;
+                    ensure!(
+                        frontier.proof.len() == BLOCK_MERKLE_TREE_HEIGHT,
+                        "invalid proof"
+                    );
                     mt.remember(mt.num_leaves() - 1, *elem, &frontier)
                         .context("verifying block proof")?;
                     anyhow::Ok(mt)

--- a/types/src/v0/impls/fee_info.rs
+++ b/types/src/v0/impls/fee_info.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 use super::v0_1::IterableFeeInfo;
 use crate::{
     eth_signature_key::EthKeyPair, AccountQueryData, FeeAccount, FeeAccountProof, FeeAmount,
-    FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, SeqTypes,
+    FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, SeqTypes, FEE_MERKLE_TREE_HEIGHT,
 };
 
 /// Possible charge fee failures
@@ -371,6 +371,7 @@ impl FeeAccountProof {
     pub fn verify(&self, comm: &FeeMerkleCommitment) -> anyhow::Result<U256> {
         match &self.proof {
             FeeMerkleProof::Presence(proof) => {
+                ensure!(proof.proof.len() == FEE_MERKLE_TREE_HEIGHT, "invalid proof");
                 ensure!(
                     FeeMerkleTree::verify(comm.digest(), FeeAccount(self.account), proof)?.is_ok(),
                     "invalid proof"
@@ -381,6 +382,7 @@ impl FeeAccountProof {
                     .0)
             },
             FeeMerkleProof::Absence(proof) => {
+                ensure!(proof.proof.len() == FEE_MERKLE_TREE_HEIGHT, "invalid proof");
                 let tree = FeeMerkleTree::from_commitment(comm);
                 ensure!(
                     tree.non_membership_verify(FeeAccount(self.account), proof)?,

--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -386,7 +386,7 @@ pub mod mock {
     use std::collections::HashMap;
 
     use alloy::primitives::U256;
-    use anyhow::Context;
+    use anyhow::{ensure, Context};
     use async_trait::async_trait;
     use committable::Commitment;
     use hotshot_types::{data::ViewNumber, stake_table::HSStakeTable};
@@ -398,6 +398,7 @@ pub mod mock {
         v0_3::{RewardAccountProofV1, RewardAccountV1, RewardMerkleCommitmentV1},
         v0_4::{RewardAccountProofV2, RewardAccountV2, RewardMerkleCommitmentV2},
         BackoffParams, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment, Leaf2,
+        BLOCK_MERKLE_TREE_HEIGHT,
     };
 
     #[derive(Debug, Clone, Default)]
@@ -476,6 +477,12 @@ pub mod mock {
 
             let index = src.num_leaves() - 1;
             let (elem, proof) = src.lookup(index).expect_ok().unwrap();
+            // NOTE: Proof length check strictly speaking not needed, height is
+            // determined by `mt`.
+            ensure!(
+                proof.proof.len() == BLOCK_MERKLE_TREE_HEIGHT,
+                "invalid proof"
+            );
             mt.remember(index, elem, proof.clone())
                 .expect("Proof verifies");
 

--- a/types/src/v0/impls/reward.rs
+++ b/types/src/v0/impls/reward.rs
@@ -38,7 +38,7 @@ use crate::{
     eth_signature_key::EthKeyPair,
     v0_3::{
         RewardAccountProofV1, RewardAccountV1, RewardMerkleCommitmentV1, RewardMerkleProofV1,
-        RewardMerkleTreeV1,
+        RewardMerkleTreeV1, REWARD_MERKLE_TREE_V1_HEIGHT,
     },
     v0_4::{Delta, REWARD_MERKLE_TREE_V2_ARITY, REWARD_MERKLE_TREE_V2_HEIGHT},
     DrbAndHeaderUpgradeVersion, EpochVersion, FeeAccount,
@@ -369,6 +369,10 @@ impl RewardAccountProofV2 {
         match &self.proof {
             RewardMerkleProofV2::Presence(proof) => {
                 ensure!(
+                    proof.proof.len() == REWARD_MERKLE_TREE_V2_HEIGHT,
+                    "invalid proof"
+                );
+                ensure!(
                     RewardMerkleTreeV2::verify(
                         comm.digest(),
                         RewardAccountV2(self.account),
@@ -383,6 +387,10 @@ impl RewardAccountProofV2 {
                     .0)
             },
             RewardMerkleProofV2::Absence(proof) => {
+                ensure!(
+                    proof.proof.len() == REWARD_MERKLE_TREE_V2_HEIGHT,
+                    "invalid proof"
+                );
                 let tree = RewardMerkleTreeV2::from_commitment(comm);
                 ensure!(
                     tree.non_membership_verify(RewardAccountV2(self.account), proof)?,
@@ -528,6 +536,10 @@ impl RewardAccountProofV1 {
         match &self.proof {
             RewardMerkleProofV1::Presence(proof) => {
                 ensure!(
+                    proof.proof.len() == REWARD_MERKLE_TREE_V1_HEIGHT,
+                    "invalid proof"
+                );
+                ensure!(
                     RewardMerkleTreeV1::verify(
                         comm.digest(),
                         RewardAccountV1(self.account),
@@ -542,6 +554,10 @@ impl RewardAccountProofV1 {
                     .0)
             },
             RewardMerkleProofV1::Absence(proof) => {
+                ensure!(
+                    proof.proof.len() == REWARD_MERKLE_TREE_V1_HEIGHT,
+                    "invalid proof"
+                );
                 let tree = RewardMerkleTreeV1::from_commitment(comm);
                 ensure!(
                     tree.non_membership_verify(RewardAccountV1(self.account), proof)?,


### PR DESCRIPTION
Since we're using an outdated version of jf I think the proof length is not enforced on the proof API when verifying proofs.

To add a regression test I think we'd need to find a collision which is hard.

cc @mrain @alxiong 