### PR TITLE
Static versioning for external messages

### DIFF
--- a/crates/hotshot/hotshot/src/tasks/mod.rs
+++ b/crates/hotshot/hotshot/src/tasks/mod.rs
@@ -34,7 +34,7 @@ use hotshot_task_impls::{
 use hotshot_types::{
     consensus::OuterConsensus,
     constants::EVENT_CHANNEL_SIZE,
-    message::{Message, UpgradeLock},
+    message::{Message, MessageKind, UpgradeLock, EXTERNAL_MESSAGE_VERSION},
     storage_metrics::StorageMetricsValue,
     traits::{
         network::ConnectedNetwork,
@@ -42,7 +42,7 @@ use hotshot_types::{
     },
 };
 use tokio::{spawn, time::sleep};
-use vbs::version::StaticVersionType;
+use vbs::version::{StaticVersionType, Version};
 
 use crate::{
     genesis_epoch_from_version, tasks::task_state::CreateTaskState, types::SystemContextHandle,
@@ -166,14 +166,23 @@ pub fn add_network_message_task<
                         continue;
                     };
 
-                    // Deserialize the message
-                    let deserialized_message: Message<TYPES> = match upgrade_lock.deserialize(&message).await {
+                    // Deserialize the message and get the version
+                    let (deserialized_message, version): (Message<TYPES>, Version) = match upgrade_lock.deserialize(&message).await {
                         Ok(message) => message,
                         Err(e) => {
                             tracing::error!("Failed to deserialize message: {:?}", e);
                             continue;
                         }
                     };
+
+                    // Special case: external messages (version 0.0). We want to make sure it is an external message
+                    // and warn and continue otherwise.
+                    if version == EXTERNAL_MESSAGE_VERSION
+                        && !matches!(deserialized_message.kind, MessageKind::<TYPES>::External(_))
+                    {
+                        tracing::warn!("Received a non-external message with version 0.0");
+                        continue;
+                    }
 
                     // Handle the message
                     state.handle_message(deserialized_message).await;

--- a/crates/hotshot/testing/src/test_task.rs
+++ b/crates/hotshot/testing/src/test_task.rs
@@ -213,7 +213,7 @@ pub async fn add_network_message_test_task<
             // Deserialize the message
             let deserialized_message: Message<TYPES> =
                 match upgrade_lock.deserialize(&message).await {
-                    Ok(message) => message,
+                    Ok((message, _)) => message,
                     Err(e) => {
                         tracing::error!("Failed to deserialize message: {e:?}");
                         continue;

--- a/crates/hotshot/testing/tests/tests_3/memory_network.rs
+++ b/crates/hotshot/testing/tests/tests_3/memory_network.rs
@@ -172,7 +172,7 @@ async fn memory_network_direct_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(timeout(Duration::from_secs(1), network2.recv_message())
             .await
             .is_err());
@@ -193,7 +193,7 @@ async fn memory_network_direct_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(timeout(Duration::from_secs(1), network1.recv_message())
             .await
             .is_err());
@@ -229,7 +229,7 @@ async fn memory_network_broadcast_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(timeout(Duration::from_secs(1), network2.recv_message())
             .await
             .is_err());
@@ -254,7 +254,7 @@ async fn memory_network_broadcast_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let deserialized_message = upgrade_lock.deserialize(&recv_message).await.unwrap();
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).await.unwrap();
         assert!(timeout(Duration::from_secs(1), network1.recv_message())
             .await
             .is_err());

--- a/sequencer/src/context.rs
+++ b/sequencer/src/context.rs
@@ -211,7 +211,6 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, V: Versions> Sequence
             outbound_message_receiver,
             network,
             pub_key,
-            handle.hotshot.upgrade_lock.clone(),
         )
         .await
         .with_context(|| "Failed to create external event handler")?;


### PR DESCRIPTION
### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

Adds a special version for external messages (0.0). Adds associated checks to make sure they are indeed external.
