### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: rustsec/audit-check@v2
         with:
@@ -38,10 +38,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: github.event_name != 'pull_request'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: github.event_name == 'pull_request'
         with:
           # By default github will checkout a ref of the HEAD merged into the

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,6 @@ jobs:
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create backport pull requests
         uses: korthout/backport-action@v3

--- a/.github/workflows/benchmark-build.yaml
+++ b/.github/workflows/benchmark-build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -66,7 +66,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204-arm
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -125,7 +125,7 @@ jobs:
       bridge-tag: ${{ steps.bridge.outputs.tags }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download executables AMD
         uses: actions/download-artifact@v4
@@ -378,7 +378,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull docker images
         run: |

--- a/.github/workflows/build-crypto-helper.yml
+++ b/.github/workflows/build-crypto-helper.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-without-lockfile.yml
+++ b/.github/workflows/build-without-lockfile.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # NOTE: no rust cache, this isn't a time critical job
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -130,7 +130,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download executables AMD
         uses: actions/download-artifact@v4
@@ -300,7 +300,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download executables ARM
         uses: actions/download-artifact@v4
@@ -433,7 +433,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -472,7 +472,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Match the docker image tag built or pushed to the registry
         run: |

--- a/.github/workflows/cargo-features.yml
+++ b/.github/workflows/cargo-features.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -39,7 +39,7 @@ jobs:
           skipPush: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -103,7 +103,7 @@ jobs:
           skipPush: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/doc-rust.yml
+++ b/.github/workflows/doc-rust.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: taiki-e/install-action@just
 

--- a/.github/workflows/hotshot.yml
+++ b/.github/workflows/hotshot.yml
@@ -20,7 +20,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: taiki-e/install-action@just
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: set-matrix
         run: echo "matrix=$(just hotshot::matrix)" >> "$GITHUB_OUTPUT"
 
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout Repository
 
       - name: Install Rust
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout Repository
 
       - name: Install Rust

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -34,7 +34,7 @@ jobs:
     name: clippy (postgres)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main'  }}
@@ -48,7 +48,7 @@ jobs:
       name: clippy (embedded-db)
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: Swatinem/rust-cache@v2
           with:
             save-if: false

--- a/.github/workflows/nix-env-macos-arm.yml
+++ b/.github/workflows/nix-env-macos-arm.yml
@@ -39,7 +39,7 @@ jobs:
           skipPush: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # NOTE: no rust cache, these tests are very slow anyway
 
@@ -79,7 +79,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # NOTE: no rust cache, these tests are very slow anyway
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
         
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: rui314/setup-mold@v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rui314/setup-mold@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rui314/setup-mold@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Enable Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -219,7 +219,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install node deps
         run: yarn
@@ -251,7 +251,7 @@ jobs:
         with:
           version: nightly
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -288,7 +288,7 @@ jobs:
           extraPullNames: nix-community
           skipPush: ${{ github.actor == 'dependabot[bot]' }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build espresso-dev-node
         run: |
@@ -322,7 +322,7 @@ jobs:
       - name: Configure PATH
         run: PATH="$PWD/target/debug:$PATH"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: taiki-e/install-action@nextest
 
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v31
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
         # TODO: this downloads all (available) artifacts, which is a bit wasteful but artifact
         # downloads always fail if I try to select a subset.

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -20,7 +20,7 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout Repository
 
       - name: typos-action

--- a/.github/workflows/ubuntu-install-without-nix.yml
+++ b/.github/workflows/ubuntu-install-without-nix.yml
@@ -13,7 +13,7 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@nightly
         id: toolchain

--- a/.github/workflows/update_nix.yml
+++ b/.github/workflows/update_nix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0