### PR TITLE
Trigger DRB calculation on every view change

### DIFF
--- a/crates/hotshot/task-impls/src/consensus/mod.rs
+++ b/crates/hotshot/task-impls/src/consensus/mod.rs
@@ -153,7 +153,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions> ConsensusTaskSt
             HotShotEvent::ViewChange(new_view_number, epoch_number) => {
                 // Request the randomized stake table for the subsequent epoch,
                 // to trigger catchup and the DRB calculation if it happens to be missing.
-                let _ = self.membership_coordinator
+                let _ = self
+                    .membership_coordinator
                     .membership_for_epoch(epoch_number.map(|e| e + 1))
                     .await;
 


### PR DESCRIPTION
If we miss the initial decide for an epoch root for epoch `e` for any reason (e.g. we don't have the DRB for the current epoch yet), we will never begin the DRB calculation for `e` until we attempt to transition into that epoch. This means we remain perpetually behind, because we now will miss the decide for the root for `e + 1` and so on.

This PR has us request the randomized stake table for the subsequent epoch on every view change, without blocking on the request succeeding. This means we ensure that the DRB calculation for the subsequent epoch is always in progress.