### PR TITLE
Fix stake tables reloading

### DIFF
--- a/sequencer/src/persistence/sql.rs
+++ b/sequencer/src/persistence/sql.rs
@@ -2433,8 +2433,8 @@ impl MembershipPersistence for Persistence {
         let mut tx = self.db.read().await?;
 
         let rows = match query_as::<(i64, Vec<u8>, Option<Vec<u8>>, Option<Vec<u8>>)>(
-            "SELECT epoch, stake, block_reward, stake_table_hash FROM epoch_drb_and_root ORDER BY \
-             epoch DESC LIMIT $1",
+            "SELECT epoch, stake, block_reward, stake_table_hash FROM epoch_drb_and_root WHERE \
+             stake is NOT NULL ORDER BY epoch DESC LIMIT $1",
         )
         .bind(limit as i64)
         .fetch_all(tx.as_mut())


### PR DESCRIPTION
Fixes stake table reloading by selecting only rows where the stake is NOT NULL.
If storing the stake tables failed for any reason while a drb_result was added for an epoch, the node might restart with a NULL stake value which can result in this error

`error loading stake tables: error occurred while decoding column 1: unexpected null; try decoding as an `Option``


This PR also uses the replace() function when storing the drb_result and stake tables. The replace() function writes a file atomically.