### PR TITLE
fix transaction detail query for sqlite

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/explorer.rs
@@ -245,8 +245,9 @@ lazy_static::lazy_static! {
                         FROM transactions AS t1
                         WHERE t1.block_height = $1
                         ORDER BY t1.block_height, t1.ns_id, t1.position
-                        OFFSET $2
                         LIMIT 1
+                        OFFSET $2
+                       
                 )
                 ORDER BY h.height DESC",
         )


### PR DESCRIPTION
Transaction details query does not work in sqlite due to order of the offset and limit. This PR fixes it