### PR TITLE
fix: nix shell should use packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -222,6 +222,7 @@
         myShell (rustEnvVars // {
           packages = [
             # Rust dependencies
+            pkg-config
             openssl
             curl
             protobuf # to compile libp2p-autonat
@@ -301,6 +302,7 @@
         myShell (rustEnvVars // {
           packages = [
             # Rust dependencies
+            pkg-config
             openssl
             curl
             protobuf # to compile libp2p-autonat
@@ -315,6 +317,7 @@
         myShell (rustEnvVars // {
           packages = [
             # Rust dependencies
+            pkg-config
             openssl
             curl
             protobuf # to compile libp2p-autonat
@@ -338,6 +341,7 @@
         myShell (rustEnvVars // {
           packages = [
             # Rust dependencies
+            pkg-config
             openssl
             curl
             protobuf # to compile libp2p-autonat


### PR DESCRIPTION
This solves the issue failing cargo builds because the offending env vars isn't being set anymore.

See:
https://discourse.nixos.org/t/difference-between-buildinputs-and-packages-in-mkshell/60598/2

We also don't need to manually add pkg-config anymore.