### PR TITLE
Store only new stake table events fetched from contract

### DIFF
--- a/sequencer/src/persistence.rs
+++ b/sequencer/src/persistence.rs
@@ -1289,7 +1289,7 @@ mod tests {
 
         // Fetch events from stake table fetcher and compare with persisted data
         let fetched_events = stake_table_fetcher
-            .fetch_events(stake_table_contract, block)
+            .fetch_and_store_stake_table_events(stake_table_contract, block)
             .await?;
         assert_eq!(fetched_events, events);
 


### PR DESCRIPTION
Currently, we store all the stake event tables even that are already stored in storage. This PR changes it to store only new events from L1 contract.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211736924908567