### PR TITLE
Re-export `StakeTableState`

### DIFF
--- a/types/src/v0/mod.rs
+++ b/types/src/v0/mod.rs
@@ -203,7 +203,7 @@ pub type NetworkConfig = hotshot_types::network::NetworkConfig<SeqTypes>;
 
 pub use self::impls::{NodeState, RewardDistributor, UpgradeMap, ValidatedState, ValidatorMap};
 pub use crate::{
-    v0::impls::StakeTableHash,
+    v0::impls::{StakeTableHash, StakeTableState},
     v0_1::{
         BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
         NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,


### PR DESCRIPTION
We need this in the staking UI service.

This type is already public. It's just impossible to name from another crate because it is defined in a private module.

