### PR TITLE
Expose stake table state validators by reference

### DIFF
--- a/types/src/v0/impls/stake_table.rs
+++ b/types/src/v0/impls/stake_table.rs
@@ -236,8 +236,12 @@ impl StakeTableState {
         }
     }
 
-    pub fn get_validators(self) -> ValidatorMap {
+    pub fn into_validators(self) -> ValidatorMap {
         self.validators
+    }
+
+    pub fn validators(&self) -> &ValidatorMap {
+        &self.validators
     }
 
     pub fn apply_event(&mut self, event: StakeTableEvent) -> ApplyEventResult<()> {
@@ -519,7 +523,7 @@ pub fn validators_from_l1_events<I: Iterator<Item = StakeTableEvent>>(
         }
     }
     let commit = state.commit();
-    Ok((state.get_validators(), commit))
+    Ok((state.into_validators(), commit))
 }
 
 /// Select active validators


### PR DESCRIPTION
This seems like a fine thing to expose and it will make my replay test in the staking UI service much faster. This test replays a bunch of events and checks validator set consistently after each event. Currently it needs to rebuild the entire stake table state after every event, because pulling out the validators consumes the state.

This change also renames the existing `get_validators` function to `into_validators` to be more consistent with Rust patterns and avoid confusion with this new function (see e.g. `HashMap::values` and `HashMap::into_values`)

