### PR TITLE
fix: check timestamp drift w.r.t. validation start

### DIFF
--- a/types/src/v0/impls/instance_state.rs
+++ b/types/src/v0/impls/instance_state.rs
@@ -435,10 +435,21 @@ pub mod mock {
         BackoffParams, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment, Leaf2,
     };
 
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Clone)]
     pub struct MockStateCatchup {
         backoff: BackoffParams,
         state: HashMap<ViewNumber, Arc<ValidatedState>>,
+        delay: std::time::Duration,
+    }
+
+    impl Default for MockStateCatchup {
+        fn default() -> Self {
+            Self {
+                backoff: Default::default(),
+                state: Default::default(),
+                delay: std::time::Duration::ZERO,
+            }
+        }
     }
 
     impl FromIterator<(ViewNumber, Arc<ValidatedState>)> for MockStateCatchup {
@@ -446,7 +457,15 @@ pub mod mock {
             Self {
                 backoff: Default::default(),
                 state: iter.into_iter().collect(),
+                delay: std::time::Duration::ZERO,
             }
+        }
+    }
+
+    impl MockStateCatchup {
+        pub fn with_delay(mut self, delay: std::time::Duration) -> Self {
+            self.delay = delay;
+            self
         }
     }
 
@@ -471,6 +490,8 @@ pub mod mock {
             fee_merkle_tree_root: FeeMerkleCommitment,
             accounts: &[FeeAccount],
         ) -> anyhow::Result<Vec<FeeAccountProof>> {
+            tokio::time::sleep(self.delay).await;
+
             let src = &self.state[&view].fee_merkle_tree;
             assert_eq!(src.commitment(), fee_merkle_tree_root);
 
@@ -500,6 +521,8 @@ pub mod mock {
             view: ViewNumber,
             mt: &mut BlockMerkleTree,
         ) -> anyhow::Result<()> {
+            tokio::time::sleep(self.delay).await;
+
             tracing::info!("catchup: fetching frontier for view {view}");
             let src = &self.state[&view].block_merkle_tree;
 
@@ -522,6 +545,8 @@ pub mod mock {
             _retry: usize,
             _commitment: Commitment<ChainConfig>,
         ) -> anyhow::Result<ChainConfig> {
+            tokio::time::sleep(self.delay).await;
+
             Ok(ChainConfig::default())
         }
 


### PR DESCRIPTION
We should validate that the block header timestamp does not drift too much from the system time at the time we start validating the header. Before this change the catchup is performed before the timestamp drift validation. Since catchup can be slow this may cause the validation to fail. It would be better to separate the quick "stateless" validation and do that before applying the header but that's a major refactor to core logic so isn't done here.
