### PR TITLE
fix: very low epoch height

### DIFF
--- a/data/genesis/demo-da-committees.toml
+++ b/data/genesis/demo-da-committees.toml
@@ -3,7 +3,7 @@ upgrade_version = "0.5"
 genesis_version = "0.5"
 drb_difficulty = 30
 drb_upgrade_difficulty = 20
-epoch_height = 10
+epoch_height = 30
 epoch_start_block = 1
 stake_table_capacity = 10
 


### PR DESCRIPTION
This may create a race condition where we don't have stakers in the stake table contrct when we get to add_epoch_root.
