### PR TITLE
fix: arbitrum network test is flaky

### DIFF
--- a/contracts/test/LightClientArbitrumV2.t.sol
+++ b/contracts/test/LightClientArbitrumV2.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
+/* solhint-disable func-name-mixedcase, no-empty-blocks */
+
 import "forge-std/Test.sol";
 import { LightClientArbitrumV2, ArbSys } from "../src/LightClientArbitrumV2.sol";
 


### PR DESCRIPTION
- move to network tests
- try 2 providers

Not sure if this will help but I think it shouldn't make it any worse. The network test job is nice because it indicates that it's likely the network that has issues instead of the test itself.