### PR TITLE
Lower channel sizes

### DIFF
--- a/crates/hotshot/types/src/constants.rs
+++ b/crates/hotshot/types/src/constants.rs
@@ -38,10 +38,10 @@ pub const COMBINED_NETWORK_DELAY_DURATION: u64 = 5000;
 pub const REQUEST_DATA_DELAY: u64 = 5000;
 
 /// Default channel size for consensus event sharing
-pub const EVENT_CHANNEL_SIZE: usize = 100_000;
+pub const EVENT_CHANNEL_SIZE: usize = 1_000;
 
 /// Default channel size for HotShot -> application communication
-pub const EXTERNAL_EVENT_CHANNEL_SIZE: usize = 100_000;
+pub const EXTERNAL_EVENT_CHANNEL_SIZE: usize = 1_000;
 
 /// Default values for the upgrade constants
 pub const DEFAULT_UPGRADE_CONSTANTS: UpgradeConstants = UpgradeConstants {


### PR DESCRIPTION
This PR lowers the channel sizes for both the internal and external event streams.

Since these channels are implemented internally as a `VecDeque`, we are allocating a large `RawVec` equal to the channel capacity on initialization. For the internal event stream this is mostly inconsequential, since the vector holds `Arc` references (so even an array with 100,000 entries only takes up a few megabytes).

On the other hand, for the external event stream, which holds structs like `QuorumProposal`, this results in a ~200+ MB virtual allocation at startup. This memory is not immediately physically allocated to the program (because it will likely exceed `MMAP_THRESHOLD` for the allocator), but instead becomes available as we append to the vector. Broadcasts to the channel will *always* append to the array in memory (because `VecDeque` is a circular buffer), increasing the physical memory usage. Even when we drop entries at the head of the `VecDeque`, we do not free any of the initial segments of memory (of course, doing this in a circular buffer would be counterproductive), so this manifests as a memory leak up until we reach the end of the underlying array at ~200 MB (or more).
