### PR TITLE
fix: cleanup script subshell and process list

### DIFF
--- a/scripts/cleanup-process-compose
+++ b/scripts/cleanup-process-compose
@@ -44,6 +44,7 @@ get_proc_cwd() {
 # Update this list when adding/removing processes in process-compose.yaml
 NATIVE_PROCESSES=(
 	sequencer
+	sequencer-sqlite
 	orchestrator
 	state-relay-server
 	cdn-marshal
@@ -62,13 +63,17 @@ kill_project_processes() {
 	local proc_name=$1
 	local signal=$2
 
-	pgrep "$proc_name" 2>/dev/null | while read -r pid; do
+	# Collect PIDs first to avoid subshell issues when killing
+	local pids
+	pids=$(pgrep -fA "$proc_name" 2>/dev/null) || true
+
+	for pid in $pids; do
 		local proc_cwd
 		proc_cwd=$(get_proc_cwd "$pid")
 
 		if [[ -n "$proc_cwd" && "$proc_cwd" == "$PROJECT_DIR"* ]]; then
 			echo "Killing $proc_name (pid $pid) from $proc_cwd"
-			kill -"$signal" "$pid" 2>/dev/null || true
+			kill -"$signal" "$pid" || true
 		fi
 	done
 }


### PR DESCRIPTION
- Add sequencer-sqlite to NATIVE_PROCESSES list
- Fix pgrep pipe subshell issue where we were killing the running process because of the subshell.
- Use pgrep -fA for full argument matching
