### PR TITLE
fix(ci): free disk space for test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
 
       - name: Enable Rust Caching
@@ -179,6 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: rui314/setup-mold@v1
 
       - name: Enable Rust Caching
@@ -211,6 +213,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/free-disk-space
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: taiki-e/install-action@nextest
 


### PR DESCRIPTION
Add free-disk-space action to not run out of disk space.

This is the last run on main: https://github.com/EspressoSystems/espresso-network/actions/runs/20953687713