### PR TITLE
fix: drop hash table via new migrations, store hashes directly

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
@@ -21,7 +21,6 @@ use std::{
 use anyhow::Context;
 use ark_serialize::CanonicalDeserialize;
 use async_trait::async_trait;
-use futures::stream::TryStreamExt;
 use hotshot_types::traits::node_implementation::NodeType;
 use jf_merkle_tree_compat::{
     prelude::{MerkleNode, MerkleProof},
@@ -35,9 +34,8 @@ use super::{
 };
 use crate::{
     data_source::storage::{
-        pruning::PrunedHeightStorage,
-        sql::{build_where_in, sqlx::Row},
-        MerklizedStateHeightStorage, MerklizedStateStorage,
+        pruning::PrunedHeightStorage, sql::sqlx::Row, MerklizedStateHeightStorage,
+        MerklizedStateStorage,
     },
     merklized_state::{MerklizedState, Snapshot},
     QueryError, QueryResult,
@@ -71,8 +69,6 @@ where
 
         let nodes: Vec<Node> = rows.into_iter().map(|r| r.into()).collect();
 
-        let hashes: Vec<_> = nodes.iter().map(|node| node.hash_id.clone()).collect();
-
         let mut proof_path = VecDeque::with_capacity(State::tree_height());
         for Node {
             hash_id,
@@ -89,14 +85,6 @@ where
                 match (children, children_bitvec, idx, entry) {
                     // If the row has children then its a branch
                     (Some(children), Some(children_bitvec), None, None) => {
-                        let children: Vec<Vec<u8>> =
-                            serde_json::from_value(children.clone().into()).map_err(|e| {
-                                QueryError::Error {
-                                    message: format!(
-                                        "Error deserializing 'children' into Vec<i32>: {e}"
-                                    ),
-                                }
-                            })?;
                         let mut children = children.iter();
 
                         // Reconstruct the Children MerkleNodes from storage.
@@ -310,51 +298,6 @@ impl<Mode: TransactionMode> Transaction<Mode> {
     }
 }
 
-// TODO: create a generic upsert function with retries that returns the column
-#[cfg(feature = "embedded-db")]
-pub(crate) fn build_hash_batch_insert(
-    hashes: &[Vec<u8>],
-) -> QueryResult<(QueryBuilder<'_>, String)> {
-    let mut query = QueryBuilder::default();
-    let params = hashes
-        .iter()
-        .map(|hash| Ok(format!("({})", query.bind(hash)?)))
-        .collect::<QueryResult<Vec<String>>>()?;
-    let sql = format!(
-        "INSERT INTO hash(value) values {} ON CONFLICT (value) DO UPDATE SET value = \
-         EXCLUDED.value returning value, id",
-        params.join(",")
-    );
-    Ok((query, sql))
-}
-
-/// Batch insert hashes using UNNEST for large batches (postgres only).
-/// Returns a map from hash bytes to their database IDs.
-#[cfg(not(feature = "embedded-db"))]
-pub(crate) async fn batch_insert_hashes(
-    hashes: Vec<Vec<u8>>,
-    tx: &mut Transaction<Write>,
-) -> QueryResult<HashMap<Vec<u8>, i32>> {
-    if hashes.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    // Use UNNEST-based batch insert (more efficient and avoids parameter limits)
-    let sql = "INSERT INTO hash(value) SELECT * FROM UNNEST($1::bytea[]) ON CONFLICT (value) DO \
-               UPDATE SET value = EXCLUDED.value RETURNING value, id";
-
-    let result: HashMap<Vec<u8>, i32> = sqlx::query_as(sql)
-        .bind(&hashes)
-        .fetch(tx.as_mut())
-        .try_collect()
-        .await
-        .map_err(|e| QueryError::Error {
-            message: format!("batch hash insert failed: {e}"),
-        })?;
-
-    Ok(result)
-}
-
 /// Type alias for a merkle proof with its traversal path.
 pub(crate) type ProofWithPath<Entry, Key, T, const ARITY: usize> =
     (MerkleProof<Entry, Key, T, ARITY>, Vec<usize>);
@@ -510,11 +453,20 @@ impl From<sqlx::sqlite::SqliteRow> for Node {
         let children_bitvec: Option<BitVec> =
             bit_string.map(|b| b.chars().map(|c| c == '1').collect());
 
+        // SQLite stores hash_id and children as JSONB, so we need to deserialize them
+        let hash_id_json: JsonValue = row.get_unchecked("hash_id");
+        let hash_id: Vec<u8> =
+            serde_json::from_value(hash_id_json).expect("malformed hash_id in database");
+
+        let children_json: Option<JsonValue> = row.get_unchecked("children");
+        let children: Option<Vec<Vec<u8>>> = children_json
+            .map(|j| serde_json::from_value(j).expect("malformed children in database"));
+
         Self {
             path: row.get_unchecked("path"),
             created: row.get_unchecked("created"),
-            hash_id: row.get_unchecked("hash_id"),
-            children: row.get_unchecked("children"),
+            hash_id,
+            children,
             children_bitvec,
             idx: row.get_unchecked("idx"),
             entry: row.get_unchecked("entry"),
@@ -525,11 +477,16 @@ impl From<sqlx::sqlite::SqliteRow> for Node {
 #[cfg(not(feature = "embedded-db"))]
 impl From<sqlx::postgres::PgRow> for Node {
     fn from(row: sqlx::postgres::PgRow) -> Self {
+        // children is stored as JSONB (array of byte arrays), deserialize it
+        let children_json: Option<JsonValue> = row.get_unchecked("children");
+        let children: Option<Vec<Vec<u8>>> = children_json
+            .map(|j| serde_json::from_value(j).expect("malformed children in database"));
+
         Self {
             path: row.get_unchecked("path"),
             created: row.get_unchecked("created"),
             hash_id: row.get_unchecked("hash_id"),
-            children: row.get_unchecked("children"),
+            children,
             children_bitvec: row.get_unchecked("children_bitvec"),
             idx: row.get_unchecked("idx"),
             entry: row.get_unchecked("entry"),
@@ -560,11 +517,18 @@ impl Node {
                             .clone()
                             .map(|b| b.iter().map(|bit| if bit { '1' } else { '0' }).collect());
 
+                        // SQLite stores hash_id and children as JSONB
+                        let hash_id_json: JsonValue =
+                            serde_json::to_value(&n.hash_id).expect("failed to serialize hash_id");
+                        let children_json: Option<JsonValue> = n.children.as_ref().map(|c| {
+                            serde_json::to_value(c).expect("failed to serialize children")
+                        });
+
                         (
                             n.path.clone(),
                             n.created,
-                            n.hash_id,
-                            n.children.clone(),
+                            hash_id_json,
+                            children_json,
                             children_bitvec,
                             n.idx.clone(),
                             n.entry.clone(),
@@ -621,9 +585,11 @@ impl Node {
             paths.push(node.path);
             createds.push(node.created);
             hash_ids.push(node.hash_id);
-            if let Some(children) = node.children {
-            childrens.push(children);
-            }
+            // Serialize children to JSON for Postgres JSONB column
+            let children_json: Option<JsonValue> = node
+                .children
+                .map(|c| serde_json::to_value(c).expect("failed to serialize children"));
+            childrens.push(children_json);
             children_bitvecs.push(node.children_bitvec);
             idxs.push(node.idx);
             entries.push(node.entry);
@@ -632,7 +598,7 @@ impl Node {
         let sql = format!(
             r#"
             INSERT INTO "{name}" (path, created, hash_id, children, children_bitvec, idx, entry)
-            SELECT * FROM UNNEST($1::jsonb[], $2::bigint[], $3::jsonb[], $4::jsonb[], $5::bit varying[], $6::jsonb[], $7::jsonb[])
+            SELECT * FROM UNNEST($1::jsonb[], $2::bigint[], $3::bytea[], $4::jsonb[], $5::bit varying[], $6::jsonb[], $7::jsonb[])
             ON CONFLICT (path) DO UPDATE SET
                 hash_id = EXCLUDED.hash_id,
                 children = EXCLUDED.children,
@@ -646,7 +612,7 @@ impl Node {
             .bind(&paths)
             .bind(&createds)
             .bind(&hash_ids)
-            .bind(&childrens.concat())
+            .bind(&childrens)
             .bind(&children_bitvecs)
             .bind(&idxs)
             .bind(&entries)

--- a/sequencer/api/migrations/postgres/V1003__create_reward_merkle_tree_v2.sql
+++ b/sequencer/api/migrations/postgres/V1003__create_reward_merkle_tree_v2.sql
@@ -5,8 +5,8 @@
 CREATE TABLE reward_merkle_tree_v2 (
   path JSONB NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id BYTEA NOT NULL,
-  children BYTEA[2], 
+  hash_id INT NOT NULL REFERENCES hash (id), 
+  children JSONB, 
   children_bitvec BIT(2), 
   idx JSONB, 
   entry JSONB

--- a/sequencer/api/migrations/postgres/V1104__drop_hash_table.sql
+++ b/sequencer/api/migrations/postgres/V1104__drop_hash_table.sql
@@ -1,0 +1,111 @@
+-- Migrate merkle tree tables from using hash table references to storing hashes directly.
+-- This allows us to drop the hash table which was a performance bottleneck.
+-- Note: V302 already converted children from INT[] to JSONB (array of hash IDs as JSON).
+-- We keep children as JSONB but store the actual hash values as JSON arrays of numbers
+-- (matching serde_json's serialization of Vec<Vec<u8>>).
+
+-- Helper function to convert bytea to JSON array of integers (matching serde_json format)
+CREATE OR REPLACE FUNCTION bytea_to_json_array(b bytea) RETURNS jsonb AS $$
+DECLARE
+  result jsonb := '[]'::jsonb;
+  i int;
+BEGIN
+  FOR i IN 0..length(b)-1 LOOP
+    result := result || to_jsonb(get_byte(b, i));
+  END LOOP;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- fee_merkle_tree: migrate hash_id to BYTEA, update children JSONB to contain actual hashes
+ALTER TABLE fee_merkle_tree
+  DROP CONSTRAINT IF EXISTS fee_merkle_tree_hash_id_fkey,
+  ADD COLUMN hash_id_new BYTEA;
+
+UPDATE fee_merkle_tree f
+SET hash_id_new = h.value
+FROM hash h
+WHERE h.id = f.hash_id;
+
+-- Update children JSONB to contain actual hash values as JSON arrays of numbers
+UPDATE fee_merkle_tree f
+SET children = (
+  SELECT jsonb_agg(bytea_to_json_array(h.value) ORDER BY ordinality)
+  FROM jsonb_array_elements_text(f.children) WITH ORDINALITY AS elem(id, ordinality)
+  JOIN hash h ON h.id = elem.id::int
+)
+WHERE f.children IS NOT NULL AND f.children != 'null'::jsonb;
+
+ALTER TABLE fee_merkle_tree
+  DROP COLUMN hash_id;
+
+ALTER TABLE fee_merkle_tree
+  RENAME COLUMN hash_id_new TO hash_id;
+
+ALTER TABLE fee_merkle_tree
+  ALTER COLUMN hash_id SET NOT NULL;
+
+-- block_merkle_tree: migrate hash_id to BYTEA, update children JSONB to contain actual hashes
+ALTER TABLE block_merkle_tree
+  DROP CONSTRAINT IF EXISTS block_merkle_tree_hash_id_fkey,
+  ADD COLUMN hash_id_new BYTEA;
+
+UPDATE block_merkle_tree b
+SET hash_id_new = h.value
+FROM hash h
+WHERE h.id = b.hash_id;
+
+-- Update children JSONB to contain actual hash values as JSON arrays of numbers
+UPDATE block_merkle_tree b
+SET children = (
+  SELECT jsonb_agg(bytea_to_json_array(h.value) ORDER BY ordinality)
+  FROM jsonb_array_elements_text(b.children) WITH ORDINALITY AS elem(id, ordinality)
+  JOIN hash h ON h.id = elem.id::int
+)
+WHERE b.children IS NOT NULL AND b.children != 'null'::jsonb;
+
+ALTER TABLE block_merkle_tree
+  DROP COLUMN hash_id;
+
+ALTER TABLE block_merkle_tree
+  RENAME COLUMN hash_id_new TO hash_id;
+
+ALTER TABLE block_merkle_tree
+  ALTER COLUMN hash_id SET NOT NULL;
+
+-- reward_merkle_tree: no longer used (replaced by reward_merkle_tree_v2), just drop it
+DROP TABLE IF EXISTS reward_merkle_tree;
+
+-- reward_merkle_tree_v2: migrate hash_id to BYTEA, update children JSONB to contain actual hashes
+ALTER TABLE reward_merkle_tree_v2
+  DROP CONSTRAINT IF EXISTS reward_merkle_tree_v2_hash_id_fkey,
+  ADD COLUMN hash_id_new BYTEA;
+
+UPDATE reward_merkle_tree_v2 r
+SET hash_id_new = h.value
+FROM hash h
+WHERE h.id = r.hash_id;
+
+-- Update children JSONB to contain actual hash values as JSON arrays of numbers
+UPDATE reward_merkle_tree_v2 r
+SET children = (
+  SELECT jsonb_agg(bytea_to_json_array(h.value) ORDER BY ordinality)
+  FROM jsonb_array_elements_text(r.children) WITH ORDINALITY AS elem(id, ordinality)
+  JOIN hash h ON h.id = elem.id::int
+)
+WHERE r.children IS NOT NULL AND r.children != 'null'::jsonb;
+
+ALTER TABLE reward_merkle_tree_v2
+  DROP COLUMN hash_id;
+
+ALTER TABLE reward_merkle_tree_v2
+  RENAME COLUMN hash_id_new TO hash_id;
+
+ALTER TABLE reward_merkle_tree_v2
+  ALTER COLUMN hash_id SET NOT NULL;
+
+-- Drop the hash table now that nothing references it
+DROP TABLE hash;
+
+-- Clean up helper function
+DROP FUNCTION bytea_to_json_array(bytea);

--- a/sequencer/api/migrations/postgres/V14__state_tables.sql
+++ b/sequencer/api/migrations/postgres/V14__state_tables.sql
@@ -1,8 +1,12 @@
+CREATE TABLE IF NOT EXISTS hash (
+  id SERIAL PRIMARY KEY, value BYTEA NOT NULL UNIQUE
+);
+
 CREATE TABLE fee_merkle_tree (
   path INTEGER[] NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id BYTEA NOT NULL, 
-  children BYTEA[256], 
+  hash_id INT NOT NULL REFERENCES hash (id), 
+  children INT[], 
   children_bitvec BIT(256), 
   index JSONB, 
   entry JSONB
@@ -18,8 +22,8 @@ CREATE INDEX fee_merkle_tree_created ON fee_merkle_tree (created);
 CREATE TABLE block_merkle_tree (
   path INTEGER[] NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id BYTEA NOT NULL, 
-  children BYTEA[3], 
+  hash_id INT NOT NULL REFERENCES hash (id), 
+  children INT[], 
   children_bitvec BIT(3), 
   index JSONB, 
   entry JSONB

--- a/sequencer/api/migrations/sqlite/V104__state_tables.sql
+++ b/sequencer/api/migrations/sqlite/V104__state_tables.sql
@@ -1,21 +1,25 @@
+CREATE TABLE IF NOT EXISTS hash (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, value JSONB NOT NULL UNIQUE
+);
+
 CREATE TABLE fee_merkle_tree (
   path JSONB NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id JSONB NOT NULL, 
+  hash_id INT NOT NULL REFERENCES hash (id), 
   children JSONB, 
   children_bitvec BLOB, 
   idx JSONB, 
   entry JSONB,
-  PRIMARY KEY (path)
+  PRIMARY KEY (path, created)
 );
 
 CREATE TABLE block_merkle_tree (
   path JSONB NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id JSONB, 
+  hash_id INT NOT NULL REFERENCES hash (id), 
   children JSONB, 
   children_bitvec BLOB, 
   idx JSONB, 
   entry JSONB,
-  PRIMARY KEY (path)
+  PRIMARY KEY (path, created)
 );

--- a/sequencer/api/migrations/sqlite/V304__reward_merkle_tree.sql
+++ b/sequencer/api/migrations/sqlite/V304__reward_merkle_tree.sql
@@ -1,12 +1,12 @@
 CREATE TABLE reward_merkle_tree (
   path JSONB NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id JSONB NOT NULL,
+  hash_id INT NOT NULL REFERENCES hash (id), 
   children JSONB, 
   children_bitvec BLOB, 
   idx JSONB, 
   entry JSONB,
-  PRIMARY KEY (path)
+  PRIMARY KEY (path, created)
 );
 
 ALTER TABLE header

--- a/sequencer/api/migrations/sqlite/V607__create_reward_merkle_tree_v2.sql
+++ b/sequencer/api/migrations/sqlite/V607__create_reward_merkle_tree_v2.sql
@@ -5,10 +5,10 @@
 CREATE TABLE reward_merkle_tree_v2 (
   path JSONB NOT NULL, 
   created BIGINT NOT NULL, 
-  hash_id JSONB NOT NULL,
+  hash_id INT NOT NULL REFERENCES hash (id), 
   children JSONB, 
   children_bitvec BLOB, 
   idx JSONB, 
   entry JSONB,
-  PRIMARY KEY (path)
+  PRIMARY KEY (path, created)
 );

--- a/sequencer/api/migrations/sqlite/V903__drop_hash_table.sql
+++ b/sequencer/api/migrations/sqlite/V903__drop_hash_table.sql
@@ -1,0 +1,89 @@
+-- Migrate merkle tree tables from using hash table references to storing hashes directly.
+-- SQLite doesn't support ALTER COLUMN TYPE, so we recreate tables.
+
+-- fee_merkle_tree
+CREATE TABLE fee_merkle_tree_new (
+  path JSONB NOT NULL,
+  created BIGINT NOT NULL,
+  hash_id JSONB NOT NULL,
+  children JSONB,
+  children_bitvec BLOB,
+  idx JSONB,
+  entry JSONB,
+  PRIMARY KEY (path)
+);
+
+INSERT INTO fee_merkle_tree_new (path, created, hash_id, children, children_bitvec, idx, entry)
+SELECT
+  f.path,
+  f.created,
+  h.value,
+  f.children,
+  f.children_bitvec,
+  f.idx,
+  f.entry
+FROM fee_merkle_tree f
+LEFT JOIN hash h ON h.id = f.hash_id;
+
+DROP TABLE fee_merkle_tree;
+ALTER TABLE fee_merkle_tree_new RENAME TO fee_merkle_tree;
+
+-- block_merkle_tree
+CREATE TABLE block_merkle_tree_new (
+  path JSONB NOT NULL,
+  created BIGINT NOT NULL,
+  hash_id JSONB,
+  children JSONB,
+  children_bitvec BLOB,
+  idx JSONB,
+  entry JSONB,
+  PRIMARY KEY (path)
+);
+
+INSERT INTO block_merkle_tree_new (path, created, hash_id, children, children_bitvec, idx, entry)
+SELECT
+  b.path,
+  b.created,
+  h.value,
+  b.children,
+  b.children_bitvec,
+  b.idx,
+  b.entry
+FROM block_merkle_tree b
+LEFT JOIN hash h ON h.id = b.hash_id;
+
+DROP TABLE block_merkle_tree;
+ALTER TABLE block_merkle_tree_new RENAME TO block_merkle_tree;
+
+-- reward_merkle_tree: no longer used (replaced by reward_merkle_tree_v2), just drop it
+DROP TABLE IF EXISTS reward_merkle_tree;
+
+-- reward_merkle_tree_v2: migrate hash_id from INT reference to JSONB value
+CREATE TABLE reward_merkle_tree_v2_new (
+  path JSONB NOT NULL,
+  created BIGINT NOT NULL,
+  hash_id JSONB NOT NULL,
+  children JSONB,
+  children_bitvec BLOB,
+  idx JSONB,
+  entry JSONB,
+  PRIMARY KEY (path)
+);
+
+INSERT INTO reward_merkle_tree_v2_new (path, created, hash_id, children, children_bitvec, idx, entry)
+SELECT
+  r.path,
+  r.created,
+  h.value,
+  r.children,
+  r.children_bitvec,
+  r.idx,
+  r.entry
+FROM reward_merkle_tree_v2 r
+LEFT JOIN hash h ON h.id = r.hash_id;
+
+DROP TABLE reward_merkle_tree_v2;
+ALTER TABLE reward_merkle_tree_v2_new RENAME TO reward_merkle_tree_v2;
+
+-- Drop the hash table
+DROP TABLE hash;


### PR DESCRIPTION
- Revert modified migrations to original state (V14, V104, V304, V607, V1003)
- Add V1104 (postgres) and V903 (sqlite) to migrate hash_id from INT foreign key to actual bytes and drop the hash table
- Update Rust code to serialize/deserialize children as JSONB
- Remove unused hash table helper functions
