### PR TITLE
fix(sequencer): disable default features in dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ indexmap = { version = "2", features = ["serde"] }
 lazy_static = "1"
 libp2p-identity = { version = "0.2", features = ["ed25519", "serde"] }
 libp2p-swarm-derive = { version = "0.35" }
-moka = { version = "0.12.12", features = ["future"] }
 memoize = { version = "0.4", features = ["full"] }
+moka = { version = "0.12.12", features = ["future"] }
 multiaddr = { version = "0.18" }
 num_cpus = "1"
 parking_lot = { version = "0.12", features = ["send_guard"] }

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -43,7 +43,7 @@ vec1 = { workspace = true }
 
 [dev-dependencies]
 jf-signature = { workspace = true, features = ["bls"] }
-sequencer = { path = "../../sequencer", features = ["testing"] }
+sequencer = { path = "../../sequencer", default-features = false, features = ["testing"] }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 

--- a/light-client-query-service/Cargo.toml
+++ b/light-client-query-service/Cargo.toml
@@ -22,7 +22,7 @@ hotshot-query-service = { path = "../hotshot-query-service" }
 light-client = { path = "../light-client", features = ["clap"] }
 log-panics = { workspace = true }
 semver = { workspace = true }
-sequencer = { path = "../sequencer" }
+sequencer = { path = "../sequencer", default-features = false }
 tide-disco = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -49,7 +49,7 @@ light-client = { path = ".", features = ["testing"] }
 
 portpicker = { workspace = true }
 pretty_assertions = { workspace = true }
-sequencer = { path = "../sequencer", features = ["testing"] }
+sequencer = { path = "../sequencer", default-features = false, features = ["testing"] }
 test-log = { workspace = true }
 
 [lints]

--- a/slow-tests/Cargo.toml
+++ b/slow-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 embedded-db = ["sequencer/embedded-db"]
 
 [dependencies]
-sequencer = { path = "../sequencer", features = ["testing"] }
+sequencer = { path = "../sequencer", default-features = false, features = ["testing"] }
 
 alloy = { workspace = true }
 anyhow = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,7 +31,7 @@ jf-signature = { workspace = true }
 portpicker = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
-sequencer = { path = "../sequencer", features = ["testing"] }
+sequencer = { path = "../sequencer", default-features = false, features = ["testing"] }
 sequencer-utils = { path = "../utils" }
 staking-cli = { path = "../staking-cli" }
 surf-disco = { workspace = true }


### PR DESCRIPTION
Add `default-features = false` to sequencer dependencies in:
- slow-tests
- tests
- light-client-query-service
- light-client (dev-deps)
- crates/builder (dev-deps)

This prevents feature unification from enabling all sequencer version features (fee, pos, drb-and-header, da-upgrade) when building with specific features only.
