### PR TITLE
Fix Unnecessary Timeouts when View Change happens before Proposal Handling

### DIFF
--- a/crates/hotshot/task-impls/src/helpers.rs
+++ b/crates/hotshot/task-impls/src/helpers.rs
@@ -1151,7 +1151,7 @@ pub(crate) async fn validate_proposal_view_and_certs<
 ) -> Result<()> {
     let view_number = proposal.data.view_number();
     ensure!(
-        view_number >= validation_info.consensus.read().await.cur_view(),
+        view_number + 1 >= validation_info.consensus.read().await.cur_view(),
         "Proposal is from an older view {:?}",
         proposal.data
     );

--- a/crates/hotshot/task-impls/src/quorum_proposal_recv/mod.rs
+++ b/crates/hotshot/task-impls/src/quorum_proposal_recv/mod.rs
@@ -153,8 +153,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>, V: Versions>
                     "Quorum proposal recv for view {}",
                     proposal.data.view_number()
                 );
-                if self.consensus.read().await.cur_view() > proposal.data.view_number()
-                    || self.cur_view > proposal.data.view_number()
+                if self.consensus.read().await.cur_view() > proposal.data.view_number() + 1
+                    || self.cur_view > proposal.data.view_number() + 1
                 {
                     tracing::warn!(
                         "Throwing away old proposal for view {}",

--- a/crates/hotshot/testing/tests/test_epochs_restart.rs
+++ b/crates/hotshot/testing/tests/test_epochs_restart.rs
@@ -58,9 +58,8 @@ cross_tests!(
       metadata.overall_safety_properties = OverallSafetyPropertiesDescription {
           // Make sure we keep committing rounds after the catchup
           num_successful_views: 50,
-          expected_view_failures: vec![10],
           // this test seems to be flaky, so we allow an excessive number of possible view failures
-          possible_view_failures: vec![8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+          possible_view_failures: vec![8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
           decide_timeout: Duration::from_secs(60),
           ..Default::default()
       };


### PR DESCRIPTION
### This PR:
Fixes timeouts that can happen when we change views before we validate a proposal. If this happens we throw out the proposal. The way this happens is if we form a QC for the previous view as leader, before we handle the proposal. I'm not sure this would happen in a real system, but in our tests I confirmed it does happen and leads to flaky tests, especially around epoch transition

### This PR does not:
Doesn't change any consensus properties. It is also extremely low risk as handling a proposal for 1 extra view doesn't really open up any avenue for attack.

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
