### PR TITLE
fix: disallow testing feature for release (#3982)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -45,6 +45,16 @@ default-filter = 'deps(hotshot-testing)'
 final-status-level = "flaky"
 threads-required = "num-test-threads"
 
+[[profile.hotshot.overrides]]
+filter = """
+test(test_success_with_async_delay_with_epochs) |
+test(test_success_with_async_delay_2_with_epochs) |
+test(test_vid2_success) |
+test(test_combined_network_half_dc) |
+test(test_staggered_restart_first_block)
+"""
+retries = 3
+
 [profile.slow]
 slow-timeout = "2m"
 default-filter = 'package(espresso-dev-node) | package(slow-tests)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,6 +276,7 @@ jobs:
         timeout-minutes: 20
 
   test-go-sdk:
+    needs: build-test-bins-dev-node
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -289,9 +290,13 @@ jobs:
           extraPullNames: nix-community
           skipPush: ${{ github.actor == 'dependabot[bot]' }}
 
-      - name: Build espresso-dev-node
-        run: |
-          nix develop --accept-flake-config -c cargo build -p espresso-dev-node
+        # TODO: this downloads all (available) artifacts, which is a bit wasteful but artifact
+        # downloads always fail if I try to select a subset.
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Make binary executable
+        run: chmod +x test-binaries-dev-node/espresso-dev-node
 
       - name: Build verification module
         run: |
@@ -300,6 +305,8 @@ jobs:
       - name: Test
         run: |
           nix develop --accept-flake-config -c just test-go
+        env:
+          ESPRESSO_DEV_NODE_BIN: ${{ github.workspace }}/test-binaries-dev-node/espresso-dev-node
 
   test-integration:
     needs: [build-test-bins, build-test-bins-sqlite, build-test-artifacts-postgres]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,12 +2611,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "capnp"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe8af2e2d255489928e31504fa51d86a41d040179098a8ad6828e0d11c54dcd6"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3799,7 +3832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10612,6 +10645,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"
@@ -10726,6 +10763,7 @@ dependencies = [
  "vbs",
  "vec1",
  "vergen",
+ "vergen-gitcl",
  "vid",
 ]
 
@@ -13049,14 +13087,42 @@ dependencies = [
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
  "rustversion",
  "time 0.3.47",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time 0.3.47",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,8 @@ trait-set = "0.3.0"
 url = { version = "2.3", features = ["serde"] }
 vbs = "0.1"
 vec1 = { version = "1", features = ["serde"] }
-vergen = { version = "8.3", features = ["git", "gitcl"] }
+vergen = { version = "9", features = ["build", "cargo"] }
+vergen-gitcl = "9"
 zeroize = "1.7"
 
 # Push CDN imports

--- a/scripts/ci-build-binary
+++ b/scripts/ci-build-binary
@@ -9,7 +9,7 @@ set -euo pipefail
 
 case "$1" in
     "sequencer")
-        cargo build --locked --release --bin sequencer
+        cargo build --locked --release -p sequencer --bin sequencer
         ;;
     "sequencer-sqlite")
         cargo build --locked --release -p sequencer-sqlite

--- a/sdks/go/client-dev-node/client_test.go
+++ b/sdks/go/client-dev-node/client_test.go
@@ -52,13 +52,18 @@ func runDevNode(ctx context.Context, tmpDir string) func() {
 		panic(err)
 	}
 
-	invocation := []string{
-		"run",
-		"-p",
-		"espresso-dev-node",
+	var p *exec.Cmd
+	if bin := os.Getenv("ESPRESSO_DEV_NODE_BIN"); bin != "" {
+		if _, err := os.Stat(bin); err != nil {
+			panic(fmt.Sprintf("ESPRESSO_DEV_NODE_BIN=%s does not exist: %v", bin, err))
+		}
+		fmt.Println("using pre-built espresso-dev-node binary:", bin)
+		p = exec.CommandContext(ctx, bin)
+	} else {
+		fmt.Println("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run (this will compile espresso-dev-node)")
+		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
+		p.Dir = workingDir
 	}
-	p := exec.CommandContext(ctx, "cargo", invocation...)
-	p.Dir = workingDir
 
 	env := os.Environ()
 	env = append(env, "ESPRESSO_SEQUENCER_API_PORT=21000")

--- a/sdks/go/client/client_test.go
+++ b/sdks/go/client/client_test.go
@@ -114,13 +114,18 @@ func runDevNode(ctx context.Context, tmpDir string) func() {
 		panic(err)
 	}
 
-	invocation := []string{
-		"run",
-		"-p",
-		"espresso-dev-node",
+	var p *exec.Cmd
+	if bin := os.Getenv("ESPRESSO_DEV_NODE_BIN"); bin != "" {
+		if _, err := os.Stat(bin); err != nil {
+			panic(fmt.Sprintf("ESPRESSO_DEV_NODE_BIN=%s does not exist: %v", bin, err))
+		}
+		fmt.Println("using pre-built espresso-dev-node binary:", bin)
+		p = exec.CommandContext(ctx, bin)
+	} else {
+		fmt.Println("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run (this will compile espresso-dev-node)")
+		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
+		p.Dir = workingDir
 	}
-	p := exec.CommandContext(ctx, "cargo", invocation...)
-	p.Dir = workingDir
 
 	env := os.Environ()
 	env = append(env, "ESPRESSO_SEQUENCER_API_PORT=21000")

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 normal = ["hotshot-testing"]
 
 [package.metadata.cargo-machete]
-ignored = ["vergen", "include_dir", "hotshot_builder_api"]
+ignored = ["vergen", "vergen-gitcl", "include_dir", "hotshot_builder_api"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -128,6 +128,7 @@ vid = { path = "../vid" }
 [build-dependencies]
 anyhow = { workspace = true }
 vergen = { workspace = true }
+vergen-gitcl = { workspace = true }
 
 [dev-dependencies]
 escargot = "0.5.10"

--- a/sequencer/build.rs
+++ b/sequencer/build.rs
@@ -1,11 +1,24 @@
-use vergen::EmitBuilder;
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_gitcl::GitclBuilder;
 
 pub fn main() -> anyhow::Result<()> {
-    // Set an environment variable with git information
-    EmitBuilder::builder()
-        .git_sha(false)
-        .git_describe(true, true, None)
-        .git_commit_timestamp()
+    let build = BuildBuilder::default().build_timestamp(true).build()?;
+    let cargo = CargoBuilder::default()
+        .debug(true)
+        .features(true)
+        .target_triple(true)
+        .build()?;
+    let git = GitclBuilder::default()
+        .sha(false)
+        .describe(true, true, None)
+        .dirty(true)
+        .branch(true)
+        .commit_timestamp(true)
+        .build()?;
+    Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&cargo)?
+        .add_instructions(&git)?
         .emit()?;
     Ok(())
 }

--- a/sequencer/src/lib.rs
+++ b/sequencer/src/lib.rs
@@ -230,6 +230,34 @@ where
             env!("VERGEN_GIT_COMMIT_TIMESTAMP").into(),
         ]);
 
+    metrics
+        .text_family(
+            "build_info".into(),
+            vec![
+                "build_timestamp".into(),
+                "dirty".into(),
+                "branch".into(),
+                "debug".into(),
+                "features".into(),
+                "target".into(),
+                "testing".into(),
+            ],
+        )
+        .create(vec![
+            env!("VERGEN_BUILD_TIMESTAMP").into(),
+            env!("VERGEN_GIT_DIRTY").into(),
+            env!("VERGEN_GIT_BRANCH").into(),
+            env!("VERGEN_CARGO_DEBUG").into(),
+            env!("VERGEN_CARGO_FEATURES").into(),
+            env!("VERGEN_CARGO_TARGET_TRIPLE").into(),
+            if cfg!(feature = "testing") {
+                "yes"
+            } else {
+                "no"
+            }
+            .into(),
+        ]);
+
     // Expose Node Entity Information via the status/metrics API
     metrics
         .text_family(

--- a/sequencer/src/main.rs
+++ b/sequencer/src/main.rs
@@ -2,6 +2,12 @@
 // not building with --release (without debug_assertions). There is
 // unfortunately no good way to detect if a build is performed by nextest
 // because nextest doesn't expose any build time env vars.
+#[cfg(all(feature = "testing", not(debug_assertions), not(clippy)))]
+compile_error!(
+    "testing feature must not be enabled in release builds. If this is intentional, comment out \
+     this check."
+);
+
 #[cfg(all(feature = "embedded-db", not(debug_assertions), not(clippy)))]
 compile_error!(
     r#"

--- a/sequencer/src/options.rs
+++ b/sequencer/src/options.rs
@@ -44,6 +44,7 @@ use crate::{api, persistence, proposal_fetcher::ProposalFetcherConfig};
 // default value, even if it is a bit arbitrary.
 #[derive(Parser, Clone, Derivative)]
 #[derivative(Debug(bound = ""))]
+#[command(version = build_version())]
 pub struct Options {
     /// URL of the HotShot orchestrator.
     #[clap(
@@ -448,6 +449,28 @@ fn get_default_node_type() -> String {
     format!("espresso-sequencer {}", env!("CARGO_PKG_VERSION"))
 }
 
+fn build_version() -> String {
+    let testing = if cfg!(feature = "testing") {
+        "yes"
+    } else {
+        "no"
+    };
+    format!(
+        "\ndescribe: {}\nrev: {}\ndirty: {}\nbranch: {}\ncommit-timestamp: {}\nbuild-timestamp: \
+         {}\ndebug: {}\nfeatures: {}\ntarget: {}\ntesting: {}",
+        env!("VERGEN_GIT_DESCRIBE"),
+        env!("VERGEN_GIT_SHA"),
+        env!("VERGEN_GIT_DIRTY"),
+        env!("VERGEN_GIT_BRANCH"),
+        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        env!("VERGEN_CARGO_DEBUG"),
+        env!("VERGEN_CARGO_FEATURES"),
+        env!("VERGEN_CARGO_TARGET_TRIPLE"),
+        testing,
+    )
+}
+
 // The Debug implementation for Url is noisy, we just want to see the URL
 fn fmt_urls(v: &[Url], fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
     write!(
@@ -689,4 +712,36 @@ pub struct Modules {
     pub hotshot_events: Option<api::options::HotshotEvents>,
     pub explorer: Option<api::options::Explorer>,
     pub light_client: Option<api::options::LightClient>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_version() {
+        let version = build_version();
+        for field in [
+            "describe:",
+            "rev:",
+            "dirty:",
+            "branch:",
+            "commit-timestamp:",
+            "build-timestamp:",
+            "debug:",
+            "features:",
+            "target:",
+            "testing:",
+        ] {
+            assert!(version.contains(field), "missing {field}: {version}");
+        }
+        assert!(
+            version.contains("debug: true"),
+            "expected debug build in test: {version}"
+        );
+        assert!(
+            version.contains("testing: yes"),
+            "expected testing enabled in test builds: {version}"
+        );
+    }
 }

--- a/sequencer/src/run.rs
+++ b/sequencer/src/run.rs
@@ -453,6 +453,17 @@ mod test {
             ),
             "{lines:#?}"
         );
+        let build_info_line = lines
+            .iter()
+            .find(|l| l.starts_with("consensus_build_info{"));
+        assert!(
+            build_info_line.is_some(),
+            "missing consensus_build_info metric: {lines:#?}"
+        );
+        assert!(
+            build_info_line.unwrap().contains("testing=\"yes\""),
+            "expected testing=yes in test builds: {lines:#?}"
+        );
 
         task.abort();
     }


### PR DESCRIPTION
Backport of #3982, auto backport failed.

* fix: disallow testing feature for release

The extra -p sequencer gating prevents the feature from being turned on by downstream testing crates. Add compile time check for good measure.

* feat: compile time check sequencer-sqlite too

* feat(sequencer): add --version flag with build info, upgrade vergen to v9

- Add `--version` CLI flag showing describe, rev, dirty, branch, timestamps, debug, features, target, and testing status
- Upgrade vergen from v8 to v9, switch from gitcl feature to vergen-gitcl companion crate
- Only emit the env vars actually used in build_version()
- Use short SHA to match previous v8 behavior

* fix: move testing feature guard to main.rs

The guard in run.rs (library) breaks espresso-dev-node which legitimately needs the testing feature in release builds. Move it to sequencer/src/main.rs (binary only) matching the existing embedded-db guard pattern. The -p flag in ci-build-binary is the primary protection; this compile_error is a safety net for local builds.

* feat(sequencer): expose build info in metrics endpoint

Add dirty, branch, build_timestamp, debug, features, target, and testing fields to the consensus_version metric. This matches the info from --version and makes it available for monitoring.

* fix(sequencer): preserve existing version metric, add build_info metric

Keep the existing consensus_version metric unchanged (rev, desc, timestamp) to avoid breaking dashboards/alerts. Add a new consensus_build_info metric with the additional fields (build_timestamp, dirty, branch, debug, features, target, testing). Use full SHA to match existing behavior.

* fix(test): add test_staggered_restart_first_block to flaky retries

* fix(ci): reuse pre-built espresso-dev-node binary in Go SDK tests

The test-go-sdk job was building espresso-dev-node from source despite build-test-bins-dev-node already producing it as an artifact. Download the artifact instead and pass its path via ESPRESSO_DEV_NODE_BIN env var, falling back to cargo run for local development.

* fix(ci): download all artifacts in test-go-sdk to avoid download failures

* fix(ci): support pre-built binary in client-dev-node tests

(cherry picked from commit 99830000b442a0ddea7af76de35d0b9890b01d75)

Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
