### PR TITLE
chore: retry another flaky test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -52,7 +52,8 @@ test(test_success_with_async_delay_2_with_epochs) |
 test(test_vid2_success) |
 test(test_combined_network_half_dc) |
 test(test_staggered_restart_first_block) |
-test(test_epoch_success_overlap_3f)
+test(test_epoch_success_overlap_3f) |
+test(test_epoch_success_types_randomized_leader)
 """
 retries = 3
 


### PR DESCRIPTION
Failed on `main` just now: https://github.com/EspressoSystems/espresso-network/actions/runs/22304504693/job/64520291254