### PR TITLE
make state query compatible with postgres 15

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1712,7 +1712,7 @@ mod test {
         // there should be multiple nodes with same index but different created time
         let (count,) = query_as::<(i64,)>(
             " SELECT count(*) FROM (SELECT count(*) as count FROM test_tree GROUP BY path having \
-             count(*) > 1)",
+             count(*) > 1) AS s",
         )
         .fetch_one(tx.as_mut())
         .await
@@ -1731,7 +1731,7 @@ mod test {
         let mut tx = storage.read().await.unwrap();
         let (count,) = query_as::<(i64,)>(
             "SELECT count(*) FROM (SELECT count(*) as count FROM test_tree GROUP BY path having \
-             count(*) > 1)",
+             count(*) > 1) AS s",
         )
         .fetch_one(tx.as_mut())
         .await

--- a/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/state.rs
@@ -709,7 +709,7 @@ fn build_get_path_query<'q>(
 
         let sub_query = format!(
             "SELECT * FROM (SELECT * FROM {table} WHERE path = {node_path} AND created <= $1 \
-             ORDER BY created DESC LIMIT 1)",
+             ORDER BY created DESC LIMIT 1) AS latest_node",
         );
 
         sub_queries.push(sub_query);


### PR DESCRIPTION
state query does not work with Postgres 15 because the subquery requires an alias