### PR TITLE
Ensure old reward merkle tree tables get deleted

### DIFF
--- a/crates/espresso/node/api/migrations/postgres/V1401__delete_reward_merkle_trees.sql
+++ b/crates/espresso/node/api/migrations/postgres/V1401__delete_reward_merkle_trees.sql
@@ -1,0 +1,14 @@
+DO
+$$
+BEGIN
+   IF EXISTS (SELECT FROM epoch_migration WHERE table_name = 'reward_merkle_tree_v2_data' AND completed) THEN
+      -- Reward Merkle tree data has already been migrated into new tables; we can drop the old
+      -- Merkle tree tables.
+      DROP TABLE reward_merkle_tree_v2;
+      DROP TABLE reward_merkle_tree;
+   ELSE
+      -- The migration has not been completed yet. It will run when the node starts up, and will
+      -- drop the old tables when completed.
+   END IF;
+END
+$$

--- a/crates/espresso/node/api/migrations/postgres/V1401__delete_reward_merkle_trees.sql
+++ b/crates/espresso/node/api/migrations/postgres/V1401__delete_reward_merkle_trees.sql
@@ -2,13 +2,13 @@ DO
 $$
 BEGIN
    IF EXISTS (SELECT FROM epoch_migration WHERE table_name = 'reward_merkle_tree_v2_data' AND completed) THEN
-      -- Reward Merkle tree data has already been migrated into new tables; we can drop the old
+      -- Reward Merkle tree data has already been migrated into new tables; we can truncate the old
       -- Merkle tree tables.
-      DROP TABLE reward_merkle_tree_v2;
-      DROP TABLE reward_merkle_tree;
+      TRUNCATE reward_merkle_tree_v2;
+      TRUNCATE reward_merkle_tree;
    ELSE
       -- The migration has not been completed yet. It will run when the node starts up, and will
-      -- drop the old tables when completed.
+      -- truncate the old tables when completed.
    END IF;
 END
 $$

--- a/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
+++ b/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
@@ -1,10 +1,10 @@
-DROP TABLE reward_merkle_tree_v2;
-DROP TABLE reward_merkle_tree;
+TRUNCATE reward_merkle_tree_v2;
+TRUNCATE reward_merkle_tree;
 
 -- For Postgres, we execute this migration conditionally only if the `reward_merkle_tree_v2_data`
--- has already happened, allowing that migration to drop the old tables if it has yet to happen.
+-- has already happened, allowing that migration to truncate the old tables if it has yet to happen.
 -- For SQLite, procedural if/then migrations are not supported, so we can't do this. Instead, we
--- unconditionally drop the old tables and mark the `reward_merkle_tree_v2_data` migration as
+-- unconditionally truncate the old tables and mark the `reward_merkle_tree_v2_data` migration as
 -- completed, effectively skipping it if it has not run yet. This should be fine as SQLite nodes
 -- should not generally be storing full reward state anyways.
 INSERT INTO epoch_migration (table_name, completed) VALUES ('reward_merkle_tree_v2_data', TRUE)

--- a/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
+++ b/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
@@ -1,0 +1,11 @@
+DROP TABLE reward_merkle_tree_v2;
+DROP TABLE reward_merkle_tree;
+
+-- For Postgres, we execute this migration conditionally only if the `reward_merkle_tree_v2_data`
+-- has already happened, allowing that migration to drop the old tables if it has yet to happen.
+-- For SQLite, procedural if/then migrations are not supported, so we can't do this. Instead, we
+-- unconditionally drop the old tables and mark the `reward_merkle_tree_v2_data` migration as
+-- completed, effectively skipping it if it has not run yet. This should be fine as SQLite nodes
+-- should not generally be storing full reward state anyways.
+INSERT INTO epoch_migration (table_name, completed) VALUES ('reward_merkle_tree_v2_data', TRUE)
+ON CONFLICT DO UPDATE SET completed = TRUE;

--- a/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
+++ b/crates/espresso/node/api/migrations/sqlite/V1201__delete_reward_merkle_trees.sql
@@ -1,5 +1,5 @@
-TRUNCATE reward_merkle_tree_v2;
-TRUNCATE reward_merkle_tree;
+DELETE FROM reward_merkle_tree_v2;
+DELETE FROM reward_merkle_tree;
 
 -- For Postgres, we execute this migration conditionally only if the `reward_merkle_tree_v2_data`
 -- has already happened, allowing that migration to truncate the old tables if it has yet to happen.

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -1362,10 +1362,15 @@ impl SequencerPersistence for Persistence {
             [("reward_merkle_tree_v2_data".to_string(), true, offset)],
         )
         .await?;
-        query("TRUNCATE reward_merkle_tree_v2")
+        let truncate = if cfg!(feature = "embedded-db") {
+            "DELETE FROM"
+        } else {
+            "TRUNCATE"
+        };
+        query(&format!("{truncate} reward_merkle_tree_v2"))
             .execute(tx.as_mut())
             .await?;
-        query("TRUNCATE reward_merkle_tree")
+        query(&format!("{truncate} reward_merkle_tree"))
             .execute(tx.as_mut())
             .await?;
         tx.commit().await?;

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -1362,10 +1362,10 @@ impl SequencerPersistence for Persistence {
             [("reward_merkle_tree_v2_data".to_string(), true, offset)],
         )
         .await?;
-        query("DROP TABLE reward_merkle_tree_v2")
+        query("TRUNCATE reward_merkle_tree_v2")
             .execute(tx.as_mut())
             .await?;
-        query("DROP TABLE reward_merkle_tree")
+        query("TRUNCATE reward_merkle_tree")
             .execute(tx.as_mut())
             .await?;
         tx.commit().await?;

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -1353,7 +1353,7 @@ impl SequencerPersistence for Persistence {
         .await?;
         tx.commit().await?;
 
-        // Mark migration as complete
+        // Mark migration as complete, and clean up old tables.
         let mut tx = self.db.write().await?;
         tx.upsert(
             "epoch_migration",
@@ -1362,6 +1362,12 @@ impl SequencerPersistence for Persistence {
             [("reward_merkle_tree_v2_data".to_string(), true, offset)],
         )
         .await?;
+        query("DROP TABLE reward_merkle_tree_v2")
+            .execute(tx.as_mut())
+            .await?;
+        query("DROP TABLE reward_merkle_tree")
+            .execute(tx.as_mut())
+            .await?;
         tx.commit().await?;
 
         tracing::warn!("migrated reward_merkle_tree_v2 at height {max_height}");


### PR DESCRIPTION
### This PR:

Deletes old reward Merkle tree tables. These tables are extremely large (currently over 1 TB on Decaf) and are no longer needed after the `reward_merkle_tree_v2_data` migration.

On Postgres, we ensure that the `reward_merkle_tree_v2_data` runs before the tables are deleted, whether or not the migration has already run on a particular node before this upgrade is deployed.

On Sqlite, this is difficult to enforce, and it is possible that the old tables will be deleted before the `reward_merkle_tree_v2_data` migration runs, resulting in empty `reward_merkle_tree_v2_data` and `reward_merkle_tree_v2_proofs` tables. This is acceptable since we shouldn't be relying on SQLite nodes to provide the full reward history in any case; we can leave this to the postgres nodes.