### PR TITLE
fix: persist reward tree at every epoch boundary for epoch reward version

### DIFF
--- a/crates/espresso/node/src/state.rs
+++ b/crates/espresso/node/src/state.rs
@@ -19,6 +19,7 @@ use hotshot_query_service::{
     status::StatusDataSource,
     types::HeightIndexed,
 };
+use hotshot_types::utils::is_last_block;
 use jf_merkle_tree_compat::{
     LookupResult, MerkleTreeScheme, ToTraversalPath, UniversalMerkleTreeScheme,
 };
@@ -282,7 +283,8 @@ where
     // fetch_reward_merkle_tree_v2(height=12000) to catch up missing accounts and
     // fails because no tree exists in storage at that height.
     let is_epoch_boundary = version >= EPOCH_REWARD_VERSION
-        && block_number.is_multiple_of(
+        && is_last_block(
+            block_number,
             instance
                 .epoch_height
                 .expect("epoch_height should be set for version > V3"),

--- a/crates/espresso/node/src/state.rs
+++ b/crates/espresso/node/src/state.rs
@@ -24,7 +24,7 @@ use jf_merkle_tree_compat::{
 };
 use tokio::time::sleep;
 use vbs::version::Version;
-use versions::{DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_VERSION};
+use versions::{DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_REWARD_VERSION, EPOCH_VERSION};
 
 use crate::{
     NodeState, SeqTypes,
@@ -266,7 +266,29 @@ where
     .await
     .context("computing state update")?;
 
-    if version > EPOCH_VERSION && !delta.rewards_delta.is_empty() {
+    let has_changed_accounts = version > EPOCH_VERSION && !delta.rewards_delta.is_empty();
+    // For EPOCH_REWARD_VERSION+ we must persist the reward tree at every epoch
+    // boundary, even when no rewards were distributed. During a V4→V5 upgrade
+    // the first post upgrade epoch boundary skips rewards (the previous epoch's
+    // header is pre-V5), leaving rewards_delta empty. Without saving here, the
+    // tree would be missing from storage and catchup requests from peers or
+    // subsequent epoch reward calculations would fail.
+    //
+    // Example: V4→V5 upgrade at block 9756, epoch_height=3000.
+    // At block 12000 (first epoch boundary post upgrade), handle_epoch_rewards
+    // skips rewards because the previous epoch's boundary (block 9000) is pre-V5,
+    // so rewards_delta is empty. Without saving here, the tree is never persisted
+    // at height 12000. Later at block 15000, the epoch 4 reward calculation calls
+    // fetch_reward_merkle_tree_v2(height=12000) to catch up missing accounts and
+    // fails because no tree exists in storage at that height.
+    let is_epoch_boundary = version >= EPOCH_REWARD_VERSION
+        && block_number.is_multiple_of(
+            instance
+                .epoch_height
+                .expect("epoch_height should be set for version > V3"),
+        );
+
+    if has_changed_accounts || is_epoch_boundary {
         storage
             .save_and_gc_reward_tree_v2(
                 instance,


### PR DESCRIPTION
During a V4→V5 upgrade, the first post upgrade epoch boundary skips reward distribution because the previous epoch's header is pre V5, leaving `rewards_delta` empty and causing `save_and_gc_reward_tree_v2` to never be called at that height. When the next epoch's reward calculation tries to `fetch_reward_merkle_tree_v2` at that height for catchup, it fails because no tree exists in storage. This PR fixes it by saving the tree at every boundary if version is >= v5 