### PR TITLE
fix(sdk): use dynamic ports for Go SDK integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -61,7 +61,7 @@ test(test_success_with_async_delay_2_with_epochs) |
 test(test_vid2_success) |
 test(test_combined_network_half_dc) |
 test(test_staggered_restart_first_block) |
-test(=test_staggered_restart) |
+test(/test_staggered_restart$/) |
 binary(test_epoch_success_overlap_3f) |
 binary(test_epoch_success_types_randomized_leader)
 """

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -62,6 +62,7 @@ test(test_vid2_success) |
 test(test_combined_network_half_dc) |
 test(test_staggered_restart_first_block) |
 test(/test_staggered_restart$/) |
+binary(test_epoch_success_overlap_2_f) |
 binary(test_epoch_success_overlap_3f) |
 binary(test_epoch_success_types_randomized_leader)
 """

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -61,6 +61,7 @@ test(test_success_with_async_delay_2_with_epochs) |
 test(test_vid2_success) |
 test(test_combined_network_half_dc) |
 test(test_staggered_restart_first_block) |
+test(=test_staggered_restart) |
 binary(test_epoch_success_overlap_3f) |
 binary(test_epoch_success_types_randomized_leader)
 """

--- a/sdks/go/client-dev-node/client_test.go
+++ b/sdks/go/client-dev-node/client_test.go
@@ -19,8 +19,7 @@ func TestFetchDevInfo(t *testing.T) {
 	require.NoError(t, err, "failed to allocate ports")
 
 	dir := t.TempDir()
-	cleanup := devnode.Start(t, ctx, ports, dir)
-	t.Cleanup(cleanup)
+	devnode.Start(t, ctx, ports, dir)
 
 	client := NewClient(fmt.Sprintf("%s/v0", ports.DevNodeURL()))
 
@@ -30,7 +29,7 @@ func TestFetchDevInfo(t *testing.T) {
 			break
 		}
 		if ctx.Err() != nil {
-			t.Fatal("timed out waiting for node to be available", err)
+			t.Fatal("timed out waiting for node to be available")
 		}
 		t.Log("waiting for node to be available", err)
 		time.Sleep(1 * time.Second)

--- a/sdks/go/client-dev-node/client_test.go
+++ b/sdks/go/client-dev-node/client_test.go
@@ -3,36 +3,36 @@ package clientdevnode
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/devnode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-var workingDir = "../../../"
-
 func TestFetchDevInfo(t *testing.T) {
-	ctx := context.Background()
-	dir, err := os.MkdirTemp("", "espresso-dev-node")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(dir)
-	cleanup := runDevNode(ctx, dir)
-	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Second)
+	t.Cleanup(cancel)
 
-	client := NewClient("http://localhost:20000/v0")
+	ports, err := devnode.AllocatePorts()
+	require.NoError(t, err, "failed to allocate ports")
+
+	dir := t.TempDir()
+	cleanup := devnode.Start(t, ctx, ports, dir)
+	t.Cleanup(cleanup)
+
+	client := NewClient(fmt.Sprintf("%s/v0", ports.DevNodeURL()))
 
 	for {
 		available, err := client.IsAvailable(ctx)
 		if available {
 			break
 		}
-		fmt.Println("waiting for node to be available", err)
+		if ctx.Err() != nil {
+			t.Fatal("timed out waiting for node to be available", err)
+		}
+		t.Log("waiting for node to be available", err)
 		time.Sleep(1 * time.Second)
 	}
 
@@ -40,56 +40,8 @@ func TestFetchDevInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to fetch dev info", err)
 	}
-	assert.Equal(t, "http://localhost:23000/", devInfo.BuilderUrl)
-	assert.Equal(t, 21000, int(devInfo.SequencerApiPort))
+	assert.Equal(t, fmt.Sprintf("http://localhost:%d/", ports.Builder), devInfo.BuilderUrl)
+	assert.Equal(t, ports.SequencerAPI, int(devInfo.SequencerApiPort))
 	// This serves as a reminder that the L1 light client address has changed when it breaks.
 	assert.Equal(t, "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", devInfo.L1LightClientAddress)
-}
-
-func runDevNode(ctx context.Context, tmpDir string) func() {
-	tmpDir, err := filepath.Abs(tmpDir)
-	if err != nil {
-		panic(err)
-	}
-
-	var p *exec.Cmd
-	if bin := os.Getenv("ESPRESSO_DEV_NODE_BIN"); bin != "" {
-		if _, err := os.Stat(bin); err != nil {
-			panic(fmt.Sprintf("ESPRESSO_DEV_NODE_BIN=%s does not exist: %v", bin, err))
-		}
-		fmt.Println("using pre-built espresso-dev-node binary:", bin)
-		p = exec.CommandContext(ctx, bin)
-	} else {
-		fmt.Println("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run (this will compile espresso-dev-node)")
-		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
-		p.Dir = workingDir
-	}
-
-	env := os.Environ()
-	env = append(env, "ESPRESSO_SEQUENCER_API_PORT=21000")
-	env = append(env, "ESPRESSO_BUILDER_PORT=23000")
-	env = append(env, "ESPRESSO_DEV_NODE_PORT=20000")
-	env = append(env, "ESPRESSO_SEQUENCER_ETH_MNEMONIC=test test test test test test test test test test test junk")
-	env = append(env, "ESPRESSO_DEPLOYER_ACCOUNT_INDEX=0")
-	env = append(env, "ESPRESSO_SEQUENCER_STORAGE_PATH="+tmpDir)
-	p.Env = env
-
-	go func() {
-		if err := p.Run(); err != nil {
-			if err.Error() != "signal: killed" {
-				log.Error(err.Error())
-				panic(err)
-			}
-		}
-	}()
-
-	return func() {
-		if p.Process != nil {
-			err := p.Process.Kill()
-			if err != nil {
-				log.Error(err.Error())
-				panic(err)
-			}
-		}
-	}
 }

--- a/sdks/go/client/client_test.go
+++ b/sdks/go/client/client_test.go
@@ -26,8 +26,7 @@ func setupDevNode(t *testing.T) (context.Context, devNodeInfo) {
 	require.NoError(t, err, "failed to allocate ports")
 
 	dir := t.TempDir()
-	cleanup := devnode.Start(t, ctx, ports, dir)
-	t.Cleanup(cleanup)
+	devnode.Start(t, ctx, ports, dir)
 
 	err = waitForEspressoNode(ctx, ports.NodeURL())
 	require.NoError(t, err, "failed to start espresso dev node")

--- a/sdks/go/client/client_test.go
+++ b/sdks/go/client/client_test.go
@@ -3,36 +3,36 @@ package client
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/EspressoSystems/espresso-network/sdks/go/internal/devnode"
 	types "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/EspressoSystems/espresso-network/sdks/go/verification"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
-var workingDir = "../../../"
+type devNodeInfo struct {
+	nodeURL    string
+	builderURL string
+}
 
-const devNodeURL = "http://localhost:21000"
-const devNodeBuilderURL = "http://localhost:23000"
-
-func setupDevNode(t *testing.T) context.Context {
+func setupDevNode(t *testing.T) (context.Context, devNodeInfo) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	ports, err := devnode.AllocatePorts()
+	require.NoError(t, err, "failed to allocate ports")
+
 	dir := t.TempDir()
-	cleanup := runDevNode(ctx, dir)
+	cleanup := devnode.Start(t, ctx, ports, dir)
 	t.Cleanup(cleanup)
 
-	err := waitForEspressoNode(ctx)
+	err = waitForEspressoNode(ctx, ports.NodeURL())
 	require.NoError(t, err, "failed to start espresso dev node")
 
-	return ctx
+	return ctx, devNodeInfo{nodeURL: ports.NodeURL(), builderURL: ports.BuilderURL()}
 }
 
 func testNamespaceTransactionsInRange(t *testing.T, ctx context.Context, client EspressoClient, txPayload string) {
@@ -65,19 +65,19 @@ func testNamespaceTransactionsInRange(t *testing.T, ctx context.Context, client 
 }
 
 func TestApiWithEspressoDevNode(t *testing.T) {
-	ctx := setupDevNode(t)
-	client := NewClient(devNodeURL)
+	ctx, info := setupDevNode(t)
+	client := NewClient(info.nodeURL)
 
 	ClientTestHelper(ctx, client, t)
 
 	var clientOptions []EspressoClientConfigOption
-	builderSubmitter, err := NewBuilderSubmitter([]string{devNodeBuilderURL})
+	builderSubmitter, err := NewBuilderSubmitter([]string{info.builderURL})
 	if err != nil {
 		t.Fatal("failed to create builder submitter", err)
 	}
 
 	clientOptions = append(clientOptions, WithTransactionSubmitter(builderSubmitter))
-	clientOptions = append(clientOptions, WithBaseUrl(devNodeURL))
+	clientOptions = append(clientOptions, WithBaseUrl(info.nodeURL))
 
 	client, err = NewClientFromOptions(clientOptions...)
 	if err != nil {
@@ -87,12 +87,12 @@ func TestApiWithEspressoDevNode(t *testing.T) {
 	ClientTestHelper(ctx, client, t)
 
 	clientOptions = []EspressoClientConfigOption{}
-	querySubmitter := NewQuerySubmitter(devNodeURL)
+	querySubmitter := NewQuerySubmitter(info.nodeURL)
 	if err != nil {
 		t.Fatal("failed to create builder submitter", err)
 	}
 	clientOptions = append(clientOptions, WithTransactionSubmitter(querySubmitter))
-	clientOptions = append(clientOptions, WithBaseUrl(devNodeURL))
+	clientOptions = append(clientOptions, WithBaseUrl(info.nodeURL))
 
 	client, err = NewClientFromOptions(clientOptions...)
 	if err != nil {
@@ -174,54 +174,6 @@ func ClientTestHelper(ctx context.Context, client EspressoClient, t *testing.T) 
 	}
 }
 
-func runDevNode(ctx context.Context, tmpDir string) func() {
-	tmpDir, err := filepath.Abs(tmpDir)
-	if err != nil {
-		panic(err)
-	}
-
-	var p *exec.Cmd
-	if bin := os.Getenv("ESPRESSO_DEV_NODE_BIN"); bin != "" {
-		if _, err := os.Stat(bin); err != nil {
-			panic(fmt.Sprintf("ESPRESSO_DEV_NODE_BIN=%s does not exist: %v", bin, err))
-		}
-		fmt.Println("using pre-built espresso-dev-node binary:", bin)
-		p = exec.CommandContext(ctx, bin)
-	} else {
-		fmt.Println("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run (this will compile espresso-dev-node)")
-		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
-		p.Dir = workingDir
-	}
-
-	env := os.Environ()
-	env = append(env, "ESPRESSO_SEQUENCER_API_PORT=21000")
-	env = append(env, "ESPRESSO_BUILDER_PORT=23000")
-	env = append(env, "ESPRESSO_DEV_NODE_PORT=20000")
-	env = append(env, "ESPRESSO_SEQUENCER_ETH_MNEMONIC=test test test test test test test test test test test junk")
-	env = append(env, "ESPRESSO_DEPLOYER_ACCOUNT_INDEX=0")
-	env = append(env, "ESPRESSO_SEQUENCER_STORAGE_PATH="+tmpDir)
-	p.Env = env
-
-	go func() {
-		if err := p.Run(); err != nil {
-			if err.Error() != "signal: killed" {
-				log.Error(err.Error())
-				panic(err)
-			}
-		}
-	}()
-
-	return func() {
-		if p.Process != nil {
-			err := p.Process.Kill()
-			if err != nil {
-				log.Error(err.Error())
-				panic(err)
-			}
-		}
-	}
-}
-
 func waitForWith(
 	ctxinput context.Context,
 	timeout time.Duration,
@@ -243,8 +195,8 @@ func waitForWith(
 	}
 }
 
-func waitForEspressoNode(ctx context.Context) error {
-	client := NewClient(devNodeURL)
+func waitForEspressoNode(ctx context.Context, nodeURL string) error {
+	client := NewClient(nodeURL)
 	return waitForWith(ctx, 200*time.Second, 1*time.Second, func() bool {
 		height, err := client.FetchLatestBlockHeight(ctx)
 		return err == nil && height >= 2
@@ -252,8 +204,8 @@ func waitForEspressoNode(ctx context.Context) error {
 }
 
 func TestExplorerFetchTransactionByHash(t *testing.T) {
-	ctx := setupDevNode(t)
-	client := NewClient(devNodeURL)
+	ctx, info := setupDevNode(t)
+	client := NewClient(info.nodeURL)
 
 	tx := types.Transaction{Namespace: 1, Payload: []byte("explorer test")}
 	hash, err := client.SubmitTransaction(ctx, tx)
@@ -268,7 +220,7 @@ func TestExplorerFetchTransactionByHash(t *testing.T) {
 }
 
 func TestNamespaceTransactionsInRange(t *testing.T) {
-	ctx := setupDevNode(t)
-	client := NewClient(devNodeURL)
+	ctx, info := setupDevNode(t)
+	client := NewClient(info.nodeURL)
 	testNamespaceTransactionsInRange(t, ctx, client, "namespace range test")
 }

--- a/sdks/go/client/multiple_nodes_test.go
+++ b/sdks/go/client/multiple_nodes_test.go
@@ -156,15 +156,15 @@ func TestFetchWithMajority(t *testing.T) {
 }
 
 func TestApiWithSingleEspressoDevNode(t *testing.T) {
-	ctx := setupDevNode(t)
+	ctx, info := setupDevNode(t)
 
 	// Test constructing the client with a single url to ensure that it requires more than one.
-	_, err := NewMultipleNodesClient([]string{devNodeURL})
+	_, err := NewMultipleNodesClient([]string{info.nodeURL})
 	if err == nil {
 		t.Fatal("Constructing the client with 1 url should result in an error")
 	}
 
-	client, err := NewMultipleNodesClient([]string{devNodeURL, devNodeURL})
+	client, err := NewMultipleNodesClient([]string{info.nodeURL, info.nodeURL})
 	if err != nil {
 		t.Fatal("Constructing the client with more than 1 url should succeed")
 	}
@@ -199,8 +199,8 @@ func TestApiWithSingleEspressoDevNode(t *testing.T) {
 }
 
 func TestNamespaceTransactionsInRangeForMultiClient(t *testing.T) {
-	ctx := setupDevNode(t)
-	client, err := NewMultipleNodesClient([]string{devNodeURL, devNodeURL})
+	ctx, info := setupDevNode(t)
+	client, err := NewMultipleNodesClient([]string{info.nodeURL, info.nodeURL})
 	require.NoError(t, err)
 	testNamespaceTransactionsInRange(t, ctx, client, "multi-client namespace test")
 }

--- a/sdks/go/internal/devnode/devnode.go
+++ b/sdks/go/internal/devnode/devnode.go
@@ -1,0 +1,134 @@
+package devnode
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+type Ports struct {
+	SequencerAPI int
+	Builder      int
+	DevNode      int
+}
+
+func (p Ports) NodeURL() string {
+	return fmt.Sprintf("http://localhost:%d", p.SequencerAPI)
+}
+
+func (p Ports) BuilderURL() string {
+	return fmt.Sprintf("http://localhost:%d", p.Builder)
+}
+
+func (p Ports) DevNodeURL() string {
+	return fmt.Sprintf("http://localhost:%d", p.DevNode)
+}
+
+func AllocatePorts() (Ports, error) {
+	ports := make([]int, 3)
+	listeners := make([]net.Listener, 3)
+	for i := range listeners {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			// Close any already opened listeners.
+			for j := 0; j < i; j++ {
+				listeners[j].Close()
+			}
+			return Ports{}, fmt.Errorf("failed to allocate port: %w", err)
+		}
+		listeners[i] = l
+		ports[i] = l.Addr().(*net.TCPAddr).Port
+	}
+	// Close all listeners so the dev node can bind to these ports.
+	for _, l := range listeners {
+		l.Close()
+	}
+	return Ports{
+		SequencerAPI: ports[0],
+		Builder:      ports[1],
+		DevNode:      ports[2],
+	}, nil
+}
+
+func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) func() {
+	t.Helper()
+
+	storageDir, err := filepath.Abs(storageDir)
+	if err != nil {
+		t.Fatalf("failed to get absolute path for storage dir: %v", err)
+	}
+
+	var p *exec.Cmd
+	if bin := os.Getenv("ESPRESSO_DEV_NODE_BIN"); bin != "" {
+		if _, err := os.Stat(bin); err != nil {
+			t.Fatalf("ESPRESSO_DEV_NODE_BIN=%s does not exist: %v", bin, err)
+		}
+		t.Logf("using pre-built espresso-dev-node binary: %s", bin)
+		p = exec.CommandContext(ctx, bin)
+	} else {
+		t.Log("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run")
+		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
+		// Resolve repo root from this source file: sdks/go/internal/devnode/devnode.go
+		_, thisFile, _, _ := runtime.Caller(0)
+		p.Dir = filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	}
+
+	logFile, err := os.CreateTemp(storageDir, "dev-node-*.log")
+	if err != nil {
+		t.Fatalf("failed to create log file: %v", err)
+	}
+	logPath := logFile.Name()
+	t.Logf("dev-node logs: %s", logPath)
+
+	p.Stdout = logFile
+	p.Stderr = logFile
+
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("ESPRESSO_SEQUENCER_API_PORT=%d", ports.SequencerAPI))
+	env = append(env, fmt.Sprintf("ESPRESSO_BUILDER_PORT=%d", ports.Builder))
+	env = append(env, fmt.Sprintf("ESPRESSO_DEV_NODE_PORT=%d", ports.DevNode))
+	env = append(env, "ESPRESSO_SEQUENCER_ETH_MNEMONIC=test test test test test test test test test test test junk")
+	env = append(env, "ESPRESSO_DEPLOYER_ACCOUNT_INDEX=0")
+	env = append(env, fmt.Sprintf("ESPRESSO_SEQUENCER_STORAGE_PATH=%s", storageDir))
+	p.Env = env
+
+	if err := p.Start(); err != nil {
+		logFile.Close()
+		t.Fatalf("failed to start dev node: %v", err)
+	}
+
+	// Wait for process to exit in background so we can collect the exit status.
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Wait()
+	}()
+
+	t.Cleanup(func() {
+		logFile.Close()
+		if t.Failed() {
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Logf("failed to read dev-node log: %v", err)
+			} else {
+				t.Logf("=== dev-node logs ===\n%s\n=== end dev-node logs ===", string(data))
+			}
+		}
+	})
+
+	return func() {
+		if p.Process != nil {
+			_ = p.Process.Kill()
+			// Wait for process to actually exit to avoid zombies.
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+}

--- a/sdks/go/internal/devnode/devnode.go
+++ b/sdks/go/internal/devnode/devnode.go
@@ -82,7 +82,7 @@ func AllocatePorts() (Ports, error) {
 	}, nil
 }
 
-func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) func() {
+func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) {
 	t.Helper()
 
 	storageDir, err := filepath.Abs(storageDir)
@@ -100,8 +100,11 @@ func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) fu
 	} else {
 		t.Log("ESPRESSO_DEV_NODE_BIN not set, falling back to cargo run")
 		p = exec.CommandContext(ctx, "cargo", "run", "-p", "espresso-dev-node")
-		// Resolve repo root from this source file: sdks/go/internal/devnode/devnode.go
-		_, thisFile, _, _ := runtime.Caller(0)
+		// Resolve repo root from this source file at sdks/go/internal/devnode/
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			t.Fatal("runtime.Caller failed")
+		}
 		p.Dir = filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
 	}
 
@@ -125,7 +128,6 @@ func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) fu
 	p.Env = env
 
 	if err := p.Start(); err != nil {
-		logFile.Close()
 		t.Fatalf("failed to start dev node: %v", err)
 	}
 
@@ -135,6 +137,7 @@ func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) fu
 		done <- p.Wait()
 	}()
 
+	// Cleanups run in LIFO order: kill process first, then read/close log.
 	t.Cleanup(func() {
 		logFile.Close()
 		if t.Failed() {
@@ -146,15 +149,13 @@ func Start(t *testing.T, ctx context.Context, ports Ports, storageDir string) fu
 			}
 		}
 	})
-
-	return func() {
+	t.Cleanup(func() {
 		if p.Process != nil {
 			_ = p.Process.Kill()
-			// Wait for process to actually exit to avoid zombies.
 			select {
 			case <-done:
 			case <-time.After(5 * time.Second):
 			}
 		}
-	}
+	})
 }

--- a/sdks/go/internal/devnode/devnode.go
+++ b/sdks/go/internal/devnode/devnode.go
@@ -30,29 +30,55 @@ func (p Ports) DevNodeURL() string {
 	return fmt.Sprintf("http://localhost:%d", p.DevNode)
 }
 
-func AllocatePorts() (Ports, error) {
-	ports := make([]int, 3)
-	listeners := make([]net.Listener, 3)
-	for i := range listeners {
-		l, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			// Close any already opened listeners.
-			for j := 0; j < i; j++ {
-				listeners[j].Close()
-			}
-			return Ports{}, fmt.Errorf("failed to allocate port: %w", err)
-		}
-		listeners[i] = l
-		ports[i] = l.Addr().(*net.TCPAddr).Port
+// reservePort allocates a free TCP port and puts it into TIME_WAIT state.
+// This prevents the OS from handing it out via ephemeral allocation, while
+// still allowing explicit binds (like the dev node will do).
+// Mirrors the Rust reserve_tcp_port() in test-utils/src/lib.rs.
+func reservePort() (int, error) {
+	server, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to listen: %w", err)
 	}
-	// Close all listeners so the dev node can bind to these ports.
-	for _, l := range listeners {
-		l.Close()
+	addr := server.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Complete a TCP handshake to force TIME_WAIT on close.
+	client, err := net.Dial("tcp", addr.String())
+	if err != nil {
+		server.Close()
+		return 0, fmt.Errorf("failed to dial: %w", err)
+	}
+	accepted, err := server.Accept()
+	if err != nil {
+		client.Close()
+		server.Close()
+		return 0, fmt.Errorf("failed to accept: %w", err)
+	}
+	// Close all sockets -- port enters TIME_WAIT.
+	accepted.Close()
+	client.Close()
+	server.Close()
+
+	return port, nil
+}
+
+func AllocatePorts() (Ports, error) {
+	apiPort, err := reservePort()
+	if err != nil {
+		return Ports{}, err
+	}
+	builderPort, err := reservePort()
+	if err != nil {
+		return Ports{}, err
+	}
+	devNodePort, err := reservePort()
+	if err != nil {
+		return Ports{}, err
 	}
 	return Ports{
-		SequencerAPI: ports[0],
-		Builder:      ports[1],
-		DevNode:      ports[2],
+		SequencerAPI: apiPort,
+		Builder:      builderPort,
+		DevNode:      devNodePort,
 	}, nil
 }
 


### PR DESCRIPTION
Goal: fix or at least gain some visibility into why go sdk tests are flaky.

Each test now gets its own espresso-dev-node with unique ports allocated via net.Listen(":0"), preventing port conflicts from lingering processes. Dev node stdout/stderr are captured and printed on test failure for CI debugging.

