### PR TITLE
Make RewardMerkleTreeV2 permits configurable

### DIFF
--- a/crates/espresso/types/src/v0/v0_4/state.rs
+++ b/crates/espresso/types/src/v0/v0_4/state.rs
@@ -39,7 +39,18 @@ impl PermittedRewardMerkleTreeV2 {
         balances: Vec<(RewardAccountV2, RewardAmount)>,
     ) -> anyhow::Result<Self> {
         let permit = REWARD_MERKLE_TREE_V2_MEMORY_LOCK
-            .get_or_init(|| Arc::new(Semaphore::new(1)))
+            .get_or_init(|| {
+                let num_permits: usize =
+                    std::env::var("ESPRESSO_SEQUENCER_REWARD_MERKLE_TREE_PERMITS")
+                        .ok()
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .unwrap_or(1);
+
+                tracing::warn!(
+                    "Initializing RewardMerkleTreeV2 semaphore with {num_permits} permits"
+                );
+                Arc::new(Semaphore::new(num_permits))
+            })
             .clone()
             .acquire_owned()
             .await


### PR DESCRIPTION
This commit is present on `release-mainnet-1.0.1-rc`, which was merged into `main`, but appears to have been lost in the merge somehow.
