### PR TITLE
chore(deployment-info): re-run to avoid future reordering

### DIFF
--- a/contracts/rust/deployment-info/deployments/decaf.toml
+++ b/contracts/rust/deployment-info/deployments/decaf.toml
@@ -1,4 +1,4 @@
-# fetched at block 10439344 (2026-03-13T13:31:00Z)
+# fetched at block 10649689 (2026-04-13T07:56:24Z)
 network = "decaf"
 
 [multisigs.espresso_labs]
@@ -22,28 +22,12 @@ status = "deployed"
 address = "0x0eb0ef3b5a46a444c38da452055bddb273550d5c"
 min_delay = "10m"
 
-[stake_table]
-status = "deployed"
-address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037"
-default_admin_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
-default_admin_name = "espresso_labs"
-version = "2.0.0"
-pauser_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
-pauser_name = "espresso_labs"
-
 [esp_token]
 status = "deployed"
 address = "0xb3e655a030e2e34a18b72757b40be086a8f43f3b"
 owner_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
 owner_name = "espresso_labs"
 version = "2.0.0"
-
-[light_client]
-status = "deployed"
-address = "0x303872bb82a191771321d4828888920100d0b3e4"
-owner_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
-owner_name = "espresso_labs"
-version = "3.0.0"
 
 [fee_contract]
 status = "deployed"
@@ -52,11 +36,27 @@ owner_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
 owner_name = "espresso_labs"
 version = "1.0.0"
 
+[light_client]
+status = "deployed"
+address = "0x303872bb82a191771321d4828888920100d0b3e4"
+owner_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
+owner_name = "espresso_labs"
+version = "3.0.0"
+
 [reward_claim]
 status = "deployed"
 address = "0xe81908e34dbb4ba01f27f8769264199727be50c8"
 default_admin_address = "0x0eb0ef3b5a46a444c38da452055bddb273550d5c"
 default_admin_name = "safe_exit_timelock"
 version = "1.0.0"
+pauser_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
+pauser_name = "espresso_labs"
+
+[stake_table]
+status = "deployed"
+address = "0x40304fbe94d5e7d1492dd90c53a2d63e8506a037"
+default_admin_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
+default_admin_name = "espresso_labs"
+version = "2.0.0"
 pauser_address = "0xb76834e371b666feee48e5d7d9a97ca08b5a0620"
 pauser_name = "espresso_labs"

--- a/contracts/rust/deployment-info/deployments/hoodi.toml
+++ b/contracts/rust/deployment-info/deployments/hoodi.toml
@@ -1,4 +1,4 @@
-# fetched at block 2271945 (2026-02-20T09:42:12Z)
+# fetched at block 2608269 (2026-04-13T07:56:24Z)
 network = "hoodi"
 
 [multisigs.espresso_labs]
@@ -22,28 +22,12 @@ status = "deployed"
 address = "0xe34cdddf2271492809728c83eb347b36ba001438"
 min_delay = "10m"
 
-[stake_table]
-status = "deployed"
-address = "0x6e9c2dce0cb780a06c811ca245b8d497ef6e96c5"
-default_admin_address = "0xf04e9344f0f28aa5ef0f321a9cfc00680bc53118"
-default_admin_name = "ops_timelock"
-version = "2.0.0"
-pauser_address = "0x26bf8656f1654a14570af587adc8cac68fda6fcf"
-pauser_name = "espresso_labs"
-
 [esp_token]
 status = "deployed"
 address = "0x7397063418df1ee7a6c49b5bbc664f8f2c82283a"
 owner_address = "0xe34cdddf2271492809728c83eb347b36ba001438"
 owner_name = "safe_exit_timelock"
 version = "2.0.0"
-
-[light_client]
-status = "deployed"
-address = "0x578767719287386043d3aaf2f5a68993c3a42cd5"
-owner_address = "0xf04e9344f0f28aa5ef0f321a9cfc00680bc53118"
-owner_name = "ops_timelock"
-version = "3.0.0"
 
 [fee_contract]
 status = "deployed"
@@ -52,11 +36,27 @@ owner_address = "0xf04e9344f0f28aa5ef0f321a9cfc00680bc53118"
 owner_name = "ops_timelock"
 version = "1.0.0"
 
+[light_client]
+status = "deployed"
+address = "0x578767719287386043d3aaf2f5a68993c3a42cd5"
+owner_address = "0xf04e9344f0f28aa5ef0f321a9cfc00680bc53118"
+owner_name = "ops_timelock"
+version = "3.0.0"
+
 [reward_claim]
 status = "deployed"
 address = "0xf6fcfd30f1b22bf6e78ade09c54566594c703183"
 default_admin_address = "0xe34cdddf2271492809728c83eb347b36ba001438"
 default_admin_name = "safe_exit_timelock"
 version = "1.0.0"
+pauser_address = "0x26bf8656f1654a14570af587adc8cac68fda6fcf"
+pauser_name = "espresso_labs"
+
+[stake_table]
+status = "deployed"
+address = "0x6e9c2dce0cb780a06c811ca245b8d497ef6e96c5"
+default_admin_address = "0xf04e9344f0f28aa5ef0f321a9cfc00680bc53118"
+default_admin_name = "ops_timelock"
+version = "2.0.0"
 pauser_address = "0x26bf8656f1654a14570af587adc8cac68fda6fcf"
 pauser_name = "espresso_labs"

--- a/contracts/rust/deployment-info/deployments/mainnet.toml
+++ b/contracts/rust/deployment-info/deployments/mainnet.toml
@@ -1,4 +1,4 @@
-# fetched at block 24850430 (2026-04-10T16:09:59Z)
+# fetched at block 24869498 (2026-04-13T07:56:23Z)
 network = "mainnet"
 
 [multisigs.espresso_labs]

--- a/contracts/rust/deployment-info/src/contracts.rs
+++ b/contracts/rust/deployment-info/src/contracts.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt, time::Duration};
 
 use alloy::{
-    eips::BlockId,
+    eips::{BlockId, BlockNumberOrTag},
     primitives::{Address, FixedBytes},
     providers::Provider,
     sol,
@@ -400,15 +400,12 @@ impl CollectedDeployment {
     ) -> Result<Self> {
         let provider = alloy::providers::ProviderBuilder::new().connect_http(rpc_url);
 
-        let block_number = provider
-            .get_block_number()
-            .await
-            .context("Failed to get block number")?;
         let block = provider
-            .get_block_by_number(block_number.into())
+            .get_block_by_number(BlockNumberOrTag::Latest)
             .await
-            .context("Failed to get block")?
-            .context("Block not found")?;
+            .context("Failed to get latest block")?
+            .context("Latest block not found")?;
+        let block_number = block.header.number;
         let block_timestamp = block.header.timestamp;
 
         let known = KnownAddresses::from_deployment(&addresses);

--- a/crates/hotshot/new-protocol/Cargo.toml
+++ b/crates/hotshot/new-protocol/Cargo.toml
@@ -24,6 +24,7 @@ hotshot-example-types = { workspace = true }
 hotshot-testing = { workspace = true }
 hotshot-types = { workspace = true }
 hotshot-utils = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 thiserror = { workspace = true }
@@ -32,7 +33,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 versions = { workspace = true }
-rand = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
The order is the same as the rust struct but the check if it should be rewritten is not sensitive to ordering. The decaf and hoodi files were generated by an older version where the struct fields where in a different order.

Re-run the tool so that when we get future automated PRs there will only be the actual changes and no re-ordering.