### PR TITLE
chore: add pruning debug scripts for reproducing proposal timeouts

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@
 #   sequencer service.
 #
 
-RUST_LOG=info,libp2p=off
+RUST_LOG=info,libp2p=off,cliquenet=error
 RUST_LOG_FORMAT=full
 
 # Parallelism config

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -115,6 +115,7 @@ processes:
         condition: process_completed
       espresso-node-0:
         condition: process_healthy
+    availability: *run-forever
 
   fund-builder:
     command: espresso-bridge deposit
@@ -226,16 +227,6 @@ processes:
       - ESPRESSO_SEQUENCER_IDENTITY_LATITUDE=40.7128
       - ESPRESSO_SEQUENCER_IDENTITY_LONGITUDE=-74.0060
       - ESPRESSO_SEQUENCER_PUBLIC_API_URL=http://localhost:${ESPRESSO_SEQUENCER0_API_PORT}/
-      # Aggressive pruning to reproduce proposal timeout issue
-      - ESPRESSO_SEQUENCER_DATABASE_PRUNE=true
-      - ESPRESSO_SEQUENCER_PRUNER_BATCH_SIZE=10
-      - ESPRESSO_SEQUENCER_PRUNER_INTERVAL=5s
-      - ESPRESSO_SEQUENCER_PRUNER_MINIMUM_RETENTION=30s
-      - ESPRESSO_SEQUENCER_PRUNER_TARGET_RETENTION=1m
-      - ESPRESSO_SEQUENCER_PRUNER_PRUNING_THRESHOLD=1MB
-      - ESPRESSO_SEQUENCER_PRUNER_MAX_USAGE=100
-      # Debug logging for storage and consensus
-      - RUST_LOG=info,libp2p=off,hotshot_query_service::data_source::storage=debug,espresso_node::persistence=debug,hotshot_consensus=debug
     depends_on:
       orchestrator:
         condition: process_healthy
@@ -691,20 +682,6 @@ processes:
       success_threshold: 2
       failure_threshold: 20
     availability: *run-forever
-
-  install-slow-delete-triggers:
-    command: |
-      until PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -c "SET search_path TO hotshot; SELECT 1 FROM block_merkle_tree LIMIT 0"; do
-        echo "Waiting for tables..."
-        sleep 2
-      done
-      PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -f scripts/seed-merkle-trees.sql
-      echo "Triggers installed"
-    namespace: setup
-    depends_on:
-      espresso-node-0:
-        condition: process_healthy
-    availability: *exit-ok
 
   block-explorer:
     command:

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -115,7 +115,6 @@ processes:
         condition: process_completed
       espresso-node-0:
         condition: process_healthy
-    availability: *run-forever
 
   fund-builder:
     command: espresso-bridge deposit
@@ -227,6 +226,16 @@ processes:
       - ESPRESSO_SEQUENCER_IDENTITY_LATITUDE=40.7128
       - ESPRESSO_SEQUENCER_IDENTITY_LONGITUDE=-74.0060
       - ESPRESSO_SEQUENCER_PUBLIC_API_URL=http://localhost:${ESPRESSO_SEQUENCER0_API_PORT}/
+      # Aggressive pruning to reproduce proposal timeout issue
+      - ESPRESSO_SEQUENCER_DATABASE_PRUNE=true
+      - ESPRESSO_SEQUENCER_PRUNER_BATCH_SIZE=10
+      - ESPRESSO_SEQUENCER_PRUNER_INTERVAL=5s
+      - ESPRESSO_SEQUENCER_PRUNER_MINIMUM_RETENTION=30s
+      - ESPRESSO_SEQUENCER_PRUNER_TARGET_RETENTION=1m
+      - ESPRESSO_SEQUENCER_PRUNER_PRUNING_THRESHOLD=1MB
+      - ESPRESSO_SEQUENCER_PRUNER_MAX_USAGE=100
+      # Debug logging for storage and consensus
+      - RUST_LOG=info,libp2p=off,hotshot_query_service::data_source::storage=debug,espresso_node::persistence=debug,hotshot_consensus=debug
     depends_on:
       orchestrator:
         condition: process_healthy
@@ -682,6 +691,20 @@ processes:
       success_threshold: 2
       failure_threshold: 20
     availability: *run-forever
+
+  install-slow-delete-triggers:
+    command: |
+      until PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -c "SET search_path TO hotshot; SELECT 1 FROM block_merkle_tree LIMIT 0"; do
+        echo "Waiting for tables..."
+        sleep 2
+      done
+      PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -f scripts/seed-merkle-trees.sql
+      echo "Triggers installed"
+    namespace: setup
+    depends_on:
+      espresso-node-0:
+        condition: process_healthy
+    availability: *exit-ok
 
   block-explorer:
     command:

--- a/scripts/pruning-debug/README.md
+++ b/scripts/pruning-debug/README.md
@@ -1,0 +1,83 @@
+# Pruning Issue Reproduction
+
+Reproducing proposal timeouts caused by query service pruning.
+
+## Run the demo
+
+Use the process-compose override to enable pruning and slow delete triggers on node-0:
+
+```bash
+just demo-native-drb-header -f scripts/pruning-debug/process-compose.override.yaml --tui=false 2>&1 | tee tmp/log-prune.txt
+```
+
+## Slow delete triggers
+
+`slow-delete-triggers.sql` adds `pg_sleep` triggers to tables pruned by the query service. Default delay is 0.05s per
+deleted row. The override file installs them automatically.
+
+Manual install (after tables are created):
+
+```bash
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -f scripts/pruning-debug/slow-delete-triggers.sql
+```
+
+Override delay for a specific table (new connections only):
+
+```bash
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -c 'ALTER DATABASE espresso SET "slow_delete.header" = '\''1'\'';'
+```
+
+Override delay globally (all connections after reload):
+
+```bash
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -c 'ALTER SYSTEM SET "slow_delete.header" = '\''1'\'';'
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -c 'SELECT pg_reload_conf();'
+```
+
+Reset:
+
+```bash
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -c 'ALTER SYSTEM RESET "slow_delete.header";'
+PGPASSWORD=password psql -h localhost -p 5432 -U root -d espresso -c 'SELECT pg_reload_conf();'
+```
+
+## Monitor postgres activity
+
+Log active queries every 2 seconds:
+
+```bash
+env PGPASSWORD=password bash -c 'while true; do echo "--- $(date -Iseconds) ---"; psql -h localhost -p 5432 -U root -d espresso -c "SELECT pid, state, wait_event_type, wait_event,
+                    left(query, 80) as query, now() - query_start as duration FROM pg_stat_activity WHERE datname = '\''espresso'\'' AND state != '\''idle'\'' ORDER BY query_start"; sleep 2; done' 2>&1 | tee tmp/pg_activity.log
+```
+
+## Useful log queries
+
+Slow header queries and timeouts:
+
+```bash
+rg -a "slow state.*max\(height\)|fetching missing acc|timed out" tmp/log-prune.txt
+```
+
+Pruner activity:
+
+```bash
+rg -a "pruner.*(slow statement|Pruned to|pruner run|error)" tmp/log-prune.txt
+```
+
+Catchup timeouts:
+
+```bash
+rg -a "local provider timed out" tmp/log-prune.txt
+```
+
+Node-0 timeout votes:
+
+```bash
+rg -a "espresso-node-0.*sending timeout vote" tmp/log-prune.txt
+```
+
+SafeSnapshot waits in pg_activity log:
+
+```bash
+grep SafeSnapshot tmp/pg_activity.log
+```

--- a/scripts/pruning-debug/process-compose.override.yaml
+++ b/scripts/pruning-debug/process-compose.override.yaml
@@ -1,0 +1,26 @@
+version: "3"
+
+processes:
+  espresso-node-0:
+    environment:
+      - ESPRESSO_SEQUENCER_DATABASE_PRUNE=true
+      - ESPRESSO_SEQUENCER_PRUNER_BATCH_SIZE=10
+      - ESPRESSO_SEQUENCER_PRUNER_INTERVAL=5s
+      - ESPRESSO_SEQUENCER_PRUNER_MINIMUM_RETENTION=30s
+      - ESPRESSO_SEQUENCER_PRUNER_TARGET_RETENTION=1m
+      - ESPRESSO_SEQUENCER_PRUNER_PRUNING_THRESHOLD=1MB
+      - ESPRESSO_SEQUENCER_PRUNER_MAX_USAGE=100 # basis points (1%), forces pruning to always run
+      - RUST_LOG=info,libp2p=off,cliquenet=error,hotshot_query_service::data_source::storage=debug,espresso_node::persistence=debug,hotshot_consensus=debug
+
+  install-slow-delete-triggers:
+    command: |
+      until PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -c "SET search_path TO hotshot; SELECT 1 FROM block_merkle_tree LIMIT 0"; do
+        echo "Waiting for tables..."
+        sleep 2
+      done
+      PGPASSWORD=password psql -h localhost -p ${ESPRESSO_SEQUENCER0_DB_PORT} -U root -d espresso -f scripts/pruning-debug/slow-delete-triggers.sql
+      echo "Triggers installed"
+    namespace: setup
+    depends_on:
+      espresso-node-0:
+        condition: process_healthy

--- a/scripts/pruning-debug/slow-delete-triggers.sql
+++ b/scripts/pruning-debug/slow-delete-triggers.sql
@@ -1,0 +1,47 @@
+-- Adds pg_sleep triggers to query-service-pruned tables to simulate slow deletes.
+-- Default delay is 0.05s per row. Override per table with GUC variables.
+-- See scripts/pruning-debug/README.md for usage.
+
+SET search_path TO hotshot;
+
+CREATE OR REPLACE FUNCTION slow_delete() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_sleep(COALESCE(current_setting('slow_delete.' || TG_TABLE_NAME, true)::float, 0.05));
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON block_merkle_tree;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON block_merkle_tree
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON fee_merkle_tree;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON fee_merkle_tree
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON header;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON header
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON leaf2;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON leaf2
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON payload;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON payload
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON vid_common;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON vid_common
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();
+
+DROP TRIGGER IF EXISTS slow_delete_trigger ON transactions;
+CREATE TRIGGER slow_delete_trigger
+  BEFORE DELETE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION slow_delete();


### PR DESCRIPTION
Process-compose override enables aggressive pruning on node-0 and installs pg_sleep triggers to simulate slow deletes. Per-table delay is configurable via Postgres GUC variables.

Usage: 

```
just demo-native-drb-header -f scripts/pruning-debug/process-compose.override.yaml --tui=false 2>&1 | tee tmp/log-prune.txt
```
