### PR TITLE
Allow light client to trust server for 0.3 stake tables on Decaf

### DIFF
--- a/light-client-query-service/genesis/decaf.toml
+++ b/light-client-query-service/genesis/decaf.toml
@@ -1,6 +1,5 @@
 epoch_height = 3000
-first_epoch_with_dynamic_stake_table = 1744
-decaf_first_pos_epoch = 1056
+first_epoch_with_dynamic_stake_table = 1056
 
 [[stake_table]]
 stake_key = "BLS_VER_KEY~VbTfoVdZmeJUiHebyyBezOApsjmmta0UoL9zu11P1RNC3ULFX3lz7q-xDa0E9o0Ree0a1gRp0No4jP_W8Bg6BDN6eupTvYJB1OENCql8w_MIIEzMuTh8dVND1-kfyucenqbrO8Gk39DTvKUqY7-cENpGJ7112L2tutALjttJRADF"

--- a/light-client-query-service/src/bin/genesis.rs
+++ b/light-client-query-service/src/bin/genesis.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf, process::ExitCode};
 use anyhow::{Context, Result};
 use clap::Parser;
 use espresso_node::SequencerApiVersion;
-use espresso_types::{DrbAndHeaderUpgradeVersion, Header, config::PublicNetworkConfig};
+use espresso_types::{EpochVersion, Header, config::PublicNetworkConfig};
 use hotshot_types::{data::EpochNumber, utils::epoch_from_block_number};
 use light_client::state::Genesis;
 use light_client_query_service::{LogFormat, init_logging};
@@ -27,11 +27,6 @@ struct Options {
     #[clap(short, long, env = "LIGHT_CLIENT_ESPRESSO_URL")]
     espresso_url: Url,
 
-    /// Enable testnet-only configuration.
-    #[cfg(feature = "decaf")]
-    #[clap(long, env = "LIGHT_CLIENT_DECAF")]
-    decaf: bool,
-
     /// Formatting options for tracing.
     #[clap(long, env = "RUST_LOG_FORMAT")]
     log_format: Option<LogFormat>,
@@ -52,45 +47,18 @@ impl Options {
             .context("fetching HotShot config")?;
         let epoch_height = config.hotshot_config().blocks_per_epoch();
 
-        // Check if we are enabling Decaf-specific options.
-        #[cfg(feature = "decaf")]
-        let decaf = self.decaf;
-        #[cfg(not(feature = "decaf"))]
-        let decaf = false;
+        // We know the upgrade to proof of stake must have occurred before the first epoch.
+        let upper_bound_pos = config.hotshot_config().epoch_start_block();
 
-        // Get a lower bound on the block height where the upgrade to version 0.4 occurred.
-        let lower_bound_0_4 = if decaf {
-            // For Decaf, we know that the first PoS epoch happened before 0.4, since Decaf deployed 0.3.
-            config.hotshot_config().epoch_start_block()
-        } else {
-            // Mainnet went straight to 0.4, so we don't have a useful lower bound.
-            0
-        };
-
-        // Get an upper bound on the block height where the upgrade to version 0.4 occurred.
-        let upper_bound_0_4 = if decaf {
-            // On Decaf we don't necessarily know the upper bound, except that it occurred before
-            // this service was implemented, and so before the current block height.
-            client
-                .get("node/block-height")
-                .send()
-                .await
-                .context("getting chain height")?
-        } else {
-            // On Mainnet, PoS was only enabled after the version 0.4 upgrade, so we know the
-            // upgrade occurred before the first epoch.
-            config.hotshot_config().epoch_start_block()
-        };
-
-        // Through binary search, find the first block where the upgrade to version 0.4 occurred.
-        let target_version = DrbAndHeaderUpgradeVersion::VERSION;
-        let mut start = lower_bound_0_4;
-        let mut end = upper_bound_0_4;
-        tracing::info!(start, end, "searching for upgrade to version 0.4 in range");
+        // Through binary search, find the first block where the upgrade to PoS occurred.
+        let target_version = EpochVersion::VERSION;
+        let mut start = 0;
+        let mut end = upper_bound_pos;
+        tracing::info!(start, end, "searching for upgrade to PoS in range");
 
         // Search invariants:
-        // * `start` is a block strictly before the upgrade (i.e. with version < 0.4)
-        // * `end` is a block after the upgrade (i.e. with version >= 0.4)
+        // * `start` is a block strictly before the upgrade (i.e. with version < 0.3)
+        // * `end` is a block after the upgrade (i.e. with version >= 0.3)
         while start + 1 < end {
             let midpoint = (start + end) / 2;
             let header: Header = client
@@ -113,9 +81,7 @@ impl Options {
         }
         let upgrade_block = start + 1;
         let start_epoch = epoch_from_block_number(upgrade_block, epoch_height);
-        tracing::info!(
-            "found upgrade to version 0.4 at block {upgrade_block}, epoch {start_epoch}"
-        );
+        tracing::info!("found upgrade to PoS at block {upgrade_block}, epoch {start_epoch}");
 
         // Start from the third epoch, since we need the prior epoch's root to have the upgraded
         // header with the stake table hash.
@@ -130,10 +96,6 @@ impl Options {
                 .iter()
                 .map(|node| node.stake_table_entry.clone())
                 .collect(),
-            #[cfg(feature = "decaf")]
-            decaf_first_pos_epoch: decaf.then_some(EpochNumber::new(
-                epoch_from_block_number(lower_bound_0_4, epoch_height) + 2,
-            )),
         })
     }
 }

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -2,12 +2,12 @@
 
 use std::{collections::BTreeMap, future::Future, sync::Arc};
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use async_lock::RwLock;
 use committable::Committable;
 use espresso_types::{
-    Header, Leaf2, NamespaceId, PubKey, SeqTypes, StakeTableState, Transaction,
-    select_active_validator_set,
+    DrbAndHeaderUpgradeVersion, Header, Leaf2, NamespaceId, PubKey, SeqTypes, StakeTableState,
+    Transaction, select_active_validator_set,
 };
 use hotshot_query_service_types::{
     HeightIndexed,
@@ -16,6 +16,7 @@ use hotshot_query_service_types::{
 };
 use hotshot_types::{data::EpochNumber, stake_table::StakeTableEntry, utils::root_block_in_epoch};
 use serde::{Deserialize, Serialize};
+use vbs::version::StaticVersionType;
 
 use crate::{
     client::Client,
@@ -44,17 +45,6 @@ pub struct Genesis {
 
     /// The fixed stake table used before epochs begin.
     pub stake_table: Vec<StakeTableEntry<PubKey>>,
-
-    /// Enable special cases for Decaf testnet.
-    ///
-    /// On Decaf, `first_epoch_with_dynamic_stake_table` is not actually the first epoch of PoS, but
-    /// the first Epoch after the upgrade to version 0.4 (version 0.3 is completely unsupported
-    /// since it will never be deployed on Mainnet). Thus, when we perform stake table catchup on
-    /// Decaf, we need to replay all events from epochs between the upgrade to proof-of-stake (this
-    /// number) and the upgrade to version 0.4.
-    #[cfg(feature = "decaf")]
-    #[serde(default)]
-    pub decaf_first_pos_epoch: Option<EpochNumber>,
 }
 
 #[derive(Clone, Debug)]
@@ -70,12 +60,26 @@ pub struct LightClientOptions {
         )
     )]
     pub num_stake_tables_in_memory: usize,
+
+    /// Enable unsafe behavior for Decaf testnet.
+    ///
+    /// This flag allows the light client to skip certain safety checks that are not possible to
+    /// evaluate on Decaf. It is NOT SAFE to provide this flag in a Mainnet environment.
+    #[cfg(feature = "decaf")]
+    #[cfg_attr(
+        feature = "clap",
+        clap(long = "light-client-decaf", env = "LIGHT_CLIENT_DECAF")
+    )]
+    pub decaf: bool,
 }
 
 impl Default for LightClientOptions {
     fn default() -> Self {
         Self {
             num_stake_tables_in_memory: 100,
+
+            #[cfg(feature = "decaf")]
+            decaf: false,
         }
     }
 }
@@ -96,9 +100,6 @@ pub struct LightClient<P, S> {
     epoch_height: u64,
     first_epoch_with_dynamic_stake_table: EpochNumber,
     genesis_stake_table: Arc<StakeTable>,
-
-    #[cfg(feature = "decaf")]
-    decaf_first_pos_epoch: Option<EpochNumber>,
 
     // We cache stake tables in memory since they are large and expensive to load from the database.
     stake_tables: RwLock<BTreeMap<EpochNumber, Arc<StakeTable>>>,
@@ -139,9 +140,6 @@ where
             genesis_stake_table: Arc::new(genesis.stake_table.into()),
             first_epoch_with_dynamic_stake_table: genesis.first_epoch_with_dynamic_stake_table,
             stake_tables: Default::default(),
-
-            #[cfg(feature = "decaf")]
-            decaf_first_pos_epoch: genesis.decaf_first_pos_epoch,
         }
     }
 
@@ -506,34 +504,6 @@ where
             };
         tracing::info!(from = %lower_bound, to = %epoch, "performing stake table catchup");
 
-        // On decaf, replay the events from epochs on version 0.3 without checking stake table
-        // hashes (since these were only added in version 0.4). We will effectively check all this
-        // work at once when we check the stake table hash after the first epoch of version 0.4
-        #[cfg(feature = "decaf")]
-        if lower_bound < self.first_epoch_with_dynamic_stake_table
-            && let Some(first_pos_epoch) = self.decaf_first_pos_epoch
-        {
-            tracing::info!(
-                %first_pos_epoch,
-                to = %lower_bound,
-                "performing Decaf catchup through version 0.3",
-            );
-            for epoch in *first_pos_epoch..=*lower_bound {
-                let events = self
-                    .server
-                    .stake_table_events(EpochNumber::new(epoch))
-                    .await?;
-                tracing::debug!(epoch, num_events = events.len(), "reconstruct stake table");
-                for event in events {
-                    tracing::debug!(epoch, ?event, "replay event");
-                    if let Err(err) = stake_table.apply_event(event).context("applying event")? {
-                        tracing::warn!("allowed error in event: {err:#}");
-                    }
-                }
-            }
-            prev_quorum = Arc::new(stake_table_state_to_quorum(stake_table.clone())?);
-        }
-
         // Replay one epoch at a time from the lower bound stake table to the requested epoch.
         for epoch in *lower_bound + 1..=*epoch {
             let events = self
@@ -559,15 +529,30 @@ where
                 })
                 .await
                 .context("fetching epoch root for {epoch}")?;
-            let hash = root.next_stake_table_hash().context(format!(
-                "epoch {epoch} root {root_height} does not have next stake table hash"
-            ))?;
-            ensure!(
-                hash == stake_table.commit(),
-                "epoch {epoch} root {root_height} stake table hash {hash} does not match \
-                 reconstructed hash {}",
-                stake_table.commit(),
-            );
+            if let Some(hash) = root.next_stake_table_hash() {
+                ensure!(
+                    hash == stake_table.commit(),
+                    "epoch {epoch} root {root_height} stake table hash {hash} does not match \
+                     reconstructed hash {}",
+                    stake_table.commit(),
+                );
+            } else if cfg!(feature = "decaf")
+                && self.opt.decaf
+                && root.version() < DrbAndHeaderUpgradeVersion::VERSION
+            {
+                // Decaf briefly ran a version of PoS where epoch root headers did not contain the
+                // hash of the expeected stake table, and so we can not verify that we computed the
+                // correct stake table. Since this applies only to Decaf, which is a testnet, it is
+                // acceptable to trust that the server supplied the correct events in this case.
+                tracing::warn!(
+                    ?epoch,
+                    root_height,
+                    computed_hash = %stake_table.commit(),
+                    "trusting stake table prior to DRB upgrade on Decaf",
+                );
+            } else {
+                bail!("epoch {epoch} root {root_height} does not have next stake table hash");
+            }
 
             // Cache the reconstructed stake table in the database.
             if let Err(err) = self
@@ -1097,6 +1082,7 @@ mod test {
             genesis.clone(),
             LightClientOptions {
                 num_stake_tables_in_memory: 2,
+                ..Default::default()
             },
         );
 

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -528,7 +528,7 @@ where
                     StakeTableQuorum::new((prev_quorum, next_quorum.clone()), self.epoch_height)
                 })
                 .await
-                .context("fetching epoch root for {epoch}")?;
+                .context(format!("fetching epoch root for {epoch}"))?;
             if let Some(hash) = root.next_stake_table_hash() {
                 ensure!(
                     hash == stake_table.commit(),
@@ -536,12 +536,9 @@ where
                      reconstructed hash {}",
                     stake_table.commit(),
                 );
-            } else if cfg!(feature = "decaf")
-                && self.opt.decaf
-                && root.version() < DrbAndHeaderUpgradeVersion::VERSION
-            {
+            } else if self.decaf() && root.version() < DrbAndHeaderUpgradeVersion::VERSION {
                 // Decaf briefly ran a version of PoS where epoch root headers did not contain the
-                // hash of the expeected stake table, and so we can not verify that we computed the
+                // hash of the expected stake table, and so we can not verify that we computed the
                 // correct stake table. Since this applies only to Decaf, which is a testnet, it is
                 // acceptable to trust that the server supplied the correct events in this case.
                 tracing::warn!(
@@ -643,6 +640,14 @@ where
         }
 
         cache.entry(epoch).insert_entry(stake_table).get().clone()
+    }
+
+    fn decaf(&self) -> bool {
+        #[cfg(feature = "decaf")]
+        return self.opt.decaf;
+
+        #[cfg(not(feature = "decaf"))]
+        return false;
     }
 }
 

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -560,9 +560,6 @@ impl TestClient {
             first_epoch_with_dynamic_stake_table: EpochNumber::new(
                 inner.first_epoch_with_dynamic_stake_table,
             ),
-
-            #[cfg(feature = "decaf")]
-            decaf_first_pos_epoch: None,
         }
     }
 


### PR DESCRIPTION
Previously, the light client had a special case for stake table catchup in the epoch range corresponding to protocol version 0.3 on Decaf (a range which does not exist on Mainnet). Not only does this add complexity for an edge case that is only present on testnet, but it made it impossible to use the light client to query blocks in this range, which in turn makes it impossible to use the light client as a catchup provider on Decaf.

Because of these drawbacks, it is better just to trust the server for 0.3 stake table catchup (on Decaf only), which greatly simplifies the configuration of the light client and the logic for stake table catchup, and makes the light client fully functional on Decaf for historical data.
