### PR TITLE
Persist updated network config after genesis file updates are applied

### DIFF
--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -382,13 +382,13 @@ where
     info!("Starting Libp2p with PeerID: {libp2p_public_key}");
 
     let loaded_network_config_from_persistence = persistence.load_config().await?;
-    let (mut network_config, wait_for_orchestrator) = match (
+    let (mut network_config, wait_for_orchestrator, persist_config) = match (
         loaded_network_config_from_persistence,
         network_params.config_peers,
     ) {
         (Some(config), _) => {
             tracing::warn!("loaded network config from storage, rejoining existing network");
-            (config, false)
+            (config, false, false)
         },
         // If we were told to fetch the config from an already-started peer, do so.
         (None, Some(peers)) => {
@@ -406,8 +406,7 @@ where
                 stake_table = ?config.config.known_nodes_with_stake,
                 "loaded config",
             );
-            persistence.save_config(&config).await?;
-            (config, false)
+            (config, false, true)
         },
         // Otherwise, this is a fresh network; load from the orchestrator.
         (None, None) => {
@@ -431,9 +430,8 @@ where
                 stake_table = ?config.config.known_nodes_with_stake,
                 "loaded config",
             );
-            persistence.save_config(&config).await?;
             tracing::warn!("all nodes connected");
-            (config, true)
+            (config, true, true)
         },
     };
 
@@ -472,6 +470,13 @@ where
     if let Some(da_committees) = &genesis.da_committees {
         tracing::warn!("setting da_committees from genesis: {da_committees:?}");
         network_config.config.da_committees = da_committees.clone();
+    }
+
+    // Save *after* the above updates. The orchestrator and peer fetched configs don't include
+    // epoch_height, drb_difficulty, etc. those come from genesis and are applied above.
+    // Saving before these updates would persist zeros for those values
+    if persist_config {
+        persistence.save_config(&network_config).await?;
     }
 
     // If the `Libp2p` bootstrap nodes were supplied via the command line, override those


### PR DESCRIPTION
Save hotshot config after the genesis updates are applied. Saving before these updates would just insert zeros for values coming from genesis file such as epoch_height, epoch_start_block.


The new protocol's `Coordinator::new` reads `epoch_height` out of `HotShotInitializer`, which is built by persistence.load_consensus_state() from the saved NetworkConfig. The legacy `SystemContext` dodges this because it reads epoch_height from the live in-memory HotShotConfig passed into SystemContext::init, not from the initializer. This PR fixes the root cause by persisting NetworkConfig after the genesis file updates are applied