### PR TITLE
Enable query service backfilling in chronological order.

### DIFF
--- a/crates/espresso/node/src/api/options.rs
+++ b/crates/espresso/node/src/api/options.rs
@@ -429,7 +429,6 @@ impl Options {
         // missing from the query service from ephemeral consensus storage.
         let db_provider = mod_opt.clone().create().await?;
         provider = provider
-            .with_leaf_provider(db_provider.clone())
             .with_block_provider(db_provider.clone())
             .with_vid_common_provider(db_provider);
         // If that fails, fetch missing data from peers.

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -33,21 +33,21 @@ use hotshot_libp2p_networking::network::behaviours::dht::store::persistent::{
 };
 use hotshot_new_protocol::message::Certificate2;
 use hotshot_query_service::{
-    availability::{BlockId, LeafQueryData},
+    availability::BlockId,
     data_source::{
         Transaction as _, VersionedDataSource,
         storage::{
             AvailabilityStorage,
             pruning::PrunerCfg,
             sql::{
-                Config, Db, Read, SqlStorage, StorageConnectionType, Transaction, TransactionMode,
-                Write, include_migrations, query_as, syntax_helpers::MAX_FN,
+                Config, Db, Read, SqlStorage, StorageConnectionType, Transaction, Write,
+                include_migrations, query_as, syntax_helpers::MAX_FN,
             },
         },
     },
     fetching::{
         Provider,
-        request::{LeafRequest, PayloadRequest, VidCommonRequest},
+        request::{PayloadRequest, VidCommonRequest},
     },
     merklized_state::MerklizedState,
 };
@@ -3546,71 +3546,6 @@ impl Provider<SeqTypes, PayloadRequest> for Persistence {
     }
 }
 
-#[async_trait]
-impl Provider<SeqTypes, LeafRequest<SeqTypes>> for Persistence {
-    #[tracing::instrument(skip(self))]
-    async fn fetch(&self, req: LeafRequest<SeqTypes>) -> Option<LeafQueryData<SeqTypes>> {
-        let mut tx = match self.db.read().await {
-            Ok(tx) => tx,
-            Err(err) => {
-                tracing::warn!("could not open transaction: {err:#}");
-                return None;
-            },
-        };
-
-        let (leaf, qc) = match fetch_leaf_from_proposals(&mut tx, req).await {
-            Ok(res) => res?,
-            Err(err) => {
-                tracing::info!("requested leaf not found in undecided proposals: {err:#}");
-                return None;
-            },
-        };
-
-        match LeafQueryData::new(leaf, qc) {
-            Ok(leaf) => Some(leaf),
-            Err(err) => {
-                tracing::warn!("fetched invalid leaf: {err:#}");
-                None
-            },
-        }
-    }
-}
-
-async fn fetch_leaf_from_proposals<Mode: TransactionMode>(
-    tx: &mut Transaction<Mode>,
-    req: LeafRequest<SeqTypes>,
-) -> anyhow::Result<Option<(Leaf2, QuorumCertificate2<SeqTypes>)>> {
-    // Look for a quorum proposal corresponding to this leaf.
-    let Some((proposal_bytes,)) =
-        query_as::<(Vec<u8>,)>("SELECT data FROM quorum_proposals2 WHERE leaf_hash = $1 LIMIT 1")
-            .bind(req.expected_leaf.to_string())
-            .fetch_optional(tx.as_mut())
-            .await
-            .context("fetching proposal")?
-    else {
-        return Ok(None);
-    };
-
-    // Look for a QC corresponding to this leaf.
-    let Some((qc_bytes,)) =
-        query_as::<(Vec<u8>,)>("SELECT data FROM quorum_certificate2 WHERE leaf_hash = $1 LIMIT 1")
-            .bind(req.expected_leaf.to_string())
-            .fetch_optional(tx.as_mut())
-            .await
-            .context("fetching QC")?
-    else {
-        return Ok(None);
-    };
-
-    let proposal: Proposal<SeqTypes, QuorumProposalWrapper<SeqTypes>> =
-        bincode::deserialize(&proposal_bytes).context("deserializing quorum proposal")?;
-    let qc: QuorumCertificate2<SeqTypes> =
-        bincode::deserialize(&qc_bytes).context("deserializing quorum certificate")?;
-
-    let leaf = Leaf2::from_quorum_proposal(&proposal.data);
-    Ok(Some((leaf, qc)))
-}
-
 #[cfg(test)]
 mod testing {
     use hotshot_query_service::data_source::storage::sql::testing::TmpDb;
@@ -4064,7 +3999,6 @@ mod test {
             .justify_qc
             .data
             .leaf_commit = Committable::commit(&leaf.clone());
-        let qc = next_quorum_proposal.data.justify_qc();
 
         // Add to database.
         storage
@@ -4094,18 +4028,6 @@ mod test {
             leaf_payload,
             storage
                 .fetch(PayloadRequest(vid_share.data.payload_commitment()))
-                .await
-                .unwrap()
-        );
-        assert_eq!(
-            LeafQueryData::new(leaf.clone(), qc.clone()).unwrap(),
-            storage
-                .fetch(LeafRequest::new(
-                    leaf.block_header().block_number(),
-                    Committable::commit(&leaf),
-                    qc.view_number(),
-                    qc.data,
-                ))
                 .await
                 .unwrap()
         );
@@ -4726,7 +4648,8 @@ mod postgres_tests {
     use espresso_types::{FeeAccount, Header, Leaf, NodeState, Transaction as Tx};
     use hotshot_example_types::node_types::TEST_VERSIONS;
     use hotshot_query_service::{
-        availability::BlockQueryData, data_source::storage::UpdateAvailabilityStorage,
+        availability::{BlockQueryData, LeafQueryData},
+        data_source::storage::UpdateAvailabilityStorage,
     };
     use hotshot_types::{
         data::vid_commitment,

--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -1498,15 +1498,7 @@ where
 
                     // Break the range into manageable, aligned chunks (which improves cacheability
                     // for the upstream server).
-                    //
-                    // We iterate in reverse order because leaves are inherently fetched in reverse,
-                    // since we cannot (actively) fetch a leaf until we have the subsequent leaf,
-                    // which tells us what the hash of its parent should be.
-                    for chunk in range_chunks_aligned_rev(
-                        Bound::Included(range.start),
-                        range.end - 1,
-                        chunk_size,
-                    ) {
+                    for chunk in range_chunks_aligned(range.start..range.end, chunk_size) {
                         tracing::info!(?chunk, "fetching missing block chunk");
 
                         // Fetching the payload metadata is enough to trigger an active fetch of the
@@ -1534,11 +1526,7 @@ where
                     }
 
                     tracing::info!(?range, "fetching missing VID range");
-                    for chunk in range_chunks_aligned_rev(
-                        Bound::Included(range.start),
-                        range.end - 1,
-                        chunk_size,
-                    ) {
+                    for chunk in range_chunks_aligned(range.start..range.end, chunk_size) {
                         tracing::info!(?chunk, "fetching missing VID chunk");
                         self.get::<NonEmptyRange<VidCommonQueryData<Types>>>(RangeRequest {
                             start: chunk.start as u64,
@@ -2103,8 +2091,8 @@ where
 
 /// A provider which can be used as a fetcher by the availability service.
 pub trait AvailabilityProvider<Types: NodeType>:
-    Provider<Types, request::LeafRequest<Types>>
-    + Provider<Types, request::LeafRangeRequest<Types>>
+    Provider<Types, request::LeafRequest>
+    + Provider<Types, request::LeafRangeRequest>
     + Provider<Types, request::PayloadRequest>
     + Provider<Types, request::BlockRangeRequest>
     + Provider<Types, request::VidCommonRequest>
@@ -2115,8 +2103,8 @@ pub trait AvailabilityProvider<Types: NodeType>:
 {
 }
 impl<Types: NodeType, P> AvailabilityProvider<Types> for P where
-    P: Provider<Types, request::LeafRequest<Types>>
-        + Provider<Types, request::LeafRangeRequest<Types>>
+    P: Provider<Types, request::LeafRequest>
+        + Provider<Types, request::LeafRangeRequest>
         + Provider<Types, request::PayloadRequest>
         + Provider<Types, request::BlockRangeRequest>
         + Provider<Types, request::VidCommonRequest>
@@ -2310,7 +2298,6 @@ where
 /// Each chunk is of size `alignment`, and starts on a multiple of `alignment`, with the possible
 /// exception of the first chunk (which may be misaligned and small) and the last (which may be
 /// small).
-#[allow(dead_code)]
 fn range_chunks_aligned<R>(range: R, alignment: usize) -> impl Iterator<Item = Range<usize>>
 where
     R: RangeBounds<usize>,
@@ -2384,56 +2371,6 @@ fn range_chunks_rev(
         end = chunk_start;
         Some(chunk)
     })
-}
-
-/// Break a range into fixed-alignment chunks, starting from the end and moving towards the start.
-///
-/// Each chunk is of size `alignment`, and starts on a multiple of `alignment` (that is, the lower
-/// bound an _exclusive_ upper bound of each chunk are multiples of `alignment`), with the possible
-/// exception of the first chunk (the last chunk in numerical order, which may be small) and the
-/// last (which may be misaligned and small).
-///
-/// While the chunks are yielded in reverse order, from `end` to `start`, each individual chunk is
-/// in the usual ascending order. That is, the first chunk ends with `end` and the last chunk starts
-/// with `start`.
-///
-/// Note that unlike [`range_chunks_aligned`], which accepts any range and yields an infinite
-/// iterator if the range has no upper bound, this function requires there to be a defined upper
-/// bound, otherwise we don't know where the reversed iterator should _start_. The `end` bound given
-/// here is inclusive; i.e. the end of the first chunk yielded by the stream will be exactly `end`.
-fn range_chunks_aligned_rev(
-    start: Bound<usize>,
-    end: usize,
-    alignment: usize,
-) -> impl Iterator<Item = Range<usize>> {
-    // Transform the start bound to be inclusive.
-    let start = match start {
-        Bound::Included(i) => i,
-        Bound::Excluded(i) => i + 1,
-        Bound::Unbounded => 0,
-    };
-    // Transform the end bound to be exclusive.
-    let mut end = end + 1;
-
-    // If necessary, generate a partial first chunk to force the remaining chunks into alignment.
-    let first = if end.is_multiple_of(alignment) {
-        None
-    } else {
-        // The partial first chunk starts at the previous multiple of the alignment, or at the start
-        // of the overall range, whichever comes first.
-        let next_multiple = end.next_multiple_of(alignment);
-        let prev_multiple = next_multiple - alignment;
-        let chunk_start = max(prev_multiple, start);
-        let chunk = chunk_start..end;
-
-        // Start the reverse series of aligned chunks at the start of the partial first chunk.
-        end = chunk_start;
-        Some(chunk)
-    };
-
-    first
-        .into_iter()
-        .chain(range_chunks_rev(Bound::Included(start), end - 1, alignment))
 }
 
 trait ResultExt<T, E> {
@@ -2746,29 +2683,6 @@ mod test {
         assert_eq!(
             range_chunks_rev(Bound::Excluded(0), 4, 2).collect::<Vec<_>>(),
             [3..5, 1..3]
-        );
-    }
-
-    #[test]
-    fn test_range_chunks_aligned_rev() {
-        #![allow(clippy::single_range_in_vec_init)]
-
-        // Aligned first chunk, partial last chunk.
-        assert_eq!(
-            range_chunks_aligned_rev(Bound::Included(1), 3, 2).collect::<Vec<_>>(),
-            [2..4, 1..2]
-        );
-
-        // Misaligned first chunk, complete last chunk.
-        assert_eq!(
-            range_chunks_aligned_rev(Bound::Included(0), 2, 2).collect::<Vec<_>>(),
-            [2..3, 0..2]
-        );
-
-        // Incomplete chunk.
-        assert_eq!(
-            range_chunks_aligned_rev(Bound::Excluded(0), 3, 10).collect::<Vec<_>>(),
-            [1..4]
         );
     }
 

--- a/hotshot-query-service/src/data_source/fetching/block.rs
+++ b/hotshot-query-service/src/data_source/fetching/block.rs
@@ -481,9 +481,10 @@ where
     }
 }
 
-pub(super) fn fetch_block_range_with_headers<Types, S, P>(
+pub(super) fn fetch_block_range<Types, S, P>(
     fetcher: Arc<Fetcher<Types, S, P>>,
-    headers: NonEmptyRange<Header<Types>>,
+    start: u64,
+    end: u64,
 ) where
     Types: NodeType,
     Header<Types>: QueryableHeader<Types>,
@@ -497,14 +498,9 @@ pub(super) fn fetch_block_range_with_headers<Types, S, P>(
         return;
     };
 
-    // Now that we have the header, we only need to retrieve the payload.
-    tracing::info!(
-        "spawned active fetch for payload range {}..{}",
-        headers.start(),
-        headers.end()
-    );
+    tracing::info!("spawned active fetch for payload range {start}..{end}");
     payload_range_fetcher.spawn_fetch(
-        BlockRangeRequest::from_headers(&headers),
+        BlockRangeRequest { start, end },
         fetcher.provider.clone(),
         once(BlockRangeCallback {
             fetcher: fetcher.clone(),

--- a/hotshot-query-service/src/data_source/fetching/header.rs
+++ b/hotshot-query-service/src/data_source/fetching/header.rs
@@ -31,9 +31,9 @@ use crate::{
     data_source::{
         fetching::{
             Fetchable, HeaderQueryData, LeafQueryData, Notifiers,
-            block::fetch_block_range_with_headers,
+            block::fetch_block_range,
             leaf::{RangeRequest, fetch_leaf_range_with_callbacks},
-            vid::fetch_vid_common_range_with_headers,
+            vid::fetch_vid_common_range,
         },
         storage::{
             AvailabilityStorage, NodeStorage, UpdateAvailabilityStorage,
@@ -195,23 +195,15 @@ where
         }
     }
 
-    pub(super) fn run_range(self, headers: NonEmptyRange<Header<Types>>) {
+    pub(super) fn run_range(self, start: u64, end: u64) {
         match self {
             Self::Payload { fetcher } => {
-                tracing::info!(
-                    "fetched leaves {}..{}, will now fetch payload",
-                    headers.start(),
-                    headers.end(),
-                );
-                fetch_block_range_with_headers(fetcher, headers);
+                tracing::info!("fetched leaves {start}..{end}, will now fetch payload",);
+                fetch_block_range(fetcher, start, end);
             },
             Self::VidCommon { fetcher } => {
-                tracing::info!(
-                    "fetched leaves {}..{}, will now fetch VID common",
-                    headers.start(),
-                    headers.end(),
-                );
-                fetch_vid_common_range_with_headers(fetcher, headers);
+                tracing::info!("fetched leaves {start}..{end}, will now fetch VID common",);
+                fetch_vid_common_range(fetcher, start, end);
             },
         }
     }
@@ -262,7 +254,7 @@ where
     // header and leaf.
     match req {
         BlockId::Number(n) => {
-            fetch_leaf_with_callbacks(tx, callback.fetcher(), n.into(), [callback.into()]).await?;
+            fetch_leaf_with_callbacks(callback.fetcher(), n.into(), [callback.into()]).await?;
         },
         BlockId::Hash(h) => {
             // Given only the hash, we cannot tell if the corresponding leaf actually exists, since
@@ -292,10 +284,11 @@ where
     for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
     P: AvailabilityProvider<Types>,
 {
-    // Check if at least the headers are available in local storage.
+    // Check if the headers are already available in local storage; then we only need to fetch the
+    // payload data.
     match <NonEmptyRange<LeafQueryData<Types>>>::load(tx, req).await {
-        Ok(leaves) => {
-            callback.run_range(leaves.as_ref_cloned());
+        Ok(_) => {
+            callback.run_range(req.start, req.end);
             return Ok(());
         },
         Err(QueryError::Missing | QueryError::NotFound) => {
@@ -311,7 +304,7 @@ where
     }
 
     // Fetch the headers (in fact, the entire leaves) first, then fetch the remaining payload data.
-    fetch_leaf_range_with_callbacks(tx, callback.fetcher(), req, [callback.into()]).await?;
+    fetch_leaf_range_with_callbacks(callback.fetcher(), req, [callback.into()]).await?;
 
     Ok(())
 }

--- a/hotshot-query-service/src/data_source/fetching/leaf.rs
+++ b/hotshot-query-service/src/data_source/fetching/leaf.rs
@@ -21,12 +21,11 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::bail;
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::From;
 use futures::future::{BoxFuture, FutureExt, join_all};
-use hotshot_types::{traits::node_implementation::NodeType, vote::HasViewNumber};
+use hotshot_types::traits::node_implementation::NodeType;
 use tokio::spawn;
 use tracing::Instrument;
 
@@ -52,10 +51,10 @@ use crate::{
 };
 
 pub(super) type LeafFetcher<Types, S, P> =
-    fetching::Fetcher<request::LeafRequest<Types>, LeafCallback<Types, S, P>>;
+    fetching::Fetcher<request::LeafRequest, LeafCallback<Types, S, P>>;
 
 pub(super) type LeafRangeFetcher<Types, S, P> =
-    fetching::Fetcher<LeafRangeRequest<Types>, LeafCallback<Types, S, P>>;
+    fetching::Fetcher<LeafRangeRequest, LeafCallback<Types, S, P>>;
 
 impl<Types> FetchRequest for LeafId<Types>
 where
@@ -99,7 +98,7 @@ where
     }
 
     async fn active_fetch<S, P>(
-        tx: &mut impl AvailabilityStorage<Types>,
+        _tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
     ) -> anyhow::Result<()>
@@ -110,7 +109,7 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_leaf_with_callbacks(tx, fetcher, req, None).await
+        fetch_leaf_with_callbacks(fetcher, req, None).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -122,7 +121,6 @@ where
 }
 
 pub(super) async fn fetch_leaf_with_callbacks<Types, S, P, I>(
-    tx: &mut impl AvailabilityStorage<Types>,
     fetcher: Arc<Fetcher<Types, S, P>>,
     req: LeafId<Types>,
     callbacks: I,
@@ -140,79 +138,9 @@ where
 {
     match req {
         LeafId::Number(n) => {
-            // We need the next leaf in the chain so we can figure out what hash we expect for this
-            // leaf, so we can fetch it securely from an untrusted provider.
-            let next = (n + 1) as u64;
-            let next = match tx.first_available_leaf(next).await {
-                Ok(leaf) if leaf.height() == next => leaf,
-                Ok(leaf) => {
-                    // If we don't have the immediate successor leaf, but we have some later leaf,
-                    // then we can't trigger this exact fetch, but we can fetch the (apparently)
-                    // missing parent of the leaf we do have, which will trigger a chain of fetches
-                    // that eventually reaches all the way back to the desired leaf.
-                    tracing::debug!(
-                        n,
-                        fetching = leaf.height() - 1,
-                        "do not have necessary leaf; trigger fetch of a later leaf"
-                    );
-
-                    let mut callbacks = vec![LeafCallback::Leaf {
-                        fetcher: fetcher.clone(),
-                    }];
-
-                    if !fetcher.leaf_only {
-                        callbacks.push(
-                            HeaderCallback::Payload {
-                                fetcher: fetcher.clone(),
-                            }
-                            .into(),
-                        );
-                        callbacks.push(
-                            HeaderCallback::VidCommon {
-                                fetcher: fetcher.clone(),
-                            }
-                            .into(),
-                        );
-                    }
-
-                    let parent_qc = leaf.leaf().justify_qc();
-                    fetcher.leaf_fetcher.clone().spawn_fetch(
-                        request::LeafRequest::new(
-                            leaf.height() - 1,
-                            leaf.leaf().parent_commitment(),
-                            parent_qc.view_number(),
-                            parent_qc.data,
-                        ),
-                        fetcher.provider.clone(),
-                        // After getting the leaf, grab the other data as well; that will be missing
-                        // whenever the leaf was.
-                        callbacks,
-                    );
-                    return Ok(());
-                },
-                Err(QueryError::Missing | QueryError::NotFound) => {
-                    // We successfully queried the database, but the next leaf wasn't there. We
-                    // know for sure that based on the current state of the DB, we cannot fetch this
-                    // leaf.
-                    tracing::debug!(n, "not fetching leaf with unknown successor");
-                    return Ok(());
-                },
-                Err(QueryError::Error { message }) => {
-                    // An error occurred while querying the database. We don't know if we need to
-                    // fetch the leaf or not. Return an error so we can try again.
-                    bail!("failed to fetch successor for leaf {n}: {message}");
-                },
-            };
-
             let fetcher = fetcher.clone();
-            let parent_qc = next.leaf().justify_qc();
             fetcher.leaf_fetcher.clone().spawn_fetch(
-                request::LeafRequest::new(
-                    n as u64,
-                    next.leaf().parent_commitment(),
-                    parent_qc.view_number(),
-                    parent_qc.data,
-                ),
+                request::LeafRequest::new(n as u64),
                 fetcher.provider.clone(),
                 once(LeafCallback::Leaf { fetcher }).chain(callbacks),
             );
@@ -230,13 +158,9 @@ where
 
 /// Trigger a fetch of the parent of the given `leaf`, if it is missing.
 ///
-/// Leaves have a unique constraint among fetchable objects: we cannot fetch a given leaf at height
-/// `h` unless we have its child at height `h + 1`. This is because the child, through its
-/// `parent_commitment`, tells us what the hash of the parent should be, which lets us authenticate
-/// it when fetching from an untrusted provider. Thus, requests for leaf `h` might block if `h + 1`
-/// is not available. To ensure all these requests are eventually unblocked, and all leaves are
-/// eventually fetched, we call this function whenever we receive leaf `h + 1` to check if we need
-/// to then fetch leaf `h`.
+/// This ensures that a passive fetch for a leaf will always resolve eventually, even if we miss the
+/// decide event for that leaf: we will eventually get a decide for a later leaf, and then fetch the
+/// chain backwards.
 pub(super) fn trigger_fetch_for_parent<Types, S, P>(
     fetcher: &Arc<Fetcher<Types, S, P>>,
     leaf: &LeafQueryData<Types>,
@@ -250,10 +174,6 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
     P: AvailabilityProvider<Types>,
 {
     let height = leaf.height();
-    let parent = leaf.leaf().parent_commitment();
-    let parent_qc = leaf.leaf().justify_qc();
-    let parent_qc_view = parent_qc.view_number();
-    let parent_qc_data = parent_qc.data;
 
     // Check that there is a parent to fetch.
     if height == 0 {
@@ -263,7 +183,7 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
     // Spawn an async task; we're triggering a fire-and-forget fetch of a leaf that might now be
     // available; we don't need to block the caller on this.
     let fetcher = fetcher.clone();
-    let span = tracing::info_span!("fetch parent leaf", height, %parent, %parent_qc_view);
+    let span = tracing::info_span!("fetch parent leaf", height);
     spawn(
         async move {
             // Check if we already have the parent.
@@ -286,15 +206,14 @@ pub(super) fn trigger_fetch_for_parent<Types, S, P>(
                     // parent, so we fall through to fetching it just to be safe.
                     tracing::warn!(
                         height,
-                        %parent,
                         "error opening transaction to check for parent leaf: {err:#}",
                     );
                 },
             }
 
-            tracing::info!(height, %parent, "received new leaf; fetching missing parent");
+            tracing::info!(height, "received new leaf; fetching missing parent");
             fetcher.leaf_fetcher.clone().spawn_fetch(
-                request::LeafRequest::new(height - 1, parent, parent_qc_view, parent_qc_data),
+                request::LeafRequest::new(height - 1),
                 fetcher.provider.clone(),
                 // After getting the leaf, grab the other data as well; that will be missing
                 // whenever the leaf was.
@@ -445,7 +364,7 @@ where
                 // continue bulk fetching, rather than kick of a chain reaction of individual
                 // fetches, which will end up fetching the same data, slower.
             },
-            Self::Continuation { callback } => callback.run_range(leaves.as_ref_cloned()),
+            Self::Continuation { callback } => callback.run_range(leaves.start(), leaves.end()),
         }
     }
 }
@@ -512,7 +431,7 @@ where
     }
 
     async fn active_fetch<S, P>(
-        tx: &mut impl AvailabilityStorage<Types>,
+        _tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
     ) -> anyhow::Result<()>
@@ -523,7 +442,7 @@ where
             AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
         P: AvailabilityProvider<Types>,
     {
-        fetch_leaf_range_with_callbacks(tx, fetcher, req, None).await
+        fetch_leaf_range_with_callbacks(fetcher, req, None).await
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
@@ -573,7 +492,6 @@ where
 }
 
 pub(super) async fn fetch_leaf_range_with_callbacks<Types, S, P, I>(
-    tx: &mut impl AvailabilityStorage<Types>,
     fetcher: Arc<Fetcher<Types, S, P>>,
     req: RangeRequest,
     callbacks: I,
@@ -589,79 +507,11 @@ where
     I: IntoIterator<Item = LeafCallback<Types, S, P>> + Send + 'static,
     I::IntoIter: Send,
 {
-    // We need the next leaf after the chain so we can figure out what hash we expect for the last
-    // leaf in the chain, so we can fetch it securely from an untrusted provider.
-    let next = match tx.first_available_leaf(req.end).await {
-        Ok(leaf) if leaf.height() == req.end => leaf,
-        Ok(leaf) => {
-            // If we don't have the immediate successor leaf, but we have some later leaf,
-            // then we can't trigger this exact fetch, but we can fetch the (apparently)
-            // missing parent of the leaf we do have, which will trigger a chain of fetches
-            // that eventually reaches all the way back to the desired leaf.
-            tracing::debug!(
-                req.end,
-                fetching = leaf.height() - 1,
-                "do not have necessary leaf; trigger fetch of a later leaf"
-            );
-
-            let mut callbacks = vec![LeafCallback::Leaf {
-                fetcher: fetcher.clone(),
-            }];
-
-            if !fetcher.leaf_only {
-                callbacks.push(
-                    HeaderCallback::Payload {
-                        fetcher: fetcher.clone(),
-                    }
-                    .into(),
-                );
-                callbacks.push(
-                    HeaderCallback::VidCommon {
-                        fetcher: fetcher.clone(),
-                    }
-                    .into(),
-                );
-            }
-
-            let parent_qc = leaf.leaf().justify_qc();
-            fetcher.leaf_fetcher.clone().spawn_fetch(
-                request::LeafRequest::new(
-                    leaf.height() - 1,
-                    leaf.leaf().parent_commitment(),
-                    parent_qc.view_number(),
-                    parent_qc.data,
-                ),
-                fetcher.provider.clone(),
-                // After getting the leaf, grab the other data as well; that will be missing
-                // whenever the leaf was.
-                callbacks,
-            );
-            return Ok(());
-        },
-        Err(QueryError::Missing | QueryError::NotFound) => {
-            // We successfully queried the database, but the next leaf wasn't there. We know for
-            // sure that based on the current state of the DB, we cannot fetch this leaf.
-            tracing::debug!(req.end, "not fetching leaf chain with unknown successor");
-            return Ok(());
-        },
-        Err(QueryError::Error { message }) => {
-            // An error occurred while querying the database. We don't know if we need to fetch the
-            // leaf or not. Return an error so we can try again.
-            bail!(
-                "failed to fetch successor for leaf chain {}: {message}",
-                req.end
-            );
-        },
-    };
-
     let fetcher = fetcher.clone();
     fetcher.leaf_range_fetcher.clone().spawn_fetch(
         LeafRangeRequest {
             start: req.start,
             end: req.end,
-            last_leaf: next.leaf().parent_commitment(),
-            last_qc_view: next.leaf().justify_qc().view_number(),
-            last_qc_data: next.leaf().justify_qc().data,
         },
         fetcher.provider.clone(),
         once(LeafCallback::Leaf { fetcher }).chain(callbacks),

--- a/hotshot-query-service/src/data_source/fetching/vid.rs
+++ b/hotshot-query-service/src/data_source/fetching/vid.rs
@@ -437,9 +437,10 @@ where
     }
 }
 
-pub(super) fn fetch_vid_common_range_with_headers<Types, S, P>(
+pub(super) fn fetch_vid_common_range<Types, S, P>(
     fetcher: Arc<Fetcher<Types, S, P>>,
-    headers: NonEmptyRange<Header<Types>>,
+    start: u64,
+    end: u64,
 ) where
     Types: NodeType,
     Header<Types>: QueryableHeader<Types>,
@@ -453,14 +454,9 @@ pub(super) fn fetch_vid_common_range_with_headers<Types, S, P>(
         return;
     };
 
-    // Now that we have the header, we only need to retrieve the VID common.
-    tracing::info!(
-        "spawned active fetch for VID common range {}..{}",
-        headers.start(),
-        headers.end()
-    );
+    tracing::info!("spawned active fetch for VID common range {start}..{end}");
     vid_common_range_fetcher.spawn_fetch(
-        VidCommonRangeRequest::from_headers(&headers),
+        VidCommonRangeRequest { start, end },
         fetcher.provider.clone(),
         once(VidCommonRangeCallback {
             fetcher: fetcher.clone(),

--- a/hotshot-query-service/src/data_source/storage.rs
+++ b/hotshot-query-service/src/data_source/storage.rs
@@ -195,9 +195,6 @@ where
         &mut self,
         hash: TransactionHash<Types>,
     ) -> QueryResult<BlockQueryData<Types>>;
-
-    /// Get the first leaf which is available in the database with height >= `from`.
-    async fn first_available_leaf(&mut self, from: u64) -> QueryResult<LeafQueryData<Types>>;
 }
 
 pub trait UpdateAvailabilityStorage<Types>: Send

--- a/hotshot-query-service/src/data_source/storage/fail_storage.rs
+++ b/hotshot-query-service/src/data_source/storage/fail_storage.rs
@@ -448,12 +448,6 @@ where
         self.maybe_fail_read(FailableAction::GetTransaction).await?;
         self.inner.get_block_with_transaction(hash).await
     }
-
-    async fn first_available_leaf(&mut self, from: u64) -> QueryResult<LeafQueryData<Types>> {
-        self.maybe_fail_read(FailableAction::FirstAvailableLeaf)
-            .await?;
-        self.inner.first_available_leaf(from).await
-    }
 }
 
 impl<Types, T> UpdateAvailabilityStorage<Types> for Transaction<T>

--- a/hotshot-query-service/src/data_source/storage/fs.rs
+++ b/hotshot-query-service/src/data_source/storage/fs.rs
@@ -624,13 +624,6 @@ where
             .context(NotFoundSnafu)?;
         self.inner.get_block((*height as usize).into())
     }
-
-    async fn first_available_leaf(&mut self, from: u64) -> QueryResult<LeafQueryData<Types>> {
-        // The file system backend doesn't index by whether a leaf is present, so we can't
-        // efficiently seek to the first leaf with height >= `from`. Our best effort is to return
-        // `from` itself if we can, or fail.
-        self.get_leaf((from as usize).into()).await
-    }
 }
 
 impl<Types: NodeType> UpdateAvailabilityStorage<Types>

--- a/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
@@ -357,17 +357,6 @@ where
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;
         Ok(BlockQueryData::from_row(&row)?)
     }
-
-    async fn first_available_leaf(&mut self, from: u64) -> QueryResult<LeafQueryData<Types>> {
-        let row = query(&format!(
-            "SELECT {LEAF_COLUMNS} FROM leaf2 WHERE height >= $1 ORDER BY height ASC LIMIT 1"
-        ))
-        .bind(from as i64)
-        .fetch_one(self.as_mut())
-        .await?;
-        let leaf = LeafQueryData::from_row(&row)?;
-        Ok(leaf)
-    }
 }
 
 impl<Mode> Transaction<Mode>

--- a/hotshot-query-service/src/fetching.rs
+++ b/hotshot-query-service/src/fetching.rs
@@ -246,15 +246,6 @@ where
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.0.iter()
     }
-
-    /// Convert a range of objects into an equivalent range of sub-objects with the same heights.
-    pub(crate) fn as_ref_cloned<U>(&self) -> NonEmptyRange<U>
-    where
-        T: AsRef<U>,
-        U: Clone,
-    {
-        NonEmptyRange(self.0.iter().map(|t| t.as_ref().clone()).collect())
-    }
 }
 
 impl<T> TryFrom<Vec<T>> for NonEmptyRange<T>

--- a/hotshot-query-service/src/fetching/provider.rs
+++ b/hotshot-query-service/src/fetching/provider.rs
@@ -46,7 +46,7 @@ mod query_service;
 mod testing;
 
 pub use any::AnyProvider;
-pub use query_service::QueryServiceProvider;
+pub use query_service::TrustedQueryServiceProvider;
 #[cfg(any(test, feature = "testing"))]
 pub use testing::TestProvider;
 

--- a/hotshot-query-service/src/fetching/provider.rs
+++ b/hotshot-query-service/src/fetching/provider.rs
@@ -28,7 +28,7 @@
 //! This module defines an abstract interface [`Provider`], which allows data to be fetched from any
 //! data availability provider, as well as various implementations for different data sources,
 //! including:
-//! * [`QueryServiceProvider`]
+//! * [`TrustedQueryServiceProvider`]
 //!
 //! We also provide combinators for modularly adding functionality to existing fetchers:
 //! * [`AnyProvider`]

--- a/hotshot-query-service/src/fetching/provider/any.rs
+++ b/hotshot-query-service/src/fetching/provider/any.rs
@@ -52,8 +52,8 @@ where
 
 type PayloadProvider<Types> = Arc<dyn DebugProvider<Types, PayloadRequest>>;
 type PayloadRangeProvider<Types> = Arc<dyn DebugProvider<Types, BlockRangeRequest>>;
-type LeafProvider<Types> = Arc<dyn DebugProvider<Types, LeafRequest<Types>>>;
-type LeafRangeProvider<Types> = Arc<dyn DebugProvider<Types, LeafRangeRequest<Types>>>;
+type LeafProvider<Types> = Arc<dyn DebugProvider<Types, LeafRequest>>;
+type LeafRangeProvider<Types> = Arc<dyn DebugProvider<Types, LeafRangeRequest>>;
 type VidCommonProvider<Types> = Arc<dyn DebugProvider<Types, VidCommonRequest>>;
 type VidCommonRangeProvider<Types> = Arc<dyn DebugProvider<Types, VidCommonRangeRequest>>;
 type Cert2Provider<Types> = Arc<dyn DebugProvider<Types, Certificate2Request>>;
@@ -132,24 +132,21 @@ where
 }
 
 #[async_trait]
-impl<Types> Provider<Types, LeafRequest<Types>> for AnyProvider<Types>
+impl<Types> Provider<Types, LeafRequest> for AnyProvider<Types>
 where
     Types: NodeType,
 {
-    async fn fetch(&self, req: LeafRequest<Types>) -> Option<LeafQueryData<Types>> {
+    async fn fetch(&self, req: LeafRequest) -> Option<LeafQueryData<Types>> {
         any_fetch(&self.leaf_providers, req).await
     }
 }
 
 #[async_trait]
-impl<Types> Provider<Types, LeafRangeRequest<Types>> for AnyProvider<Types>
+impl<Types> Provider<Types, LeafRangeRequest> for AnyProvider<Types>
 where
     Types: NodeType,
 {
-    async fn fetch(
-        &self,
-        req: LeafRangeRequest<Types>,
-    ) -> Option<NonEmptyRange<LeafQueryData<Types>>> {
+    async fn fetch(&self, req: LeafRangeRequest) -> Option<NonEmptyRange<LeafQueryData<Types>>> {
         any_fetch(&self.leaf_range_providers, req).await
     }
 }
@@ -228,7 +225,7 @@ where
     /// Add a sub-provider which fetches leaves.
     pub fn with_leaf_provider<P>(mut self, provider: P) -> Self
     where
-        P: Provider<Types, LeafRequest<Types>> + Debug + 'static,
+        P: Provider<Types, LeafRequest> + Debug + 'static,
     {
         self.leaf_providers.push(Arc::new(provider));
         self
@@ -237,7 +234,7 @@ where
     /// Add a sub-provider which fetches leaf ranges.
     pub fn with_leaf_range_provider<P>(mut self, provider: P) -> Self
     where
-        P: Provider<Types, LeafRangeRequest<Types>> + Debug + 'static,
+        P: Provider<Types, LeafRangeRequest> + Debug + 'static,
     {
         self.leaf_range_providers.push(Arc::new(provider));
         self
@@ -308,7 +305,7 @@ mod test {
         ApiState, Error,
         availability::{AvailabilityDataSource, UpdateAvailabilityData, define_api},
         data_source::storage::sql::testing::TmpDb,
-        fetching::provider::{NoFetching, QueryServiceProvider},
+        fetching::provider::{NoFetching, TrustedQueryServiceProvider},
         task::BackgroundTask,
         testing::{
             consensus::{MockDataSource, MockNetwork},
@@ -344,13 +341,12 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider =
-            Provider::default()
-                .with_provider(NoFetching)
-                .with_provider(QueryServiceProvider::new(
-                    format!("http://localhost:{port}").parse().unwrap(),
-                    MockBase::instance(),
-                ));
+        let provider = Provider::default().with_provider(NoFetching).with_provider(
+            TrustedQueryServiceProvider::new(
+                format!("http://localhost:{port}").parse().unwrap(),
+                MockBase::instance(),
+            ),
+        );
         let data_source = db.config().connect(provider.clone()).await.unwrap();
 
         // Start consensus.

--- a/hotshot-query-service/src/fetching/provider/any.rs
+++ b/hotshot-query-service/src/fetching/provider/any.rs
@@ -65,12 +65,12 @@ type Cert2Provider<Types> = Arc<dyn DebugProvider<Types, Certificate2Request>>;
 /// have the object, the request will eventually succeed.
 ///
 /// This can be used to combine multiple instances of the same kind of provider, like using
-/// [`QueryServiceProvider`](super::QueryServiceProvider) to request objects from a number of
-/// different query services. It can also be used to search different kinds of data providers for
-/// the same object, like searching for a block both in another instance of the query service and in
-/// the HotShot DA committee. Finally, [`AnyProvider`] can be used to combine a provider which only
-/// provides blocks and one which only provides leaves into a provider which provides both, and thus
-/// can be used as a provider for the availability API module.
+/// [`TrustedQueryServiceProvider`](super::TrustedQueryServiceProvider) to request objects from a
+/// number of different query services. It can also be used to search different kinds of data
+/// providers for the same object, like searching for a block both in another instance of the query
+/// service and in the HotShot DA committee. Finally, [`AnyProvider`] can be used to combine a
+/// provider which only provides blocks and one which only provides leaves into a provider which
+/// provides both, and thus can be used as a provider for the availability API module.
 ///
 /// # Examples
 ///
@@ -84,12 +84,12 @@ type Cert2Provider<Types> = Arc<dyn DebugProvider<Types, Certificate2Request>>;
 /// #   Types: NodeType,
 /// # {
 /// use hotshot_query_service::{
-///     fetching::provider::{AnyProvider, QueryServiceProvider},
+///     fetching::provider::{AnyProvider, TrustedQueryServiceProvider},
 ///     testing::mocks::MockBase,
 /// };
 ///
-/// let qs1 = QueryServiceProvider::new("https://backup.query-service.1".parse()?, MockBase::instance());
-/// let qs2 = QueryServiceProvider::new("https://backup.query-service.2".parse()?, MockBase::instance());
+/// let qs1 = TrustedQueryServiceProvider::new("https://backup.query-service.1".parse()?, MockBase::instance());
+/// let qs2 = TrustedQueryServiceProvider::new("https://backup.query-service.2".parse()?, MockBase::instance());
 /// let provider = AnyProvider::<Types>::default()
 ///     .with_provider(qs1)
 ///     .with_provider(qs2);

--- a/hotshot-query-service/src/fetching/provider/query_service.rs
+++ b/hotshot-query-service/src/fetching/provider/query_service.rs
@@ -15,17 +15,7 @@ use std::fmt::Debug;
 use anyhow::{Context, ensure};
 use async_trait::async_trait;
 use futures::{TryFutureExt, future::try_join_all};
-use hotshot_types::{
-    data::{VidCommitment, VidCommon, ns_table},
-    traits::{EncodeBytes, node_implementation::NodeType},
-    vid::{
-        advz::{ADVZScheme, advz_scheme},
-        avidm::{AvidMScheme, init_avidm_param},
-        avidm_gf2::AvidmGf2Scheme,
-    },
-    vote::HasViewNumber,
-};
-use jf_advz::VidScheme;
+use hotshot_types::{data::VidCommon, traits::node_implementation::NodeType};
 use surf_disco::{Client, Url};
 use vbs::version::StaticVersionType;
 
@@ -37,7 +27,7 @@ use crate::{
         NonEmptyRange,
         request::{
             BlockRangeRequest, Certificate2Request, LeafRangeRequest, LeafRequest, PayloadRequest,
-            RangeRequest, VidCommonRangeRequest, VidCommonRequest,
+            VidCommonRangeRequest, VidCommonRequest,
         },
     },
     types::HeightIndexed,
@@ -47,12 +37,21 @@ use crate::{
 ///
 /// This fetcher implements the [`Provider`] interface by querying the REST API provided by another
 /// instance of this query service to try and retrieve missing objects.
+///
+/// This provider trusts the external query service is connected to: it does not verify the
+/// responses it receives. Instantiating this provider adds a trust assumption not only on the
+/// external service, but on the correctness of this node's local TLS configuration, etc.: anything
+/// needed to ensure that the HTTP client is connected to the intended, trusted server.
+///
+/// To avoid adding additional trust dependencies, do not use this provider; instead, use a provider
+/// implementation that verifies the data it receives, for example using a light client for the
+/// protocol.
 #[derive(Clone, Debug)]
-pub struct QueryServiceProvider<Ver: StaticVersionType> {
+pub struct TrustedQueryServiceProvider<Ver: StaticVersionType> {
     client: Client<Error, Ver>,
 }
 
-impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
+impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     pub fn new(url: Url, _: Ver) -> Self {
         Self {
             client: Client::new(url),
@@ -60,37 +59,17 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
     }
 }
 
-impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
+impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     pub async fn fetch_payload<Types: NodeType>(
         &self,
         req: PayloadRequest,
     ) -> anyhow::Result<Payload<Types>> {
-        let req_hash = req.0;
-
-        // Fetch the payload and the VID common data. We need the common data to recompute the VID
-        // commitment, to ensure the payload we received is consistent with the commitment we
-        // requested.
         let block = self
             .client
-            .get::<BlockQueryData<Types>>(&format!("availability/block/payload-hash/{req_hash}"))
+            .get::<BlockQueryData<Types>>(&format!("availability/block/payload-hash/{}", req.0))
             .send()
             .await
             .context("fetching block")?;
-        let common = self
-            .client
-            .get::<VidCommonQueryData<Types>>(&format!(
-                "availability/vid/common/payload-hash/{req_hash}",
-            ))
-            .send()
-            .await
-            .context("fetching VID common")?;
-
-        let comm =
-            recompute_payload_commitment(&block, &common).context("computing VID commitment")?;
-        ensure!(
-            comm == req_hash,
-            "VID commitment {comm} does not match request"
-        );
 
         Ok(block.payload)
     }
@@ -99,11 +78,6 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
         &self,
         req: BlockRangeRequest,
     ) -> anyhow::Result<NonEmptyRange<BlockQueryData<Types>>> {
-        let req = RangeRequest::from(req);
-
-        // Fetch the payload and the VID common data. We need the common data to recompute the VID
-        // commitment, to ensure the payloads we received are consistent with the expected
-        // commitments.
         let blocks = self
             .client
             .get::<NonEmptyRange<BlockQueryData<Types>>>(&format!(
@@ -113,33 +87,12 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             .send()
             .await
             .context("fetching blocks")?;
-        let common = self
-            .fetch_vid_common_range_with_fallback(req.start, req.end)
-            .await?;
 
         ensure!(
             blocks.start() == req.start && blocks.end() == req.end,
             "wrong block range ({}..{})",
             blocks.start(),
             blocks.end()
-        );
-        ensure!(
-            common.start() == req.start && common.end() == req.end,
-            "wrong VID common range (expected {}..{})",
-            common.start(),
-            common.end()
-        );
-
-        let commits = blocks
-            .iter()
-            .zip(&common)
-            .map(|(block, common)| recompute_payload_commitment(block, common))
-            .collect::<Result<Vec<VidCommitment>, _>>()
-            .context("computing VID commitments")?;
-        let hash = RangeRequest::hash_payloads(commits.iter().copied());
-        ensure!(
-            hash == req.expected_hash,
-            "server returned blocks with wrong payload hash ({hash}, commits {commits:?})",
         );
 
         Ok(blocks)
@@ -157,7 +110,8 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
 }
 
 #[async_trait]
-impl<Types, Ver: StaticVersionType> Provider<Types, PayloadRequest> for QueryServiceProvider<Ver>
+impl<Types, Ver: StaticVersionType> Provider<Types, PayloadRequest>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
@@ -167,7 +121,8 @@ where
 }
 
 #[async_trait]
-impl<Types, Ver: StaticVersionType> Provider<Types, BlockRangeRequest> for QueryServiceProvider<Ver>
+impl<Types, Ver: StaticVersionType> Provider<Types, BlockRangeRequest>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
@@ -176,57 +131,10 @@ where
     }
 }
 
-fn recompute_payload_commitment<Types>(
-    block: &BlockQueryData<Types>,
-    common: &VidCommonQueryData<Types>,
-) -> anyhow::Result<VidCommitment>
-where
-    Types: NodeType,
-{
-    match common.common() {
-        VidCommon::V0(common) => {
-            let num_storage_nodes = ADVZScheme::get_num_storage_nodes(common) as usize;
-            let bytes = block.payload().encode();
-            advz_scheme(num_storage_nodes)
-                .commit_only(bytes)
-                .map(VidCommitment::V0)
-                .context("failed to compute VID commitment (V0)")
-        },
-        VidCommon::V1(common) => {
-            let bytes = block.payload().encode();
-            let avidm_param = init_avidm_param(common.total_weights).context(format!(
-                "failed to initialize AVIDM params. total_weight={}",
-                common.total_weights
-            ))?;
-            let metadata = block.metadata().encode();
-            AvidMScheme::commit(
-                &avidm_param,
-                &bytes,
-                ns_table::parse_ns_table(bytes.len(), &metadata),
-            )
-            .map(VidCommitment::V1)
-            .map_err(anyhow::Error::msg)
-            .context("failed to compute AVIDM commitment")
-        },
-        VidCommon::V2(common) => {
-            let bytes = block.payload().encode();
-            let metadata = block.metadata().encode();
-            AvidmGf2Scheme::commit(
-                &common.param,
-                &bytes,
-                ns_table::parse_ns_table(bytes.len(), &metadata),
-            )
-            .map(|(commit, _)| VidCommitment::V2(commit))
-            .map_err(anyhow::Error::msg)
-            .context("failed to compute AvidmGf2 commitment")
-        },
-    }
-}
-
-impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
+impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     pub async fn fetch_leaf<Types: NodeType>(
         &self,
-        req: LeafRequest<Types>,
+        req: LeafRequest,
     ) -> anyhow::Result<LeafQueryData<Types>> {
         let leaf = self
             .client
@@ -240,33 +148,13 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             "received leaf with the wrong height ({})",
             leaf.height(),
         );
-        ensure!(
-            leaf.hash() == req.expected_leaf,
-            "received leaf with the wrong hash ({})",
-            leaf.hash()
-        );
-        // Compare QC by `(view, data)` rather than full commit: under the new protocol,
-        // the cert1 stored at decide may aggregate a different vote subset than the QC
-        // so commits diverge even though both certify the same leaf.
-        ensure!(
-            leaf.qc().view_number() == req.expected_qc_view,
-            "received leaf with QC for wrong view ({}, expected {})",
-            leaf.qc().view_number(),
-            req.expected_qc_view,
-        );
-        ensure!(
-            leaf.qc().data == req.expected_qc_data,
-            "received leaf with QC for wrong data ({:?}, expected {:?})",
-            leaf.qc().data,
-            req.expected_qc_data,
-        );
 
         Ok(leaf)
     }
 
     pub async fn fetch_leaf_range<Types: NodeType>(
         &self,
-        req: LeafRangeRequest<Types>,
+        req: LeafRangeRequest,
     ) -> anyhow::Result<NonEmptyRange<LeafQueryData<Types>>> {
         let leaves = self
             .client
@@ -285,68 +173,34 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             leaves.end()
         );
 
-        let mut expected_leaf = req.last_leaf;
-        let mut expected_qc_view = req.last_qc_view;
-        let mut expected_qc_data = req.last_qc_data;
-        for leaf in leaves.iter().rev() {
-            let leaf_hash = leaf.hash();
-            let qc = leaf.qc();
-            ensure!(
-                leaf_hash == expected_leaf,
-                "received leaf {} with wrong hash {leaf_hash}",
-                leaf.height(),
-            );
-            ensure!(
-                qc.view_number() == expected_qc_view,
-                "received leaf {} with QC for wrong view ({}, expected {expected_qc_view})",
-                leaf.height(),
-                qc.view_number(),
-            );
-            ensure!(
-                qc.data == expected_qc_data,
-                "received leaf {} with QC for wrong data ({:?}, expected {expected_qc_data:?})",
-                leaf.height(),
-                qc.data,
-            );
-            let parent_qc = leaf.leaf().justify_qc();
-            expected_leaf = leaf.leaf().parent_commitment();
-            expected_qc_view = parent_qc.view_number();
-            expected_qc_data = parent_qc.data;
-        }
-
         Ok(leaves)
     }
 }
 
 #[async_trait]
-impl<Types, Ver: StaticVersionType> Provider<Types, LeafRequest<Types>>
-    for QueryServiceProvider<Ver>
+impl<Types, Ver: StaticVersionType> Provider<Types, LeafRequest>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
-    async fn fetch(&self, req: LeafRequest<Types>) -> Option<LeafQueryData<Types>> {
+    async fn fetch(&self, req: LeafRequest) -> Option<LeafQueryData<Types>> {
         self.handle_result(req, self.fetch_leaf(req).await)
     }
 }
 
 #[async_trait]
-impl<Types, Ver: StaticVersionType> Provider<Types, LeafRangeRequest<Types>>
-    for QueryServiceProvider<Ver>
+impl<Types, Ver: StaticVersionType> Provider<Types, LeafRangeRequest>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
-    async fn fetch(
-        &self,
-        req: LeafRangeRequest<Types>,
-    ) -> Option<NonEmptyRange<LeafQueryData<Types>>> {
+    async fn fetch(&self, req: LeafRangeRequest) -> Option<NonEmptyRange<LeafQueryData<Types>>> {
         self.handle_result(req, self.fetch_leaf_range(req).await)
     }
 }
 
-impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
+impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     /// Fetch a cert2 from a peer at the given height.
-    ///
-    /// TODO: need to verify the cert2 against the stake table
     pub async fn fetch_cert2<Types: NodeType>(
         &self,
         height: u64,
@@ -361,7 +215,7 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
 
 #[async_trait]
 impl<Types, Ver: StaticVersionType> Provider<Types, Certificate2Request>
-    for QueryServiceProvider<Ver>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
@@ -370,7 +224,7 @@ where
     }
 }
 
-impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
+impl<Ver: StaticVersionType> TrustedQueryServiceProvider<Ver> {
     pub async fn fetch_vid_common<Types: NodeType>(
         &self,
         req: VidCommonRequest,
@@ -385,11 +239,6 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             .await
             .context("fetching VID common")?;
 
-        ensure!(
-            res.common().is_consistent(&req.0),
-            "inconsistent VID common data {:?}",
-            res.common,
-        );
         Ok(res.common)
     }
 
@@ -436,7 +285,6 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
         &self,
         req: VidCommonRangeRequest,
     ) -> anyhow::Result<NonEmptyRange<VidCommonQueryData<Types>>> {
-        let req = RangeRequest::from(req);
         let common = self
             .fetch_vid_common_range_with_fallback(req.start, req.end)
             .await?;
@@ -448,32 +296,13 @@ impl<Ver: StaticVersionType> QueryServiceProvider<Ver> {
             common.end()
         );
 
-        let commits = common
-            .iter()
-            .map(|common| {
-                // Check that the given `VidCommon` matches the claimed payload commitment.
-                ensure!(
-                    common.common().is_consistent(&common.payload_hash()),
-                    "server returned VID common with inconsistent commitment {common:?}"
-                );
-
-                // Yield the payload commitment for hashing, to check that the full sequence of payloads
-                // is consistent with the request.
-                Ok(common.payload_hash())
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        let hash = RangeRequest::hash_payloads(commits.iter().copied());
-        ensure!(
-            hash == req.expected_hash,
-            "server returned wrong VID common (hash {hash}, commits {commits:?})"
-        );
-
         Ok(common)
     }
 }
 
 #[async_trait]
-impl<Types, Ver: StaticVersionType> Provider<Types, VidCommonRequest> for QueryServiceProvider<Ver>
+impl<Types, Ver: StaticVersionType> Provider<Types, VidCommonRequest>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
@@ -484,7 +313,7 @@ where
 
 #[async_trait]
 impl<Types, Ver: StaticVersionType> Provider<Types, VidCommonRangeRequest>
-    for QueryServiceProvider<Ver>
+    for TrustedQueryServiceProvider<Ver>
 where
     Types: NodeType,
 {
@@ -501,27 +330,20 @@ where
 mod test {
     use std::{future::IntoFuture, time::Duration};
 
-    use committable::{Commitment, Committable};
+    use committable::Committable;
     use futures::{
         future::{FutureExt, join},
         stream::StreamExt,
     };
-    // generic-array 0.14.x is deprecated, but VidCommitment requires this version
-    // for From<Output<H>> impl in jf-merkle-tree
-    #[allow(deprecated)]
-    use generic_array::GenericArray;
     use hotshot_example_types::node_types::{EpochVersion, TEST_VERSIONS};
-    use hotshot_types::{data::ViewNumber, simple_vote::QuorumData2};
-    use rand::RngCore;
     use test_utils::reserve_tcp_port;
-    use tide_disco::{Api, App, error::ServerError};
+    use tide_disco::{Api, App};
     use toml::toml;
     use vbs::version::StaticVersion;
 
     use super::*;
     use crate::{
         ApiState,
-        api::load_api,
         availability::{
             self, AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, BlockWithTransaction,
             Fetch, UpdateAvailabilityData, define_api,
@@ -547,8 +369,8 @@ mod test {
         types::HeightIndexed,
     };
 
-    type Provider = TestProvider<QueryServiceProvider<MockBase>>;
-    type EpochProvider = TestProvider<QueryServiceProvider<EpochVersion>>;
+    type Provider = TestProvider<TrustedQueryServiceProvider<MockBase>>;
+    type EpochProvider = TestProvider<TrustedQueryServiceProvider<EpochVersion>>;
 
     fn ignore<T>(_: T) {}
 
@@ -599,7 +421,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -830,7 +652,7 @@ mod test {
         // Start a data source which is not receiving events from consensus, only from a peer.
         // Use our special test provider that handles epoch version transitions
         let db = TmpDb::init().await;
-        let provider = EpochProvider::new(QueryServiceProvider::new(
+        let provider = EpochProvider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             EpochVersion::instance(),
         ));
@@ -1055,7 +877,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1116,7 +938,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1181,7 +1003,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1243,7 +1065,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1381,7 +1203,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1430,256 +1252,6 @@ mod test {
         );
     }
 
-    // Uses deprecated generic-array 0.14.x via digest, required for VidCommitment compatibility
-    #[allow(deprecated)]
-    fn random_vid_commit() -> VidCommitment {
-        let mut bytes = [0; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        VidCommitment::V0(GenericArray::from(bytes).into())
-    }
-
-    fn random_leaf_request() -> LeafRequest<MockTypes> {
-        let mut bytes = [0; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        let leaf_commit = Commitment::from_raw(bytes);
-        LeafRequest {
-            height: 1,
-            expected_leaf: leaf_commit,
-            expected_qc_view: ViewNumber::new(rand::random()),
-            expected_qc_data: QuorumData2 {
-                leaf_commit,
-                epoch: None,
-                block_number: None,
-            },
-        }
-    }
-
-    async fn malicious_server(port: u16) {
-        let mut api = load_api::<(), ServerError, MockBase>(
-            None::<std::path::PathBuf>,
-            include_str!("../../../api/availability.toml"),
-            vec![],
-        )
-        .unwrap();
-
-        api.get("get_leaf", move |req, _| {
-            async move {
-                let height = req.integer_param("height")?;
-
-                // Respond with a leaf of the correct height, but with a dummy hash.
-                let mut leaf = LeafQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test,
-                )
-                .await;
-                leaf.leaf.block_header_mut().block_number = height;
-                leaf.qc.data.leaf_commit = leaf.hash();
-                Ok(leaf)
-            }
-            .boxed()
-        })
-        .unwrap()
-        .get("get_leaf_range", move |req, _| {
-            async move {
-                let start = req.integer_param("from")?;
-                let end = req.integer_param("until")?;
-
-                // Respond with the correct range, but using leaves with dummy data.
-                let leaf = LeafQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test,
-                )
-                .await;
-                let leaves = (start..end)
-                    .map(|i| {
-                        let mut leaf = leaf.clone();
-                        leaf.leaf.block_header_mut().block_number = i;
-                        leaf.qc.data.leaf_commit = leaf.hash();
-                        leaf
-                    })
-                    .collect::<Vec<_>>();
-
-                Ok(leaves)
-            }
-            .boxed()
-        })
-        .unwrap()
-        .get("get_block", move |_, _| {
-            async move {
-                // No matter what data we are asked for, always respond with dummy data.
-                Ok(BlockQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test.base,
-                )
-                .await)
-            }
-            .boxed()
-        })
-        .unwrap()
-        .get("get_block_range", move |req, _| {
-            async move {
-                let start = req.integer_param("from")?;
-                let end = req.integer_param("until")?;
-
-                // Respond with the correct range, but using blocks with dummy data.
-                let block = BlockQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test.base,
-                )
-                .await;
-                let blocks = (start..end)
-                    .map(|i| {
-                        let mut block = block.clone();
-                        block.header.block_number = i;
-                        block
-                    })
-                    .collect::<Vec<_>>();
-
-                Ok(blocks)
-            }
-            .boxed()
-        })
-        .unwrap()
-        .get("get_vid_common", move |_, _| {
-            async move {
-                // No matter what data we are asked for, always respond with dummy data.
-                Ok(VidCommonQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test.base,
-                )
-                .await)
-            }
-            .boxed()
-        })
-        .unwrap()
-        .get("get_vid_common_range", move |req, _| {
-            async move {
-                let start = req.integer_param("from")?;
-                let end = req.integer_param("until")?;
-
-                // Respond with the correct range, but using VID with dummy data.
-                let vid = VidCommonQueryData::<MockTypes>::genesis(
-                    &Default::default(),
-                    &Default::default(),
-                    TEST_VERSIONS.test.base,
-                )
-                .await;
-                let vids = (start..end)
-                    .map(|i| {
-                        let mut vid = vid.clone();
-                        vid.height = i;
-                        vid
-                    })
-                    .collect::<Vec<_>>();
-
-                Ok(vids)
-            }
-            .boxed()
-        })
-        .unwrap();
-
-        let mut app = App::<(), ServerError>::with_state(());
-        app.register_module("availability", api).unwrap();
-        app.serve(format!("0.0.0.0:{port}"), MockBase::instance())
-            .await
-            .ok();
-    }
-
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    async fn test_fetch_from_malicious_server() {
-        let port = reserve_tcp_port().unwrap();
-        let _server = BackgroundTask::spawn("malicious server", malicious_server(port));
-
-        let provider = QueryServiceProvider::new(
-            format!("http://localhost:{port}").parse().unwrap(),
-            MockBase::instance(),
-        );
-        provider.client.connect(None).await;
-
-        // Query for a random leaf, the server will respond with a different leaf, and we should
-        // detect the error.
-        tracing::info!("fetch leaf");
-        let err = provider
-            .fetch_leaf(random_leaf_request())
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("wrong hash"), "{err:#}");
-
-        // Ranged leaf request.
-        tracing::info!("fetch leaf range");
-        let req = random_leaf_request();
-        let err = provider
-            .fetch_leaf_range(LeafRangeRequest {
-                start: 0,
-                end: req.height + 1,
-                last_leaf: req.expected_leaf,
-                last_qc_view: req.expected_qc_view,
-                last_qc_data: req.expected_qc_data,
-            })
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("wrong hash"), "{err:#}");
-
-        // Query for a random payload, the server will respond with a different payload, and we
-        // should detect the error.
-        tracing::info!("fetch payload");
-        let err = provider
-            .fetch_payload::<MockTypes>(PayloadRequest(random_vid_commit()))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("does not match request"),
-            "{err:#}"
-        );
-
-        // Payload range request.
-        tracing::info!("fetch payload range");
-        let err = provider
-            .fetch_payload_range::<MockTypes>(BlockRangeRequest::from(RangeRequest {
-                start: 0,
-                end: 2,
-                expected_hash: RangeRequest::hash_payloads([
-                    random_vid_commit(),
-                    random_vid_commit(),
-                ]),
-            }))
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("wrong payload hash"), "{err:#}");
-
-        // Query for a random VID common, the server will respond with a different one, and we
-        // should detect the error.
-        tracing::info!("fetch VID");
-        let err = provider
-            .fetch_vid_common::<MockTypes>(VidCommonRequest(random_vid_commit()))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("inconsistent VID common"),
-            "{err:#}"
-        );
-
-        // VID range request.
-        tracing::info!("fetch VID range");
-        let err = provider
-            .fetch_vid_common_range::<MockTypes>(VidCommonRangeRequest::from(RangeRequest {
-                start: 0,
-                end: 2,
-                expected_hash: RangeRequest::hash_payloads([
-                    random_vid_commit(),
-                    random_vid_commit(),
-                ]),
-            }))
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("wrong VID common"), "{err:#}");
-    }
-
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_archive_recovery() {
         // Create the consensus network.
@@ -1706,7 +1278,7 @@ mod test {
         // Start a data source which is not receiving events from consensus, only from a peer. The
         // data source is at first configured to aggressively prune data.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1793,6 +1365,7 @@ mod test {
             .await
             .unwrap()
             .with_proactive_interval(Duration::from_secs(1))
+            .with_sync_status_ttl(Duration::from_secs(1))
             .build()
             .await
             .unwrap();
@@ -1858,7 +1431,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -1964,7 +1537,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2064,7 +1637,7 @@ mod test {
 
         // Start a data source which is not receiving events from consensus.
         let db = TmpDb::init().await;
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2132,7 +1705,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2197,7 +1770,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2280,7 +1853,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2385,7 +1958,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2459,7 +2032,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2538,7 +2111,7 @@ mod test {
         );
 
         // Start a data source which is not receiving events from consensus, only from a peer.
-        let provider = Provider::new(QueryServiceProvider::new(
+        let provider = Provider::new(TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         ));
@@ -2679,7 +2252,7 @@ mod test {
             .await;
 
         // Connect a fetching provider.
-        let provider = QueryServiceProvider::new(
+        let provider = TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             MockBase::instance(),
         );
@@ -2688,33 +2261,23 @@ mod test {
         tracing::info!("fetch leaf range");
         assert_eq!(
             provider
-                .fetch(LeafRangeRequest {
-                    start: 0,
-                    end: 5,
-                    last_leaf: leaves[4].hash(),
-                    last_qc_view: leaves[4].qc().view_number(),
-                    last_qc_data: leaves[4].qc().data,
-                })
+                .fetch(LeafRangeRequest { start: 0, end: 5 })
                 .await
                 .unwrap(),
             leaves
         );
-        let headers = NonEmptyRange::new(leaves.iter().map(|leaf| leaf.header().clone())).unwrap();
-        tracing::info!(?headers, "fetch block range");
+        tracing::info!("fetch block range");
         assert_eq!(
-            ProviderTrait::<MockTypes, _>::fetch(
-                &provider,
-                BlockRangeRequest::from(RangeRequest::from_headers::<MockTypes>(&headers))
-            )
-            .await
-            .unwrap(),
+            ProviderTrait::<MockTypes, _>::fetch(&provider, BlockRangeRequest { start: 0, end: 5 })
+                .await
+                .unwrap(),
             blocks
         );
-        tracing::info!(?headers, "fetch VID common range");
+        tracing::info!("fetch VID common range");
         assert_eq!(
             ProviderTrait::<MockTypes, _>::fetch(
                 &provider,
-                VidCommonRangeRequest::from(RangeRequest::from_headers::<MockTypes>(&headers))
+                VidCommonRangeRequest { start: 0, end: 5 }
             )
             .await
             .unwrap(),
@@ -2758,7 +2321,7 @@ mod test {
     async fn test_vid_common_fallback() {
         let port = reserve_tcp_port().unwrap();
         let _server = BackgroundTask::spawn("old server", old_server(port));
-        let provider = QueryServiceProvider::new(
+        let provider = TrustedQueryServiceProvider::new(
             format!("http://localhost:{port}").parse().unwrap(),
             StaticVersion::<1, 0>::instance(),
         );
@@ -2774,20 +2337,10 @@ mod test {
         .unwrap();
 
         // Now fetch the whole thing as a range.
-        let expected_hash =
-            RangeRequest::hash_payloads(common.iter().map(|common| common.payload_hash));
-        let req = RangeRequest {
-            start: 0,
-            end: 5,
-            expected_hash,
-        };
+        let req = VidCommonRangeRequest { start: 0, end: 5 };
         assert_eq!(
             common.as_slice(),
-            provider
-                .fetch_vid_common_range(req.into())
-                .await
-                .unwrap()
-                .as_ref()
+            provider.fetch_vid_common_range(req).await.unwrap().as_ref()
         );
     }
 }

--- a/hotshot-query-service/src/fetching/request.rs
+++ b/hotshot-query-service/src/fetching/request.rs
@@ -14,19 +14,15 @@
 
 use std::{fmt::Debug, hash::Hash};
 
-use alloy::primitives::{FixedBytes, Keccak256};
 use derive_more::{From, Into};
 use hotshot_types::{
-    data::{VidCommitment, VidCommon, ViewNumber},
-    simple_vote::QuorumData2,
+    data::{VidCommitment, VidCommon},
     traits::node_implementation::NodeType,
 };
 
 use crate::{
     Payload,
-    availability::{
-        BlockQueryData, Certificate2, LeafHash, LeafQueryData, QueryableHeader, VidCommonQueryData,
-    },
+    availability::{BlockQueryData, Certificate2, LeafQueryData, VidCommonQueryData},
     fetching::NonEmptyRange,
 };
 
@@ -44,63 +40,15 @@ impl<Types: NodeType> Request<Types> for PayloadRequest {
     type Response = Payload<Types>;
 }
 
-/// A request for a consecutive range of objects.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct RangeRequest {
-    /// The first block in the requested range.
-    pub start: u64,
-
-    /// The first block after the requested range.
-    pub end: u64,
-
-    /// The Keccak256 hash of the concatenation of the expected payload commitments.
-    ///
-    /// This can be used to verify the fetched data. We use the hash rather than passing in the full
-    /// list of expected payload commitments because a [`Request`] is expected to be small and easy
-    /// to copy and pass around.
-    pub expected_hash: FixedBytes<32>,
-}
-
-impl RangeRequest {
-    /// A request for a range of data corresponding to a range of headers.
-    pub fn from_headers<Types: NodeType>(
-        headers: &NonEmptyRange<impl QueryableHeader<Types>>,
-    ) -> Self {
-        let expected_hash =
-            Self::hash_payloads(headers.iter().map(|header| header.payload_commitment()));
-        Self {
-            start: headers.start(),
-            end: headers.end(),
-            expected_hash,
-        }
-    }
-
-    /// Compute the expected hash of a range of payload commitments.
-    pub fn hash_payloads(
-        payload_commitments: impl IntoIterator<Item = VidCommitment>,
-    ) -> FixedBytes<32> {
-        let mut hasher = Keccak256::new();
-        for comm in payload_commitments {
-            hasher.update(comm);
-        }
-        hasher.finalize()
-    }
-}
-
 /// A request for a consecutive range of blocks.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
-pub struct BlockRangeRequest(RangeRequest);
+pub struct BlockRangeRequest {
+    pub start: u64,
+    pub end: u64,
+}
 
 impl<Types: NodeType> Request<Types> for BlockRangeRequest {
     type Response = NonEmptyRange<BlockQueryData<Types>>;
-}
-
-impl BlockRangeRequest {
-    pub fn from_headers<Types: NodeType>(
-        headers: &NonEmptyRange<impl QueryableHeader<Types>>,
-    ) -> Self {
-        RangeRequest::from_headers(headers).into()
-    }
 }
 
 /// A request for VID common data.
@@ -113,18 +61,13 @@ impl<Types: NodeType> Request<Types> for VidCommonRequest {
 
 /// A request for a consecutive range of VID common.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
-pub struct VidCommonRangeRequest(RangeRequest);
+pub struct VidCommonRangeRequest {
+    pub start: u64,
+    pub end: u64,
+}
 
 impl<Types: NodeType> Request<Types> for VidCommonRangeRequest {
     type Response = NonEmptyRange<VidCommonQueryData<Types>>;
-}
-
-impl VidCommonRangeRequest {
-    pub fn from_headers<Types: NodeType>(
-        headers: &NonEmptyRange<impl QueryableHeader<Types>>,
-    ) -> Self {
-        RangeRequest::from_headers(headers).into()
-    }
 }
 
 /// A request for a leaf with a given height.
@@ -138,57 +81,31 @@ impl VidCommonRangeRequest {
 /// certify the same `(view, leaf)` but can be assembled from different voting set
 /// so their aggregated signatures (and commits) differ.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
-pub struct LeafRequest<Types: NodeType> {
+pub struct LeafRequest {
     pub height: u64,
-    pub expected_leaf: LeafHash<Types>,
-    pub expected_qc_view: ViewNumber,
-    pub expected_qc_data: QuorumData2<Types>,
 }
 
-impl<Types: NodeType> LeafRequest<Types> {
-    pub fn new(
-        height: u64,
-        expected_leaf: LeafHash<Types>,
-        expected_qc_view: ViewNumber,
-        expected_qc_data: QuorumData2<Types>,
-    ) -> Self {
-        Self {
-            height,
-            expected_leaf,
-            expected_qc_view,
-            expected_qc_data,
-        }
+impl LeafRequest {
+    pub fn new(height: u64) -> Self {
+        Self { height }
     }
 }
 
-impl<Types: NodeType> Request<Types> for LeafRequest<Types> {
+impl<Types: NodeType> Request<Types> for LeafRequest {
     type Response = LeafQueryData<Types>;
 }
 
 /// A request for a consecutive range of leaves.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct LeafRangeRequest<Types: NodeType> {
+pub struct LeafRangeRequest {
     /// The first block in the requested range.
     pub start: u64,
 
     /// The first block after the requested range.
     pub end: u64,
-
-    /// The expected hash of the last leaf in the chain.
-    ///
-    /// Earlier leaves can be verified based on the subsequent leaf.
-    pub last_leaf: LeafHash<Types>,
-
-    /// The expected view of the QC certifying the last leaf in the chain.
-    ///
-    /// See [`LeafRequest`] for why we compare `(view, data)` rather than full commit.
-    pub last_qc_view: ViewNumber,
-
-    /// The expected `data` of the QC certifying the last leaf in the chain.
-    pub last_qc_data: QuorumData2<Types>,
 }
 
-impl<Types: NodeType> Request<Types> for LeafRangeRequest<Types> {
+impl<Types: NodeType> Request<Types> for LeafRangeRequest {
     type Response = NonEmptyRange<LeafQueryData<Types>>;
 }
 

--- a/hotshot-query-service/src/fetching/request.rs
+++ b/hotshot-query-service/src/fetching/request.rs
@@ -71,15 +71,6 @@ impl<Types: NodeType> Request<Types> for VidCommonRangeRequest {
 }
 
 /// A request for a leaf with a given height.
-///
-/// The expected leaf hash, the QC's view, and the certifying QC's `data` are provided
-/// so the request can be verified against a response from an untrusted provider.
-///
-/// We compare the QC's `(view, data)` instead of its full commit because under the new protocol
-/// we store leaves alongside a `cert1` taken from the decide event, and that `cert1` is
-/// not necessarily the same `cert1` that the next leaf's `justify_qc` will reference. Both
-/// certify the same `(view, leaf)` but can be assembled from different voting set
-/// so their aggregated signatures (and commits) differ.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
 pub struct LeafRequest {
     pub height: u64,

--- a/light-client/src/provider.rs
+++ b/light-client/src/provider.rs
@@ -8,7 +8,7 @@ use hotshot_query_service::{
         NonEmptyRange, Provider,
         request::{
             BlockRangeRequest, Certificate2Request, LeafRangeRequest, LeafRequest, PayloadRequest,
-            RangeRequest, VidCommonRangeRequest, VidCommonRequest,
+            VidCommonRangeRequest, VidCommonRequest,
         },
     },
     node::BlockId,
@@ -18,12 +18,12 @@ use hotshot_types::data::VidCommon;
 use crate::{LightClient, client::Client, storage::Storage};
 
 #[async_trait]
-impl<P, S> Provider<SeqTypes, LeafRequest<SeqTypes>> for LightClient<P, S>
+impl<P, S> Provider<SeqTypes, LeafRequest> for LightClient<P, S>
 where
     P: Storage,
     S: Client,
 {
-    async fn fetch(&self, req: LeafRequest<SeqTypes>) -> Option<LeafQueryData<SeqTypes>> {
+    async fn fetch(&self, req: LeafRequest) -> Option<LeafQueryData<SeqTypes>> {
         match self.fetch_leaf(LeafId::Number(req.height as usize)).await {
             Ok(leaf) => Some(leaf),
             Err(err) => {
@@ -69,15 +69,12 @@ where
 }
 
 #[async_trait]
-impl<P, S> Provider<SeqTypes, LeafRangeRequest<SeqTypes>> for LightClient<P, S>
+impl<P, S> Provider<SeqTypes, LeafRangeRequest> for LightClient<P, S>
 where
     P: Storage,
     S: Client,
 {
-    async fn fetch(
-        &self,
-        req: LeafRangeRequest<SeqTypes>,
-    ) -> Option<NonEmptyRange<LeafQueryData<SeqTypes>>> {
+    async fn fetch(&self, req: LeafRangeRequest) -> Option<NonEmptyRange<LeafQueryData<SeqTypes>>> {
         let leaves = match self
             .fetch_leaves_in_range(req.start as usize, req.end as usize)
             .await
@@ -108,7 +105,6 @@ where
         &self,
         req: BlockRangeRequest,
     ) -> Option<NonEmptyRange<BlockQueryData<SeqTypes>>> {
-        let req = RangeRequest::from(req);
         let blocks = match self
             .fetch_blocks_in_range(req.start as usize, req.end as usize)
             .await
@@ -139,7 +135,6 @@ where
         &self,
         req: VidCommonRangeRequest,
     ) -> Option<NonEmptyRange<VidCommonQueryData<SeqTypes>>> {
-        let req = RangeRequest::from(req);
         let vid_common = match self
             .fetch_vid_common_in_range(req.start as usize, req.end as usize)
             .await


### PR DESCRIPTION
Previously, we needed the hash of a leaf before we could fetch that leaf, in order to verify that the leaf we fetched was correct. This lead to backfilling proceeding in reverse order, where we would fetch the most recent leave, then use it's `parent_hash` to fetch and verify the preceding leaf, and so on back towards genesis. This behavior is somewhat unintuitive, and it works very badly with the merklized state update loop and the aggregator task, which have to proceed in chronological order. When syncing a node from scratch, this means we fetch every single leaf in reverse order, and only when we reach genesis can the state update loop and the aggregator even begin to start syncing.

With the light client, this reverse fetching is no longer necessary. We can fetch and verify an arbitrary leaf given only its height. Thus, we now proceed to fetch things in chronological order.