### PR TITLE
[new-protocol] skip Timeout Certificate processing if it already exists

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -540,6 +540,9 @@ impl<T: NodeType> Consensus<T> {
         outbox: &mut Outbox<ConsensusOutput<T>>,
     ) -> Protocol {
         let view = certificate.view_number() + 1;
+        if self.timeout_certs.contains_key(&view) {
+            return Protocol::Continue;
+        }
         let Some(epoch) = certificate.epoch() else {
             warn!(view = %certificate.view_number(), "timeout certificate has no epoch number");
             return Protocol::Abort;


### PR DESCRIPTION
`handle_timeout_certificate` was missing the check that other handlers already have, so every time a peer sent the same timeout certificate back, the handler re pushed `ConsensusOutput::ViewChanged() `and `ConsensusOutput::SendTimeoutCertificate(...)`, and so the network was stuck in an infinitely timeout certificate handling loop