### PR TITLE
chore: fix slow cargo fmt, format all files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs rustfmt +nightly --check
+        run: git ls-files '*.rs' | grep -vE '^contracts/rust/adapter/src/bindings/|\.api\.v[0-9]+\.rs$' | xargs rustfmt +nightly --check
 
   clippy-postgres:
     name: clippy (postgres)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs rustfmt --check
+        run: git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs rustfmt +nightly --check
 
   clippy-postgres:
     name: clippy (postgres)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,18 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  cargo-sort:
+    name: cargo sort
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort
+
+      - name: Check workspace Cargo.toml sort order
+        run: cargo sort --check --grouped --workspace
+
   cargo-fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: git ls-files '*.rs' | grep -vE '^contracts/rust/adapter/src/bindings/|\.api\.v[0-9]+\.rs$' | xargs rustfmt +nightly --check
+        run: git ls-files '*.rs' | xargs rustfmt +nightly --check
 
   clippy-postgres:
     name: clippy (postgres)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Check workspace Cargo.toml sort order
         run: cargo sort --check --grouped --workspace
 
-  cargo-fmt:
-    name: cargo fmt
+  rustfmt:
+    name: rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: cargo +nightly fmt -- --check
+        run: git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs rustfmt --check
 
   clippy-postgres:
     name: clippy (postgres)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/rust/safe-tx-builder",
     "crates/builder",
     "crates/cliquenet",
+    "crates/espresso/api",
     "crates/espresso/dev-node",
     "crates/espresso/node",
     "crates/espresso/node-sqlite",
@@ -34,7 +35,6 @@ members = [
     "crates/hotshot/types",
     "crates/hotshot/utils",
     "crates/serialization/api",
-    "crates/espresso/api",
     "crates/versions",
     "hotshot-events-service",
     "hotshot-query-service",
@@ -111,6 +111,7 @@ authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2024"
 
 [workspace.dependencies]
+aide = { version = "0.15.1", features = ["axum", "axum-json", "scalar", "swagger", "redoc"] }
 alloy = { version = "1.0", features = [
     "eips",
     "provider-ws",
@@ -140,7 +141,6 @@ async-trait = "0.1"
 atomic = "0.6"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.5" }
 automod = "1.0.14"
-aide = { version = "0.15.1", features = ["axum", "axum-json", "scalar", "swagger", "redoc"] }
 axum = "0.8.8"
 backoff = "0.4"
 base64 = "0.22"

--- a/crates/espresso/api/Cargo.toml
+++ b/crates/espresso/api/Cargo.toml
@@ -4,22 +4,22 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-serialization-api = { path = "../../serialization/api" }
+aide = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
-tokio = { workspace = true }
-tower = { workspace = true }
+hex = { workspace = true }
+prost = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serialization-api = { path = "../../serialization/api" }
+tokio = { workspace = true }
 tonic = { workspace = true }
-tonic-reflection = { workspace = true }
 tonic-prost = { workspace = true }
-prost = { workspace = true }
+tonic-reflection = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
-aide = { workspace = true }
-schemars = { workspace = true }
-async-trait = { workspace = true }
-anyhow = { workspace = true }
-hex = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [build-dependencies]

--- a/crates/espresso/node/Cargo.toml
+++ b/crates/espresso/node/Cargo.toml
@@ -49,11 +49,10 @@ derivative = { workspace = true }
 derive_more = { workspace = true }
 dotenvy = { workspace = true }
 either = { workspace = true }
-espresso-contract-deployer = { workspace = true }
 espresso-api = { path = "../api" }
+espresso-contract-deployer = { workspace = true }
 espresso-types = { workspace = true }
 espresso-utils = { workspace = true }
-serialization-api = { path = "../../serialization/api" }
 futures = { workspace = true }
 generic-tests = { workspace = true }
 hotshot = { workspace = true }
@@ -92,6 +91,7 @@ rstest_reuse = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serialization-api = { path = "../../serialization/api" }
 sha2 = { workspace = true }
 snafu = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/espresso/types/src/v0/v0_1/block.rs
+++ b/crates/espresso/types/src/v0/v0_1/block.rs
@@ -1,13 +1,9 @@
-use serde::{Deserialize, Serialize};
-use std::iter::Peekable;
+use std::{default::Default, iter::Peekable, ops::Range};
 
 use derive_more::Display;
-use std::ops::Range;
-use thiserror::Error;
-
 use hotshot_types::vid::advz::{LargeRangeProofType, SmallRangeProofType};
-
-use std::default::Default;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Proof of correctness for namespace payload bytes in a block.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/espresso/types/src/v0/v0_1/chain_config.rs
+++ b/crates/espresso/types/src/v0/v0_1/chain_config.rs
@@ -3,7 +3,6 @@ use alloy_compat::ethers_serde;
 use committable::{Commitment, Committable};
 use derive_more::{Deref, Display, From, Into};
 use itertools::Either;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{FeeAccount, FeeAmount};

--- a/crates/espresso/types/src/v0/v0_1/header.rs
+++ b/crates/espresso/types/src/v0/v0_1/header.rs
@@ -1,17 +1,17 @@
-use crate::NsTable;
-
-use super::{
-    BlockMerkleCommitment, BuilderSignature, FeeInfo, FeeMerkleCommitment, L1BlockInfo,
-    ResolvableChainConfig,
-};
 use alloy_compat::ethers_serde;
 use ark_serialize::CanonicalSerialize;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
 use serde::{
-    de::{self, SeqAccess},
     Deserialize, Serialize,
+    de::{self, SeqAccess},
 };
+
+use super::{
+    BlockMerkleCommitment, BuilderSignature, FeeInfo, FeeMerkleCommitment, L1BlockInfo,
+    ResolvableChainConfig,
+};
+use crate::NsTable;
 
 /// A header is like a [`Block`] with the body replaced by a digest.
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, PartialEq, Eq)]

--- a/crates/espresso/types/src/v0/v0_1/instance_state.rs
+++ b/crates/espresso/types/src/v0/v0_1/instance_state.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
 
 use crate::{v0::utils::Timestamp, v0_3::ChainConfig};
 

--- a/crates/espresso/types/src/v0/v0_1/l1.rs
+++ b/crates/espresso/types/src/v0/v0_1/l1.rs
@@ -1,9 +1,15 @@
+use std::{
+    num::NonZeroUsize,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use alloy::{
     network::Ethereum,
     primitives::{B256, U256},
     providers::{
-        fillers::{FillProvider, JoinFill, RecommendedFillers},
         Identity, Provider, RootProvider,
+        fillers::{FillProvider, JoinFill, RecommendedFillers},
     },
     transports::http::{Client, Http},
 };
@@ -15,11 +21,6 @@ use hotshot_types::traits::metrics::{Counter, Gauge, Metrics, NoMetrics};
 use lru::LruCache;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::{
-    num::NonZeroUsize,
-    sync::Arc,
-    time::{Duration, Instant},
-};
 use tokio::{
     sync::{Mutex, Notify},
     task::JoinHandle,
@@ -86,11 +87,7 @@ pub struct L1ClientOptions {
     pub l1_polling_interval: Duration,
 
     /// Maximum number of L1 blocks to keep in cache at once.
-    #[clap(
-        long,
-        env = "ESPRESSO_L1_BLOCKS_CACHE_SIZE",
-        default_value = "100"
-    )]
+    #[clap(long, env = "ESPRESSO_L1_BLOCKS_CACHE_SIZE", default_value = "100")]
     pub l1_blocks_cache_size: NonZeroUsize,
 
     /// Number of L1 events to buffer before discarding.

--- a/crates/espresso/types/src/v0/v0_1/mod.rs
+++ b/crates/espresso/types/src/v0/v0_1/mod.rs
@@ -19,4 +19,5 @@ pub use instance_state::*;
 pub use l1::*;
 pub use state::*;
 pub use transaction::*;
+
 pub use crate::eth_signature_key::BuilderSignature;

--- a/crates/espresso/types/src/v0/v0_1/state.rs
+++ b/crates/espresso/types/src/v0/v0_1/state.rs
@@ -1,8 +1,8 @@
 use committable::Commitment;
 use jf_merkle_tree_compat::{
+    MerkleTreeScheme,
     prelude::{LightWeightSHA3MerkleTree, Sha3Digest, Sha3Node},
     universal_merkle_tree::UniversalMerkleTree,
-    MerkleTreeScheme,
 };
 
 use super::{FeeAccount, FeeAmount};

--- a/crates/espresso/types/src/v0/v0_1/transaction.rs
+++ b/crates/espresso/types/src/v0/v0_1/transaction.rs
@@ -1,6 +1,5 @@
-use derive_more::{Display, From, Into};
-
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use derive_more::{Display, From, Into};
 use serde::{Deserialize, Serialize};
 
 #[derive(

--- a/crates/espresso/types/src/v0/v0_2/mod.rs
+++ b/crates/espresso/types/src/v0/v0_2/mod.rs
@@ -2,16 +2,16 @@ use vbs::version::Version;
 
 // Re-export types which haven't changed since the last minor version.
 pub use super::v0_1::{
-    ADVZNsProof, ADVZTxProof, AccountQueryData, BlockMerkleCommitment, BlockMerkleTree, BlockSize,
-    BuilderSignature, ChainConfig, ChainId, FeeAccount, FeeAccountProof, FeeAmount, FeeInfo,
-    FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Header, Index, Iter, L1BlockInfo, L1Client,
-    L1ClientOptions, L1Snapshot, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
-    NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable, NsTableBuilder,
-    NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload, PayloadByteLen,
-    ResolvableChainConfig, TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload,
-    TxPayloadRange, TxTableEntries, TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType,
-    ViewBasedUpgrade, BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN,
-    NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
+    ADVZNsProof, ADVZTxProof, AccountQueryData, BLOCK_MERKLE_TREE_HEIGHT, BlockMerkleCommitment,
+    BlockMerkleTree, BlockSize, BuilderSignature, ChainConfig, ChainId, FEE_MERKLE_TREE_HEIGHT,
+    FeeAccount, FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment, FeeMerkleProof,
+    FeeMerkleTree, Header, Index, Iter, L1BlockInfo, L1Client, L1ClientOptions, L1Snapshot,
+    NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, NamespaceId, NsIndex,
+    NsIter, NsPayload, NsPayloadBuilder, NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable,
+    NsTableBuilder, NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload,
+    PayloadByteLen, ResolvableChainConfig, TX_OFFSET_BYTE_LEN, TimeBasedUpgrade, Transaction,
+    TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries, TxTableEntriesRange, Upgrade,
+    UpgradeMode, UpgradeType, ViewBasedUpgrade,
 };
 
 pub const VERSION: Version = Version { major: 0, minor: 2 };

--- a/crates/espresso/types/src/v0/v0_3/chain_config.rs
+++ b/crates/espresso/types/src/v0/v0_3/chain_config.rs
@@ -1,9 +1,10 @@
-use crate::{v0_1, BlockSize, ChainId, FeeAccount, FeeAmount};
 use alloy::primitives::{Address, U256};
 use alloy_compat::ethers_serde;
 use committable::{Commitment, Committable};
 use itertools::Either;
 use serde::{Deserialize, Serialize};
+
+use crate::{BlockSize, ChainId, FeeAccount, FeeAmount, v0_1};
 
 /// Global variables for an Espresso blockchain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -146,8 +147,6 @@ impl From<v0_1::ChainConfig> for ChainConfig {
     }
 }
 
-  
-
 impl From<ChainConfig> for v0_1::ChainConfig {
     fn from(chain_config: ChainConfig) -> v0_1::ChainConfig {
         let ChainConfig {
@@ -182,7 +181,6 @@ impl Default for ChainConfig {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -200,8 +198,6 @@ mod test {
         assert_eq!(expectation, v3_resolvable);
     }
 
-     
-
     #[test]
     fn test_upgrade_chain_config_v1_chain_config_from_v3() {
         let expectation = v0_1::ChainConfig::default();
@@ -209,6 +205,4 @@ mod test {
         let v1_chain_config = v0_1::ChainConfig::from(v3_chain_config);
         assert_eq!(expectation, v1_chain_config);
     }
-
-    
 }

--- a/crates/espresso/types/src/v0/v0_3/header.rs
+++ b/crates/espresso/types/src/v0/v0_3/header.rs
@@ -1,13 +1,13 @@
-use crate::{ v0_3::state::RewardMerkleCommitmentV1, NsTable};
+use ark_serialize::CanonicalSerialize;
+use committable::{Commitment, Committable, RawCommitmentBuilder};
+use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
+use serde::{Deserialize, Serialize};
 
 use super::{
     BlockMerkleCommitment, BuilderSignature, FeeInfo, FeeMerkleCommitment, L1BlockInfo,
     ResolvableChainConfig,
 };
-use ark_serialize::CanonicalSerialize;
-use committable::{Commitment, Committable, RawCommitmentBuilder};
-use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
-use serde::{Deserialize, Serialize};
+use crate::{NsTable, v0_3::state::RewardMerkleCommitmentV1};
 
 /// A header is like a [`Block`] with the body replaced by a digest.
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, PartialEq, Eq)]

--- a/crates/espresso/types/src/v0/v0_3/mod.rs
+++ b/crates/espresso/types/src/v0/v0_3/mod.rs
@@ -2,16 +2,15 @@ use vbs::version::Version;
 
 // Re-export types which haven't changed since the last minor version.
 pub use super::v0_1::{
-    ADVZNsProof, ADVZTxProof, AccountQueryData, BlockMerkleCommitment, BlockMerkleTree, BlockSize,
-    BuilderSignature, ChainId, FeeAccount, FeeAccountProof, FeeAmount, FeeInfo,
-    FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Index, Iter, L1BlockInfo, L1Client,
-    L1ClientOptions, L1Snapshot, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
+    ADVZNsProof, ADVZTxProof, AccountQueryData, BLOCK_MERKLE_TREE_HEIGHT, BlockMerkleCommitment,
+    BlockMerkleTree, BlockSize, BuilderSignature, ChainId, FEE_MERKLE_TREE_HEIGHT, FeeAccount,
+    FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Index,
+    Iter, L1BlockInfo, L1Client, L1ClientOptions, L1Snapshot, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
+    NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
     NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable, NsTableBuilder,
     NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload, PayloadByteLen,
-    TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries,
-    TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
-    BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
-    NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
+    TX_OFFSET_BYTE_LEN, TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange,
+    TxTableEntries, TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
 };
 pub(crate) use super::v0_1::{L1ClientMetrics, L1Event, L1State, L1UpdateTask};
 

--- a/crates/espresso/types/src/v0/v0_3/stake_table.rs
+++ b/crates/espresso/types/src/v0/v0_3/stake_table.rs
@@ -13,8 +13,8 @@ use hotshot_contract_adapter::sol_types::StakeTableV2::{
     UndelegatedV2, ValidatorExit, ValidatorExitV2, ValidatorRegistered, ValidatorRegisteredV2,
 };
 use hotshot_types::{
-    PeerConfig, data::EpochNumber, light_client::StateVerKey, network::PeerConfigKeys, x25519,
-    addr::NetAddr
+    PeerConfig, addr::NetAddr, data::EpochNumber, light_client::StateVerKey,
+    network::PeerConfigKeys, x25519,
 };
 use itertools::Itertools;
 use jf_utils::to_bytes;
@@ -24,10 +24,10 @@ use tokio::task::JoinHandle;
 
 use super::L1Client;
 use crate::{
-    traits::{MembershipPersistence, StateCatchup},
-    v0::{impls::StakeTableHash, ChainConfig},
-    v0_3::RewardAmount,
     AuthenticatedValidatorMap, SeqTypes,
+    traits::{MembershipPersistence, StateCatchup},
+    v0::{ChainConfig, impls::StakeTableHash},
+    v0_3::RewardAmount,
 };
 /// Stake table holding all staking information (DA and non-DA stakers)
 #[derive(Debug, Clone, Serialize, Deserialize, From)]
@@ -70,7 +70,7 @@ pub struct RegisteredValidator<KEY: SignatureKey> {
     /// Public X25519 key for network communication.
     pub x25519_key: Option<x25519::PublicKey>,
     /// Network address.
-    pub p2p_addr: Option<NetAddr>
+    pub p2p_addr: Option<NetAddr>,
 }
 
 /// Validator eligible for consensus participation.
@@ -152,8 +152,8 @@ impl<KEY: SignatureKey> Committable for RegisteredValidator<KEY> {
             .fixed_size_field("stake", &to_fixed_bytes(self.stake))
             .constant_str("commission")
             .u16(self.commission);
-            //.var_size_field("x25519_key", self.x25519_key.as_ref().map(|k| k.as_slice()).unwrap_or_default())
-            //.var_size_field("p2p_addr", self.p2p_addr.as_ref().map(|a| a.to_string()).unwrap_or_default().as_bytes());
+        //.var_size_field("x25519_key", self.x25519_key.as_ref().map(|k| k.as_slice()).unwrap_or_default())
+        //.var_size_field("p2p_addr", self.p2p_addr.as_ref().map(|a| a.to_string()).unwrap_or_default().as_bytes());
 
         builder = builder.constant_str("delegators");
         for (address, stake) in self.delegators.iter().sorted() {

--- a/crates/espresso/types/src/v0/v0_3/state.rs
+++ b/crates/espresso/types/src/v0/v0_3/state.rs
@@ -1,9 +1,9 @@
 use alloy::primitives::{Address, U256};
-use derive_more::{derive::AddAssign, Add, Display, From, Into, Mul, Sub};
+use derive_more::{Add, Display, From, Into, Mul, Sub, derive::AddAssign};
 use jf_merkle_tree_compat::{
+    MerkleTreeScheme, UniversalMerkleTreeScheme,
     prelude::{Sha3Digest, Sha3Node},
     universal_merkle_tree::UniversalMerkleTree,
-    MerkleTreeScheme, UniversalMerkleTreeScheme,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/espresso/types/src/v0/v0_3/state_cert.rs
+++ b/crates/espresso/types/src/v0/v0_3/state_cert.rs
@@ -2,8 +2,7 @@
 
 use derive_more::From;
 use hotshot_types::{
-    simple_certificate::LightClientStateUpdateCertificateV1,
-    traits::node_implementation::NodeType,
+    simple_certificate::LightClientStateUpdateCertificateV1, traits::node_implementation::NodeType,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/espresso/types/src/v0/v0_3/txproof.rs
+++ b/crates/espresso/types/src/v0/v0_3/txproof.rs
@@ -1,5 +1,6 @@
-use super::{AvidMNsProof, TxIndex};
 use serde::{Deserialize, Serialize};
+
+use super::{AvidMNsProof, TxIndex};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AvidMTxProof {

--- a/crates/espresso/types/src/v0/v0_4/header.rs
+++ b/crates/espresso/types/src/v0/v0_4/header.rs
@@ -1,13 +1,16 @@
-use crate::{v0::impls::StakeTableHash, v0_3::RewardAmount, v0_4::RewardMerkleCommitmentV2, NsTable, TimestampMillis};
+use ark_serialize::CanonicalSerialize;
+use committable::{Commitment, Committable, RawCommitmentBuilder};
+use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
+use serde::{Deserialize, Serialize};
 
 use super::{
     BlockMerkleCommitment, BuilderSignature, FeeInfo, FeeMerkleCommitment, L1BlockInfo,
     ResolvableChainConfig,
 };
-use ark_serialize::CanonicalSerialize;
-use committable::{Commitment, Committable, RawCommitmentBuilder};
-use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
-use serde::{Deserialize, Serialize};
+use crate::{
+    NsTable, TimestampMillis, v0::impls::StakeTableHash, v0_3::RewardAmount,
+    v0_4::RewardMerkleCommitmentV2,
+};
 
 /// A header is like a [`Block`] with the body replaced by a digest.
 #[derive(Clone, Debug, Deserialize, Serialize, Hash, PartialEq, Eq)]
@@ -63,7 +66,10 @@ impl Committable for Header {
             .var_size_field("fee_merkle_tree_root", &fmt_bytes)
             .field("fee_info", self.fee_info.commit())
             .var_size_field("reward_merkle_tree_root", &rwd_bytes)
-            .var_size_field("total_reward_distributed", &self.total_reward_distributed.to_fixed_bytes());
+            .var_size_field(
+                "total_reward_distributed",
+                &self.total_reward_distributed.to_fixed_bytes(),
+            );
 
         if let Some(next_stake_table_hash) = self.next_stake_table_hash {
             cb = cb.field("next_stake_table_hash", next_stake_table_hash);

--- a/crates/espresso/types/src/v0/v0_4/mod.rs
+++ b/crates/espresso/types/src/v0/v0_4/mod.rs
@@ -2,18 +2,16 @@ use vbs::version::Version;
 
 // Re-export types which haven't changed since the last minor version.
 pub use super::v0_1::{
-    ADVZNsProof, ADVZTxProof, AccountQueryData, BlockMerkleCommitment, BlockMerkleTree, BlockSize,
-    BuilderSignature, ChainId, FeeAccount, FeeAccountProof, FeeAmount, FeeInfo,
-    FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Index, Iter, L1BlockInfo, L1Client,
-    L1ClientOptions, L1Snapshot, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
+    ADVZNsProof, ADVZTxProof, AccountQueryData, BLOCK_MERKLE_TREE_HEIGHT, BlockMerkleCommitment,
+    BlockMerkleTree, BlockSize, BuilderSignature, ChainId, FEE_MERKLE_TREE_HEIGHT, FeeAccount,
+    FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Index,
+    Iter, L1BlockInfo, L1Client, L1ClientOptions, L1Snapshot, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
+    NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
     NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable, NsTableBuilder,
     NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload, PayloadByteLen,
-    TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries,
-    TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
-    BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN,
-    NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, TX_OFFSET_BYTE_LEN,
+    TX_OFFSET_BYTE_LEN, TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange,
+    TxTableEntries, TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
 };
-
 pub use super::v0_3::{
     AvidMIncorrectEncodingNsProof, AvidMNsProof, AvidMTxProof, ChainConfig, MAX_VALIDATORS,
     ResolvableChainConfig,

--- a/crates/espresso/types/src/v0/v0_4/state.rs
+++ b/crates/espresso/types/src/v0/v0_4/state.rs
@@ -40,11 +40,10 @@ impl PermittedRewardMerkleTreeV2 {
     ) -> anyhow::Result<Self> {
         let permit = REWARD_MERKLE_TREE_V2_MEMORY_LOCK
             .get_or_init(|| {
-                let num_permits: usize =
-                    std::env::var("ESPRESSO_NODE_REWARD_MERKLE_TREE_PERMITS")
-                        .ok()
-                        .and_then(|v| v.parse::<usize>().ok())
-                        .unwrap_or(1);
+                let num_permits: usize = std::env::var("ESPRESSO_NODE_REWARD_MERKLE_TREE_PERMITS")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(1);
 
                 tracing::warn!(
                     "Initializing RewardMerkleTreeV2 semaphore with {num_permits} permits"

--- a/crates/espresso/types/src/v0/v0_5/header.rs
+++ b/crates/espresso/types/src/v0/v0_5/header.rs
@@ -1,20 +1,19 @@
-use crate::{
-    v0::impls::StakeTableHash,
-    v0_3::RewardAmount,
-    v0_4::RewardMerkleCommitmentV2,
-    v0_5::{LeaderCounts, MAX_VALIDATORS},
-    NsTable, TimestampMillis,
-};
+use ark_serialize::CanonicalSerialize;
+use committable::{Commitment, Committable, RawCommitmentBuilder};
+use hotshot_types::{data::VidCommitment, utils::BuilderCommitment};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{
     BlockMerkleCommitment, BuilderSignature, FeeInfo, FeeMerkleCommitment, L1BlockInfo,
     ResolvableChainConfig,
 };
-use ark_serialize::CanonicalSerialize;
-use committable::{Commitment, Committable, RawCommitmentBuilder};
-use hotshot_types::data::VidCommitment;
-use hotshot_types::utils::BuilderCommitment;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use crate::{
+    NsTable, TimestampMillis,
+    v0::impls::StakeTableHash,
+    v0_3::RewardAmount,
+    v0_4::RewardMerkleCommitmentV2,
+    v0_5::{LeaderCounts, MAX_VALIDATORS},
+};
 
 mod leader_counts_serde {
     use super::*;
@@ -91,7 +90,6 @@ impl Committable for Header {
         self.reward_merkle_tree_root
             .serialize_with_mode(&mut rwd_bytes, ark_serialize::Compress::Yes)
             .unwrap();
-
 
         let leader_counts_bytes: Vec<u8> = self
             .leader_counts

--- a/crates/espresso/types/src/v0/v0_5/mod.rs
+++ b/crates/espresso/types/src/v0/v0_5/mod.rs
@@ -3,19 +3,18 @@ use vbs::version::Version;
 // Re-export types which haven't changed since the last minor version.
 pub use super::v0_4::{
     ADVZNsProof, ADVZTxProof, AccountQueryData, AvidMIncorrectEncodingNsProof, AvidMNsProof,
-    AvidMTxProof, BlockMerkleCommitment, BlockMerkleTree, BlockSize, BuilderSignature, ChainConfig,
-    ChainId, Delta, FeeAccount, FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment,
-    FeeMerkleProof, FeeMerkleTree, Index, Iter, L1BlockInfo, L1Client, L1ClientOptions,
-    L1Snapshot, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder, NsPayloadByteLen,
-    NsPayloadOwned, NsPayloadRange, NsTable, NsTableBuilder, NsTableValidationError, NumNss,
-    NumTxs, NumTxsRange, NumTxsUnchecked, Payload, PayloadByteLen, ResolvableChainConfig,
-    RewardAccountProofV2, RewardAccountQueryDataV2, RewardAccountV2, RewardClaimError,
-    RewardMerkleCommitmentV2, RewardMerkleProofV2, RewardMerkleTreeV2, TimeBasedUpgrade,
-    Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries, TxTableEntriesRange,
-    Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade, BLOCK_MERKLE_TREE_HEIGHT,
-    FEE_MERKLE_TREE_HEIGHT, MAX_VALIDATORS, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN,
-    NUM_TXS_BYTE_LEN,
-    REWARD_MERKLE_TREE_V2_ARITY, REWARD_MERKLE_TREE_V2_HEIGHT, TX_OFFSET_BYTE_LEN,
+    AvidMTxProof, BLOCK_MERKLE_TREE_HEIGHT, BlockMerkleCommitment, BlockMerkleTree, BlockSize,
+    BuilderSignature, ChainConfig, ChainId, Delta, FEE_MERKLE_TREE_HEIGHT, FeeAccount,
+    FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree, Index,
+    Iter, L1BlockInfo, L1Client, L1ClientOptions, L1Snapshot, MAX_VALIDATORS, NS_ID_BYTE_LEN,
+    NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, NamespaceId, NsIndex, NsIter,
+    NsPayload, NsPayloadBuilder, NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable,
+    NsTableBuilder, NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload,
+    PayloadByteLen, REWARD_MERKLE_TREE_V2_ARITY, REWARD_MERKLE_TREE_V2_HEIGHT,
+    ResolvableChainConfig, RewardAccountProofV2, RewardAccountQueryDataV2, RewardAccountV2,
+    RewardClaimError, RewardMerkleCommitmentV2, RewardMerkleProofV2, RewardMerkleTreeV2,
+    TX_OFFSET_BYTE_LEN, TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange,
+    TxTableEntries, TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
 };
 
 pub const VERSION: Version = Version { major: 0, minor: 5 };

--- a/crates/espresso/types/src/v0/v0_6/mod.rs
+++ b/crates/espresso/types/src/v0/v0_6/mod.rs
@@ -3,19 +3,19 @@ use vbs::version::Version;
 // Re-export types which haven't changed since the last minor version.
 pub use super::v0_5::{
     ADVZNsProof, ADVZTxProof, AccountQueryData, AvidMIncorrectEncodingNsProof, AvidMNsProof,
-    AvidMTxProof, BlockMerkleCommitment, BlockMerkleTree, BlockSize, BuilderSignature, ChainConfig,
-    ChainId, Delta, FeeAccount, FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment,
-    FeeMerkleProof, FeeMerkleTree, Header, Index, Iter, L1BlockInfo, L1Client, L1ClientOptions,
-    L1Snapshot, LeaderCounts, NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder,
-    NsPayloadByteLen, NsPayloadOwned, NsPayloadRange, NsTable, NsTableBuilder,
-    NsTableValidationError, NumNss, NumTxs, NumTxsRange, NumTxsUnchecked, Payload, PayloadByteLen,
-    ResolvableChainConfig, RewardAccountProofV2, RewardAccountQueryDataV2, RewardAccountV2,
-    RewardClaimError, RewardMerkleCommitmentV2, RewardMerkleProofV2, RewardMerkleTreeV2,
-    TimeBasedUpgrade, Transaction, TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries,
-    TxTableEntriesRange, Upgrade, UpgradeMode, UpgradeType, ViewBasedUpgrade,
-    BLOCK_MERKLE_TREE_HEIGHT, FEE_MERKLE_TREE_HEIGHT, MAX_VALIDATORS, NS_ID_BYTE_LEN,
-    NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN, REWARD_MERKLE_TREE_V2_ARITY,
-    REWARD_MERKLE_TREE_V2_HEIGHT, TX_OFFSET_BYTE_LEN,
+    AvidMTxProof, BLOCK_MERKLE_TREE_HEIGHT, BlockMerkleCommitment, BlockMerkleTree, BlockSize,
+    BuilderSignature, ChainConfig, ChainId, Delta, FEE_MERKLE_TREE_HEIGHT, FeeAccount,
+    FeeAccountProof, FeeAmount, FeeInfo, FeeMerkleCommitment, FeeMerkleProof, FeeMerkleTree,
+    Header, Index, Iter, L1BlockInfo, L1Client, L1ClientOptions, L1Snapshot, LeaderCounts,
+    MAX_VALIDATORS, NS_ID_BYTE_LEN, NS_OFFSET_BYTE_LEN, NUM_NSS_BYTE_LEN, NUM_TXS_BYTE_LEN,
+    NamespaceId, NsIndex, NsIter, NsPayload, NsPayloadBuilder, NsPayloadByteLen, NsPayloadOwned,
+    NsPayloadRange, NsTable, NsTableBuilder, NsTableValidationError, NumNss, NumTxs, NumTxsRange,
+    NumTxsUnchecked, Payload, PayloadByteLen, REWARD_MERKLE_TREE_V2_ARITY,
+    REWARD_MERKLE_TREE_V2_HEIGHT, ResolvableChainConfig, RewardAccountProofV2,
+    RewardAccountQueryDataV2, RewardAccountV2, RewardClaimError, RewardMerkleCommitmentV2,
+    RewardMerkleProofV2, RewardMerkleTreeV2, TX_OFFSET_BYTE_LEN, TimeBasedUpgrade, Transaction,
+    TxIndex, TxIter, TxPayload, TxPayloadRange, TxTableEntries, TxTableEntriesRange, Upgrade,
+    UpgradeMode, UpgradeType, ViewBasedUpgrade,
 };
 
 pub const VERSION: Version = Version { major: 0, minor: 6 };

--- a/crates/espresso/types/src/v0/v0_6/txproof.rs
+++ b/crates/espresso/types/src/v0/v0_6/txproof.rs
@@ -1,5 +1,6 @@
-use super::{AvidmGf2NsProof, TxIndex};
 use serde::{Deserialize, Serialize};
+
+use super::{AvidmGf2NsProof, TxIndex};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AvidmGf2TxProof {

--- a/crates/hotshot/testing/src/node_ctx.rs
+++ b/crates/hotshot/testing/src/node_ctx.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use hotshot::{traits::TestableNodeImplementation, HotShotError};
+use hotshot::{HotShotError, traits::TestableNodeImplementation};
 use hotshot_types::traits::node_implementation::NodeType;
 
 /// context for a round

--- a/crates/hotshot/testing/tests/tests_1/block_builder.rs
+++ b/crates/hotshot/testing/tests/tests_1/block_builder.rs
@@ -21,7 +21,7 @@ use hotshot_testing::block_builder::{
 use hotshot_types::{
     data::vid_commitment,
     network::RandomBuilderConfig,
-    traits::{node_implementation::NodeType, signature_key::SignatureKey, BlockPayload},
+    traits::{BlockPayload, node_implementation::NodeType, signature_key::SignatureKey},
 };
 use test_utils::reserve_tcp_port;
 use tide_disco::Url;

--- a/crates/hotshot/testing/tests/tests_1/da_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/da_task.rs
@@ -4,7 +4,10 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-use std::{sync::{Arc, atomic::Ordering}, time::Duration};
+use std::{
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
 
 use futures::StreamExt;
 use hotshot::tasks::task_state::CreateTaskState;
@@ -22,16 +25,14 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, PackedBundle, ViewNumber},
+    data::{PackedBundle, ViewNumber, null_block},
     simple_vote::DaData2,
 };
 use versions::VERSION_0_0;
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_da_task() {
-
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
     let default_version = VERSION_0_0;
@@ -111,12 +112,10 @@ async fn test_da_task() {
                 },
                 ViewNumber::new(2),
                 None,
-                vec1::vec1![null_block::builder_fee::<TestTypes>(
-                    num_storage_node,
-                    TEST_VERSIONS.test.base
-                )
-                .unwrap()],
-
+                vec1::vec1![
+                    null_block::builder_fee::<TestTypes>(num_storage_node, TEST_VERSIONS.test.base)
+                        .unwrap()
+                ],
             )),
         ],
         serial![DaProposalRecv(proposals[1].clone(), leaders[1])],
@@ -143,12 +142,13 @@ async fn test_da_task() {
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_da_task_storage_failure() {
-
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     // Set the error flag here for the system handle. This causes it to emit an error on append.
-    handle.storage().should_return_err.store( true, Ordering::Relaxed);
+    handle
+        .storage()
+        .should_return_err
+        .store(true, Ordering::Relaxed);
     let membership = handle.hotshot.membership_coordinator.clone();
     let default_version = VERSION_0_0;
 
@@ -227,12 +227,10 @@ async fn test_da_task_storage_failure() {
                 },
                 ViewNumber::new(2),
                 None,
-                vec1::vec1![null_block::builder_fee::<TestTypes>(
-                    num_storage_node,
-                    TEST_VERSIONS.test.base
-                )
-                .unwrap()],
-
+                vec1::vec1![
+                    null_block::builder_fee::<TestTypes>(num_storage_node, TEST_VERSIONS.test.base)
+                        .unwrap()
+                ],
             ),)
         ],
         serial![DaProposalRecv(proposals[1].clone(), leaders[1])],

--- a/crates/hotshot/testing/tests/tests_1/libp2p.rs
+++ b/crates/hotshot/testing/tests/tests_1/libp2p.rs
@@ -21,7 +21,6 @@ use tracing::instrument;
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
@@ -52,7 +51,6 @@ async fn libp2p_network() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_failures_2() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
@@ -98,9 +96,7 @@ async fn libp2p_network_failures_2() {
 #[instrument]
 #[ignore]
 async fn test_stress_libp2p_network() {
-
-    let metadata: TestDescription<TestTypes, Libp2pImpl> =
-        TestDescription::default_stress();
+    let metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription::default_stress();
     metadata
         .gen_launcher()
         .launch()

--- a/crates/hotshot/testing/tests/tests_1/message.rs
+++ b/crates/hotshot/testing/tests/tests_1/message.rs
@@ -10,11 +10,16 @@ use std::marker::PhantomData;
 use committable::Committable;
 use hotshot_example_types::node_types::{TEST_VERSIONS, TestTypes};
 use hotshot_types::{
-    data::ViewNumber, message::{GeneralConsensusMessage, Message, MessageKind, SequencingMessage}, signature_key::BLSPubKey, simple_certificate::{SimpleCertificate, ViewSyncCommitCertificate2}, simple_vote::ViewSyncCommitData2, traits::signature_key::SignatureKey
+    data::ViewNumber,
+    message::{GeneralConsensusMessage, Message, MessageKind, SequencingMessage},
+    signature_key::BLSPubKey,
+    simple_certificate::{SimpleCertificate, ViewSyncCommitCertificate2},
+    simple_vote::ViewSyncCommitData2,
+    traits::signature_key::SignatureKey,
 };
 use vbs::{
-    version::{StaticVersion, Version},
     BinarySerializer, Serializer,
+    version::{StaticVersion, Version},
 };
 
 #[test]
@@ -70,8 +75,7 @@ async fn test_certificate2_validity() {
 
     let node_id = 1;
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
     let membership = handle.hotshot.membership_coordinator.clone();
 
     let mut generator =
@@ -102,21 +106,23 @@ async fn test_certificate2_validity() {
     let membership_stake_table = StakeTableEntries::from(epoch_mem.stake_table().await).0;
     let membership_success_threshold = epoch_mem.success_threshold().await;
 
-    assert!(qc
-        .is_valid_cert(
+    assert!(
+        qc.is_valid_cert(
             &membership_stake_table,
             membership_success_threshold,
             &handle.hotshot.upgrade_lock
         )
-        .is_ok());
+        .is_ok()
+    );
 
-    assert!(qc2
-        .is_valid_cert(
+    assert!(
+        qc2.is_valid_cert(
             &membership_stake_table,
             membership_success_threshold,
             &handle.hotshot.upgrade_lock
         )
-        .is_ok());
+        .is_ok()
+    );
 
     // ensure that we don't break the leaf commitment chain
     let leaf2 = Leaf2::from_quorum_proposal(&proposal.data);

--- a/crates/hotshot/testing/tests/tests_1/network_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/network_task.rs
@@ -5,7 +5,7 @@
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
 use std::{
-    sync::{atomic::Ordering, Arc},
+    sync::{Arc, atomic::Ordering},
     time::Duration,
 };
 
@@ -23,10 +23,7 @@ use hotshot_types::{
     consensus::OuterConsensus,
     data::ViewNumber,
     message::UpgradeLock,
-    traits::{
-        election::Membership,
-        node_implementation::{NodeType},
-    },
+    traits::{election::Membership, node_implementation::NodeType},
 };
 use tokio::time::timeout;
 
@@ -45,8 +42,7 @@ async fn test_network_task() {
         TestDescription::default_multiple_rounds();
     let upgrade_lock = UpgradeLock::<TestTypes>::new(TEST_VERSIONS.test);
     let node_id = 1;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
     let launcher = builder.gen_launcher();
 
     let network = (launcher.resource_generators.channel_generator)(node_id).await;
@@ -224,8 +220,7 @@ async fn test_network_storage_fail() {
     let builder: TestDescription<TestTypes, MemoryImpl> =
         TestDescription::default_multiple_rounds();
     let node_id = 1;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
     let launcher = builder.gen_launcher();
 
     let network = (launcher.resource_generators.channel_generator)(node_id).await;

--- a/crates/hotshot/testing/tests/tests_1/quorum_proposal_recv_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_proposal_recv_task.rs
@@ -31,11 +31,8 @@ use hotshot_types::{
     data::{EpochNumber, Leaf2, ViewNumber},
     request_response::ProposalRequestPayload,
     traits::{
-        consensus_api::ConsensusApi,
-        election::Membership,
-        node_implementation::{NodeType},
-        signature_key::SignatureKey,
-        ValidatedState,
+        ValidatedState, consensus_api::ConsensusApi, election::Membership,
+        node_implementation::NodeType, signature_key::SignatureKey,
     },
 };
 
@@ -49,8 +46,7 @@ async fn test_quorum_proposal_recv_task() {
         script::{Expectations, TaskScript},
     };
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
     let membership = handle.hotshot.membership_coordinator.clone();
     let consensus = handle.hotshot.consensus();
     let mut consensus_writer = consensus.write().await;
@@ -96,9 +92,7 @@ async fn test_quorum_proposal_recv_task() {
         exact(ViewChange(ViewNumber::new(2), None)),
     ])];
 
-    let state =
-        QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle)
-            .await;
+    let state = QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
     let mut script = TaskScript {
         timeout: Duration::from_millis(35),
         state,
@@ -121,8 +115,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
     };
     use hotshot_types::{data::Leaf2, vote::HasViewNumber};
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(4).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(4).await;
     let membership = handle.hotshot.membership_coordinator.clone();
     let consensus = handle.hotshot.consensus();
     let mut consensus_writer = consensus.write().await;
@@ -187,9 +180,7 @@ async fn test_quorum_proposal_recv_task_liveness_check() {
         exact(QuorumProposalRequestSend(req, signature)),
     ])];
 
-    let state =
-        QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle)
-            .await;
+    let state = QuorumProposalRecvTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
     let mut script = TaskScript {
         timeout: Duration::from_millis(35),
         state,

--- a/crates/hotshot/testing/tests/tests_1/quorum_proposal_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_proposal_task.rs
@@ -18,20 +18,19 @@ use hotshot_task_impls::{events::HotShotEvent::*, quorum_proposal::QuorumProposa
 use hotshot_testing::{
     all_predicates,
     helpers::{build_payload_commitment, build_system_handle},
-    predicates::event::{all_predicates, quorum_proposal_send},
+    predicates::event::{all_predicates, quorum_proposal_send, view_change},
     random,
     script::{Expectations, InputOrder, TaskScript},
     serial,
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, EpochNumber, Leaf2, ViewChangeEvidence2, ViewNumber},
+    data::{EpochNumber, Leaf2, ViewChangeEvidence2, ViewNumber, null_block},
     simple_vote::{TimeoutData2, ViewSyncFinalizeData2},
     utils::BuilderCommitment,
 };
 use sha2::Digest;
 use vec1::vec1;
-use hotshot_testing::predicates::event::view_change;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 
@@ -42,8 +41,7 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     use hotshot_testing::script::{Expectations, TaskScript};
 
     let node_id = 1;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
     let epoch_1_mem = membership
@@ -55,12 +53,9 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
         .upgrade_lock
         .version_infallible(ViewNumber::new(node_id));
 
-    let payload_commitment = build_payload_commitment::<TestTypes>(
-        &epoch_1_mem,
-        ViewNumber::new(node_id),
-        version,
-    )
-    .await;
+    let payload_commitment =
+        build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(node_id), version)
+            .await;
 
     let mut generator =
         TestViewGenerator::generate(membership.clone(), node_key_map, TEST_VERSIONS.test);
@@ -94,11 +89,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
     let num_storage_node = epoch_1_mem.total_nodes().await;
     let genesis_cert = proposals[0].data.justify_qc().clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee = null_block::builder_fee::<TestTypes>(
-        num_storage_node,
-        TEST_VERSIONS.test.base
-    )
-    .unwrap();
+    let builder_fee =
+        null_block::builder_fee::<TestTypes>(num_storage_node, TEST_VERSIONS.test.base).unwrap();
     drop(consensus_writer);
 
     let inputs = vec![
@@ -116,7 +108,6 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
                 },
                 ViewNumber::new(1),
                 vec1![builder_fee.clone()],
-
             ),
         ],
     ];
@@ -140,10 +131,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_1() {
 #[cfg(test)]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
-
     let node_id = 3;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
     let epoch_1_mem = membership
@@ -187,11 +176,8 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
     drop(consensus_writer);
 
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee = null_block::builder_fee::<TestTypes>(
-        num_storage_node,
-        TEST_VERSIONS.test.base
-    )
-    .unwrap();
+    let builder_fee =
+        null_block::builder_fee::<TestTypes>(num_storage_node, TEST_VERSIONS.test.base).unwrap();
 
     let upgrade_lock = &handle.hotshot.upgrade_lock;
     let version_1 = upgrade_lock.version_infallible(ViewNumber::new(1));
@@ -204,19 +190,14 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
         random![
             Qc2Formed(either::Left(genesis_cert.clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(1),
-                    version_1,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(1), version_1,)
+                    .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
                 },
                 ViewNumber::new(1),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[0].clone(), handle.public_key()),
         ],
@@ -224,17 +205,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalPreliminarilyValidated(proposals[0].clone()),
             Qc2Formed(either::Left(proposals[1].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(2),
-                    version_2,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(2), version_2,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header().metadata,
                 ViewNumber::new(2),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
         ],
@@ -242,17 +218,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalPreliminarilyValidated(proposals[1].clone()),
             Qc2Formed(either::Left(proposals[2].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(3),
-                    version_3,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(3), version_3,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header().metadata,
                 ViewNumber::new(3),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
         ],
@@ -260,17 +231,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalPreliminarilyValidated(proposals[2].clone()),
             Qc2Formed(either::Left(proposals[3].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(4),
-                    version_4,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(4), version_4,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header().metadata,
                 ViewNumber::new(4),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[3].clone(), handle.public_key()),
         ],
@@ -278,17 +244,12 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
             QuorumProposalPreliminarilyValidated(proposals[3].clone()),
             Qc2Formed(either::Left(proposals[4].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(5),
-                    version_5,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(5), version_5,)
+                    .await,
                 builder_commitment,
                 proposals[3].data.block_header().metadata,
                 ViewNumber::new(5),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[4].clone(), handle.public_key()),
         ],
@@ -317,11 +278,9 @@ async fn test_quorum_proposal_task_quorum_proposal_view_gt_1() {
 #[cfg(test)]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_qc_timeout() {
-
     let node_id = 3;
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
     let membership = handle.hotshot.membership_coordinator.clone();
     let epoch_1_mem = membership
         .membership_for_epoch(Some(EpochNumber::new(1)))
@@ -332,12 +291,9 @@ async fn test_quorum_proposal_task_qc_timeout() {
         .upgrade_lock
         .version_infallible(ViewNumber::new(node_id));
 
-    let payload_commitment = build_payload_commitment::<TestTypes>(
-        &epoch_1_mem,
-        ViewNumber::new(node_id),
-        version,
-    )
-    .await;
+    let payload_commitment =
+        build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(node_id), version)
+            .await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator =
@@ -384,13 +340,10 @@ async fn test_quorum_proposal_task_qc_timeout() {
                 num_transactions: 0
             },
             ViewNumber::new(3),
-            vec1![null_block::builder_fee::<TestTypes>(
-                num_storage_nodes,
-                TEST_VERSIONS.test.base
-
-            )
-            .unwrap()],
-
+            vec1![
+                null_block::builder_fee::<TestTypes>(num_storage_nodes, TEST_VERSIONS.test.base)
+                    .unwrap()
+            ],
         ),
         VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
     ]];
@@ -415,8 +368,7 @@ async fn test_quorum_proposal_task_view_sync() {
     use hotshot_types::data::null_block;
 
     let node_id = 2;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
     let epoch_1_mem = membership
@@ -428,12 +380,9 @@ async fn test_quorum_proposal_task_view_sync() {
         .upgrade_lock
         .version_infallible(ViewNumber::new(node_id));
 
-    let payload_commitment = build_payload_commitment::<TestTypes>(
-        &epoch_1_mem,
-        ViewNumber::new(node_id),
-        version,
-    )
-    .await;
+    let payload_commitment =
+        build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(node_id), version)
+            .await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
 
     let mut generator =
@@ -482,13 +431,10 @@ async fn test_quorum_proposal_task_view_sync() {
                 num_transactions: 0
             },
             ViewNumber::new(2),
-            vec1![null_block::builder_fee::<TestTypes>(
-                num_storage_nodes,
-                TEST_VERSIONS.test.base
-
-            )
-            .unwrap()],
-
+            vec1![
+                null_block::builder_fee::<TestTypes>(num_storage_nodes, TEST_VERSIONS.test.base)
+                    .unwrap()
+            ],
         ),
         VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
     ]];
@@ -510,8 +456,7 @@ async fn test_quorum_proposal_task_view_sync() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_liveness_check() {
     let node_id = 3;
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
     let epoch_1_mem = membership
@@ -550,11 +495,8 @@ async fn test_quorum_proposal_task_liveness_check() {
 
     let num_storage_nodes = epoch_1_mem.total_nodes().await;
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee = null_block::builder_fee::<TestTypes>(
-        num_storage_nodes,
-        TEST_VERSIONS.test.base
-    )
-    .unwrap();
+    let builder_fee =
+        null_block::builder_fee::<TestTypes>(num_storage_nodes, TEST_VERSIONS.test.base).unwrap();
 
     // We need to handle the views where we aren't the leader to ensure that the states are
     // updated properly.
@@ -571,19 +513,14 @@ async fn test_quorum_proposal_task_liveness_check() {
         random![
             Qc2Formed(either::Left(genesis_cert.clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(1),
-                    version_1,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(1), version_1,)
+                    .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
                 },
                 ViewNumber::new(1),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[0].clone(), handle.public_key()),
         ],
@@ -591,17 +528,12 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalPreliminarilyValidated(proposals[0].clone()),
             Qc2Formed(either::Left(proposals[1].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(2),
-                    version_2,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(2), version_2,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header().metadata,
                 ViewNumber::new(2),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
         ],
@@ -609,17 +541,12 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalPreliminarilyValidated(proposals[1].clone()),
             Qc2Formed(either::Left(proposals[2].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(3),
-                    version_3,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(3), version_3,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header().metadata,
                 ViewNumber::new(3),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
         ],
@@ -627,17 +554,12 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalPreliminarilyValidated(proposals[2].clone()),
             Qc2Formed(either::Left(proposals[3].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(4),
-                    version_4,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(4), version_4,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[2].data.block_header().metadata,
                 ViewNumber::new(4),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[3].clone(), handle.public_key()),
         ],
@@ -645,17 +567,12 @@ async fn test_quorum_proposal_task_liveness_check() {
             QuorumProposalPreliminarilyValidated(proposals[3].clone()),
             Qc2Formed(either::Left(proposals[4].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(5),
-                    version_5,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(5), version_5,)
+                    .await,
                 builder_commitment,
                 proposals[3].data.block_header().metadata,
                 ViewNumber::new(5),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[4].clone(), handle.public_key()),
         ],
@@ -683,9 +600,7 @@ async fn test_quorum_proposal_task_liveness_check() {
 #[cfg(test)]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_proposal_task_with_incomplete_events() {
-
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
     let membership = handle.hotshot.membership_coordinator.clone();
     let mut generator = TestViewGenerator::generate(membership, node_key_map, TEST_VERSIONS.test);
 

--- a/crates/hotshot/testing/tests/tests_1/quorum_vote_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/quorum_vote_task.rs
@@ -22,9 +22,7 @@ use hotshot_testing::{
     random,
     script::{Expectations, InputOrder, TaskScript},
 };
-use hotshot_types::{
-    data::{Leaf2, ViewNumber},
-};
+use hotshot_types::data::{Leaf2, ViewNumber};
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 
@@ -38,8 +36,7 @@ async fn test_quorum_vote_task_success() {
         view_generator::TestViewGenerator,
     };
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
 
@@ -102,8 +99,7 @@ async fn test_quorum_vote_task_miss_dependency() {
         helpers::build_system_handle, predicates::event::exact, view_generator::TestViewGenerator,
     };
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
 
@@ -183,8 +179,7 @@ async fn test_quorum_vote_task_incorrect_dependency() {
         helpers::build_system_handle, predicates::event::exact, view_generator::TestViewGenerator,
     };
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     let membership = handle.hotshot.membership_coordinator.clone();
 

--- a/crates/hotshot/testing/tests/tests_1/test_success.rs
+++ b/crates/hotshot/testing/tests/tests_1/test_success.rs
@@ -8,14 +8,14 @@ use std::collections::HashMap;
 
 use hotshot_example_types::{
     node_types::{
-        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS, TestConsecutiveLeaderTypes, TestTypes, TestTypesRandomizedLeader
+        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS,
+        TestConsecutiveLeaderTypes, TestTypes, TestTypesRandomizedLeader,
     },
     testable_delay::{DelayConfig, DelayOptions, DelaySettings, SupportedTraitTypesForAsyncDelay},
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
-    block_builder::SimpleBuilderImplementation,
-    test_builder::TestDescription,
+    block_builder::SimpleBuilderImplementation, test_builder::TestDescription,
     view_sync_task::ViewSyncTaskDescription,
 };
 

--- a/crates/hotshot/testing/tests/tests_1/test_with_failures_2.rs
+++ b/crates/hotshot/testing/tests/tests_1/test_with_failures_2.rs
@@ -10,7 +10,8 @@ use std::{collections::HashMap, time::Duration};
 
 use hotshot_example_types::{
     node_types::{
-        CliquenetImpl, CombinedImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS, TestConsecutiveLeaderTypes, TestTwoStakeTablesTypes
+        CliquenetImpl, CombinedImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl,
+        TEST_VERSIONS, TestConsecutiveLeaderTypes, TestTwoStakeTablesTypes,
     },
     state_types::TestTypes,
 };
@@ -24,11 +25,7 @@ use hotshot_testing::{
 use hotshot_types::{
     data::ViewNumber,
     message::{GeneralConsensusMessage, MessageKind, SequencingMessage},
-    traits::{
-        election::Membership,
-        network::TransmitType,
-        node_implementation::{NodeType},
-    },
+    traits::{election::Membership, network::TransmitType, node_implementation::NodeType},
     vote::HasViewNumber,
 };
 

--- a/crates/hotshot/testing/tests/tests_1/transaction_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/transaction_task.rs
@@ -7,20 +7,16 @@ use hotshot_task_impls::{
     events::HotShotEvent, harness::run_harness, transactions::TransactionTaskState,
 };
 use hotshot_testing::helpers::build_system_handle;
-use hotshot_types::{
-    data::{null_block, EpochNumber, PackedBundle, ViewNumber},
-};
+use hotshot_types::data::{EpochNumber, PackedBundle, ViewNumber, null_block};
 
 #[cfg(test)]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_transaction_task_leader_two_views_in_a_row() {
-
     // Build the API for node 2.
     let node_id = 2;
-    let handle =
-        build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id)
-            .await
-            .0;
+    let handle = build_system_handle::<TestConsecutiveLeaderTypes, MemoryImpl>(node_id)
+        .await
+        .0;
 
     let mut input = Vec::new();
     let mut output = Vec::new();
@@ -58,7 +54,6 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
             )
             .unwrap()
         ],
-
     );
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle.clone()));
 
@@ -67,9 +62,6 @@ async fn test_transaction_task_leader_two_views_in_a_row() {
     output.push(HotShotEvent::BlockRecv(exp_packed_bundle));
 
     let transaction_state =
-        TransactionTaskState::<TestConsecutiveLeaderTypes>::create_from(
-            &handle,
-        )
-        .await;
+        TransactionTaskState::<TestConsecutiveLeaderTypes>::create_from(&handle).await;
     run_harness(input, output, transaction_state, false).await;
 }

--- a/crates/hotshot/testing/tests/tests_1/unit.rs
+++ b/crates/hotshot/testing/tests/tests_1/unit.rs
@@ -1,8 +1,8 @@
-use sha2::{Sha256, Digest};
-use hotshot_types::traits::storage::null_store_drb_progress_fn;
-use hotshot_types::traits::storage::null_load_drb_progress_fn;
-use hotshot_types::drb::compute_drb_result;
-use hotshot_types::drb::DrbInput;
+use hotshot_types::{
+    drb::{DrbInput, compute_drb_result},
+    traits::storage::{null_load_drb_progress_fn, null_store_drb_progress_fn},
+};
+use sha2::{Digest, Sha256};
 
 #[cfg(test)]
 #[tokio::test(flavor = "multi_thread")]
@@ -18,14 +18,19 @@ async fn test_compute_drb_result() {
 
     let mut expected_result = [0u8; 32];
     {
-    let mut hash = drb_input.value.to_vec().clone();
+        let mut hash = drb_input.value.to_vec().clone();
         for _ in 0..difficulty_level {
             hash = Sha256::digest(hash).to_vec();
         }
-    expected_result.copy_from_slice(&hash);
+        expected_result.copy_from_slice(&hash);
     }
 
-    let actual_result = compute_drb_result(drb_input, null_store_drb_progress_fn(), null_load_drb_progress_fn()).await;
+    let actual_result = compute_drb_result(
+        drb_input,
+        null_store_drb_progress_fn(),
+        null_load_drb_progress_fn(),
+    )
+    .await;
 
     assert_eq!(expected_result, actual_result);
 }
@@ -43,14 +48,19 @@ async fn test_compute_drb_result_2() {
 
     let mut expected_result = [0u8; 32];
     {
-    let mut hash = drb_input.value.to_vec().clone();
+        let mut hash = drb_input.value.to_vec().clone();
         for _ in 2..difficulty_level {
             hash = Sha256::digest(hash).to_vec();
         }
-    expected_result.copy_from_slice(&hash);
+        expected_result.copy_from_slice(&hash);
     }
 
-    let actual_result = compute_drb_result(drb_input, null_store_drb_progress_fn(), null_load_drb_progress_fn()).await;
+    let actual_result = compute_drb_result(
+        drb_input,
+        null_store_drb_progress_fn(),
+        null_load_drb_progress_fn(),
+    )
+    .await;
 
     assert_eq!(expected_result, actual_result);
 }

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_proposal.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_proposal.rs
@@ -30,18 +30,15 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, EpochNumber, Leaf2, ViewNumber},
+    data::{EpochNumber, Leaf2, ViewNumber, null_block},
     simple_vote::UpgradeProposalData,
-    traits::{
-        election::Membership,
-        ValidatedState,
-    },
+    traits::{ValidatedState, election::Membership},
     utils::BuilderCommitment,
     vote::HasViewNumber,
 };
 use sha2::Digest;
-use versions::version;
 use vec1::vec1;
+use versions::version;
 
 const TIMEOUT: Duration = Duration::from_millis(35);
 
@@ -52,13 +49,12 @@ async fn test_upgrade_task_with_proposal() {
 
     use hotshot_testing::helpers::build_system_handle;
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(3).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(3).await;
 
     let other_handles = futures::future::join_all((0..=9).map(build_system_handle)).await;
 
-    let old_version = version(0,1);
-    let new_version = version(0,2);
+    let old_version = version(0, 1);
+    let new_version = version(0, 2);
 
     let upgrade_data: UpgradeProposalData = UpgradeProposalData {
         old_version,
@@ -127,11 +123,8 @@ async fn test_upgrade_task_with_proposal() {
 
     let genesis_cert = proposals[0].data.justify_qc().clone();
     let builder_commitment = BuilderCommitment::from_raw_digest(sha2::Sha256::new().finalize());
-    let builder_fee = null_block::builder_fee::<TestTypes>(
-        num_storage_nodes,
-        TEST_VERSIONS.test.base
-    )
-    .unwrap();
+    let builder_fee =
+        null_block::builder_fee::<TestTypes>(num_storage_nodes, TEST_VERSIONS.test.base).unwrap();
 
     let mut upgrade_votes = Vec::new();
 
@@ -158,19 +151,14 @@ async fn test_upgrade_task_with_proposal() {
         random![
             Qc2Formed(either::Left(genesis_cert.clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(1),
-                    version_1,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(1), version_1,)
+                    .await,
                 builder_commitment.clone(),
                 TestMetadata {
                     num_transactions: 0
                 },
                 ViewNumber::new(1),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[0].clone(), handle.public_key()),
         ],
@@ -178,17 +166,12 @@ async fn test_upgrade_task_with_proposal() {
             QuorumProposalPreliminarilyValidated(proposals[0].clone()),
             Qc2Formed(either::Left(proposals[1].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(2),
-                    version_2,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(2), version_2,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[0].data.block_header().metadata,
                 ViewNumber::new(2),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[1].clone(), handle.public_key()),
         ],
@@ -197,17 +180,12 @@ async fn test_upgrade_task_with_proposal() {
             QuorumProposalPreliminarilyValidated(proposals[1].clone()),
             Qc2Formed(either::Left(proposals[2].data.justify_qc().clone())),
             SendPayloadCommitmentAndMetadata(
-                build_payload_commitment::<TestTypes>(
-                    &epoch_1_mem,
-                    ViewNumber::new(3),
-                    version_3,
-                )
-                .await,
+                build_payload_commitment::<TestTypes>(&epoch_1_mem, ViewNumber::new(3), version_3,)
+                    .await,
                 builder_commitment.clone(),
                 proposals[1].data.block_header().metadata,
                 ViewNumber::new(3),
                 vec1![builder_fee.clone()],
-
             ),
             VidDisperseSend(vid_dispersals[2].clone(), handle.public_key()),
         ],

--- a/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
+++ b/crates/hotshot/testing/tests/tests_1/upgrade_task_with_vote.rs
@@ -29,9 +29,9 @@ use hotshot_testing::{
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
-    data::{null_block, EpochNumber, Leaf2, ViewNumber},
+    data::{EpochNumber, Leaf2, ViewNumber, null_block},
     simple_vote::UpgradeProposalData,
-    traits::{election::Membership},
+    traits::election::Membership,
     vote::HasViewNumber,
 };
 use versions::version;
@@ -44,8 +44,7 @@ const TIMEOUT: Duration = Duration::from_millis(65);
 async fn test_upgrade_task_with_vote() {
     use hotshot_testing::helpers::build_system_handle;
 
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(2).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(2).await;
 
     let old_version = version(0, 1);
     let new_version = version(0, 2);
@@ -168,8 +167,7 @@ async fn test_upgrade_task_with_vote() {
         ),
     ];
 
-    let vote_state =
-        QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
+    let vote_state = QuorumVoteTaskState::<TestTypes, MemoryImpl>::create_from(&handle).await;
     let mut vote_script = TaskScript {
         timeout: TIMEOUT,
         state: vote_state,

--- a/crates/hotshot/testing/tests/tests_1/vid_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/vid_task.rs
@@ -21,13 +21,9 @@ use hotshot_testing::{
     serial,
 };
 use hotshot_types::{
-    data::{null_block, DaProposal, PackedBundle, VidDisperse, ViewNumber},
+    data::{DaProposal, PackedBundle, VidDisperse, ViewNumber, null_block},
     message::UpgradeLock,
-    traits::{
-        consensus_api::ConsensusApi,
-        node_implementation::NodeType,
-        BlockPayload,
-    },
+    traits::{BlockPayload, consensus_api::ConsensusApi, node_implementation::NodeType},
 };
 use vec1::vec1;
 
@@ -36,9 +32,7 @@ async fn test_vid_task() {
     use hotshot_types::message::Proposal;
 
     // Build the API for node 2.
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(2)
-        .await
-        .0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(2).await.0;
     let pub_key = handle.public_key();
 
     let membership = handle.hotshot.membership_coordinator.clone();
@@ -111,12 +105,13 @@ async fn test_vid_task() {
                 },
                 ViewNumber::new(2),
                 None,
-                vec1::vec1![null_block::builder_fee::<TestTypes>(
-                    num_storage_nodes,
-                    TEST_VERSIONS.test.base
-                )
-                .unwrap()],
-
+                vec1::vec1![
+                    null_block::builder_fee::<TestTypes>(
+                        num_storage_nodes,
+                        TEST_VERSIONS.test.base
+                    )
+                    .unwrap()
+                ],
             )),
         ],
     ];
@@ -131,12 +126,13 @@ async fn test_vid_task() {
                     num_transactions: transactions.len() as u64,
                 },
                 ViewNumber::new(2),
-                vec1![null_block::builder_fee::<TestTypes>(
-                    num_storage_nodes,
-                    TEST_VERSIONS.test.base
-                )
-                .unwrap()],
-
+                vec1![
+                    null_block::builder_fee::<TestTypes>(
+                        num_storage_nodes,
+                        TEST_VERSIONS.test.base
+                    )
+                    .unwrap()
+                ],
             )),
             exact(VidDisperseSend(vid_proposal.clone(), pub_key)),
         ]),

--- a/crates/hotshot/testing/tests/tests_1/view_sync_task.rs
+++ b/crates/hotshot/testing/tests/tests_1/view_sync_task.rs
@@ -10,18 +10,13 @@ use hotshot_task_impls::{
     events::HotShotEvent, harness::run_harness, view_sync::ViewSyncTaskState,
 };
 use hotshot_testing::helpers::build_system_handle;
-use hotshot_types::{
-    data::ViewNumber, simple_vote::ViewSyncPreCommitData2,
-};
+use hotshot_types::{data::ViewNumber, simple_vote::ViewSyncPreCommitData2};
 
 #[cfg(test)]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_view_sync_task() {
-
     // Build the API for node 5.
-    let handle = build_system_handle::<TestTypes, MemoryImpl>(5)
-        .await
-        .0;
+    let handle = build_system_handle::<TestTypes, MemoryImpl>(5).await.0;
 
     let vote_data = ViewSyncPreCommitData2 {
         relay: 0,

--- a/crates/hotshot/testing/tests/tests_1/vote_dependency_handle.rs
+++ b/crates/hotshot/testing/tests/tests_1/vote_dependency_handle.rs
@@ -10,13 +10,13 @@ use hotshot_task::dependency_task::HandleDepOutput;
 use hotshot_task_impls::{events::HotShotEvent::*, quorum_vote::VoteDependencyHandle};
 use hotshot_testing::{
     helpers::build_system_handle,
-    predicates::{event::*, Predicate, PredicateResult},
+    predicates::{Predicate, PredicateResult, event::*},
     view_generator::TestViewGenerator,
 };
 use hotshot_types::{
     consensus::OuterConsensus,
     data::{Leaf2, ViewNumber},
-    traits::{consensus_api::ConsensusApi},
+    traits::consensus_api::ConsensusApi,
 };
 use itertools::Itertools;
 use tokio::time::timeout;
@@ -31,8 +31,7 @@ async fn test_vote_dependency_handle() {
     // We use a node ID of 2 here arbitrarily. We just need it to build the system handle.
     let node_id = 2;
     // Construct the system handle for the node ID to build all of the state objects.
-    let (handle, _, _, node_key_map) =
-        build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
+    let (handle, _, _, node_key_map) = build_system_handle::<TestTypes, MemoryImpl>(node_id).await;
     let membership = handle.hotshot.membership_coordinator.clone();
     let mut generator = TestViewGenerator::generate(membership, node_key_map, TEST_VERSIONS.test);
 
@@ -80,27 +79,26 @@ async fn test_vote_dependency_handle() {
         let (_sender, cancel_receiver) = broadcast(1);
         let view_number = ViewNumber::new(node_id);
 
-        let vote_dependency_handle_state =
-            VoteDependencyHandle::<TestTypes, MemoryImpl> {
-                public_key: handle.public_key(),
-                private_key: handle.private_key().clone(),
-                consensus: OuterConsensus::new(consensus.clone()),
-                consensus_metrics: Arc::clone(&consensus.read().await.metrics),
-                instance_state: handle.hotshot.instance_state(),
-                membership_coordinator: handle.hotshot.membership_coordinator.clone(),
-                storage: handle.storage(),
-                storage_metrics: handle.storage_metrics(),
-                view_number,
-                sender: event_sender.clone(),
-                receiver: event_receiver.clone().deactivate(),
-                upgrade_lock: handle.hotshot.upgrade_lock.clone(),
-                id: handle.hotshot.id,
-                epoch_height: handle.hotshot.config.epoch_height,
-                state_private_key: handle.state_private_key().clone(),
-                first_epoch: None,
-                stake_table_capacity: hotshot_types::light_client::DEFAULT_STAKE_TABLE_CAPACITY,
-                cancel_receiver,
-            };
+        let vote_dependency_handle_state = VoteDependencyHandle::<TestTypes, MemoryImpl> {
+            public_key: handle.public_key(),
+            private_key: handle.private_key().clone(),
+            consensus: OuterConsensus::new(consensus.clone()),
+            consensus_metrics: Arc::clone(&consensus.read().await.metrics),
+            instance_state: handle.hotshot.instance_state(),
+            membership_coordinator: handle.hotshot.membership_coordinator.clone(),
+            storage: handle.storage(),
+            storage_metrics: handle.storage_metrics(),
+            view_number,
+            sender: event_sender.clone(),
+            receiver: event_receiver.clone().deactivate(),
+            upgrade_lock: handle.hotshot.upgrade_lock.clone(),
+            id: handle.hotshot.id,
+            epoch_height: handle.hotshot.config.epoch_height,
+            state_private_key: handle.state_private_key().clone(),
+            first_epoch: None,
+            stake_table_capacity: hotshot_types::light_client::DEFAULT_STAKE_TABLE_CAPACITY,
+            cancel_receiver,
+        };
 
         vote_dependency_handle_state
             .handle_dep_result(inputs.clone().into_iter().map(|i| i.into()).collect())

--- a/crates/hotshot/testing/tests/tests_1/vote_participation.rs
+++ b/crates/hotshot/testing/tests/tests_1/vote_participation.rs
@@ -14,16 +14,16 @@ mod tests {
     use hotshot_example_types::node_types::TestTypes;
     use hotshot_testing::helpers::key_pair_for_id;
     use hotshot_types::{
+        PeerConfig,
         consensus::{Consensus, ConsensusMetricsValue},
         data::{EpochNumber, ViewNumber},
         simple_certificate::{QuorumCertificate2, SimpleCertificate, SuccessThreshold},
         simple_vote::QuorumData2,
-        stake_table::{supermajority_threshold, HSStakeTable},
+        stake_table::{HSStakeTable, supermajority_threshold},
         traits::{
             node_implementation::NodeType,
             signature_key::{SignatureKey, StateSignatureKey},
         },
-        PeerConfig,
     };
 
     /// Build an n-node stake table (each node has 1 unit of stake) plus the
@@ -34,8 +34,7 @@ mod tests {
                 let (_, pub_key) = key_pair_for_id::<TestTypes>(i as u64);
                 let (state_key, _) =
                     <TestTypes as NodeType>::StateSignatureKey::generated_from_seed_indexed(
-                        [0u8; 32],
-                        i as u64,
+                        [0u8; 32], i as u64,
                     );
                 PeerConfig::<TestTypes> {
                     stake_table_entry: pub_key.stake_table_entry(U256::from(1u64)),
@@ -111,9 +110,8 @@ mod tests {
         }
         // Get a valid BLS signature from the first signer (or signer 0 if none).
         // signers() only reads the bitvec; the aggregated sig is irrelevant.
-        let (priv_key, _) = key_pair_for_id::<TestTypes>(
-            signer_indices.first().copied().unwrap_or(0) as u64,
-        );
+        let (priv_key, _) =
+            key_pair_for_id::<TestTypes>(signer_indices.first().copied().unwrap_or(0) as u64);
         let dummy_sig = <TestTypes as NodeType>::SignatureKey::sign(&priv_key, &[0u8; 32])
             .expect("signing must succeed");
         let qc_type = (dummy_sig, bv);
@@ -156,15 +154,15 @@ mod tests {
         let mut consensus = make_test_consensus(stake_table.clone(), threshold, None);
 
         let qc = make_qc(&stake_table, 5, &[0, 1, 2], None);
-        consensus.update_vote_participation(qc).expect("update must succeed");
+        consensus
+            .update_vote_participation(qc)
+            .expect("update must succeed");
 
         let participation = consensus.current_vote_participation();
         assert_eq!(participation.len(), 5);
 
         // Nodes 0, 1, 2 signed in 1 of 1 views.
-        let node_keys: Vec<_> = (0..5)
-            .map(|i| key_pair_for_id::<TestTypes>(i).1)
-            .collect();
+        let node_keys: Vec<_> = (0..5).map(|i| key_pair_for_id::<TestTypes>(i).1).collect();
         for i in 0..3usize {
             let ratio = participation[&node_keys[i]];
             assert!(
@@ -298,7 +296,8 @@ mod tests {
     #[test]
     fn test_epoch_transition_preserves_history() {
         let (stake_table, threshold) = make_stake_table(5);
-        let mut consensus = make_test_consensus(stake_table.clone(), threshold, Some(EpochNumber::new(1)));
+        let mut consensus =
+            make_test_consensus(stake_table.clone(), threshold, Some(EpochNumber::new(1)));
 
         // Apply 3 QCs in epoch None; nodes [0,1,2] sign each.
         for view in 1u64..=3 {

--- a/crates/hotshot/testing/tests/tests_2/catchup.rs
+++ b/crates/hotshot/testing/tests/tests_2/catchup.rs
@@ -7,7 +7,8 @@
 use std::time::Duration;
 
 use hotshot_example_types::node_types::{
-    CliquenetImpl, CombinedImpl, CompatNetImpl, PushCdnImpl, TEST_VERSIONS, TestTypes, TestTypesRandomizedLeader
+    CliquenetImpl, CombinedImpl, CompatNetImpl, PushCdnImpl, TEST_VERSIONS, TestTypes,
+    TestTypesRandomizedLeader,
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{

--- a/crates/hotshot/testing/tests/tests_3/byzantine_tests.rs
+++ b/crates/hotshot/testing/tests/tests_3/byzantine_tests.rs
@@ -2,22 +2,23 @@ use std::{collections::HashSet, rc::Rc, sync::Arc, time::Duration};
 
 use async_lock::RwLock;
 use hotshot_example_types::{
-    node_types::{CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS},
+    node_types::{
+        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS,
+    },
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,
     byzantine::byzantine_behaviour::{
-        BadProposalViewDos, DishonestDa, DishonestLeader, DishonestVoter, DishonestVoting,
-        DoubleProposeVote, DishonestViewSyncRelay,
+        BadProposalViewDos, DishonestDa, DishonestLeader, DishonestViewSyncRelay,
+        DishonestViewSyncWrongEpoch, DishonestVoter, DishonestVoting, DoubleProposeVote,
     },
     completion_task::{CompletionTaskDescription, TimeBasedCompletionTaskDescription},
     overall_safety_task::OverallSafetyPropertiesDescription,
     test_builder::{Behaviour, TestDescription},
+    view_sync_task::ViewSyncTaskDescription,
 };
-use hotshot_testing::byzantine::byzantine_behaviour::DishonestViewSyncWrongEpoch;
-use hotshot_testing::view_sync_task::ViewSyncTaskDescription;
 use hotshot_types::{
     message::{GeneralConsensusMessage, MessageKind, SequencingMessage},
     traits::{election::Membership, network::TransmitType, node_implementation::NodeType},

--- a/crates/hotshot/testing/tests/tests_3/memory_network.rs
+++ b/crates/hotshot/testing/tests/tests_3/memory_network.rs
@@ -21,10 +21,11 @@ use hotshot_types::{
     signature_key::BLSPubKey,
     traits::{
         network::{BroadcastDelay, ConnectedNetwork, TestableNetworkingImplementation, Topic},
-        node_implementation::{NodeType},
-    }, vote::HasViewNumber,
+        node_implementation::NodeType,
+    },
+    vote::HasViewNumber,
 };
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use tokio::time::timeout;
 use tracing::{instrument, trace};
 
@@ -128,11 +129,12 @@ async fn memory_network_direct_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let (deserialized_message, _version) =
-            upgrade_lock.deserialize(&recv_message).unwrap();
-        assert!(timeout(Duration::from_secs(1), network2.recv_message())
-            .await
-            .is_err());
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).unwrap();
+        assert!(
+            timeout(Duration::from_secs(1), network2.recv_message())
+                .await
+                .is_err()
+        );
         fake_message_eq(sent_message, deserialized_message);
     }
 
@@ -151,11 +153,12 @@ async fn memory_network_direct_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let (deserialized_message, _version) =
-            upgrade_lock.deserialize(&recv_message).unwrap();
-        assert!(timeout(Duration::from_secs(1), network1.recv_message())
-            .await
-            .is_err());
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).unwrap();
+        assert!(
+            timeout(Duration::from_secs(1), network1.recv_message())
+                .await
+                .is_err()
+        );
         fake_message_eq(sent_message, deserialized_message);
     }
 }
@@ -182,18 +185,24 @@ async fn memory_network_broadcast_queue() {
         let view = sent_message.view_number();
         let serialized_message = upgrade_lock.serialize(&sent_message).unwrap();
         network1
-            .broadcast_message(view, serialized_message.clone(), Topic::Da, BroadcastDelay::None)
+            .broadcast_message(
+                view,
+                serialized_message.clone(),
+                Topic::Da,
+                BroadcastDelay::None,
+            )
             .await
             .expect("Failed to message node");
         let recv_message = network2
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let (deserialized_message, _version) =
-            upgrade_lock.deserialize(&recv_message).unwrap();
-        assert!(timeout(Duration::from_secs(1), network2.recv_message())
-            .await
-            .is_err());
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).unwrap();
+        assert!(
+            timeout(Duration::from_secs(1), network2.recv_message())
+                .await
+                .is_err()
+        );
         fake_message_eq(sent_message, deserialized_message);
     }
 
@@ -217,11 +226,12 @@ async fn memory_network_broadcast_queue() {
             .recv_message()
             .await
             .expect("Failed to receive message");
-        let (deserialized_message, _version) =
-            upgrade_lock.deserialize(&recv_message).unwrap();
-        assert!(timeout(Duration::from_secs(1), network1.recv_message())
-            .await
-            .is_err());
+        let (deserialized_message, _version) = upgrade_lock.deserialize(&recv_message).unwrap();
+        assert!(
+            timeout(Duration::from_secs(1), network1.recv_message())
+                .await
+                .is_err()
+        );
         fake_message_eq(sent_message, deserialized_message);
     }
 }

--- a/crates/hotshot/testing/tests/tests_3/test_with_failures_half_f.rs
+++ b/crates/hotshot/testing/tests/tests_3/test_with_failures_half_f.rs
@@ -7,7 +7,9 @@
 use std::time::Duration;
 
 use hotshot_example_types::{
-    node_types::{CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS},
+    node_types::{
+        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS,
+    },
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;

--- a/crates/hotshot/testing/tests/tests_4/test_with_builder_failures.rs
+++ b/crates/hotshot/testing/tests/tests_4/test_with_builder_failures.rs
@@ -6,7 +6,9 @@
 
 use std::time::Duration;
 
-use hotshot_example_types::node_types::{CliquenetImpl, CompatNetImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS, TestTypes};
+use hotshot_example_types::node_types::{
+    CliquenetImpl, CompatNetImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS, TestTypes,
+};
 use hotshot_macros::cross_tests;
 use hotshot_testing::{
     block_builder::SimpleBuilderImplementation,

--- a/crates/hotshot/testing/tests/tests_4/test_with_failures_f.rs
+++ b/crates/hotshot/testing/tests/tests_4/test_with_failures_f.rs
@@ -7,7 +7,9 @@
 use std::time::Duration;
 
 use hotshot_example_types::{
-    node_types::{CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS},
+    node_types::{
+        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS,
+    },
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;

--- a/crates/hotshot/testing/tests/tests_5/broken_3_chain.rs
+++ b/crates/hotshot/testing/tests/tests_5/broken_3_chain.rs
@@ -16,7 +16,6 @@ use tracing::instrument;
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn broken_3_chain() {
-
     let mut metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,

--- a/crates/hotshot/testing/tests/tests_5/combined_network.rs
+++ b/crates/hotshot/testing/tests/tests_5/combined_network.rs
@@ -50,7 +50,6 @@ async fn test_combined_network() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_cdn_crash() {
-
     let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             next_view_timeout: 10_000,
@@ -95,7 +94,6 @@ async fn test_combined_network_cdn_crash() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_reup() {
-
     let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             next_view_timeout: 10_000,
@@ -145,7 +143,6 @@ async fn test_combined_network_reup() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn test_combined_network_half_dc() {
-
     let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             next_view_timeout: 10_000,
@@ -218,7 +215,6 @@ fn generate_random_node_changes(
 #[instrument]
 #[ignore]
 async fn test_stress_combined_network_fuzzy() {
-
     let mut metadata: TestDescription<TestTypes, CombinedImpl> = TestDescription {
         timing_data: TimingData {
             next_view_timeout: 10_000,

--- a/crates/hotshot/testing/tests/tests_5/push_cdn.rs
+++ b/crates/hotshot/testing/tests/tests_5/push_cdn.rs
@@ -20,7 +20,6 @@ use tracing::instrument;
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn push_cdn_network() {
-
     let mut metadata: TestDescription<TestTypes, PushCdnImpl> = TestDescription {
         timing_data: TimingData {
             next_view_timeout: 10_000,

--- a/crates/hotshot/testing/tests/tests_5/test_with_failures.rs
+++ b/crates/hotshot/testing/tests/tests_5/test_with_failures.rs
@@ -7,7 +7,9 @@
 use std::time::Duration;
 
 use hotshot_example_types::{
-    node_types::{CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS},
+    node_types::{
+        CliquenetImpl, CompatNetImpl, Libp2pImpl, MemoryImpl, PushCdnImpl, TEST_VERSIONS,
+    },
     state_types::TestTypes,
 };
 use hotshot_macros::cross_tests;

--- a/crates/hotshot/testing/tests/tests_5/unreliable_network.rs
+++ b/crates/hotshot/testing/tests/tests_5/unreliable_network.rs
@@ -21,7 +21,6 @@ use tracing::instrument;
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_sync() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
@@ -86,7 +85,6 @@ async fn test_memory_network_sync() {
 #[ignore]
 #[instrument]
 async fn libp2p_network_async() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,
@@ -99,8 +97,7 @@ async fn libp2p_network_async() {
         ),
         timing_data: TimingData {
             next_view_timeout: 25000,
-            ..TestDescription::<TestTypes, Libp2pImpl>::default_multiple_rounds()
-                .timing_data
+            ..TestDescription::<TestTypes, Libp2pImpl>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 9,
@@ -145,8 +142,7 @@ async fn test_memory_network_async() {
         ),
         timing_data: TimingData {
             next_view_timeout: 1000,
-            ..TestDescription::<TestTypes, MemoryImpl>::default_multiple_rounds()
-                .timing_data
+            ..TestDescription::<TestTypes, MemoryImpl>::default_multiple_rounds().timing_data
         },
         unreliable_network: Some(Box::new(AsynchronousNetwork {
             keep_numerator: 95,
@@ -220,7 +216,6 @@ async fn test_memory_network_partially_sync() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[instrument]
 async fn libp2p_network_partially_sync() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             ..Default::default()
@@ -299,7 +294,6 @@ async fn test_memory_network_chaos() {
 #[ignore]
 #[instrument]
 async fn libp2p_network_chaos() {
-
     let mut metadata: TestDescription<TestTypes, Libp2pImpl> = TestDescription {
         overall_safety_properties: OverallSafetyPropertiesDescription {
             check_leaf: true,

--- a/crates/serialization/api/Cargo.toml
+++ b/crates/serialization/api/Cargo.toml
@@ -8,13 +8,13 @@ edition.workspace = true
 generated = true
 
 [dependencies]
+anyhow = { workspace = true }
 prost = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-schemars = { workspace = true }
-anyhow = { workspace = true }
-
-[dev-dependencies]
 
 [build-dependencies]
 prost-build = { workspace = true }
+
+[dev-dependencies]

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,8 @@
             rustfmt = {
               enable = true;
               description = "Run rustfmt on changed files";
-              entry = "just fmt";
+              # cargo-fmt is slower, does not format all files, and doesn't allow passing file arguments
+              entry = "rustfmt";
               types_or = [ "rust" ];
               pass_filenames = true;
               excludes = [ "^contracts/rust/adapter/src/bindings/" ];

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
               entry = "rustfmt";
               types_or = [ "rust" ];
               pass_filenames = true;
-              excludes = [ "^contracts/rust/adapter/src/bindings/" ];
+              excludes = [ "^contracts/rust/adapter/src/bindings/" "\\.api\\.v[0-9]+\\.rs$" ];
             };
             cargo-sort = {
               enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -140,9 +140,10 @@
             rustfmt = {
               enable = true;
               description = "Run rustfmt on changed files";
-              entry = "rustfmt";
+              entry = "just fmt";
               types_or = [ "rust" ];
               pass_filenames = true;
+              excludes = [ "^contracts/rust/adapter/src/bindings/" ];
             };
             cargo-sort = {
               enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -137,12 +137,12 @@
               types_or = [ "plantuml" ];
               pass_filenames = false;
             };
-            cargo-fmt = {
+            rustfmt = {
               enable = true;
-              description = "Enforce rustfmt";
-              entry = "just fmt";
-              types_or = [ "rust" "toml" ];
-              pass_filenames = false;
+              description = "Run rustfmt on changed files";
+              entry = "rustfmt";
+              types_or = [ "rust" ];
+              pass_filenames = true;
             };
             cargo-sort = {
               enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,6 @@
               entry = "rustfmt";
               types_or = [ "rust" ];
               pass_filenames = true;
-              excludes = [ "^contracts/rust/adapter/src/bindings/" "\\.api\\.v[0-9]+\\.rs$" ];
             };
             cargo-sort = {
               enable = true;

--- a/justfile
+++ b/justfile
@@ -61,11 +61,11 @@ demo-native *args: (build "test")
 fmt *files:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -z "{{files}}" ]; then
-        git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs -P "$(nproc)" -n 50 rustfmt
-    else
-        rustfmt {{files}}
+    files="{{files}}"
+    if [ -z "$files" ]; then
+        files=$(git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/')
     fi
+    echo "$files" | xargs -P $(nproc) -n 10 rustfmt
 
 fix *args:
     just clippy --fix {{args}}

--- a/justfile
+++ b/justfile
@@ -63,9 +63,11 @@ fmt *files:
     set -euo pipefail
     files="{{files}}"
     if [ -z "$files" ]; then
-        files=$(git ls-files '*.rs' | grep -vE '^contracts/rust/adapter/src/bindings/|\.api\.v[0-9]+\.rs$')
+        files=$(git ls-files '*.rs')
     fi
-    echo "$files" | xargs -P $(nproc) -n 10 rustfmt
+    if [ -n "$files" ]; then
+        echo "$files" | xargs -P $(getconf _NPROCESSORS_ONLN) -n 10 rustfmt
+    fi
 
 fix *args:
     just clippy --fix {{args}}

--- a/justfile
+++ b/justfile
@@ -57,8 +57,15 @@ demo *args:
 demo-native *args: (build "test")
     scripts/demo-native {{args}}
 
-fmt:
-    cargo fmt --all
+# cargo fmt misses files whose `mod` declarations are produced by macro expansion
+fmt *files:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{files}}" ]; then
+        git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/' | xargs -P "$(nproc)" -n 50 rustfmt
+    else
+        rustfmt {{files}}
+    fi
 
 fix *args:
     just clippy --fix {{args}}

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ fmt *files:
     set -euo pipefail
     files="{{files}}"
     if [ -z "$files" ]; then
-        files=$(git ls-files '*.rs' | grep -v '^contracts/rust/adapter/src/bindings/')
+        files=$(git ls-files '*.rs' | grep -vE '^contracts/rust/adapter/src/bindings/|\.api\.v[0-9]+\.rs$')
     fi
     echo "$files" | xargs -P $(nproc) -n 10 rustfmt
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,5 +14,5 @@ ignore = [
   # the contract bindings are generated files
   "contracts/rust/adapter/src/bindings",
   # tonic-prost generated protobuf stubs
-  "**/*.api.v*.rs",
+  "**/*.api.v[0-9]*.rs",
 ]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -12,5 +12,7 @@ format_strings = true
 
 ignore = [
   # the contract bindings are generated files
-  "contracts/rust/adapter/src/bindings"
+  "contracts/rust/adapter/src/bindings",
+  # tonic-prost generated protobuf stubs
+  "**/*.api.v*.rs",
 ]


### PR DESCRIPTION
- `cargo fmt` is slow, several seconds
- it does not format all files due to macro use
- `cargo fmt` does not support passing file names making it awkward (and very slow) with pre-commit hooks.

We can drop down to rustfmt to solve all of this with a bit of extra complexity.

Also adds a cargo sort check to the CI because it often gets forgotten.