### PR TITLE
  fix(reconstruct_state): load latest reward tree for V5+ block height

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -1340,6 +1340,30 @@ pub(crate) trait RewardMerkleTreeDataSource: Send + Sync + Clone + 'static {
         }
     }
 
+    /// Returns the RewardMerkleTreeV2 for height <= requested height
+    ///
+    /// After V5 the tree is only written at epoch boundaries, so `reward_merkle_tree_v2_data`
+    /// has no row for most heights. Within an epoch the tree doesn't change, so the previous
+    /// boundary's tree matches the current block's reward root but only if we're actually in
+    /// the same epoch. The caller is responsible for checking the returned tree's commitment
+    /// against the header at `height`.
+    /// if they differ we loaded a tree from an older epoch.
+    fn load_latest_reward_merkle_tree_v2(
+        &self,
+        height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<PermittedRewardMerkleTreeV2>> {
+        async move {
+            let tree_bytes = self.load_latest_tree(height).await?;
+
+            let tree_data = bincode::deserialize::<RewardMerkleTreeV2Data>(&tree_bytes)
+                .context("Failed to deserialize RewardMerkleTreeV2 from storage")?;
+
+            PermittedRewardMerkleTreeV2::try_from_kv_set(tree_data.balances)
+                .await
+                .context("Failed to reconstruct reward merkle tree from storage")
+        }
+    }
+
     fn load_reward_account_proof_v2(
         &self,
         _height: u64,
@@ -1374,6 +1398,10 @@ pub(crate) trait RewardMerkleTreeDataSource: Send + Sync + Clone + 'static {
     ) -> impl Send + Future<Output = anyhow::Result<()>>;
 
     fn load_tree(&self, height: u64) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>>;
+
+    /// Load the latest serialized reward merkle tree v2 at height `<= height`.
+    fn load_latest_tree(&self, height: u64)
+    -> impl Send + Future<Output = anyhow::Result<Vec<u8>>>;
 
     fn persist_proofs(
         &self,
@@ -1432,6 +1460,15 @@ impl RewardMerkleTreeDataSource for hotshot_query_service::data_source::MetricsD
     }
 
     fn load_tree(&self, _height: u64) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
+        async move {
+            bail!("reward merklized state is not supported for this data source");
+        }
+    }
+
+    fn load_latest_tree(
+        &self,
+        _height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
         async move {
             bail!("reward merklized state is not supported for this data source");
         }
@@ -1528,6 +1565,13 @@ where
         async move { self.inner().load_tree(height).await }
     }
 
+    fn load_latest_tree(
+        &self,
+        height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
+        async move { self.inner().load_latest_tree(height).await }
+    }
+
     fn garbage_collect(&self, height: u64) -> impl Send + Future<Output = anyhow::Result<()>> {
         async move { self.inner().garbage_collect(height).await }
     }
@@ -1597,6 +1641,13 @@ where
 
     fn load_tree(&self, height: u64) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
         async move { (**self).load_tree(height).await }
+    }
+
+    fn load_latest_tree(
+        &self,
+        height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
+        async move { (**self).load_latest_tree(height).await }
     }
 
     fn load_reward_merkle_tree_v2(

--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -50,7 +50,7 @@ use super::{
 };
 use crate::{
     SeqTypes,
-    api::{RewardMerkleTreeDataSource, RewardMerkleTreeV2Data},
+    api::RewardMerkleTreeDataSource,
     catchup::{CatchupStorage, NullStateCatchup},
     persistence::{ChainConfigPersistence, sql::Options},
     state::compute_state_update,
@@ -195,6 +195,38 @@ impl RewardMerkleTreeDataSource for SqlStorage {
             .await?
             .context(format!(
                 "No reward merkle tree for height {} in storage",
+                height
+            ))?;
+
+            row.try_get::<Vec<u8>, _>("balances")
+                .context("Missing field balances from row; this should never happen")
+        }
+    }
+
+    fn load_latest_tree(
+        &self,
+        height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
+        async move {
+            let mut tx = self
+                .read()
+                .await
+                .context("opening transaction for load_latest_tree")?;
+
+            let row = sqlx::query(
+                r#"
+                SELECT balances
+                FROM reward_merkle_tree_v2_data
+                WHERE height <= $1
+                ORDER BY height DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(height as i64)
+            .fetch_optional(tx.as_mut())
+            .await?
+            .context(format!(
+                "No reward merkle tree at or below height {} in storage",
                 height
             ))?;
 
@@ -815,6 +847,13 @@ impl RewardMerkleTreeDataSource for DataSource {
         async move { self.as_ref().load_tree(height).await }
     }
 
+    fn load_latest_tree(
+        &self,
+        height: u64,
+    ) -> impl Send + Future<Output = anyhow::Result<Vec<u8>>> {
+        async move { self.as_ref().load_latest_tree(height).await }
+    }
+
     fn garbage_collect(&self, height: u64) -> impl Send + Future<Output = anyhow::Result<()>> {
         async move { self.as_ref().garbage_collect(height).await }
     }
@@ -1172,53 +1211,6 @@ async fn load_reward_merkle_tree_v2(
     Ok((snapshot, leaf.leaf().clone()))
 }
 
-/// Returns the RewardMerkleTreeV2 for height <= requested height
-///
-/// After V5 the tree is only written at epoch boundaries, so `reward_merkle_tree_v2_data`
-/// has no row for most heights. Within an epoch the tree doesn't change, so the previous
-/// boundary's tree matches the current block's reward root but only if we're actually in
-/// the same epoch. The caller is responsible for checking the returned tree's commitment
-/// against the header at `height`.
-/// if they differ we loaded a tree from an older epoch.
-async fn load_latest_reward_merkle_tree_v2(
-    db: &SqlStorage,
-    height: u64,
-) -> anyhow::Result<PermittedRewardMerkleTreeV2> {
-    let mut tx = db
-        .read()
-        .await
-        .with_context(|| "failed to open read transaction")?;
-
-    let row = sqlx::query(
-        r#"
-        SELECT balances
-        FROM reward_merkle_tree_v2_data
-        WHERE height <= $1
-        ORDER BY height DESC
-        LIMIT 1
-        "#,
-    )
-    .bind(height as i64)
-    .fetch_optional(tx.as_mut())
-    .await?
-    .context(format!(
-        "No reward merkle tree at or below height {height} in storage"
-    ))?;
-
-    let balances: Vec<u8> = row
-        .try_get("balances")
-        .context("Missing balances column; this should never happen")?;
-
-    let tree_data = bincode::deserialize::<RewardMerkleTreeV2Data>(&balances)
-        .context("Failed to deserialize RewardMerkleTreeV2 from storage")?;
-
-    let tree = PermittedRewardMerkleTreeV2::try_from_kv_set(tree_data.balances)
-        .await
-        .context("Failed to reconstruct reward merkle tree from storage")?;
-
-    Ok(tree)
-}
-
 async fn load_accounts<Mode: TransactionMode>(
     tx: &mut Transaction<Mode>,
     height: u64,
@@ -1401,7 +1393,8 @@ pub(crate) async fn reconstruct_state<Mode: TransactionMode>(
             // we ended up with a tree from an older epoch.
             // But this should never happen as we don't garbage collect the latest tree
             if version >= EPOCH_REWARD_VERSION && !is_last_block(from_height, epoch_height) {
-                let tree = load_latest_reward_merkle_tree_v2(db, from_height)
+                let tree = db
+                    .load_latest_reward_merkle_tree_v2(from_height)
                     .await
                     .context("RewardMerkleTreeV2 not available at or below origin")?;
                 state.reward_merkle_tree_v2 = tree.tree;

--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -50,7 +50,7 @@ use super::{
 };
 use crate::{
     SeqTypes,
-    api::RewardMerkleTreeDataSource,
+    api::{RewardMerkleTreeDataSource, RewardMerkleTreeV2Data},
     catchup::{CatchupStorage, NullStateCatchup},
     persistence::{ChainConfigPersistence, sql::Options},
     state::compute_state_update,
@@ -1172,6 +1172,53 @@ async fn load_reward_merkle_tree_v2(
     Ok((snapshot, leaf.leaf().clone()))
 }
 
+/// Returns the RewardMerkleTreeV2 for height <= requested height
+///
+/// After V5 the tree is only written at epoch boundaries, so `reward_merkle_tree_v2_data`
+/// has no row for most heights. Within an epoch the tree doesn't change, so the previous
+/// boundary's tree matches the current block's reward root but only if we're actually in
+/// the same epoch. The caller is responsible for checking the returned tree's commitment
+/// against the header at `height`.
+/// if they differ we loaded a tree from an older epoch.
+async fn load_latest_reward_merkle_tree_v2(
+    db: &SqlStorage,
+    height: u64,
+) -> anyhow::Result<PermittedRewardMerkleTreeV2> {
+    let mut tx = db
+        .read()
+        .await
+        .with_context(|| "failed to open read transaction")?;
+
+    let row = sqlx::query(
+        r#"
+        SELECT balances
+        FROM reward_merkle_tree_v2_data
+        WHERE height <= $1
+        ORDER BY height DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(height as i64)
+    .fetch_optional(tx.as_mut())
+    .await?
+    .context(format!(
+        "No reward merkle tree at or below height {height} in storage"
+    ))?;
+
+    let balances: Vec<u8> = row
+        .try_get("balances")
+        .context("Missing balances column; this should never happen")?;
+
+    let tree_data = bincode::deserialize::<RewardMerkleTreeV2Data>(&balances)
+        .context("Failed to deserialize RewardMerkleTreeV2 from storage")?;
+
+    let tree = PermittedRewardMerkleTreeV2::try_from_kv_set(tree_data.balances)
+        .await
+        .context("Failed to reconstruct reward merkle tree from storage")?;
+
+    Ok(tree)
+}
+
 async fn load_accounts<Mode: TransactionMode>(
     tx: &mut Transaction<Mode>,
     height: u64,
@@ -1342,14 +1389,28 @@ pub(crate) async fn reconstruct_state<Mode: TransactionMode>(
             );
         },
         either::Either::Right(expected_root) => {
-            state.reward_merkle_tree_v2 = load_reward_merkle_tree_v2(db, from_height)
-                .await
-                .context(
-                    "unable to reconstruct state because RewardMerkleTreeV2 not available at \
-                     origin",
-                )?
-                .0
-                .tree;
+            let version = parent.block_header().version();
+            let epoch_height = instance
+                .epoch_height
+                .context("epoch_height not set but parent has V2 reward tree")?;
+
+            // Under V5+ the reward tree is only persisted at epoch boundaries, so an exact
+            // load at `from_height` will fail off-boundary. Walk back to the most recent
+            // persisted tree <= from_height instead; the commitment check below still
+            // guarantees we got the right tree (V5+ doesn't mutate the tree between
+            // boundaries, so any heights in the same epoch share the same root).
+            if version >= EPOCH_REWARD_VERSION && !is_last_block(from_height, epoch_height) {
+                let tree = load_latest_reward_merkle_tree_v2(db, from_height)
+                    .await
+                    .context("RewardMerkleTreeV2 not available at or below origin")?;
+                state.reward_merkle_tree_v2 = tree.tree;
+            } else {
+                state.reward_merkle_tree_v2 = load_reward_merkle_tree_v2(db, from_height)
+                    .await
+                    .context("RewardMerkleTreeV2 not available at origin")?
+                    .0
+                    .tree;
+            }
             ensure!(
                 state.reward_merkle_tree_v2.commitment() == expected_root,
                 "loaded reward state does not match parent header"

--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -1394,11 +1394,12 @@ pub(crate) async fn reconstruct_state<Mode: TransactionMode>(
                 .epoch_height
                 .context("epoch_height not set but parent has V2 reward tree")?;
 
-            // Under V5+ the reward tree is only persisted at epoch boundaries, so an exact
-            // load at `from_height` will fail off-boundary. Walk back to the most recent
-            // persisted tree <= from_height instead; the commitment check below still
-            // guarantees we got the right tree (V5+ doesn't mutate the tree between
-            // boundaries, so any heights in the same epoch share the same root).
+            // V5+ only stores the reward merkle tree at epoch's last block, so if we're
+            // reconstructing at a non boundary height there is no row at from_height.
+            // Load the latest tree instead
+            // the commitment check below will catch it if
+            // we ended up with a tree from an older epoch.
+            // But this should never happen as we don't garbage collect the latest tree
             if version >= EPOCH_REWARD_VERSION && !is_last_block(from_height, epoch_height) {
                 let tree = load_latest_reward_merkle_tree_v2(db, from_height)
                     .await


### PR DESCRIPTION
reward_merkle_tree_v2 is only persisted at last block of an epoch, so it fails to load the tree if height is not last block of the epoch. This PR fixes it by loading the last stored tree with height <= requested height for V5+ state reconstruction. The loaded tree should be the correct one because v5+ only updates tree at epoch boundary. We also do commitment check so it should catch the wrong tree.