### PR TITLE
feat(migration): trait architecture for non-blocking storage migrations

### DIFF
--- a/doc/storage-migrations.md
+++ b/doc/storage-migrations.md
@@ -1,0 +1,216 @@
+# Storage Migrations
+
+This document describes how to add new SQL storage migrations such that they do not block consensus startup.
+
+## Why this exists
+
+Until migration infrastructure was added in `hotshot_query_service::migration`, every refinery migration ran inside
+`SqlStorage::connect()` before `SequencerContext::start_consensus()` was called. A migration that scanned a large table
+or rebuilt a merkle tree would hold the node out of consensus for hours.
+
+The architecture in this document keeps fast schema changes in the pre-consensus path and moves slow operations behind a
+runner that executes after consensus is running. Consensus must remain fully functional while deferred migrations are in
+progress, so any data-shape change ships with a dual-read adapter that keeps the reader correct against both the old and
+new shapes for one release cycle.
+
+This applies only to migrations introduced after the infrastructure landed. Existing refinery migrations are unchanged.
+
+## Expand-migrate-contract
+
+Any data-shape change in this system is split across (at least) two releases, following a pattern called
+**expand-migrate-contract**. The motivation: at no point during the migration is the database in a state the running
+code cannot read.
+
+- **Expand** (release N): introduce the new shape alongside the old. Add the new table or column; do not remove anything
+  yet. Writers start writing the new shape. Readers route through a dual-read adapter that returns the same domain value
+  whether a given row is in the old shape or the new shape.
+- **Migrate** (release N, background): a backfill rewrites every existing legacy row into the new shape. Runs as a
+  deferred task while consensus continues; can take hours without blocking the node.
+- **Contract** (release N+1): once the backfill has finished on every operator, a follow-up release drops the legacy
+  columns or tables and removes the dual-read code path. The schema "contracts" back down.
+
+The three phases map onto the migration system as follows: expand is a plain refinery SQL file (the same way every
+existing schema change in this repo is authored), migrate is a `DataBackfill`, contract is a `CleanupMigration`.
+`DeferredSchemaChange` is a separate kind that covers slow DDL (Data Definition Language, the SQL subset that creates or
+alters schema objects: `CREATE TABLE`, `CREATE INDEX`, `ALTER`, `DROP`) — typically `CREATE INDEX CONCURRENTLY` — which
+has no data-shape implication and needs no adapter.
+
+### Why cleanup is a separate release
+
+The cleanup phase ships in a _separate release_ from the expand and migrate phases. There are two reasons.
+
+**Verification.** If `migrate_batch` returned `None` because of a backfill bug that silently skipped rows, the gap
+between releases gives an operator time to sample the new columns and confirm completeness before the destructive step.
+An auto-cleanup that fires at the end of the backfill makes a backfill bug silently destructive on every operator at
+once, with no recovery path because the legacy data is gone.
+
+**Rollback compatibility (forward-looking).** The repo does not support binary rollback today: refinery migrations are
+up-only, there is no schema version negotiation between binary and DB, and no operator-facing rollback policy is
+documented. Forward-only migrations make rollback impossible by construction.
+
+This architecture is one of the pieces that has to be in place _before_ rollback can ever be supported. By keeping
+legacy and new shapes coexisting for one release, the database stays readable by both the previous binary and the
+current one. If we later add the rest of what rollback needs (schema-version checks, a documented downgrade window),
+this design will already accommodate it. If we ship cleanup in the same release as expand, that future is closed off.
+
+Concretely, the failure mode this prevents:
+
+1. Operator upgrades to release N. Schema has both legacy and new columns.
+2. Backfill runs for hours. Completes. Cleanup fires. Legacy columns dropped.
+3. Operator hits a bug in N and tries to roll back to N-1.
+4. N-1 only knows the legacy shape. Legacy columns are gone. The node will not start.
+
+The two-release gap is what makes step 4 recoverable: in the version-N window, both shapes coexist, so any rollback
+target that knows either shape works.
+
+Mitigations exist (auto-cleanup with a configurable delay, per-migration opt-in, operator-triggered application) but
+each shifts the risk rather than removing it. Until rollback is a supported operator capability and the verification gap
+can be closed some other way, this document mandates the two-release pattern.
+
+## The three migration kinds (plus refinery)
+
+Fast pre-consensus DDL stays as a plain refinery SQL file in `migrations/{postgres,sqlite}/V{N}__name.sql`, the way
+every existing schema change in the repo works today. Refinery already handles fast DDL well: SQL files, history table,
+idempotency-by-version, embedded at compile time. The trait architecture below covers only the cases refinery cannot.
+
+| Kind                   | Trait                  | Runs                       | Transactional | Use for                                                                                                                                |
+| ---------------------- | ---------------------- | -------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Fast pre-consensus DDL | (refinery SQL file)    | Pre-consensus, at startup  | Yes           | `CREATE TABLE`, nullable `ADD COLUMN`, small `ALTER`, `DROP`, `TRUNCATE` of small tables                                               |
+| Deferred schema change | `DeferredSchemaChange` | Background, post-consensus | No            | Slow DDL: `CREATE INDEX CONCURRENTLY`, table rewrites without long locks                                                               |
+| Data backfill          | `DataBackfill`         | Background, post-consensus | Per-batch     | Copying or transforming rows from a legacy shape into a new shape                                                                      |
+| Cleanup migration      | `CleanupMigration`     | Pre-consensus, at startup  | Yes           | Dropping legacy columns or tables after a paired backfill has shipped to all operators (the contract phase of expand-migrate-contract) |
+
+Pick the kind by what the migration physically does, not how long you think it will take. `CREATE INDEX` on a table that
+is small today will block startup for hours once the table grows. The buckets exist so that the choice is explicit at
+review time.
+
+`CleanupMigration` is its own kind rather than a refinery file because the runner enforces its `REQUIRES` precondition
+against the `deferred_migrations` table; refinery has no such hook.
+
+## Authoring rules
+
+A migration that does not satisfy these rules will leave the node either unable to start or unable to serve consensus
+correctly during the migration window.
+
+### Rules for `DeferredSchemaChange`
+
+- Must run outside any transaction. `CREATE INDEX CONCURRENTLY` and similar operations forbid wrapping transactions.
+- Must be idempotent. The runner may invoke `run` repeatedly across restarts. Use `IF NOT EXISTS` and similar guards on
+  every statement. Completion is tracked by the runner in `deferred_migrations`; there is no separate schema-level
+  applied check.
+- For SQLite (where `CONCURRENTLY` is unsupported) the implementation may emit a plain `CREATE INDEX`. Authors implement
+  two `impl` blocks behind `#[cfg(feature = "embedded-db")]` when the SQL differs.
+
+### Rules for `DataBackfill`
+
+- Must be batched. The trait carries a `batch_size()` method (default 1000).
+- Must be resumable. Each call to `migrate_batch(offset)` returns the next offset, or `None` when there is no more work.
+  The runner persists the offset in `deferred_migrations` between batches.
+- Must be idempotent. A batch reapplied at the same offset must produce the same state.
+- Must declare a `DualReadAdapter` (associated type `Adapter`). Reader code routes through the adapter while the
+  backfill is in progress.
+
+### Rules for `CleanupMigration`
+
+- Must declare `requires()`, returning the names of the deferred migrations and backfills it cleans up after. Only data
+  dependencies belong here; index builds and other performance-only migrations do not.
+- The runner refuses to run a cleanup until every required name is marked completed in `deferred_migrations`. This
+  protects an operator who upgrades across two releases without waiting for backfills to finish.
+- Must ship in a release strictly after the release that introduced the paired backfill, and only once telemetry
+  confirms the backfill has completed on every operator. There is no automation for this; it is a release-management
+  decision.
+
+## The dual-read adapter contract
+
+A `DataBackfill` exists because the storage shape of some data changed. While the backfill is in progress, the database
+contains a mixture of legacy rows (unmigrated) and new rows (migrated or freshly written). Reader code must produce
+identical results regardless of which shape a row is in.
+
+This is the role of `DualReadAdapter`. It carries three associated types:
+
+- `Legacy`: the row as written before the migration.
+- `New`: the row as written after the migration (and into which the backfill rewrites legacy rows).
+- `View`: the domain type that callers consume. Stable across the migration window.
+
+And three functions:
+
+- `view_from_legacy(legacy) -> view`: project a legacy row into the domain type.
+- `view_from_new(new) -> view`: project a new row into the domain type.
+- `legacy_to_new(legacy) -> new`: convert in one direction. The backfill calls this. Writers always produce `New`
+  directly.
+
+The contract on these functions is:
+
+1. For any logically equivalent `(legacy, new)` pair, `view_from_legacy(legacy)` equals `view_from_new(new)`.
+2. For any `legacy`, `view_from_new(legacy_to_new(legacy))` equals `view_from_legacy(legacy)`.
+
+The test traits in `hotshot_query_service::testing::migration` enforce both.
+
+Once a backfill is marked complete in `deferred_migrations` on every operator (checked by release management, not the
+runner), a follow-up release may drop the legacy path: remove the `view_from_legacy` callsite, ship a `CleanupMigration`
+that drops the legacy columns or tables, and remove the adapter. This is the contract phase of expand-migrate-contract.
+
+## Testing
+
+Every production trait has a paired test trait under `testing::migration`. The test traits provide default-method
+assertions for invariants the production traits cannot enforce on their own.
+
+| Production trait       | Test trait           | Default-method invariants                             |
+| ---------------------- | -------------------- | ----------------------------------------------------- |
+| `DualReadAdapter`      | `AdapterTest`        | view equivalence, conversion roundtrip                |
+| `DataBackfill`         | `BackfillTest`       | runs to completion, idempotent, resumable from offset |
+| `DeferredSchemaChange` | `DeferredSchemaTest` | not applied before run, applied after run, idempotent |
+
+Implementing a test trait requires only a small amount of boilerplate per migration: an `equivalent_pair()` for
+`AdapterTest`, plus a `seed_legacy` and `assert_all_readable_as_new` for `BackfillTest`. The default methods do the
+rest.
+
+Run the tests with `cargo nextest run -p espresso-node persistence::migrations` or the equivalent for whichever crate
+hosts the migration.
+
+## The `deferred_migrations` table
+
+The runner persists state for deferred and backfill migrations in a single table:
+
+```sql
+CREATE TABLE deferred_migrations (
+    name         TEXT PRIMARY KEY,
+    started_at   TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    error        TEXT,
+    last_offset  BIGINT
+);
+```
+
+- `name`: the migration's `NAME` constant.
+- `started_at`: set on first invocation.
+- `completed_at`: set when `migrate_batch` returns `None` or `is_applied` returns true.
+- `error`: most recent error string, cleared on success. Surfaced via metrics and the `/status/migrations` endpoint.
+- `last_offset`: backfill progress. `NULL` for `DeferredSchemaChange`.
+
+This table is created by a refinery SQL file shipped alongside the runner (at
+`migrations/{postgres,sqlite}/V{N}__deferred_migrations.sql`); it must be present before any deferred work runs.
+
+## Operator visibility (planned)
+
+The runner is planned to expose:
+
+- Metrics: per-migration gauge for state (`pending`, `running`, `completed`, `errored`) and counter for batches
+  processed.
+- HTTP: `GET /status/migrations` returns the rows of `deferred_migrations` plus the static `description()` for each
+  registered migration.
+- Logs: each batch logs its offset and rows processed.
+
+These hooks land alongside the deferred runner. Until then, operators inspect the `deferred_migrations` table directly
+to know when it is safe to upgrade past a contract migration.
+
+## Worked example
+
+A runnable worked example lives at `hotshot-query-service/examples/migration_traits.rs`. It exercises every production
+trait and every test trait against a real Postgres database (via the existing `TmpDb` test helper), using a fictional
+`scores` table whose storage shape changes from a raw byte blob to a structured JSON value. Run it with:
+
+```text
+cargo run -p hotshot-query-service --example migration_traits \
+    --features "sql-data-source,testing"
+```

--- a/hotshot-query-service/Cargo.toml
+++ b/hotshot-query-service/Cargo.toml
@@ -130,5 +130,9 @@ test-log = { workspace = true }
 name = "simple-server"
 required-features = ["sql-data-source", "testing"]
 
+[[example]]
+name = "migration_traits"
+required-features = ["sql-data-source", "testing"]
+
 [lints]
 workspace = true

--- a/hotshot-query-service/examples/migration_traits.rs
+++ b/hotshot-query-service/examples/migration_traits.rs
@@ -1,0 +1,375 @@
+//! Worked example of the storage-migration trait architecture.
+//!
+//! Demonstrates a fictional storage-shape change for a `scores` table. The
+//! legacy table holds a height key and a bincode-encoded byte blob; the new
+//! table holds the same height key and a structured JSONB value. Every
+//! production trait and every test trait is exercised against a real
+//! Postgres database.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p hotshot-query-service \
+//!     --example migration_traits \
+//!     --features "sql-data-source,testing"
+//! ```
+//!
+//! Requires Docker on the host: the example spins up a Postgres container
+//! via [`TmpDb`] and tears it down on exit. The example is deliberately
+//! Postgres-only; `CREATE INDEX CONCURRENTLY` does not exist in SQLite, and
+//! a real-world migration of this shape would only ship for the Postgres
+//! backend.
+
+use anyhow::Context;
+use async_trait::async_trait;
+use hotshot_query_service::{
+    data_source::{
+        Transaction as _, VersionedDataSource,
+        storage::sql::{Db, SqlStorage, StorageConnectionType, Transaction, Write, testing::TmpDb},
+    },
+    migration::{
+        CleanupMigration, DataBackfill, DeferredSchemaChange, DualReadAdapter, MigrationMeta,
+        MigrationRegistry,
+    },
+    testing::migration::{AdapterTest, BackfillTest, DeferredSchemaTest},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Score {
+    pub height: u64,
+    pub value: u64,
+    pub label: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct LegacyScoreRow {
+    pub height: u64,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewScoreRow {
+    pub height: u64,
+    pub value: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize)]
+struct LegacyPayload {
+    value: u64,
+    label: String,
+}
+
+pub struct ScoreAdapter;
+
+impl DualReadAdapter for ScoreAdapter {
+    type View = Score;
+    type Legacy = LegacyScoreRow;
+    type New = NewScoreRow;
+
+    fn view_from_legacy(legacy: Self::Legacy) -> Self::View {
+        let payload: LegacyPayload =
+            bincode::deserialize(&legacy.payload).expect("legacy_scores.payload is valid bincode");
+        Score {
+            height: legacy.height,
+            value: payload.value,
+            label: payload.label,
+        }
+    }
+
+    fn view_from_new(new: Self::New) -> Self::View {
+        Score {
+            height: new.height,
+            value: new.value["value"]
+                .as_u64()
+                .expect("scores.value.value is u64"),
+            label: new.value["label"]
+                .as_str()
+                .expect("scores.value.label is string")
+                .to_owned(),
+        }
+    }
+
+    fn legacy_to_new(legacy: Self::Legacy) -> Self::New {
+        let payload: LegacyPayload =
+            bincode::deserialize(&legacy.payload).expect("legacy_scores.payload is valid bincode");
+        NewScoreRow {
+            height: legacy.height,
+            value: serde_json::json!({ "value": payload.value, "label": payload.label }),
+        }
+    }
+}
+
+pub struct BackfillScores;
+
+impl MigrationMeta for BackfillScores {
+    fn name(&self) -> &'static str {
+        "scores_v1_backfill"
+    }
+    fn order(&self) -> u32 {
+        1
+    }
+}
+
+#[async_trait]
+impl DataBackfill for BackfillScores {
+    type Adapter = ScoreAdapter;
+
+    fn batch_size(&self) -> usize {
+        4
+    }
+
+    async fn migrate_batch(
+        &self,
+        tx: &mut Transaction<Write>,
+        offset: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        let rows = sqlx::query(
+            "SELECT height, payload FROM legacy_scores ORDER BY height LIMIT $1 OFFSET $2",
+        )
+        .bind(self.batch_size() as i64)
+        .bind(offset as i64)
+        .fetch_all(tx.as_mut())
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let n = rows.len();
+        for row in rows {
+            let height: i64 = row.try_get("height")?;
+            let payload: Vec<u8> = row.try_get("payload")?;
+            let new = ScoreAdapter::legacy_to_new(LegacyScoreRow {
+                height: height as u64,
+                payload,
+            });
+            sqlx::query(
+                "INSERT INTO scores (height, value) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            )
+            .bind(new.height as i64)
+            .bind(&new.value)
+            .execute(tx.as_mut())
+            .await?;
+        }
+
+        if n < self.batch_size() {
+            Ok(None)
+        } else {
+            Ok(Some(offset + n as u64))
+        }
+    }
+}
+
+pub struct IndexScores;
+
+impl MigrationMeta for IndexScores {
+    fn name(&self) -> &'static str {
+        "scores_v1_index"
+    }
+    fn order(&self) -> u32 {
+        2
+    }
+}
+
+#[async_trait]
+impl DeferredSchemaChange for IndexScores {
+    async fn run(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        sqlx::query(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS scores_label_idx ON scores \
+             ((value->>'label'))",
+        )
+        .execute(&storage.pool())
+        .await?;
+        Ok(())
+    }
+}
+
+pub struct DropLegacyScores;
+
+impl MigrationMeta for DropLegacyScores {
+    fn name(&self) -> &'static str {
+        "scores_v1_drop_legacy"
+    }
+    fn order(&self) -> u32 {
+        1
+    }
+}
+
+#[async_trait]
+impl CleanupMigration for DropLegacyScores {
+    fn requires(&self) -> &'static [&'static str] {
+        &["scores_v1_backfill"]
+    }
+
+    async fn run(&self, tx: &mut Transaction<Write>) -> anyhow::Result<()> {
+        sqlx::query("DROP TABLE legacy_scores")
+            .execute(tx.as_mut())
+            .await?;
+        Ok(())
+    }
+}
+
+impl AdapterTest for ScoreAdapter {
+    fn equivalent_pair() -> (LegacyScoreRow, NewScoreRow) {
+        let inner = LegacyPayload {
+            value: 42,
+            label: "alpha".to_owned(),
+        };
+        let payload = bincode::serialize(&inner).unwrap();
+        let legacy = LegacyScoreRow { height: 7, payload };
+        let new = NewScoreRow {
+            height: 7,
+            value: serde_json::json!({ "value": 42, "label": "alpha" }),
+        };
+        (legacy, new)
+    }
+}
+
+#[async_trait]
+impl BackfillTest for BackfillScores {
+    async fn seed_legacy(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+        let mut tx = storage.write().await?;
+        sqlx::query("TRUNCATE legacy_scores, scores")
+            .execute(tx.as_mut())
+            .await?;
+        for i in 0..n as u64 {
+            let inner = LegacyPayload {
+                value: i,
+                label: format!("score-{i}"),
+            };
+            let payload = bincode::serialize(&inner)?;
+            sqlx::query("INSERT INTO legacy_scores (height, payload) VALUES ($1, $2)")
+                .bind(i as i64)
+                .bind(&payload)
+                .execute(tx.as_mut())
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn assert_all_readable_as_new(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        let mut tx = storage.read().await?;
+        let legacy_count: i64 = sqlx::query_scalar("SELECT count(*) FROM legacy_scores")
+            .fetch_one(tx.as_mut())
+            .await?;
+        let new_count: i64 = sqlx::query_scalar("SELECT count(*) FROM scores")
+            .fetch_one(tx.as_mut())
+            .await?;
+        anyhow::ensure!(
+            legacy_count == new_count,
+            "row counts diverge after backfill: legacy={legacy_count} new={new_count}",
+        );
+        let rows = sqlx::query("SELECT height, value FROM scores ORDER BY height")
+            .fetch_all(tx.as_mut())
+            .await?;
+        for row in rows {
+            let height: i64 = row.try_get("height")?;
+            let value: serde_json::Value = row.try_get("value")?;
+            let actual = ScoreAdapter::view_from_new(NewScoreRow {
+                height: height as u64,
+                value,
+            });
+            let expected = Score {
+                height: height as u64,
+                value: height as u64,
+                label: format!("score-{}", height),
+            };
+            anyhow::ensure!(
+                actual == expected,
+                "row at height {height} read incorrectly: {actual:?} != {expected:?}",
+            );
+        }
+        Ok(())
+    }
+
+    // assert_runs_to_completion, assert_idempotent, and assert_resumable are
+    // default-implemented by BackfillTest in terms of seed_legacy,
+    // assert_all_readable_as_new, and migrate_batch.
+}
+
+impl DeferredSchemaTest for IndexScores {}
+
+async fn drop_index_if_exists(pool: &sqlx::Pool<Db>) -> anyhow::Result<()> {
+    sqlx::query("DROP INDEX IF EXISTS scores_label_idx")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let db = TmpDb::init().await;
+    let storage = SqlStorage::connect(db.config(), StorageConnectionType::Query)
+        .await
+        .context("connect to TmpDb")?;
+    let pool = storage.pool();
+
+    // The expand phase of any real migration ships as a refinery SQL file in
+    // `migrations/{postgres,sqlite}/V{N}__name.sql`. The example does not have
+    // its own migrations folder, so we run the equivalent DDL inline here to
+    // simulate "release N has shipped and refinery has run." Pretend this
+    // happens before the example starts.
+    apply_expand_phase(&storage).await?;
+
+    let registry = MigrationRegistry::new()
+        .backfill(BackfillScores)
+        .deferred_schema(IndexScores)
+        .cleanup(DropLegacyScores);
+    registry.validate().context("registry validation")?;
+    println!("registry validated");
+    let _ = registry; // registry consumed once the runner wires up
+
+    ScoreAdapter::assert_adapter_laws();
+    println!("adapter laws hold");
+
+    BackfillScores
+        .assert_runs_to_completion(&storage, 10)
+        .await?;
+    println!("backfill: assert_runs_to_completion(n=10) ok");
+
+    BackfillScores
+        .assert_runs_to_completion(&storage, 0)
+        .await?;
+    println!("backfill: assert_runs_to_completion(n=0) ok (empty source)");
+
+    BackfillScores
+        .assert_runs_to_completion(&storage, BackfillScores.batch_size())
+        .await?;
+    println!(
+        "backfill: assert_runs_to_completion(n={}) ok (exact batch boundary)",
+        BackfillScores.batch_size()
+    );
+
+    BackfillScores.assert_idempotent(&storage, 7).await?;
+    println!("backfill: assert_idempotent(n=7) ok");
+
+    BackfillScores.assert_resumable(&storage, 9).await?;
+    println!("backfill: assert_resumable(n=9) ok");
+
+    drop_index_if_exists(&pool).await?;
+    IndexScores.assert_idempotent(&storage).await?;
+    println!("deferred schema: rerun is idempotent");
+
+    let mut tx = storage.write().await?;
+    DropLegacyScores.run(&mut tx).await?;
+    tx.commit().await?;
+    println!("cleanup migration applied");
+
+    println!("\nall migrations and tests passed");
+    Ok(())
+}
+
+async fn apply_expand_phase(storage: &SqlStorage) -> anyhow::Result<()> {
+    let mut tx = storage.write().await?;
+    sqlx::query("CREATE TABLE legacy_scores (height BIGINT PRIMARY KEY, payload BYTEA NOT NULL)")
+        .execute(tx.as_mut())
+        .await?;
+    sqlx::query("CREATE TABLE scores (height BIGINT PRIMARY KEY, value JSONB NOT NULL)")
+        .execute(tx.as_mut())
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/hotshot-query-service/examples/migration_traits.rs
+++ b/hotshot-query-service/examples/migration_traits.rs
@@ -31,7 +31,7 @@ use hotshot_query_service::{
         CleanupMigration, DataBackfill, DeferredSchemaChange, DualReadAdapter, MigrationMeta,
         MigrationRegistry,
     },
-    testing::migration::{AdapterTest, BackfillTest, DeferredSchemaTest},
+    testing::migration::{AdapterTest, BackfillTest, CleanupTest, DeferredSchemaTest},
 };
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
@@ -292,6 +292,47 @@ impl BackfillTest for BackfillScores {
 
 impl DeferredSchemaTest for IndexScores {}
 
+#[async_trait]
+impl CleanupTest for DropLegacyScores {
+    async fn seed_deferred_state(
+        &self,
+        storage: &SqlStorage,
+        completed: &[&'static str],
+    ) -> anyhow::Result<()> {
+        let mut tx = storage.write().await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS deferred_migrations (
+                name TEXT PRIMARY KEY,
+                completed_at TIMESTAMPTZ
+            )",
+        )
+        .execute(tx.as_mut())
+        .await?;
+        sqlx::query("DELETE FROM deferred_migrations")
+            .execute(tx.as_mut())
+            .await?;
+        for name in completed {
+            sqlx::query("INSERT INTO deferred_migrations (name, completed_at) VALUES ($1, NOW())")
+                .bind(*name)
+                .execute(tx.as_mut())
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn assert_legacy_gone(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        let mut tx = storage.read().await?;
+        let count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM information_schema.tables WHERE table_name = 'legacy_scores'",
+        )
+        .fetch_one(tx.as_mut())
+        .await?;
+        anyhow::ensure!(count == 0, "legacy_scores still exists after cleanup");
+        Ok(())
+    }
+}
+
 async fn drop_index_if_exists(pool: &sqlx::Pool<Db>) -> anyhow::Result<()> {
     sqlx::query("DROP INDEX IF EXISTS scores_label_idx")
         .execute(pool)
@@ -353,10 +394,15 @@ async fn main() -> anyhow::Result<()> {
     IndexScores.assert_idempotent(&storage).await?;
     println!("deferred schema: rerun is idempotent");
 
-    let mut tx = storage.write().await?;
-    DropLegacyScores.run(&mut tx).await?;
-    tx.commit().await?;
-    println!("cleanup migration applied");
+    DropLegacyScores
+        .assert_refuses_when_requires_unmet(&storage)
+        .await?;
+    println!("cleanup: refuses when requires unmet");
+
+    DropLegacyScores
+        .assert_succeeds_when_requires_met(&storage)
+        .await?;
+    println!("cleanup: succeeds when requires met (legacy_scores dropped)");
 
     println!("\nall migrations and tests passed");
     Ok(())

--- a/hotshot-query-service/examples/migration_traits.rs
+++ b/hotshot-query-service/examples/migration_traits.rs
@@ -68,36 +68,38 @@ impl DualReadAdapter for ScoreAdapter {
     type Legacy = LegacyScoreRow;
     type New = NewScoreRow;
 
-    fn view_from_legacy(legacy: Self::Legacy) -> Self::View {
-        let payload: LegacyPayload =
-            bincode::deserialize(&legacy.payload).expect("legacy_scores.payload is valid bincode");
-        Score {
+    fn view_from_legacy(legacy: Self::Legacy) -> anyhow::Result<Self::View> {
+        let payload: LegacyPayload = bincode::deserialize(&legacy.payload)
+            .context("legacy_scores.payload is not valid bincode")?;
+        Ok(Score {
             height: legacy.height,
             value: payload.value,
             label: payload.label,
-        }
+        })
     }
 
-    fn view_from_new(new: Self::New) -> Self::View {
-        Score {
+    fn view_from_new(new: Self::New) -> anyhow::Result<Self::View> {
+        let value = new.value["value"]
+            .as_u64()
+            .context("scores.value.value missing or not u64")?;
+        let label = new.value["label"]
+            .as_str()
+            .context("scores.value.label missing or not string")?
+            .to_owned();
+        Ok(Score {
             height: new.height,
-            value: new.value["value"]
-                .as_u64()
-                .expect("scores.value.value is u64"),
-            label: new.value["label"]
-                .as_str()
-                .expect("scores.value.label is string")
-                .to_owned(),
-        }
+            value,
+            label,
+        })
     }
 
-    fn legacy_to_new(legacy: Self::Legacy) -> Self::New {
-        let payload: LegacyPayload =
-            bincode::deserialize(&legacy.payload).expect("legacy_scores.payload is valid bincode");
-        NewScoreRow {
+    fn legacy_to_new(legacy: Self::Legacy) -> anyhow::Result<Self::New> {
+        let payload: LegacyPayload = bincode::deserialize(&legacy.payload)
+            .context("legacy_scores.payload is not valid bincode")?;
+        Ok(NewScoreRow {
             height: legacy.height,
             value: serde_json::json!({ "value": payload.value, "label": payload.label }),
-        }
+        })
     }
 }
 
@@ -126,10 +128,10 @@ impl DataBackfill for BackfillScores {
         offset: u64,
     ) -> anyhow::Result<Option<u64>> {
         let rows = sqlx::query(
-            "SELECT height, payload FROM legacy_scores ORDER BY height LIMIT $1 OFFSET $2",
+            "SELECT height, payload FROM legacy_scores WHERE height >= $1 ORDER BY height LIMIT $2",
         )
-        .bind(self.batch_size() as i64)
         .bind(offset as i64)
+        .bind(self.batch_size() as i64)
         .fetch_all(tx.as_mut())
         .await?;
 
@@ -138,13 +140,14 @@ impl DataBackfill for BackfillScores {
         }
 
         let n = rows.len();
+        let mut last_height = offset;
         for row in rows {
             let height: i64 = row.try_get("height")?;
             let payload: Vec<u8> = row.try_get("payload")?;
             let new = ScoreAdapter::legacy_to_new(LegacyScoreRow {
                 height: height as u64,
                 payload,
-            });
+            })?;
             sqlx::query(
                 "INSERT INTO scores (height, value) VALUES ($1, $2) ON CONFLICT DO NOTHING",
             )
@@ -152,12 +155,13 @@ impl DataBackfill for BackfillScores {
             .bind(&new.value)
             .execute(tx.as_mut())
             .await?;
+            last_height = height as u64;
         }
 
         if n < self.batch_size() {
             Ok(None)
         } else {
-            Ok(Some(offset + n as u64))
+            Ok(Some(last_height + 1))
         }
     }
 }
@@ -271,7 +275,7 @@ impl BackfillTest for BackfillScores {
             let actual = ScoreAdapter::view_from_new(NewScoreRow {
                 height: height as u64,
                 value,
-            });
+            })?;
             let expected = Score {
                 height: height as u64,
                 value: height as u64,
@@ -363,7 +367,7 @@ async fn main() -> anyhow::Result<()> {
     println!("registry validated");
     let _ = registry; // registry consumed once the runner wires up
 
-    ScoreAdapter::assert_adapter_laws();
+    ScoreAdapter::assert_adapter_laws()?;
     println!("adapter laws hold");
 
     BackfillScores

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1373,36 +1373,6 @@ mod test {
         connect(true, migrations).await.unwrap();
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    #[cfg(not(feature = "embedded-db"))]
-    async fn test_create_index_concurrently_via_refinery() {
-        let db = TmpDb::init().await;
-        let cfg = db.config();
-
-        SqlStorage::connect(cfg.clone(), StorageConnectionType::Query)
-            .await
-            .unwrap();
-
-        let migrations = vec![
-            Migration::unapplied(
-                "V9999__concurrent_index.sql",
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS leaf2_view_idx ON leaf2 (view);",
-            )
-            .unwrap(),
-        ];
-
-        let err = SqlStorage::connect(cfg.migrations(migrations), StorageConnectionType::Query)
-            .await
-            .expect_err("CREATE INDEX CONCURRENTLY must fail under refinery's tx wrapper");
-
-        let msg = format!("{err:#}");
-        tracing::info!("refinery rejected CREATE INDEX CONCURRENTLY: {msg}");
-        assert!(
-            msg.contains("CREATE INDEX CONCURRENTLY cannot run inside a transaction block"),
-            "unexpected error: {msg}"
-        );
-    }
-
     #[test]
     #[cfg(not(feature = "embedded-db"))]
     fn test_config_from_str() {

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -1373,6 +1373,36 @@ mod test {
         connect(true, migrations).await.unwrap();
     }
 
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg(not(feature = "embedded-db"))]
+    async fn test_create_index_concurrently_via_refinery() {
+        let db = TmpDb::init().await;
+        let cfg = db.config();
+
+        SqlStorage::connect(cfg.clone(), StorageConnectionType::Query)
+            .await
+            .unwrap();
+
+        let migrations = vec![
+            Migration::unapplied(
+                "V9999__concurrent_index.sql",
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS leaf2_view_idx ON leaf2 (view);",
+            )
+            .unwrap(),
+        ];
+
+        let err = SqlStorage::connect(cfg.migrations(migrations), StorageConnectionType::Query)
+            .await
+            .expect_err("CREATE INDEX CONCURRENTLY must fail under refinery's tx wrapper");
+
+        let msg = format!("{err:#}");
+        tracing::info!("refinery rejected CREATE INDEX CONCURRENTLY: {msg}");
+        assert!(
+            msg.contains("CREATE INDEX CONCURRENTLY cannot run inside a transaction block"),
+            "unexpected error: {msg}"
+        );
+    }
+
     #[test]
     #[cfg(not(feature = "embedded-db"))]
     fn test_config_from_str() {

--- a/hotshot-query-service/src/lib.rs
+++ b/hotshot-query-service/src/lib.rs
@@ -421,6 +421,8 @@ pub mod explorer;
 pub mod fetching;
 pub mod merklized_state;
 pub mod metrics;
+#[cfg(feature = "sql-data-source")]
+pub mod migration;
 pub mod node;
 mod resolvable;
 pub mod status;

--- a/hotshot-query-service/src/migration.rs
+++ b/hotshot-query-service/src/migration.rs
@@ -1,0 +1,456 @@
+//! Trait architecture for non-blocking SQL storage migrations.
+//!
+//! See `doc/storage-migrations.md` in the workspace root for the prose
+//! description and authoring rules. This module defines only the trait
+//! surface and the registry that organizes migrations into three buckets.
+//! The actual runner that drives deferred work lives alongside the
+//! [`SqlStorage`] in `data_source::storage::sql`.
+//!
+//! Fast pre-consensus DDL stays as plain refinery SQL files in
+//! `migrations/{postgres,sqlite}/`; this module covers only the cases
+//! refinery cannot handle. Each migration implements [`MigrationMeta`] for
+//! its identity plus exactly one of the three kind traits:
+//!
+//! - [`DeferredSchemaChange`]: slow DDL (for example
+//!   `CREATE INDEX CONCURRENTLY`), runs post-consensus, non-transactional.
+//! - [`DataBackfill`]: batched data rewrite, runs post-consensus, paired with
+//!   a [`DualReadAdapter`] that keeps readers correct during the backfill
+//!   window.
+//! - [`CleanupMigration`]: cleanup that drops legacy state once a paired
+//!   backfill has shipped to every operator.
+//!
+//! The kind traits are directly object-safe; [`MigrationRegistry`] stores
+//! `Box<dyn KindTrait>` for each bucket.
+
+use std::collections::HashSet;
+
+use anyhow::bail;
+use async_trait::async_trait;
+
+use crate::data_source::storage::sql::{SqlStorage, Transaction, Write};
+
+/// Identity carried by every migration.
+///
+/// `name` is persisted in the `deferred_migrations` table and referenced from
+/// [`CleanupMigration::requires`]. It must be globally unique and stable for
+/// the lifetime of the migration. `order` is unique within each bucket and
+/// determines the order in which migrations of the same kind run.
+pub trait MigrationMeta: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+    fn order(&self) -> u32;
+}
+
+/// Slow DDL run as a background task post-consensus, outside any transaction.
+///
+/// Required for operations such as `CREATE INDEX CONCURRENTLY` that forbid a
+/// surrounding transaction. Implementations must be idempotent because the
+/// runner may invoke `run` repeatedly across restarts; in practice this means
+/// using `IF NOT EXISTS` and similar guards on every statement. Completion
+/// is tracked by the runner in `deferred_migrations`; there is no separate
+/// schema-level applied check.
+#[async_trait]
+pub trait DeferredSchemaChange: MigrationMeta {
+    async fn run(&self, storage: &SqlStorage) -> anyhow::Result<()>;
+}
+
+/// Batched data rewrite run as a background task post-consensus.
+///
+/// Each batch is processed inside a write transaction; the runner persists the
+/// returned offset in `deferred_migrations` between batches so a restart
+/// resumes from the last committed point. A backfill is paired with a
+/// [`DualReadAdapter`] that keeps reader code correct against the mixture of
+/// legacy and new rows that exists during the migration window.
+///
+/// The associated `Adapter` type is exposed for type-checking the impl; it is
+/// not visible through the registry. Reader code references the concrete
+/// adapter type directly at the callsite and does not look it up via the
+/// registry.
+#[async_trait]
+pub trait DataBackfill: MigrationMeta {
+    type Adapter: DualReadAdapter;
+
+    fn batch_size(&self) -> usize {
+        1_000
+    }
+
+    async fn migrate_batch(
+        &self,
+        tx: &mut Transaction<Write>,
+        offset: u64,
+    ) -> anyhow::Result<Option<u64>>;
+}
+
+/// Cleanup run pre-consensus that drops legacy state once a paired backfill
+/// has shipped to every operator.
+///
+/// `requires` returns the names of the deferred migrations and backfills that
+/// must be marked completed in `deferred_migrations` before this cleanup may
+/// run. The runner refuses to execute a cleanup whose requirements are unmet,
+/// protecting an operator who upgrades across two releases without waiting
+/// for the backfill to finish.
+#[async_trait]
+pub trait CleanupMigration: MigrationMeta {
+    fn requires(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    async fn run(&self, tx: &mut Transaction<Write>) -> anyhow::Result<()>;
+}
+
+/// Reader-side compatibility shim for the duration of a backfill.
+///
+/// Carries three associated types: [`DualReadAdapter::Legacy`] (the old
+/// storage shape), [`DualReadAdapter::New`] (the new storage shape, what
+/// writers produce and what the backfill rewrites legacy rows into), and
+/// [`DualReadAdapter::View`] (the domain type callers consume, stable across
+/// the migration window).
+///
+/// The two contract laws an implementation must satisfy:
+///
+/// 1. For any logically equivalent `(legacy, new)` pair,
+///    `view_from_legacy(legacy)` equals `view_from_new(new)`.
+/// 2. For any `legacy`,
+///    `view_from_new(legacy_to_new(legacy))` equals `view_from_legacy(legacy)`.
+///
+/// Both laws are enforced by the
+/// [`AdapterTest`](crate::testing::migration::AdapterTest) test trait.
+pub trait DualReadAdapter: Send + Sync + 'static {
+    type View;
+    type Legacy;
+    type New;
+
+    fn view_from_legacy(legacy: Self::Legacy) -> Self::View;
+    fn view_from_new(new: Self::New) -> Self::View;
+    fn legacy_to_new(legacy: Self::Legacy) -> Self::New;
+}
+
+/// Builder-style inventory of all migrations the application registers.
+///
+/// Heterogeneous migrations land in the bucket matching their kind. After
+/// every migration is registered, [`MigrationRegistry::validate`] enforces
+/// global invariants:
+///
+/// - `MigrationMeta::name` is unique across all three buckets.
+/// - `MigrationMeta::order` is unique within each bucket.
+/// - Every name listed in a [`CleanupMigration::requires`] refers to a
+///   registered deferred migration or backfill.
+///
+/// Validation is startup-time rather than compile-time because heterogeneous
+/// trait objects preclude const evaluation across crates. A failure here
+/// stops the node from starting, which is the desired outcome.
+#[derive(Default)]
+pub struct MigrationRegistry {
+    deferred_schema: Vec<Box<dyn DeferredSchemaChange>>,
+    backfills: Vec<Box<dyn DataBackfillErased>>,
+    cleanups: Vec<Box<dyn CleanupMigration>>,
+}
+
+/// Object-safe view of [`DataBackfill`] used inside [`MigrationRegistry`].
+///
+/// Trait objects cannot carry an associated type, so the registry stores
+/// backfills behind this erased trait. Reader code never sees this trait;
+/// it references the concrete migration type and its `Adapter` directly.
+/// The methods below are dead code until the deferred runner lands; the
+/// runner invokes them when driving registered backfills.
+#[async_trait]
+#[allow(dead_code)]
+trait DataBackfillErased: MigrationMeta {
+    fn batch_size(&self) -> usize;
+    async fn migrate_batch(
+        &self,
+        tx: &mut Transaction<Write>,
+        offset: u64,
+    ) -> anyhow::Result<Option<u64>>;
+}
+
+#[async_trait]
+impl<T: DataBackfill> DataBackfillErased for T {
+    fn batch_size(&self) -> usize {
+        DataBackfill::batch_size(self)
+    }
+    async fn migrate_batch(
+        &self,
+        tx: &mut Transaction<Write>,
+        offset: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        DataBackfill::migrate_batch(self, tx, offset).await
+    }
+}
+
+impl MigrationRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn deferred_schema<M: DeferredSchemaChange>(mut self, m: M) -> Self {
+        self.deferred_schema.push(Box::new(m));
+        self
+    }
+
+    pub fn backfill<M: DataBackfill>(mut self, m: M) -> Self {
+        self.backfills.push(Box::new(m));
+        self
+    }
+
+    pub fn cleanup<M: CleanupMigration>(mut self, m: M) -> Self {
+        self.cleanups.push(Box::new(m));
+        self
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let mut all_names: HashSet<&'static str> = HashSet::new();
+        let mut deferred_names: HashSet<&'static str> = HashSet::new();
+        let mut deferred_orders: HashSet<u32> = HashSet::new();
+        let mut backfill_orders: HashSet<u32> = HashSet::new();
+        let mut cleanup_orders: HashSet<u32> = HashSet::new();
+
+        for m in &self.deferred_schema {
+            check_unique(
+                "deferred_schema",
+                m.name(),
+                m.order(),
+                &mut all_names,
+                &mut deferred_orders,
+            )?;
+            deferred_names.insert(m.name());
+        }
+        for m in &self.backfills {
+            check_unique(
+                "backfill",
+                m.name(),
+                m.order(),
+                &mut all_names,
+                &mut backfill_orders,
+            )?;
+            deferred_names.insert(m.name());
+        }
+        for m in &self.cleanups {
+            check_unique(
+                "cleanup",
+                m.name(),
+                m.order(),
+                &mut all_names,
+                &mut cleanup_orders,
+            )?;
+        }
+
+        for c in &self.cleanups {
+            for required in c.requires() {
+                if !deferred_names.contains(required) {
+                    bail!(
+                        "cleanup migration {} requires {} which is not a registered deferred or \
+                         backfill migration",
+                        c.name(),
+                        required,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn deferred_schema_migrations(&self) -> &[Box<dyn DeferredSchemaChange>] {
+        &self.deferred_schema
+    }
+
+    pub fn cleanup_migrations(&self) -> &[Box<dyn CleanupMigration>] {
+        &self.cleanups
+    }
+}
+
+fn check_unique(
+    bucket: &'static str,
+    name: &'static str,
+    order: u32,
+    all_names: &mut HashSet<&'static str>,
+    bucket_orders: &mut HashSet<u32>,
+) -> anyhow::Result<()> {
+    if !all_names.insert(name) {
+        bail!("duplicate migration name {} (bucket {})", name, bucket);
+    }
+    if !bucket_orders.insert(order) {
+        bail!("duplicate ORDER {} in bucket {}", order, bucket);
+    }
+    Ok(())
+}
+
+// TODO: wire the background runner that drives deferred work post-consensus
+// alongside `SqlStorage::connect`. This module currently stops at the trait
+// surface and the registry.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubBackfill;
+    impl MigrationMeta for StubBackfill {
+        fn name(&self) -> &'static str {
+            "stub_backfill"
+        }
+        fn order(&self) -> u32 {
+            1
+        }
+    }
+    struct StubAdapter;
+    impl DualReadAdapter for StubAdapter {
+        type View = ();
+        type Legacy = ();
+        type New = ();
+        fn view_from_legacy(_: ()) {}
+        fn view_from_new(_: ()) {}
+        fn legacy_to_new(_: ()) {}
+    }
+    #[async_trait]
+    impl DataBackfill for StubBackfill {
+        type Adapter = StubAdapter;
+        async fn migrate_batch(
+            &self,
+            _tx: &mut Transaction<Write>,
+            _offset: u64,
+        ) -> anyhow::Result<Option<u64>> {
+            Ok(None)
+        }
+    }
+
+    struct OkCleanup;
+    impl MigrationMeta for OkCleanup {
+        fn name(&self) -> &'static str {
+            "ok_cleanup"
+        }
+        fn order(&self) -> u32 {
+            2
+        }
+    }
+    #[async_trait]
+    impl CleanupMigration for OkCleanup {
+        fn requires(&self) -> &'static [&'static str] {
+            &["stub_backfill"]
+        }
+        async fn run(&self, _tx: &mut Transaction<Write>) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct DanglingCleanup;
+    impl MigrationMeta for DanglingCleanup {
+        fn name(&self) -> &'static str {
+            "dangling_cleanup"
+        }
+        fn order(&self) -> u32 {
+            3
+        }
+    }
+    #[async_trait]
+    impl CleanupMigration for DanglingCleanup {
+        fn requires(&self) -> &'static [&'static str] {
+            &["nonexistent"]
+        }
+        async fn run(&self, _tx: &mut Transaction<Write>) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn empty_registry_is_valid() {
+        MigrationRegistry::new().validate().unwrap();
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        struct A;
+        impl MigrationMeta for A {
+            fn name(&self) -> &'static str {
+                "dup"
+            }
+            fn order(&self) -> u32 {
+                1
+            }
+        }
+        #[async_trait]
+        impl DeferredSchemaChange for A {
+            async fn run(&self, _: &SqlStorage) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+        struct B;
+        impl MigrationMeta for B {
+            fn name(&self) -> &'static str {
+                "dup"
+            }
+            fn order(&self) -> u32 {
+                2
+            }
+        }
+        #[async_trait]
+        impl DeferredSchemaChange for B {
+            async fn run(&self, _: &SqlStorage) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+        let err = MigrationRegistry::new()
+            .deferred_schema(A)
+            .deferred_schema(B)
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate migration name"));
+        assert!(err.to_string().contains("deferred_schema"));
+    }
+
+    #[test]
+    fn duplicate_order_rejected() {
+        struct A;
+        impl MigrationMeta for A {
+            fn name(&self) -> &'static str {
+                "a"
+            }
+            fn order(&self) -> u32 {
+                1
+            }
+        }
+        #[async_trait]
+        impl DeferredSchemaChange for A {
+            async fn run(&self, _: &SqlStorage) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+        struct B;
+        impl MigrationMeta for B {
+            fn name(&self) -> &'static str {
+                "b"
+            }
+            fn order(&self) -> u32 {
+                1
+            }
+        }
+        #[async_trait]
+        impl DeferredSchemaChange for B {
+            async fn run(&self, _: &SqlStorage) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+        let err = MigrationRegistry::new()
+            .deferred_schema(A)
+            .deferred_schema(B)
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate ORDER"));
+    }
+
+    #[test]
+    fn missing_requires_rejected() {
+        let err = MigrationRegistry::new()
+            .cleanup(DanglingCleanup)
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn requires_resolved_against_backfill() {
+        MigrationRegistry::new()
+            .backfill(StubBackfill)
+            .cleanup(OkCleanup)
+            .validate()
+            .unwrap();
+    }
+}

--- a/hotshot-query-service/src/migration.rs
+++ b/hotshot-query-service/src/migration.rs
@@ -119,9 +119,9 @@ pub trait DualReadAdapter: Send + Sync + 'static {
     type Legacy;
     type New;
 
-    fn view_from_legacy(legacy: Self::Legacy) -> Self::View;
-    fn view_from_new(new: Self::New) -> Self::View;
-    fn legacy_to_new(legacy: Self::Legacy) -> Self::New;
+    fn view_from_legacy(legacy: Self::Legacy) -> anyhow::Result<Self::View>;
+    fn view_from_new(new: Self::New) -> anyhow::Result<Self::View>;
+    fn legacy_to_new(legacy: Self::Legacy) -> anyhow::Result<Self::New>;
 }
 
 /// Builder-style inventory of all migrations the application registers.
@@ -296,9 +296,15 @@ mod tests {
         type View = ();
         type Legacy = ();
         type New = ();
-        fn view_from_legacy(_: ()) {}
-        fn view_from_new(_: ()) {}
-        fn legacy_to_new(_: ()) {}
+        fn view_from_legacy(_: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn view_from_new(_: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn legacy_to_new(_: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
     }
     #[async_trait]
     impl DataBackfill for StubBackfill {

--- a/hotshot-query-service/src/testing.rs
+++ b/hotshot-query-service/src/testing.rs
@@ -14,6 +14,8 @@
 use std::time::Duration;
 
 pub mod consensus;
+#[cfg(feature = "sql-data-source")]
+pub mod migration;
 pub mod mocks;
 
 pub async fn sleep(dur: Duration) {

--- a/hotshot-query-service/src/testing/migration.rs
+++ b/hotshot-query-service/src/testing/migration.rs
@@ -1,0 +1,158 @@
+//! Test trait extensions for migration implementations.
+//!
+//! Each test trait encodes invariants the corresponding production trait
+//! cannot enforce on its own. Default-method assertions cover the
+//! orchestration (drive batches, repeat runs, verify two adapter laws);
+//! authors still write the bulk of the work — fixture seeding and the
+//! shape-specific final-state checks.
+//!
+//! - [`AdapterTest`]: pure, no DB. Author supplies [`AdapterTest::equivalent_pair`].
+//! - [`BackfillTest`]: needs a DB. Author supplies [`BackfillTest::seed_legacy`]
+//!   and [`BackfillTest::assert_all_readable_as_new`]; the three assertion
+//!   methods are default-implemented in terms of those two and `migrate_batch`.
+//! - [`DeferredSchemaTest`]: needs a DB. The single assertion is
+//!   default-implemented in terms of `self.run`.
+//!
+//! The design intent is captured in `doc/storage-migrations.md`.
+
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+
+use crate::{
+    data_source::{Transaction as _, VersionedDataSource, storage::sql::SqlStorage},
+    migration::{DataBackfill, DeferredSchemaChange, DualReadAdapter},
+};
+
+/// Test extension for [`DualReadAdapter`].
+///
+/// Pure: requires no database. Implementations supply
+/// [`AdapterTest::equivalent_pair`] returning a logically equivalent
+/// `(Legacy, New)` representation of the same domain value, and the default
+/// methods verify the two adapter laws.
+pub trait AdapterTest: DualReadAdapter
+where
+    Self::Legacy: Clone + Debug,
+    Self::New: Clone + Debug,
+    Self::View: PartialEq + Debug,
+{
+    /// A logically equivalent pair: the same domain value expressed in both
+    /// storage representations.
+    fn equivalent_pair() -> (Self::Legacy, Self::New);
+
+    /// Law 1: both projections produce the same `View`.
+    fn assert_views_match() {
+        let (legacy, new) = Self::equivalent_pair();
+        let via_legacy = Self::view_from_legacy(legacy);
+        let via_new = Self::view_from_new(new);
+        assert_eq!(
+            via_legacy, via_new,
+            "view_from_legacy and view_from_new disagree"
+        );
+    }
+
+    /// Law 2: converting then reading equals reading directly.
+    fn assert_conversion_roundtrip() {
+        let (legacy, _) = Self::equivalent_pair();
+        let direct = Self::view_from_legacy(legacy.clone());
+        let converted = Self::view_from_new(Self::legacy_to_new(legacy));
+        assert_eq!(
+            direct, converted,
+            "legacy_to_new is not view-preserving: view_from_legacy != \
+             view_from_new(legacy_to_new)",
+        );
+    }
+
+    /// Combined check; call this from a test.
+    fn assert_adapter_laws() {
+        Self::assert_views_match();
+        Self::assert_conversion_roundtrip();
+    }
+}
+
+/// Test extension for [`DataBackfill`].
+///
+/// Implementations supply two methods: [`BackfillTest::seed_legacy`]
+/// populates the test database with `n` legacy-format rows, and
+/// [`BackfillTest::assert_all_readable_as_new`] verifies that every seeded
+/// row reads through the new path with the expected `View`. Both are
+/// shape-specific and non-trivial. The three assertion methods are
+/// default-implemented on top of them so authors avoid the batch driver
+/// loop and transaction plumbing.
+///
+/// Note that [`BackfillTest::assert_resumable`] currently exercises only
+/// the offset-passing path; it does not compare against an uninterrupted
+/// baseline. A stronger resumability check arrives once the deferred
+/// runner persists offsets through restarts.
+#[async_trait]
+pub trait BackfillTest: DataBackfill {
+    /// Populate the test database with `n` legacy-format rows. Implementations
+    /// should also clear any state left by a previous assertion run so
+    /// successive calls are independent.
+    async fn seed_legacy(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()>;
+
+    /// Verify every seeded row is readable through the new path with the
+    /// `View` produced by [`DualReadAdapter::view_from_legacy`].
+    async fn assert_all_readable_as_new(&self, storage: &SqlStorage) -> anyhow::Result<()>;
+
+    /// Drive the backfill to completion and verify the final state.
+    async fn assert_runs_to_completion(
+        &self,
+        storage: &SqlStorage,
+        n: usize,
+    ) -> anyhow::Result<()> {
+        self.seed_legacy(storage, n).await?;
+        drive_to_completion(self, storage).await?;
+        self.assert_all_readable_as_new(storage).await
+    }
+
+    /// Drive the backfill to completion twice; the second run must observe
+    /// an already-completed state and not change the final result.
+    async fn assert_idempotent(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+        self.seed_legacy(storage, n).await?;
+        drive_to_completion(self, storage).await?;
+        drive_to_completion(self, storage).await?;
+        self.assert_all_readable_as_new(storage).await
+    }
+
+    /// Drive a single batch, simulate a restart, then drive to completion.
+    /// The final state must match a single uninterrupted run.
+    async fn assert_resumable(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+        self.seed_legacy(storage, n).await?;
+        let mut tx = storage.write().await?;
+        let _ = self.migrate_batch(&mut tx, 0).await?;
+        tx.commit().await?;
+        drive_to_completion(self, storage).await?;
+        self.assert_all_readable_as_new(storage).await
+    }
+}
+
+async fn drive_to_completion<B: BackfillTest + ?Sized>(
+    backfill: &B,
+    storage: &SqlStorage,
+) -> anyhow::Result<()> {
+    let mut offset = 0u64;
+    loop {
+        let mut tx = storage.write().await?;
+        let next = backfill.migrate_batch(&mut tx, offset).await?;
+        tx.commit().await?;
+        match next {
+            Some(new_offset) => offset = new_offset,
+            None => return Ok(()),
+        }
+    }
+}
+
+/// Test extension for [`DeferredSchemaChange`].
+///
+/// One default-method assertion exercises idempotency: calling `run` twice
+/// must not error. The migration's SQL must use `IF NOT EXISTS` (or
+/// equivalent guards) for this to hold.
+#[async_trait]
+pub trait DeferredSchemaTest: DeferredSchemaChange {
+    async fn assert_idempotent(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        self.run(storage).await?;
+        self.run(storage).await?;
+        Ok(())
+    }
+}

--- a/hotshot-query-service/src/testing/migration.rs
+++ b/hotshot-query-service/src/testing/migration.rs
@@ -46,32 +46,34 @@ where
     fn equivalent_pair() -> (Self::Legacy, Self::New);
 
     /// Law 1: both projections produce the same `View`.
-    fn assert_views_match() {
+    fn assert_views_match() -> anyhow::Result<()> {
         let (legacy, new) = Self::equivalent_pair();
-        let via_legacy = Self::view_from_legacy(legacy);
-        let via_new = Self::view_from_new(new);
-        assert_eq!(
-            via_legacy, via_new,
-            "view_from_legacy and view_from_new disagree"
+        let via_legacy = Self::view_from_legacy(legacy)?;
+        let via_new = Self::view_from_new(new)?;
+        anyhow::ensure!(
+            via_legacy == via_new,
+            "view_from_legacy and view_from_new disagree: {via_legacy:?} != {via_new:?}",
         );
+        Ok(())
     }
 
     /// Law 2: converting then reading equals reading directly.
-    fn assert_conversion_roundtrip() {
+    fn assert_conversion_roundtrip() -> anyhow::Result<()> {
         let (legacy, _) = Self::equivalent_pair();
-        let direct = Self::view_from_legacy(legacy.clone());
-        let converted = Self::view_from_new(Self::legacy_to_new(legacy));
-        assert_eq!(
-            direct, converted,
+        let direct = Self::view_from_legacy(legacy.clone())?;
+        let converted = Self::view_from_new(Self::legacy_to_new(legacy)?)?;
+        anyhow::ensure!(
+            direct == converted,
             "legacy_to_new is not view-preserving: view_from_legacy != \
-             view_from_new(legacy_to_new)",
+             view_from_new(legacy_to_new): {direct:?} != {converted:?}",
         );
+        Ok(())
     }
 
     /// Combined check; call this from a test.
-    fn assert_adapter_laws() {
-        Self::assert_views_match();
-        Self::assert_conversion_roundtrip();
+    fn assert_adapter_laws() -> anyhow::Result<()> {
+        Self::assert_views_match()?;
+        Self::assert_conversion_roundtrip()
     }
 }
 

--- a/hotshot-query-service/src/testing/migration.rs
+++ b/hotshot-query-service/src/testing/migration.rs
@@ -2,9 +2,9 @@
 //!
 //! Each test trait encodes invariants the corresponding production trait
 //! cannot enforce on its own. Default-method assertions cover the
-//! orchestration (drive batches, repeat runs, verify two adapter laws);
-//! authors still write the bulk of the work — fixture seeding and the
-//! shape-specific final-state checks.
+//! orchestration (drive batches, repeat runs, verify two adapter laws,
+//! exercise the cleanup precondition); authors still write the bulk of the
+//! work — fixture seeding and the shape-specific final-state checks.
 //!
 //! - [`AdapterTest`]: pure, no DB. Author supplies [`AdapterTest::equivalent_pair`].
 //! - [`BackfillTest`]: needs a DB. Author supplies [`BackfillTest::seed_legacy`]
@@ -12,6 +12,11 @@
 //!   methods are default-implemented in terms of those two and `migrate_batch`.
 //! - [`DeferredSchemaTest`]: needs a DB. The single assertion is
 //!   default-implemented in terms of `self.run`.
+//! - [`CleanupTest`]: needs a DB. Author supplies
+//!   [`CleanupTest::seed_deferred_state`] and
+//!   [`CleanupTest::assert_legacy_gone`]; the two assertion methods exercise
+//!   the cleanup's precondition logic against a synthetic `deferred_migrations`
+//!   row set.
 //!
 //! The design intent is captured in `doc/storage-migrations.md`.
 
@@ -21,7 +26,7 @@ use async_trait::async_trait;
 
 use crate::{
     data_source::{Transaction as _, VersionedDataSource, storage::sql::SqlStorage},
-    migration::{DataBackfill, DeferredSchemaChange, DualReadAdapter},
+    migration::{CleanupMigration, DataBackfill, DeferredSchemaChange, DualReadAdapter},
 };
 
 /// Test extension for [`DualReadAdapter`].
@@ -141,6 +146,79 @@ async fn drive_to_completion<B: BackfillTest + ?Sized>(
             None => return Ok(()),
         }
     }
+}
+
+/// Test extension for [`CleanupMigration`].
+///
+/// Implementations supply [`CleanupTest::seed_deferred_state`] (populate the
+/// `deferred_migrations` table with rows marking the listed migration names
+/// as completed; rows for unlisted names are absent) and
+/// [`CleanupTest::assert_legacy_gone`] (verify the legacy state the cleanup
+/// removes is in fact gone). The two assertion methods exercise both branches
+/// of the precondition: the cleanup must refuse when its requirements are
+/// unmet and succeed when they are met.
+#[async_trait]
+pub trait CleanupTest: CleanupMigration {
+    /// Reset the `deferred_migrations` table (creating it if needed) and mark
+    /// each name in `completed` as done. Names not in `completed` are absent
+    /// from the table.
+    async fn seed_deferred_state(
+        &self,
+        storage: &SqlStorage,
+        completed: &[&'static str],
+    ) -> anyhow::Result<()>;
+
+    /// After the cleanup has run, verify the legacy state it targets is gone.
+    async fn assert_legacy_gone(&self, storage: &SqlStorage) -> anyhow::Result<()>;
+
+    /// With none of the requirements completed, attempting to run the cleanup
+    /// must fail. Operator upgrade safety depends on this.
+    async fn assert_refuses_when_requires_unmet(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        self.seed_deferred_state(storage, &[]).await?;
+        let result = run_cleanup_with_precondition(self, storage).await;
+        anyhow::ensure!(
+            result.is_err(),
+            "cleanup {} ran despite unmet requirements",
+            self.name(),
+        );
+        Ok(())
+    }
+
+    /// With every requirement marked completed, the cleanup must run
+    /// successfully and remove its target legacy state.
+    async fn assert_succeeds_when_requires_met(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        self.seed_deferred_state(storage, self.requires()).await?;
+        run_cleanup_with_precondition(self, storage).await?;
+        self.assert_legacy_gone(storage).await
+    }
+}
+
+/// Emulate the deferred runner's cleanup invocation: check every required
+/// name is marked completed in `deferred_migrations`, then run the cleanup
+/// inside a write transaction. Returns an error if any requirement is
+/// unmet or if the cleanup itself errors.
+async fn run_cleanup_with_precondition<C: CleanupMigration + ?Sized>(
+    cleanup: &C,
+    storage: &SqlStorage,
+) -> anyhow::Result<()> {
+    for required in cleanup.requires() {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT name FROM deferred_migrations WHERE name = $1 AND completed_at IS NOT NULL",
+        )
+        .bind(required)
+        .fetch_optional(&storage.pool())
+        .await?;
+        if row.is_none() {
+            anyhow::bail!(
+                "cleanup {} cannot run: requirement {} not complete",
+                cleanup.name(),
+                required,
+            );
+        }
+    }
+    let mut tx = storage.write().await?;
+    cleanup.run(&mut tx).await?;
+    tx.commit().await
 }
 
 /// Test extension for [`DeferredSchemaChange`].


### PR DESCRIPTION
Introduces a trait-based system for future SQL migrations that cannot run pre-consensus without holding nodes out of consensus for hours. Fast DDL stays as plain refinery SQL files; this adds three traits in hotshot-query-service for the cases refinery cannot handle:

- DeferredSchemaChange: slow DDL (e.g. CREATE INDEX CONCURRENTLY) run post-consensus, non-transactional, idempotent.
- DataBackfill + DualReadAdapter: batched data rewrite with reader-side compatibility for the migration window.
- CleanupMigration: drops legacy state once a paired backfill has shipped to every operator; ships in N+1 to preserve a future rollback window.

A MigrationRegistry validates name and order uniqueness across buckets and verifies CleanupMigration::requires references resolve to registered deferred or backfill migrations.

Test traits (AdapterTest, BackfillTest, DeferredSchemaTest) under testing::migration encode contract laws and provide default-method assertions on top of two author-supplied fixtures.

A runnable example at examples/migration_traits.rs exercises every trait end-to-end against a real Postgres TmpDb.

Architecture documented in doc/storage-migrations.md including the expand-migrate-contract pattern and rationale for the two-release gap.

The deferred runner that consumes the registry is a follow-up.
