### PR TITLE
cliquenet: accept any inbound IP when registered address is unspecified

### DIFF
--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -663,6 +663,10 @@ impl Party {
         let NetAddr::Inet(ip, _) = &self.addr else {
             return false;
         };
+        // A wildcard registered address (`0.0.0.0` / `::`) accepts any inbound IP.
+        if ip.is_unspecified() {
+            return false;
+        }
         *ip != addr
     }
 }


### PR DESCRIPTION
A peer registered with a wildcard address (0.0.0.0 / ::) means "bind locally, accept anywhere", so dropping inbound connections from a non-matching IP is wrong. This unblocks loopback demos where bind is 0.0.0.0:port and inbound TCP arrives from 127.0.0.1:ephemeral.
