### PR TITLE
fix: only publish cliquenet connect info via orchestrator on cliquenet version

### DIFF
--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -369,7 +369,7 @@ where
 
     // Only the orchestrator bootstrap path publishes these into the stake table; overridden
     // below when needed.
-    let validator_config = ValidatorConfig {
+    let mut validator_config = ValidatorConfig {
         public_key: pub_key,
         private_key: network_params.private_staking_key,
         stake_value: U256::ONE,
@@ -424,8 +424,9 @@ where
             );
 
             // Publish our cliquenet `connect_info` into the stake table from
-            // `CLIQUENET_VERSION` on, so peers can dial us.
-            let mut validator_config = validator_config.clone();
+            // `CLIQUENET_VERSION` on, so peers can dial us. Modify `validator_config`
+            // in place so the same `connect_info` is sent later when posting to
+            // `/ready` (the orchestrator equality-checks against `known_nodes_with_stake`).
             if genesis.base_version >= versions::CLIQUENET_VERSION {
                 let advertise_addr = network_params.cliquenet_advertise_addr.clone().context(
                     "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS must be set when bootstrapping a \
@@ -438,7 +439,7 @@ where
 
             let config = get_complete_config(
                 &orchestrator_client,
-                validator_config,
+                validator_config.clone(),
                 // Register in our Libp2p advertise address and public key so other nodes
                 // can contact us on startup
                 Some(libp2p_advertise_address),

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -132,8 +132,7 @@ pub struct NetworkParams {
     pub public_api_url: Option<Url>,
     /// Cliquenet network address.
     pub cliquenet_bind_addr: NetAddr,
-    /// Address to advertise to other nodes for cliquenet (registered in the stake table).
-    /// Required from `CLIQUENET_VERSION` onward; ignored on earlier versions.
+    /// Cliquenet address to advertise to other nodes (registered in the stake table).
     pub cliquenet_advertise_addr: Option<NetAddr>,
     /// X25519 secret key.
     pub x25519_secret_key: x25519::SecretKey,
@@ -368,12 +367,8 @@ where
     let orchestrator_client = OrchestratorClient::new(network_params.orchestrator_url);
     let state_key_pair = StateKeyPair::from_sign_key(network_params.private_state_key);
 
-    // The x25519 keypair and cliquenet advertise address get published in the stake table only
-    // when we register with the orchestrator (the fresh-network bootstrap path). On the persistence
-    // and peer-fetch paths the values from `validator_config` are not published, and once the
-    // stake-table-v3 contract is the source of truth they will come from L1. So we default to
-    // `None` and override below in the orchestrator branch when the network is already on
-    // `CLIQUENET_VERSION` and we therefore need real values to register.
+    // Only the orchestrator bootstrap path publishes these into the stake table; overridden
+    // below when needed.
     let validator_config = ValidatorConfig {
         public_key: pub_key,
         private_key: network_params.private_staking_key,
@@ -428,9 +423,8 @@ where
                 "waiting for other nodes to connect, DO NOT RESTART until fully connected"
             );
 
-            // Registering with the orchestrator publishes our `connect_info` (x25519 key and
-            // cliquenet advertise address) into the stake table so peers can dial us. These
-            // are required from `CLIQUENET_VERSION` on; before then they are unused.
+            // Publish our cliquenet `connect_info` into the stake table from
+            // `CLIQUENET_VERSION` on, so peers can dial us.
             let mut validator_config = validator_config.clone();
             if genesis.base_version >= versions::CLIQUENET_VERSION {
                 let advertise_addr = network_params.cliquenet_advertise_addr.clone().context(

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -132,6 +132,9 @@ pub struct NetworkParams {
     pub public_api_url: Option<Url>,
     /// Cliquenet network address.
     pub cliquenet_bind_addr: NetAddr,
+    /// Address to advertise to other nodes for cliquenet (registered in the stake table).
+    /// Required from `CLIQUENET_VERSION` onward; ignored on earlier versions.
+    pub cliquenet_advertise_addr: Option<NetAddr>,
     /// X25519 secret key.
     pub x25519_secret_key: x25519::SecretKey,
     /// The address to send to other Libp2p nodes to contact us
@@ -364,6 +367,13 @@ where
     // Orchestrator client
     let orchestrator_client = OrchestratorClient::new(network_params.orchestrator_url);
     let state_key_pair = StateKeyPair::from_sign_key(network_params.private_state_key);
+
+    // The x25519 keypair and cliquenet advertise address get published in the stake table only
+    // when we register with the orchestrator (the fresh-network bootstrap path). On the persistence
+    // and peer-fetch paths the values from `validator_config` are not published, and once the
+    // stake-table-v3 contract is the source of truth they will come from L1. So we default to
+    // `None` and override below in the orchestrator branch when the network is already on
+    // `CLIQUENET_VERSION` and we therefore need real values to register.
     let validator_config = ValidatorConfig {
         public_key: pub_key,
         private_key: network_params.private_staking_key,
@@ -371,8 +381,8 @@ where
         state_public_key: state_key_pair.ver_key(),
         state_private_key: state_key_pair.sign_key(),
         is_da,
-        x25519_keypair: Some(x25519::Keypair::from(&network_params.x25519_secret_key)),
-        p2p_addr: Some(network_params.cliquenet_bind_addr.clone()),
+        x25519_keypair: None,
+        p2p_addr: None,
     };
 
     // Derive our Libp2p public key from our private key
@@ -417,9 +427,24 @@ where
             tracing::warn!(
                 "waiting for other nodes to connect, DO NOT RESTART until fully connected"
             );
+
+            // Registering with the orchestrator publishes our `connect_info` (x25519 key and
+            // cliquenet advertise address) into the stake table so peers can dial us. These
+            // are required from `CLIQUENET_VERSION` on; before then they are unused.
+            let mut validator_config = validator_config.clone();
+            if genesis.base_version >= versions::CLIQUENET_VERSION {
+                let advertise_addr = network_params.cliquenet_advertise_addr.clone().context(
+                    "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS must be set when bootstrapping a \
+                     Cliquenet network from the orchestrator",
+                )?;
+                validator_config.x25519_keypair =
+                    Some(x25519::Keypair::from(&network_params.x25519_secret_key));
+                validator_config.p2p_addr = Some(advertise_addr);
+            }
+
             let config = get_complete_config(
                 &orchestrator_client,
-                validator_config.clone(),
+                validator_config,
                 // Register in our Libp2p advertise address and public key so other nodes
                 // can contact us on startup
                 Some(libp2p_advertise_address),

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -73,9 +73,8 @@ pub struct Options {
 
     /// The address to advertise to other nodes for cliquenet (in `host:port` | `ip:port` form).
     ///
-    /// Required when starting on the Cliquenet protocol version or later. Goes into the
-    /// stake table so peers can dial us, so it must be a publicly reachable address (not
-    /// `0.0.0.0`).
+    /// Only used for orchestrator-based setup (test networks). On real networks the address
+    /// must be registered in the stake table contract instead.
     #[clap(long, env = "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS")]
     pub cliquenet_advertise_address: Option<NetAddr>,
 

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -71,6 +71,14 @@ pub struct Options {
     )]
     pub cliquenet_bind_address: NetAddr,
 
+    /// The address to advertise to other nodes for cliquenet (in `host:port` | `ip:port` form).
+    ///
+    /// Required when starting on the Cliquenet protocol version or later. Goes into the
+    /// stake table so peers can dial us, so it must be a publicly reachable address (not
+    /// `0.0.0.0`).
+    #[clap(long, env = "ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS")]
+    pub cliquenet_advertise_address: Option<NetAddr>,
+
     /// The address to bind to for Libp2p (in `host:port` form)
     #[clap(
         long,

--- a/crates/espresso/node/src/run.rs
+++ b/crates/espresso/node/src/run.rs
@@ -75,6 +75,7 @@ where
     let network_params = NetworkParams {
         cdn_endpoint: opt.cdn_endpoint,
         cliquenet_bind_addr: opt.cliquenet_bind_address,
+        cliquenet_advertise_addr: opt.cliquenet_advertise_address,
         x25519_secret_key: x25519,
         libp2p_advertise_address: opt.libp2p_advertise_address,
         libp2p_bind_address: opt.libp2p_bind_address,


### PR DESCRIPTION
- default `validator_config.x25519_keypair` and `p2p_addr` to `None` so the
  persistence and peer-fetch paths don't push a `0.0.0.0:9977` bind address
  into the stake table
- override both in the orchestrator branch when `genesis.base_version >=
  CLIQUENET_VERSION`, requiring a real, dialable advertise address
- add `ESPRESSO_NODE_CLIQUENET_ADVERTISE_ADDRESS` env var (no default) and
  thread it through `NetworkParams`