### PR TITLE
perf(query-service): use ORDER BY ... LIMIT 1 for range-end lookup

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/node.rs
@@ -372,8 +372,10 @@ where
                 // We can easily find the end of the range from the start by finding the maximum
                 // height which is still present between the start and the next range's start.
                 let query = format!(
-                    "SELECT max(height) from {table}
-                      WHERE height < $1 AND {indicator_column} IS NOT NULL"
+                    "SELECT height FROM {table}
+                      WHERE height < $1 AND {indicator_column} IS NOT NULL
+                      ORDER BY height DESC
+                      LIMIT 1"
                 );
                 let upper_bound = if i + 1 < range_starts.len() {
                     range_starts[i + 1].0


### PR DESCRIPTION
- Replaces SELECT max(height) with SELECT height ... ORDER BY height DESC LIMIT 1 in sync_status_ranges per-range path
- max() over a JOIN does not decompose into a backward index scan; the planner materializes the join then aggregates
- ORDER BY height DESC LIMIT 1 lets a nested-loop walk header.height descending and short-circuit on the first joined row
- Slow-query logs on mainnet showed this query at 66s avg, 425s max for the header JOIN vid_common variant