### PR TITLE
Remove expensive `ORDER BY height` clause from availability queries

### DIFF
--- a/hotshot-query-service/src/data_source/storage/sql/queries.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries.rs
@@ -170,13 +170,10 @@ impl<Mode> Transaction<Mode> {
     ) -> QueryResult<Header<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id.into())?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {HEADER_COLUMNS}
                FROM header AS h
               WHERE {where_clause}
-              ORDER BY h.height
               LIMIT 1"
         );
 

--- a/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
+++ b/hotshot-query-service/src/data_source/storage/sql/queries/availability.rs
@@ -64,14 +64,11 @@ where
     async fn get_block(&mut self, id: BlockId<Types>) -> QueryResult<BlockQueryData<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id)?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {BLOCK_COLUMNS}
               FROM header AS h
               JOIN payload AS p ON (h.payload_hash, h.ns_table) = (p.hash, p.ns_table)
               WHERE {where_clause}
-              ORDER BY h.height
               LIMIT 1"
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;
@@ -86,14 +83,11 @@ where
     async fn get_payload(&mut self, id: BlockId<Types>) -> QueryResult<PayloadQueryData<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id)?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {PAYLOAD_COLUMNS}
               FROM header AS h
               JOIN payload AS p ON (h.payload_hash, h.ns_table) = (p.hash, p.ns_table)
               WHERE {where_clause}
-              ORDER BY h.height
               LIMIT 1"
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;
@@ -107,14 +101,11 @@ where
     ) -> QueryResult<PayloadMetadata<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id)?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {PAYLOAD_METADATA_COLUMNS}
               FROM header AS h
               JOIN payload AS p ON (h.payload_hash, h.ns_table) = (p.hash, p.ns_table)
               WHERE {where_clause}
-              ORDER BY h.height ASC
               LIMIT 1"
         );
         let row = query
@@ -135,14 +126,11 @@ where
     ) -> QueryResult<VidCommonQueryData<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id)?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {VID_COMMON_COLUMNS}
               FROM header AS h
               JOIN vid_common AS v ON h.payload_hash = v.hash
               WHERE {where_clause}
-              ORDER BY h.height
               LIMIT 1"
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;
@@ -156,14 +144,11 @@ where
     ) -> QueryResult<VidCommonMetadata<Types>> {
         let mut query = QueryBuilder::default();
         let where_clause = query.header_where_clause(id)?;
-        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
-        // selecting by payload ID, as payloads are not unique), we return the first one.
         let sql = format!(
             "SELECT {VID_COMMON_METADATA_COLUMNS}
               FROM header AS h
               JOIN vid_common AS v ON h.payload_hash = v.hash
               WHERE {where_clause}
-              ORDER BY h.height ASC
               LIMIT 1"
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;


### PR DESCRIPTION
The purpose of this clause is to ensure determinism when selecting by payload hash and getting duplicate results. However, there is no index we can use to both filter by hash and order by height, and so this query results in a full table scan, which can sometimes take as much as 10 minutes.

Nothing actually relies on this determinism, and so it is not worth the exorbitant cost. With this change, we will use the index on payload hash, and return an arbitrary matching row, the first one we find in that index.

