### PR TITLE
fix(just): use nightly rustfmt outside nix shell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,9 +42,10 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
+      - uses: taiki-e/install-action@just
 
       - name: Check formatting
-        run: git ls-files '*.rs' | xargs rustfmt +nightly --check
+        run: just fmt
 
   clippy-postgres:
     name: clippy (postgres)
@@ -66,18 +67,18 @@ jobs:
           cargo clippy --workspace --exclude espresso-node-sqlite --exclude espresso-dev-node --features testing --all-targets --keep-going -- -D warnings
 
   clippy-embedded:
-      name: clippy (embedded-db)
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v6
+    name: clippy (embedded-db)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-        - name: Install protoc
-          run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-        - uses: Swatinem/rust-cache@v2
-          with:
-            save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
 
-        - name: Run clippy
-          run: |
-            cargo clippy --workspace --features "embedded-db testing" --all-targets --keep-going -- -D warnings
+      - name: Run clippy
+        run: |
+          cargo clippy --workspace --features "embedded-db testing" --all-targets --keep-going -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Check formatting
-        run: just fmt --check
+        run: just fmt && git diff --exit-code
 
   clippy-postgres:
     name: clippy (postgres)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: taiki-e/install-action@just
 
       - name: Check formatting
-        run: just fmt
+        run: just fmt --check
 
   clippy-postgres:
     name: clippy (postgres)

--- a/justfile
+++ b/justfile
@@ -59,20 +59,17 @@ demo-native *args: (build "test")
     scripts/demo-native {{args}}
 
 # cargo fmt misses files whose `mod` declarations are produced by macro expansion
-fmt *files:
+fmt *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    files="{{files}}"
-    if [ -z "$files" ]; then
-        files=$(git ls-files '*.rs')
-    fi
+    files=$(git ls-files '*.rs')
     if [ -n "$files" ]; then
         if [ -n "${IN_NIX_SHELL:-}" ]; then
             rustfmt_cmd="rustfmt"
         else
             rustfmt_cmd="rustfmt +nightly"
         fi
-        echo "$files" | xargs -P $(getconf _NPROCESSORS_ONLN) -n 10 $rustfmt_cmd
+        echo "$files" | xargs -P $(getconf _NPROCESSORS_ONLN) -n 10 $rustfmt_cmd {{args}}
     fi
 
 fix *args:

--- a/justfile
+++ b/justfile
@@ -67,7 +67,12 @@ fmt *files:
         files=$(git ls-files '*.rs')
     fi
     if [ -n "$files" ]; then
-        echo "$files" | xargs -P $(getconf _NPROCESSORS_ONLN) -n 10 rustfmt
+        if [ -n "${IN_NIX_SHELL:-}" ]; then
+            rustfmt_cmd="rustfmt"
+        else
+            rustfmt_cmd="rustfmt +nightly"
+        fi
+        echo "$files" | xargs -P $(getconf _NPROCESSORS_ONLN) -n 10 $rustfmt_cmd
     fi
 
 fix *args:


### PR DESCRIPTION
- detect IN_NIX_SHELL in `just fmt`; fall back to `rustfmt +nightly` via rustup when not in the dev shell
- run `just fmt` in the lint workflow instead of duplicating the rustfmt invocation
