### PR TITLE
ci: install foundry directly to avoid foundry-toolchain rate limits

### DIFF
--- a/.github/actions/install-foundry/action.yml
+++ b/.github/actions/install-foundry/action.yml
@@ -19,7 +19,7 @@ runs:
         mkdir -p "$FOUNDRY_DIR"
 
         run_with_retry() {
-          local -i max_attempts=5
+          local -i max_attempts=15
           local -i attempts=0
           until "$@"; do
             attempts=$((attempts + 1))

--- a/.github/actions/install-foundry/action.yml
+++ b/.github/actions/install-foundry/action.yml
@@ -11,8 +11,12 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        FOUNDRY_DIR: ${{ github.workspace }}/.foundry
       run: |
         set -euo pipefail
+        mkdir -p "$FOUNDRY_DIR"
+
         attempts=0
         max_attempts=5
         until curl -sSfL https://foundry.paradigm.xyz | bash; do
@@ -24,8 +28,9 @@ runs:
           sleep $((attempts * 5))
         done
 
-        echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
-        export PATH="$HOME/.foundry/bin:$PATH"
+        echo "$FOUNDRY_DIR/bin" >> "$GITHUB_PATH"
+        echo "FOUNDRY_DIR=$FOUNDRY_DIR" >> "$GITHUB_ENV"
+        export PATH="$FOUNDRY_DIR/bin:$PATH"
 
         attempts=0
         until foundryup --install "${{ inputs.version }}"; do

--- a/.github/actions/install-foundry/action.yml
+++ b/.github/actions/install-foundry/action.yml
@@ -1,0 +1,41 @@
+name: Install Foundry
+description: Install Foundry directly from paradigm.xyz with retries.
+
+inputs:
+  version:
+    description: foundryup release to install (e.g. stable, v1.4.0, nightly)
+    required: false
+    default: stable
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        attempts=0
+        max_attempts=5
+        until curl -sSfL https://foundry.paradigm.xyz | bash; do
+          attempts=$((attempts + 1))
+          if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "foundryup install failed after $attempts attempts" >&2
+            exit 1
+          fi
+          sleep $((attempts * 5))
+        done
+
+        echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
+        export PATH="$HOME/.foundry/bin:$PATH"
+
+        attempts=0
+        until foundryup --install "${{ inputs.version }}"; do
+          attempts=$((attempts + 1))
+          if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "foundryup --install ${{ inputs.version }} failed after $attempts attempts" >&2
+            exit 1
+          fi
+          sleep $((attempts * 5))
+        done
+
+        forge --version
+        anvil --version

--- a/.github/actions/install-foundry/action.yml
+++ b/.github/actions/install-foundry/action.yml
@@ -13,6 +13,7 @@ runs:
     - shell: bash
       env:
         FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+        FOUNDRY_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         mkdir -p "$FOUNDRY_DIR"
@@ -33,10 +34,10 @@ runs:
         export PATH="$FOUNDRY_DIR/bin:$PATH"
 
         attempts=0
-        until foundryup --install "${{ inputs.version }}"; do
+        until foundryup --install "$FOUNDRY_VERSION"; do
           attempts=$((attempts + 1))
           if [ "$attempts" -ge "$max_attempts" ]; then
-            echo "foundryup --install ${{ inputs.version }} failed after $attempts attempts" >&2
+            echo "foundryup --install $FOUNDRY_VERSION failed after $attempts attempts" >&2
             exit 1
           fi
           sleep $((attempts * 5))

--- a/.github/actions/install-foundry/action.yml
+++ b/.github/actions/install-foundry/action.yml
@@ -18,30 +18,27 @@ runs:
         set -euo pipefail
         mkdir -p "$FOUNDRY_DIR"
 
-        attempts=0
-        max_attempts=5
-        until curl -sSfL https://foundry.paradigm.xyz | bash; do
-          attempts=$((attempts + 1))
-          if [ "$attempts" -ge "$max_attempts" ]; then
-            echo "foundryup install failed after $attempts attempts" >&2
-            exit 1
-          fi
-          sleep $((attempts * 5))
-        done
+        run_with_retry() {
+          local -i max_attempts=5
+          local -i attempts=0
+          until "$@"; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "Command '$*' failed after $attempts attempts." >&2
+              exit 1
+            fi
+            echo "Command failed. Retrying in $((attempts * 5))s..." >&2
+            sleep $((attempts * 5))
+          done
+        }
+
+        run_with_retry bash -c "curl -sSfL https://foundry.paradigm.xyz | bash"
 
         echo "$FOUNDRY_DIR/bin" >> "$GITHUB_PATH"
         echo "FOUNDRY_DIR=$FOUNDRY_DIR" >> "$GITHUB_ENV"
         export PATH="$FOUNDRY_DIR/bin:$PATH"
 
-        attempts=0
-        until foundryup --install "$FOUNDRY_VERSION"; do
-          attempts=$((attempts + 1))
-          if [ "$attempts" -ge "$max_attempts" ]; then
-            echo "foundryup --install $FOUNDRY_VERSION failed after $attempts attempts" >&2
-            exit 1
-          fi
-          sleep $((attempts * 5))
-        done
+        run_with_retry foundryup --install "$FOUNDRY_VERSION"
 
         forge --version
         anvil --version

--- a/.github/workflows/contracts-mutation-test.yml
+++ b/.github/workflows/contracts-mutation-test.yml
@@ -35,7 +35,7 @@ jobs:
           filter: blob:none
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: ./.github/actions/install-foundry
 
       - name: Install solc
         run: |
@@ -132,7 +132,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: ./.github/actions/install-foundry
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: ./.github/actions/install-foundry
 
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@mdbook

--- a/.github/workflows/slowtest.yaml
+++ b/.github/workflows/slowtest.yaml
@@ -52,7 +52,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: ./.github/actions/install-foundry
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/free-disk-space
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: ./.github/actions/install-foundry
       - uses: taiki-e/install-action@nextest
 
       - name: Download archive
@@ -291,9 +291,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-      - uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+      - uses: ./.github/actions/install-foundry
       - uses: taiki-e/install-action@nextest
 
       - name: Download archive


### PR DESCRIPTION
 Switch CI to a local foundryup install with retries pinned to stable, avoiding the foundry-toolchain action's anonymous GitHub API rate limits.