### PR TITLE
ci(hotshot): make new-protocol JUnit artifact names unique per shard

### DIFF
--- a/.github/workflows/hotshot.yml
+++ b/.github/workflows/hotshot.yml
@@ -145,7 +145,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: nextest-junit-hotshot-new-protocol
+          name: nextest-junit-hotshot-new-protocol-${{ matrix.name }}
           if-no-files-found: ignore
           path: target/nextest/*/junit.xml
           retention-days: 1


### PR DESCRIPTION
- Include matrix.name in the artifact name so each of the 4 shards uploads to a distinct artifact
- Fixes 409 Conflict on upload-artifact when multiple matrix jobs raced for the same name
