### PR TITLE
refactor(migrations): per-table backfills for hash_id_bigint refs

### DIFF
--- a/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
+++ b/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
@@ -440,7 +440,11 @@ impl BackfillTest for BackfillRefs {
     }
 }
 
-#[cfg(test)]
+// Tests use TmpDb which requires a PostgreSQL Docker container when not using embedded-db.
+// The migration itself is PostgreSQL-only: SQLite's INTEGER PRIMARY KEY is already 64-bit,
+// so the INT → BIGINT widening and its PostgreSQL-specific SQL (::bigint casts, CONCURRENTLY
+// index, sequences) do not apply to SQLite.
+#[cfg(all(test, not(feature = "embedded-db")))]
 mod tests {
     use super::*;
     use crate::persistence::{sql::Persistence, tests::TestablePersistence};

--- a/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
+++ b/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
@@ -17,6 +17,8 @@
 use std::borrow::Cow;
 
 use async_trait::async_trait;
+#[cfg(any(test, feature = "testing"))]
+use hotshot_query_service::data_source::{Transaction as _, VersionedDataSource};
 use hotshot_query_service::{
     data_source::storage::sql::{SqlStorage, Transaction, Write},
     migration::{
@@ -94,12 +96,12 @@ impl DataBackfill for BackfillIds {
                 LIMIT $2
             ),
             updated AS (
-                UPDATE hash SET id_big = id
+                UPDATE hash SET id_big = hash.id
                 FROM batch
                 WHERE hash.id = batch.id
                 RETURNING hash.id
             )
-            SELECT MAX(id) FROM updated",
+            SELECT MAX(id)::bigint FROM updated",
         )
         .bind(offset as i64)
         .bind(self.batch_size() as i64)
@@ -331,7 +333,7 @@ impl CleanupMigration for Cleanup {
 // ---------------------------------------------------------------------------
 
 #[cfg(any(test, feature = "testing"))]
-use hotshot_query_service::testing::migration::{AdapterTest, DeferredSchemaTest};
+use hotshot_query_service::testing::migration::{AdapterTest, BackfillTest, DeferredSchemaTest};
 
 #[cfg(any(test, feature = "testing"))]
 impl AdapterTest for HashIdAdapter {
@@ -343,12 +345,171 @@ impl AdapterTest for HashIdAdapter {
 #[cfg(any(test, feature = "testing"))]
 impl DeferredSchemaTest for CreateIndex {}
 
+#[cfg(any(test, feature = "testing"))]
+async fn seed_legacy_hash_rows(storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+    let mut tx = storage.write().await?;
+    for i in 1..=n as i32 {
+        sqlx::query(
+            "INSERT INTO hash (id, value, id_big) VALUES ($1, $2, NULL) ON CONFLICT DO NOTHING",
+        )
+        .bind(i)
+        .bind(format!("legacy-{i}").into_bytes())
+        .execute(tx.as_mut())
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+#[cfg(any(test, feature = "testing"))]
+#[async_trait]
+impl BackfillTest for BackfillIds {
+    async fn seed_legacy(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+        seed_legacy_hash_rows(storage, n).await
+    }
+
+    async fn assert_all_readable_as_new(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        let mut tx = storage.read().await?;
+        let unmigrated: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM hash WHERE id > 0 AND id_big IS NULL")
+                .fetch_one(tx.as_mut())
+                .await?;
+        anyhow::ensure!(
+            unmigrated == 0,
+            "{unmigrated} legacy hash rows still have NULL id_big after backfill",
+        );
+        let mismatch: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM hash WHERE id > 0 AND id_big <> id::bigint")
+                .fetch_one(tx.as_mut())
+                .await?;
+        anyhow::ensure!(
+            mismatch == 0,
+            "{mismatch} hash rows have id_big != id after backfill",
+        );
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+#[async_trait]
+impl BackfillTest for BackfillRefs {
+    async fn seed_legacy(&self, storage: &SqlStorage, n: usize) -> anyhow::Result<()> {
+        seed_legacy_hash_rows(storage, n).await?;
+
+        let mut tx = storage.write().await?;
+        let table = self.table;
+        let sql = format!(
+            "INSERT INTO \"{table}\" (path, created, hash_id, hash_id_big) VALUES ($1::jsonb, $2, \
+             $3, NULL)"
+        );
+        for i in 1..=n as i32 {
+            sqlx::query(&sql)
+                .bind(format!("[{i}]"))
+                .bind(i as i64)
+                .bind(i)
+                .execute(tx.as_mut())
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn assert_all_readable_as_new(&self, storage: &SqlStorage) -> anyhow::Result<()> {
+        let mut tx = storage.read().await?;
+        let table = self.table;
+        let unmigrated: i64 = sqlx::query_scalar(&format!(
+            "SELECT count(*) FROM \"{table}\" WHERE hash_id IS NOT NULL AND hash_id_big IS NULL",
+        ))
+        .fetch_one(tx.as_mut())
+        .await?;
+        anyhow::ensure!(
+            unmigrated == 0,
+            "{unmigrated} legacy {table} rows still have NULL hash_id_big after backfill",
+        );
+        let mismatch: i64 = sqlx::query_scalar(&format!(
+            "SELECT count(*) FROM \"{table}\" WHERE hash_id IS NOT NULL AND hash_id_big <> \
+             hash_id::bigint",
+        ))
+        .fetch_one(tx.as_mut())
+        .await?;
+        anyhow::ensure!(
+            mismatch == 0,
+            "{mismatch} {table} rows have hash_id_big != hash_id after backfill",
+        );
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence::{sql::Persistence, tests::TestablePersistence};
 
     #[test]
     fn adapter_laws() {
         HashIdAdapter::assert_adapter_laws();
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_ids_runs_to_completion() {
+        let db = Persistence::tmp_storage().await;
+        let persistence = Persistence::connect(&db).await;
+        BackfillIds
+            .assert_runs_to_completion(persistence.storage(), 100)
+            .await
+            .unwrap();
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_ids_idempotent() {
+        let db = Persistence::tmp_storage().await;
+        let persistence = Persistence::connect(&db).await;
+        BackfillIds
+            .assert_idempotent(persistence.storage(), 100)
+            .await
+            .unwrap();
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_ids_resumable() {
+        let db = Persistence::tmp_storage().await;
+        let persistence = Persistence::connect(&db).await;
+        BackfillIds
+            .assert_resumable(persistence.storage(), 100)
+            .await
+            .unwrap();
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_refs_runs_to_completion() {
+        for refs in BackfillRefs::all() {
+            let db = Persistence::tmp_storage().await;
+            let persistence = Persistence::connect(&db).await;
+            refs.assert_runs_to_completion(persistence.storage(), 50)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_refs_idempotent() {
+        for refs in BackfillRefs::all() {
+            let db = Persistence::tmp_storage().await;
+            let persistence = Persistence::connect(&db).await;
+            refs.assert_idempotent(persistence.storage(), 50)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn backfill_refs_resumable() {
+        for refs in BackfillRefs::all() {
+            let db = Persistence::tmp_storage().await;
+            let persistence = Persistence::connect(&db).await;
+            refs.assert_resumable(persistence.storage(), 50)
+                .await
+                .unwrap();
+        }
     }
 }

--- a/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
+++ b/crates/espresso/node/src/persistence/migrations/hash_id_bigint.rs
@@ -3,16 +3,18 @@
 //!
 //! The expand SQL migration (`V1302__hash_id_bigint_expand.sql`) adds the new
 //! `id_big` / `hash_id_big` columns and replaces the exhausted `hash_id_seq` with
-//! a placeholder sequence. This module provides the four trait implementations that
+//! a placeholder sequence. This module provides the trait implementations that
 //! complete the migration in the background:
 //!
 //! 1. [`BackfillIds`] — fills `hash.id_big = hash.id` for every existing row.
-//! 2. [`BackfillRefs`] — fills `*.hash_id_big = *.hash_id::bigint` across
-//!    all four merkle tree tables; starts only after [`BackfillIds`] is done.
+//! 2. [`BackfillRefs`] — fills `*.hash_id_big = *.hash_id::bigint` for one merkle
+//!    tree table; registered once per table so each has its own offset.
 //! 3. [`CreateIndex`] — creates `UNIQUE INDEX CONCURRENTLY` on `hash.id_big` so
 //!    the cleanup can promote it to a primary key.
 //! 4. [`Cleanup`] — drops the old columns, renames the new columns, and restores
 //!    the primary key and FK constraints.
+
+use std::borrow::Cow;
 
 use async_trait::async_trait;
 use hotshot_query_service::{
@@ -21,6 +23,20 @@ use hotshot_query_service::{
         CleanupMigration, DataBackfill, DeferredSchemaChange, DualReadAdapter, MigrationMeta,
     },
 };
+
+pub const MERKLE_TABLES: &[&str] = &[
+    "fee_merkle_tree",
+    "block_merkle_tree",
+    "reward_merkle_tree",
+    "reward_merkle_tree_v2",
+];
+
+pub const BACKFILL_REFS_NAMES: &[&str] = &[
+    "hash_id_bigint_backfill_refs_fee_merkle_tree",
+    "hash_id_bigint_backfill_refs_block_merkle_tree",
+    "hash_id_bigint_backfill_refs_reward_merkle_tree",
+    "hash_id_bigint_backfill_refs_reward_merkle_tree_v2",
+];
 
 pub struct HashIdAdapter;
 
@@ -45,8 +61,8 @@ impl DualReadAdapter for HashIdAdapter {
 pub struct BackfillIds;
 
 impl MigrationMeta for BackfillIds {
-    fn name(&self) -> &'static str {
-        "hash_id_bigint_backfill_ids"
+    fn name(&self) -> Cow<'static, str> {
+        "hash_id_bigint_backfill_ids".into()
     }
 
     fn order(&self) -> u32 {
@@ -94,15 +110,35 @@ impl DataBackfill for BackfillIds {
     }
 }
 
-pub struct BackfillRefs;
+/// Backfills `hash_id_big` for a single merkle tree table. Each table is registered
+/// as its own backfill so progress is tracked per-table — see PR #4284 discussion.
+pub struct BackfillRefs {
+    pub table: &'static str,
+    pub name: &'static str,
+    pub order: u32,
+}
+
+impl BackfillRefs {
+    pub fn all() -> impl Iterator<Item = Self> {
+        MERKLE_TABLES
+            .iter()
+            .zip(BACKFILL_REFS_NAMES.iter())
+            .enumerate()
+            .map(|(idx, (&table, &name))| Self {
+                table,
+                name,
+                order: 2 + idx as u32,
+            })
+    }
+}
 
 impl MigrationMeta for BackfillRefs {
-    fn name(&self) -> &'static str {
-        "hash_id_bigint_backfill_refs"
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(self.name)
     }
 
     fn order(&self) -> u32 {
-        2
+        self.order
     }
 }
 
@@ -119,49 +155,37 @@ impl DataBackfill for BackfillRefs {
         tx: &mut Transaction<Write>,
         offset: u64,
     ) -> anyhow::Result<Option<u64>> {
-        let mut max_created: Option<i64> = None;
+        let next: Option<i64> = sqlx::query_scalar(&format!(
+            "WITH batch AS (
+                SELECT path, created FROM \"{table}\"
+                WHERE hash_id_big IS NULL AND created > $1
+                ORDER BY created
+                LIMIT $2
+            ),
+            updated AS (
+                UPDATE \"{table}\" t
+                SET hash_id_big = t.hash_id::bigint
+                FROM batch
+                WHERE t.path = batch.path AND t.created = batch.created
+                RETURNING t.created
+            )
+            SELECT MAX(created) FROM updated",
+            table = self.table,
+        ))
+        .bind(offset as i64)
+        .bind(self.batch_size() as i64)
+        .fetch_one(tx.as_mut())
+        .await?;
 
-        for table in &[
-            "fee_merkle_tree",
-            "block_merkle_tree",
-            "reward_merkle_tree",
-            "reward_merkle_tree_v2",
-        ] {
-            let next: Option<i64> = sqlx::query_scalar(&format!(
-                "WITH batch AS (
-                    SELECT path, created FROM \"{table}\"
-                    WHERE hash_id_big IS NULL AND created > $1
-                    ORDER BY created
-                    LIMIT $2
-                ),
-                updated AS (
-                    UPDATE \"{table}\" t
-                    SET hash_id_big = t.hash_id::bigint
-                    FROM batch
-                    WHERE t.path = batch.path AND t.created = batch.created
-                    RETURNING t.created
-                )
-                SELECT MAX(created) FROM updated",
-            ))
-            .bind(offset as i64)
-            .bind(self.batch_size() as i64)
-            .fetch_one(tx.as_mut())
-            .await?;
-
-            if let Some(c) = next {
-                max_created = Some(max_created.unwrap_or(i64::MIN).max(c));
-            }
-        }
-
-        Ok(max_created.map(|c| c as u64))
+        Ok(next.map(|c| c as u64))
     }
 }
 
 pub struct CreateIndex;
 
 impl MigrationMeta for CreateIndex {
-    fn name(&self) -> &'static str {
-        "hash_id_bigint_create_index"
+    fn name(&self) -> Cow<'static, str> {
+        "hash_id_bigint_create_index".into()
     }
 
     fn order(&self) -> u32 {
@@ -191,8 +215,8 @@ impl DeferredSchemaChange for CreateIndex {
 pub struct Cleanup;
 
 impl MigrationMeta for Cleanup {
-    fn name(&self) -> &'static str {
-        "hash_id_bigint_cleanup"
+    fn name(&self) -> Cow<'static, str> {
+        "hash_id_bigint_cleanup".into()
     }
 
     fn order(&self) -> u32 {
@@ -205,7 +229,10 @@ impl CleanupMigration for Cleanup {
     fn requires(&self) -> &'static [&'static str] {
         &[
             "hash_id_bigint_backfill_ids",
-            "hash_id_bigint_backfill_refs",
+            "hash_id_bigint_backfill_refs_fee_merkle_tree",
+            "hash_id_bigint_backfill_refs_block_merkle_tree",
+            "hash_id_bigint_backfill_refs_reward_merkle_tree",
+            "hash_id_bigint_backfill_refs_reward_merkle_tree_v2",
             "hash_id_bigint_create_index",
         ]
     }

--- a/crates/espresso/node/src/persistence/migrations/mod.rs
+++ b/crates/espresso/node/src/persistence/migrations/mod.rs
@@ -6,9 +6,9 @@ use self::hash_id_bigint::{BackfillIds, BackfillRefs, Cleanup, CreateIndex};
 
 /// Build the [`MigrationRegistry`] for the espresso node's deferred migrations.
 pub fn build_registry() -> MigrationRegistry {
-    MigrationRegistry::new()
-        .backfill(BackfillIds)
-        .backfill(BackfillRefs)
-        .deferred_schema(CreateIndex)
-        .cleanup(Cleanup)
+    let mut registry = MigrationRegistry::new().backfill(BackfillIds);
+    for refs in BackfillRefs::all() {
+        registry = registry.backfill(refs);
+    }
+    registry.deferred_schema(CreateIndex).cleanup(Cleanup)
 }

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -741,6 +741,12 @@ pub struct Persistence {
 const PG_SERIALIZATION_FAILURE_CODE: &str = "40001";
 
 impl Persistence {
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
+    pub(crate) fn storage(&self) -> &SqlStorage {
+        &self.db
+    }
+
     /// Ensure the `leaf_hash` column is populated for all existing quorum proposals.
     ///
     /// This column was added in a migration, but because it requires computing a commitment of the

--- a/hotshot-query-service/examples/migration_traits.rs
+++ b/hotshot-query-service/examples/migration_traits.rs
@@ -20,6 +20,8 @@
 //! a real-world migration of this shape would only ship for the Postgres
 //! backend.
 
+use std::borrow::Cow;
+
 use anyhow::Context;
 use async_trait::async_trait;
 use hotshot_query_service::{
@@ -106,8 +108,8 @@ impl DualReadAdapter for ScoreAdapter {
 pub struct BackfillScores;
 
 impl MigrationMeta for BackfillScores {
-    fn name(&self) -> &'static str {
-        "scores_v1_backfill"
+    fn name(&self) -> Cow<'static, str> {
+        "scores_v1_backfill".into()
     }
     fn order(&self) -> u32 {
         1
@@ -167,8 +169,8 @@ impl DataBackfill for BackfillScores {
 pub struct IndexScores;
 
 impl MigrationMeta for IndexScores {
-    fn name(&self) -> &'static str {
-        "scores_v1_index"
+    fn name(&self) -> Cow<'static, str> {
+        "scores_v1_index".into()
     }
     fn order(&self) -> u32 {
         2
@@ -191,8 +193,8 @@ impl DeferredSchemaChange for IndexScores {
 pub struct DropLegacyScores;
 
 impl MigrationMeta for DropLegacyScores {
-    fn name(&self) -> &'static str {
-        "scores_v1_drop_legacy"
+    fn name(&self) -> Cow<'static, str> {
+        "scores_v1_drop_legacy".into()
     }
     fn order(&self) -> u32 {
         1

--- a/hotshot-query-service/src/data_source/storage/sql.rs
+++ b/hotshot-query-service/src/data_source/storage/sql.rs
@@ -714,19 +714,20 @@ impl SqlStorage {
     pub async fn run_pending_cleanups(&self, registry: &MigrationRegistry) -> Result<(), Error> {
         for cleanup in registry.cleanup_migrations() {
             if self.cleanup_requirements_met(cleanup.requires()).await? {
-                tracing::info!("running cleanup migration {}", cleanup.name());
+                let name = cleanup.name();
+                tracing::info!("running cleanup migration {}", name);
                 let mut tx = self.write().await?;
                 cleanup.run(&mut tx).await?;
                 sqlx::query(
                     "INSERT INTO deferred_migrations (name, done_at) VALUES ($1, $2)
                      ON CONFLICT (name) DO UPDATE SET done_at = EXCLUDED.done_at",
                 )
-                .bind(cleanup.name())
+                .bind(name.as_ref())
                 .bind(Utc::now().to_rfc3339())
                 .execute(tx.as_mut())
                 .await?;
                 tx.commit().await?;
-                tracing::info!("cleanup migration {} complete", cleanup.name());
+                tracing::info!("cleanup migration {} complete", name);
             }
         }
         Ok(())
@@ -764,15 +765,16 @@ impl SqlStorage {
         backfills.sort_by_key(|m| m.order());
 
         for backfill in &backfills {
-            if self.migration_done(backfill.name()).await? {
+            let name = backfill.name();
+            if self.migration_done(&name).await? {
                 continue;
             }
             tracing::info!(
                 "starting backfill migration {} (batch_size={})",
-                backfill.name(),
+                name,
                 backfill.batch_size()
             );
-            let mut offset = self.migration_progress(backfill.name()).await?;
+            let mut offset = self.migration_progress(&name).await?;
             loop {
                 let mut tx = self.write().await?;
                 let next = backfill.migrate_batch(&mut tx, offset).await?;
@@ -784,7 +786,7 @@ impl SqlStorage {
                             "INSERT INTO deferred_migrations (name, progress) VALUES ($1, $2)
                              ON CONFLICT (name) DO UPDATE SET progress = EXCLUDED.progress",
                         )
-                        .bind(backfill.name())
+                        .bind(name.as_ref())
                         .bind(new_offset as i64)
                         .execute(tx.as_mut())
                         .await?;
@@ -799,13 +801,13 @@ impl SqlStorage {
                                   SET progress = EXCLUDED.progress,
                                       done_at  = EXCLUDED.done_at",
                         )
-                        .bind(backfill.name())
+                        .bind(name.as_ref())
                         .bind(offset as i64)
                         .bind(Utc::now().to_rfc3339())
                         .execute(tx.as_mut())
                         .await?;
                         tx.commit().await?;
-                        tracing::info!("backfill migration {} complete", backfill.name());
+                        tracing::info!("backfill migration {} complete", name);
                         break;
                     },
                 }
@@ -817,22 +819,23 @@ impl SqlStorage {
         deferred.sort_by_key(|m| m.order());
 
         for schema_change in &deferred {
-            if self.migration_done(schema_change.name()).await? {
+            let name = schema_change.name();
+            if self.migration_done(&name).await? {
                 continue;
             }
-            tracing::info!("running deferred schema change {}", schema_change.name());
+            tracing::info!("running deferred schema change {}", name);
             schema_change.run(self).await?;
             let mut tx = self.write().await?;
             sqlx::query(
                 "INSERT INTO deferred_migrations (name, done_at) VALUES ($1, $2)
                  ON CONFLICT (name) DO UPDATE SET done_at = EXCLUDED.done_at",
             )
-            .bind(schema_change.name())
+            .bind(name.as_ref())
             .bind(Utc::now().to_rfc3339())
             .execute(tx.as_mut())
             .await?;
             tx.commit().await?;
-            tracing::info!("deferred schema change {} complete", schema_change.name());
+            tracing::info!("deferred schema change {} complete", name);
         }
 
         // Pick up any cleanup migrations that just became eligible.

--- a/hotshot-query-service/src/migration.rs
+++ b/hotshot-query-service/src/migration.rs
@@ -22,7 +22,7 @@
 //! The kind traits are directly object-safe; [`MigrationRegistry`] stores
 //! `Box<dyn KindTrait>` for each bucket.
 
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 
 use anyhow::bail;
 use async_trait::async_trait;
@@ -36,7 +36,7 @@ use crate::data_source::storage::sql::{SqlStorage, Transaction, Write};
 /// the lifetime of the migration. `order` is unique within each bucket and
 /// determines the order in which migrations of the same kind run.
 pub trait MigrationMeta: Send + Sync + 'static {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> Cow<'static, str>;
     fn order(&self) -> u32;
 }
 
@@ -196,8 +196,8 @@ impl MigrationRegistry {
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
-        let mut all_names: HashSet<&'static str> = HashSet::new();
-        let mut deferred_names: HashSet<&'static str> = HashSet::new();
+        let mut all_names: HashSet<String> = HashSet::new();
+        let mut deferred_names: HashSet<String> = HashSet::new();
         let mut deferred_orders: HashSet<u32> = HashSet::new();
         let mut backfill_orders: HashSet<u32> = HashSet::new();
         let mut cleanup_orders: HashSet<u32> = HashSet::new();
@@ -210,7 +210,7 @@ impl MigrationRegistry {
                 &mut all_names,
                 &mut deferred_orders,
             )?;
-            deferred_names.insert(m.name());
+            deferred_names.insert(m.name().into_owned());
         }
         for m in &self.backfills {
             check_unique(
@@ -220,7 +220,7 @@ impl MigrationRegistry {
                 &mut all_names,
                 &mut backfill_orders,
             )?;
-            deferred_names.insert(m.name());
+            deferred_names.insert(m.name().into_owned());
         }
         for m in &self.cleanups {
             check_unique(
@@ -234,7 +234,7 @@ impl MigrationRegistry {
 
         for c in &self.cleanups {
             for required in c.requires() {
-                if !deferred_names.contains(required) {
+                if !deferred_names.contains(*required) {
                     bail!(
                         "cleanup migration {} requires {} which is not a registered deferred or \
                          backfill migration",
@@ -262,12 +262,12 @@ impl MigrationRegistry {
 
 fn check_unique(
     bucket: &'static str,
-    name: &'static str,
+    name: Cow<'static, str>,
     order: u32,
-    all_names: &mut HashSet<&'static str>,
+    all_names: &mut HashSet<String>,
     bucket_orders: &mut HashSet<u32>,
 ) -> anyhow::Result<()> {
-    if !all_names.insert(name) {
+    if !all_names.insert(name.clone().into_owned()) {
         bail!("duplicate migration name {} (bucket {})", name, bucket);
     }
     if !bucket_orders.insert(order) {
@@ -286,8 +286,8 @@ mod tests {
 
     struct StubBackfill;
     impl MigrationMeta for StubBackfill {
-        fn name(&self) -> &'static str {
-            "stub_backfill"
+        fn name(&self) -> Cow<'static, str> {
+            "stub_backfill".into()
         }
         fn order(&self) -> u32 {
             1
@@ -322,8 +322,8 @@ mod tests {
 
     struct OkCleanup;
     impl MigrationMeta for OkCleanup {
-        fn name(&self) -> &'static str {
-            "ok_cleanup"
+        fn name(&self) -> Cow<'static, str> {
+            "ok_cleanup".into()
         }
         fn order(&self) -> u32 {
             2
@@ -341,8 +341,8 @@ mod tests {
 
     struct DanglingCleanup;
     impl MigrationMeta for DanglingCleanup {
-        fn name(&self) -> &'static str {
-            "dangling_cleanup"
+        fn name(&self) -> Cow<'static, str> {
+            "dangling_cleanup".into()
         }
         fn order(&self) -> u32 {
             3
@@ -367,8 +367,8 @@ mod tests {
     fn duplicate_name_rejected() {
         struct A;
         impl MigrationMeta for A {
-            fn name(&self) -> &'static str {
-                "dup"
+            fn name(&self) -> Cow<'static, str> {
+                "dup".into()
             }
             fn order(&self) -> u32 {
                 1
@@ -382,8 +382,8 @@ mod tests {
         }
         struct B;
         impl MigrationMeta for B {
-            fn name(&self) -> &'static str {
-                "dup"
+            fn name(&self) -> Cow<'static, str> {
+                "dup".into()
             }
             fn order(&self) -> u32 {
                 2
@@ -408,8 +408,8 @@ mod tests {
     fn duplicate_order_rejected() {
         struct A;
         impl MigrationMeta for A {
-            fn name(&self) -> &'static str {
-                "a"
+            fn name(&self) -> Cow<'static, str> {
+                "a".into()
             }
             fn order(&self) -> u32 {
                 1
@@ -423,8 +423,8 @@ mod tests {
         }
         struct B;
         impl MigrationMeta for B {
-            fn name(&self) -> &'static str {
-                "b"
+            fn name(&self) -> Cow<'static, str> {
+                "b".into()
             }
             fn order(&self) -> u32 {
                 1


### PR DESCRIPTION
- Change MigrationMeta::name to Cow<'static, str> so backfill names can be parameterized by table
- Replace single BackfillRefs (which combined four tables under one offset, permanently skipping rows in slower-progressing tables) with one BackfillRefs per merkle tree table, each registered separately
- Cleanup::requires now lists each per-table backfill name
