### PR TITLE
Check if epoch < first_epoch before triggering catchup

### DIFF
--- a/crates/espresso/node/src/message_compat_tests.rs
+++ b/crates/espresso/node/src/message_compat_tests.rs
@@ -53,6 +53,7 @@ async fn test_message_compat<Ver: StaticVersionType>(_ver: Ver) {
             TimeoutData, TimeoutVote, ViewSyncCommitData, ViewSyncCommitVote, ViewSyncFinalizeData,
             ViewSyncFinalizeVote, ViewSyncPreCommitData, ViewSyncPreCommitVote,
         },
+        traits::election::Membership,
     };
 
     let (sender, priv_key) = PubKey::generated_from_seed_indexed(Default::default(), 0);
@@ -72,6 +73,10 @@ async fn test_message_compat<Ver: StaticVersionType>(_ver: Ver) {
         epoch_height,
         &storage,
     );
+
+    EpochMembershipCoordinator::<SeqTypes>::membership(&membership)
+        .set_first_epoch(1.into(), [0u8; 32]);
+
     let upgrade_data = UpgradeProposalData {
         old_version: Version { major: 0, minor: 1 },
         new_version: Version { major: 1, minor: 0 },

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -160,6 +160,17 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
                 snapshot: EpochMembershipSnapshot::NonEpoch(self.membership.non_epoch_snapshot()),
             });
         };
+        let Some(first_epoch) = self.membership.first_epoch() else {
+            return Err(error!(
+                "stake_table_for_epoch called with epoch {epoch:?} but first_epoch is unset"
+            ));
+        };
+        if epoch < first_epoch {
+            return Err(error!(
+                "stake_table_for_epoch called with epoch {epoch:?} before first_epoch \
+                 {first_epoch}"
+            ));
+        }
         if let Some(snapshot) = self.membership.snapshot(epoch) {
             return Ok(EpochMembership {
                 coordinator: self.clone(),


### PR DESCRIPTION
We had two methods that would trigger catchup in the Membership object for a given epoch. `membership_for_epoch` would check if the requested epoch was smaller than the first epoch before triggering catchup, while `stake_table_for_epoch` would not.

This PR fixes `stake_table_for_epoch`.
