### PR TITLE
Initialise new-protocol's cliquenet epoch with 0.

### DIFF
--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -454,6 +454,13 @@ impl Server {
                                     }
                                     continue
                                 }
+                                info!(
+                                    name = %self.conf.name,
+                                    node = %self.key,
+                                    peer = %k,
+                                    addr = %a,
+                                    "adding new peer"
+                                );
                                 self.parties.insert(k, Party::new(role, a.clone()));
                                 self.spawn_connect(k, a)
                             }
@@ -487,6 +494,13 @@ impl Server {
                                     continue
                                 }
                                 if let Some(p) = self.parties.get_mut(k) {
+                                    info!(
+                                        name = %self.conf.name,
+                                        node = %self.key,
+                                        peer = %k,
+                                        %role,
+                                        "assigning role to peer"
+                                    );
                                     p.role = role
                                 } else {
                                     warn!(

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -354,8 +354,7 @@ where
                 },
                 Some(item) = self.proposal_validator.next() => match item {
                     Ok(validated) => {
-                        // Refresh the network's peer set when a proposal is validated
-                        // on_epoch_change should return immediately if the epoch is not new
+                        // Refresh the network's peer set when a proposal is validated.
                         let epoch = validated.message.proposal.data.epoch;
                         if let Err(err) = self
                             .network

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -359,10 +359,10 @@ where
                         let epoch = validated.message.proposal.data.epoch;
                         if let Err(err) = self
                             .network
-                            .on_epoch_change(epoch, &self.membership_coordinator)
+                            .apply_epoch(epoch, &self.membership_coordinator)
                             .await
                         {
-                            error!(%epoch, %err, "network on_epoch_change failed");
+                            error!(%epoch, %err, "network apply_epoch failed");
                         }
 
                         let view = validated.message.proposal.data.view_number();

--- a/crates/hotshot/new-protocol/src/network.rs
+++ b/crates/hotshot/new-protocol/src/network.rs
@@ -40,16 +40,6 @@ pub trait Network<T: NodeType> {
     fn assign_role(&mut self, r: PeerRole, ps: Vec<&T::SignatureKey>) -> Result<()>;
 
     /// Refresh the peer set for the given epoch using the membership coordinator.
-    ///
-    /// Implementations should reconcile their active peer set against the
-    /// stake tables of the surrounding epoch window (e-1, e, e+1).
-    fn on_epoch_change(
-        &mut self,
-        epoch: EpochNumber,
-        coord: &EpochMembershipCoordinator<T>,
-    ) -> impl Future<Output = Result<()>> + Send;
-
-    /// Helper used by `on_epoch_change`.
     fn apply_epoch(
         &mut self,
         epoch: EpochNumber,

--- a/crates/hotshot/new-protocol/src/network/cliquenet.rs
+++ b/crates/hotshot/new-protocol/src/network/cliquenet.rs
@@ -80,7 +80,7 @@ impl<T: NodeType> Cliquenet<T> {
             my_keys: (signing_key, public_key),
             inner: network,
             peers,
-            epoch: EpochNumber::genesis(),
+            epoch: EpochNumber::new(0),
             upgrade_lock,
         })
     }
@@ -214,7 +214,7 @@ impl<T: NodeType> Network<T> for Cliquenet<T> {
     ///
     /// We keep validators that were in `e-1` but not in `e` for one additional
     /// epoch and eagerly connect to new validators of `e+1`.
-    async fn on_epoch_change(
+    async fn apply_epoch(
         &mut self,
         epoch: EpochNumber,
         coord: &EpochMembershipCoordinator<T>,
@@ -223,14 +223,7 @@ impl<T: NodeType> Network<T> for Cliquenet<T> {
             info!(%epoch, ours = %self.epoch, "epoch already seen");
             return Ok(());
         }
-        self.apply_epoch(epoch, coord).await
-    }
 
-    async fn apply_epoch(
-        &mut self,
-        epoch: EpochNumber,
-        coord: &EpochMembershipCoordinator<T>,
-    ) -> Result<(), NetworkError> {
         // Validators of the new epoch.
         let Some(curr_infos) = coord.epoch_peers(Some(epoch)) else {
             error!(%epoch, "no stake table available");


### PR DESCRIPTION
Epoch genesis is 1 so with this change we execute `apply_epoch` for the genesis epoch.

Also merge remove `on_epoch_change` in preference to `apply_epoch`.

Finally add some more info logs to cliquenet when peers are added and removed for increased visibility in logs.
