### PR TITLE
Run `persist_reward_proofs` every block

### DIFF
--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -503,14 +503,12 @@ impl RewardMerkleTreeDataSource for SqlStorage {
         version: Version,
     ) -> impl Send + Future<Output = anyhow::Result<()>> {
         async move {
-            // For V4 (per-block rewards), only persist proofs every 30th block.
-            // For V5+ (epoch rewards), this is only called at epoch boundaries.
+            // Only attempt to persist proofs every 30th block.
             //
             // In tests, we persist proofs at every block height so
             // reward claim tests can query proofs at arbitrary heights. This can be
             // removed once all reward claim tests are updated
             if !cfg!(any(test, feature = "testing"))
-                && version < EPOCH_REWARD_VERSION
                 && !(height + node_state.node_id).is_multiple_of(30)
             {
                 return Ok(());

--- a/crates/espresso/node/src/state.rs
+++ b/crates/espresso/node/src/state.rs
@@ -300,12 +300,12 @@ where
             )
             .await
             .context("failed to save and gc reward merkle tree v2")?;
-
-        storage
-            .persist_reward_proofs(instance, block_number, version)
-            .await
-            .context("failed to persist reward proofs")?;
     }
+
+    storage
+        .persist_reward_proofs(instance, block_number, version)
+        .await
+        .context("failed to persist reward proofs")?;
 
     tracing::debug!("storing state update");
     let mut tx = storage


### PR DESCRIPTION
After the per-epoch reward upgrade, we were only attempting to generate reward proofs at epoch boundaries. This allows for long stretches of time where no current reward proof is available, if the contract's finalized height is updated near the start of the epoch.

We fix this by running the proof generation logic every block. In the vast majority of cases, this should essentially no-op after a contract query and database lookup, so should not cause any noticeable increase in load.
