### PR TITLE
Remove immediate timer reset.

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -295,11 +295,6 @@ where
                 },
                 () = &mut self.timer => {
                     let input = ConsensusInput::Timeout(self.timer.view(), self.timer.epoch());
-                    // Timer is only reset so we can resend the timeout vote
-                    // This isn't strictly necessary for the protocol, but it's a good idea to
-                    // resend the timeout vote to avoid a situation where the network is stuck
-                    // view because we fail to form a timeout certificate.
-                    self.timer.reset();
                     return Ok(input)
                 }
                 Some(output) = self.state_manager.next() => {

--- a/crates/hotshot/new-protocol/src/coordinator/timer.rs
+++ b/crates/hotshot/new-protocol/src/coordinator/timer.rs
@@ -1,6 +1,6 @@
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll, ready},
     time::Duration,
 };
 
@@ -12,6 +12,7 @@ pub struct Timer {
     view: ViewNumber,
     epoch: EpochNumber,
     duration: Duration,
+    done: bool,
 }
 
 impl Timer {
@@ -21,6 +22,7 @@ impl Timer {
             view: v,
             epoch: e,
             duration: d,
+            done: false,
         }
     }
 
@@ -33,16 +35,19 @@ impl Timer {
     }
 
     pub fn reset(&mut self) {
+        self.done = false;
         self.sleep.as_mut().reset(Instant::now() + self.duration);
     }
 
     pub fn reset_with(&mut self, v: ViewNumber) {
         self.view = v;
+        self.done = false;
         self.sleep.as_mut().reset(Instant::now() + self.duration);
     }
     pub fn reset_with_epoch(&mut self, v: ViewNumber, e: EpochNumber) {
         self.view = v;
         self.epoch = e;
+        self.done = false;
         self.sleep.as_mut().reset(Instant::now() + self.duration);
     }
 }
@@ -51,6 +56,11 @@ impl Future for Timer {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        self.sleep.as_mut().poll(cx)
+        if self.done {
+            return Poll::Pending;
+        }
+        ready!(self.sleep.as_mut().poll(cx));
+        self.done = true;
+        Poll::Ready(())
     }
 }


### PR DESCRIPTION
Messages are reliably delivered until garbage collection. Additional retries may just fill up the outbound message buffers of peers.

Change `Timer` to fire only once to avoid repeated timeouts. Thus after a timer expires it needs to be reset to make it fire again.