### PR TITLE
Use separate tasks for sending and receiving.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -475,3 +475,7 @@ opt-level = 3
 inherits = "test"
 strip = true
 debug = "none"
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/crates/cliquenet/benches/bench1.rs
+++ b/crates/cliquenet/benches/bench1.rs
@@ -3,7 +3,7 @@ use std::{
 };
 
 use cliquenet::{
-    Config, Network, RetryPolicy, SendAction, SendCommand, Slot,
+    Config, NOISE_IK_25519_AESGCM_BLAKE2S, Network, RetryPolicy, SendAction, SendCommand, Slot,
     x25519::{Keypair, PublicKey},
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -127,6 +127,7 @@ async fn setup_echo() -> Echo {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build();
 
     let conf_b = Config::builder()
@@ -138,6 +139,7 @@ async fn setup_echo() -> Echo {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build();
 
     let net_a = Network::create(conf_a).await.unwrap();
@@ -232,6 +234,7 @@ async fn setup_bidir() -> BiDir {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build();
 
     let conf_b = Config::builder()
@@ -243,6 +246,7 @@ async fn setup_bidir() -> BiDir {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build();
 
     let net_a = Network::create(conf_a).await.unwrap();

--- a/crates/cliquenet/benches/bench1.rs
+++ b/crates/cliquenet/benches/bench1.rs
@@ -13,6 +13,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     runtime::Runtime,
+    task::JoinSet,
     time::sleep,
 };
 
@@ -23,12 +24,12 @@ const GIBI: usize = MEBI * KIBI;
 const SIZES: &[usize] = &[
     1,
     128 * KIBI,
-    512 * KIBI,
-    MEBI,
-    5 * MEBI,
-    10 * MEBI,
-    50 * MEBI,
-    100 * MEBI,
+    //512 * KIBI,
+    //MEBI,
+    //5 * MEBI,
+    //10 * MEBI,
+    //50 * MEBI,
+    //100 * MEBI,
 ];
 
 static DATA: LazyLock<HashMap<usize, Vec<u8>>> = LazyLock::new(|| {
@@ -88,9 +89,9 @@ async fn tcp_echo(srv: &mut TcpStream, clt: &mut TcpStream, data: &[u8]) {
 fn bench_tcp(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let (mut srv, mut clt) = rt.block_on(setup_tcp());
-    let mut group = c.benchmark_group("tcp");
+    let mut group = c.benchmark_group("tcp echo");
     for &n in SIZES {
-        group.throughput(Throughput::Bytes(n as u64));
+        group.throughput(Throughput::Bytes(2 * n as u64));
         group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
             let data = &DATA[&n];
             b.iter(|| rt.block_on(tcp_echo(&mut srv, &mut clt, data)))
@@ -165,9 +166,9 @@ fn bench_cliquenet(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut echo = rt.block_on(setup_echo());
 
-    let mut group = c.benchmark_group("cliquenet");
+    let mut group = c.benchmark_group("cliquenet echo");
     for &n in SIZES {
-        group.throughput(Throughput::Bytes(n as u64));
+        group.throughput(Throughput::Bytes(2 * n as u64));
         group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
             let data = &DATA[&n];
             b.iter(|| {
@@ -182,9 +183,9 @@ fn bench_cliquenet(c: &mut Criterion) {
     }
     group.finish();
 
-    let mut group = c.benchmark_group("cliquenet[no-retry]");
+    let mut group = c.benchmark_group("cliquenet echo (no-retry)");
     for &n in SIZES {
-        group.throughput(Throughput::Bytes(n as u64));
+        group.throughput(Throughput::Bytes(2 * n as u64));
         group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
             let data = &DATA[&n];
             b.iter(|| {
@@ -273,89 +274,289 @@ fn bench_bidirectional(c: &mut Criterion) {
 
     let rt = Runtime::new().unwrap();
 
-    let mut group = c.benchmark_group("bidirectional");
+    let mut group = c.benchmark_group("bidirectional echos (10 rounds)");
     for &n in SIZES {
         if n > 10 * MEBI {
             continue;
         }
         let mut bd = rt.block_on(setup_bidir());
-        group.bench_with_input(
-            BenchmarkId::from_parameter(show(n * ROUNDS)),
-            &n,
-            |b, &n| {
-                let data = &DATA[&n];
-                b.iter(|| {
-                    rt.block_on(async {
-                        tokio::join!(
-                            async {
-                                for _ in 0..ROUNDS {
-                                    bd.ctrl_a.unicast(Slot::MIN, bd.pkb, data.clone()).unwrap();
-                                    let (src, recv) = bd.recv_a.receive().await.unwrap();
-                                    assert_eq!(src, bd.pkb);
-                                    assert_eq!(recv.len(), n);
-                                }
-                            },
-                            async {
-                                for _ in 0..ROUNDS {
-                                    bd.ctrl_b.unicast(Slot::MIN, bd.pka, data.clone()).unwrap();
-                                    let (src, recv) = bd.recv_b.receive().await.unwrap();
-                                    assert_eq!(src, bd.pka);
-                                    assert_eq!(recv.len(), n);
-                                }
-                            },
-                        );
-                    });
+        group.throughput(Throughput::Bytes((2 * n * ROUNDS) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
+            let data = &DATA[&n];
+            b.iter(|| {
+                rt.block_on(async {
+                    let BiDir {
+                        ctrl_a,
+                        recv_a,
+                        pka,
+                        ctrl_b,
+                        recv_b,
+                        pkb,
+                    } = &mut bd;
+                    let pka = *pka;
+                    let pkb = *pkb;
+                    let s_a = async {
+                        for _ in 0..ROUNDS {
+                            ctrl_a.unicast(Slot::MIN, pkb, data.clone()).unwrap();
+                        }
+                    };
+                    let r_a = async {
+                        for _ in 0..ROUNDS {
+                            let (src, msg) = recv_a.receive().await.unwrap();
+                            assert_eq!(src, pkb);
+                            assert_eq!(msg.len(), n);
+                        }
+                    };
+                    let s_b = async {
+                        for _ in 0..ROUNDS {
+                            ctrl_b.unicast(Slot::MIN, pka, data.clone()).unwrap();
+                        }
+                    };
+                    let r_b = async {
+                        for _ in 0..ROUNDS {
+                            let (src, msg) = recv_b.receive().await.unwrap();
+                            assert_eq!(src, pka);
+                            assert_eq!(msg.len(), n);
+                        }
+                    };
+                    tokio::join!(s_a, r_a, s_b, r_b);
                 });
-            },
-        );
+            });
+        });
     }
     group.finish();
 
-    let mut group = c.benchmark_group("bidirectional[no-retry]");
+    let mut group = c.benchmark_group("bidirectional echos (10 rounds, no-retry)");
     for &n in SIZES {
         if n > 10 * MEBI {
             continue;
         }
         let mut bd = rt.block_on(setup_bidir());
-        group.bench_with_input(
-            BenchmarkId::from_parameter(show(n * ROUNDS)),
-            &n,
-            |b, &n| {
-                let data = &DATA[&n];
-                b.iter(|| {
-                    rt.block_on(async {
-                        tokio::join!(
-                            async {
-                                for _ in 0..ROUNDS {
-                                    let cmd = SendCommand::builder()
-                                        .slot(Slot::MIN)
-                                        .retry(RetryPolicy::NoRetry)
-                                        .action(SendAction::Unicast(bd.pkb, data.clone()))
-                                        .build();
-                                    bd.ctrl_a.send(cmd).unwrap();
-                                    let (src, recv) = bd.recv_a.receive().await.unwrap();
-                                    assert_eq!(src, bd.pkb);
-                                    assert_eq!(recv.len(), n);
-                                }
-                            },
-                            async {
-                                for _ in 0..ROUNDS {
-                                    let cmd = SendCommand::builder()
-                                        .slot(Slot::MIN)
-                                        .retry(RetryPolicy::NoRetry)
-                                        .action(SendAction::Unicast(bd.pka, data.clone()))
-                                        .build();
-                                    bd.ctrl_b.send(cmd).unwrap();
-                                    let (src, recv) = bd.recv_b.receive().await.unwrap();
-                                    assert_eq!(src, bd.pka);
-                                    assert_eq!(recv.len(), n);
-                                }
-                            },
-                        );
-                    });
+        group.throughput(Throughput::Bytes((2 * n * ROUNDS) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
+            let data = &DATA[&n];
+            b.iter(|| {
+                rt.block_on(async {
+                    let BiDir {
+                        ctrl_a,
+                        recv_a,
+                        pka,
+                        ctrl_b,
+                        recv_b,
+                        pkb,
+                    } = &mut bd;
+                    let pka = *pka;
+                    let pkb = *pkb;
+                    let s_a = async {
+                        for _ in 0..ROUNDS {
+                            let cmd = SendCommand::builder()
+                                .slot(Slot::MIN)
+                                .retry(RetryPolicy::NoRetry)
+                                .action(SendAction::Unicast(pkb, data.clone()))
+                                .build();
+                            ctrl_a.send(cmd).unwrap();
+                        }
+                    };
+                    let r_a = async {
+                        for _ in 0..ROUNDS {
+                            let (src, msg) = recv_a.receive().await.unwrap();
+                            assert_eq!(src, pkb);
+                            assert_eq!(msg.len(), n);
+                        }
+                    };
+                    let s_b = async {
+                        for _ in 0..ROUNDS {
+                            let cmd = SendCommand::builder()
+                                .slot(Slot::MIN)
+                                .retry(RetryPolicy::NoRetry)
+                                .action(SendAction::Unicast(pka, data.clone()))
+                                .build();
+                            ctrl_b.send(cmd).unwrap();
+                        }
+                    };
+                    let r_b = async {
+                        for _ in 0..ROUNDS {
+                            let (src, msg) = recv_b.receive().await.unwrap();
+                            assert_eq!(src, pka);
+                            assert_eq!(msg.len(), n);
+                        }
+                    };
+                    tokio::join!(s_a, r_a, s_b, r_b);
                 });
-            },
-        );
+            });
+        });
+    }
+    group.finish();
+}
+
+// -- N-node mesh throughput ---------------------------------------------------
+
+struct MeshNode {
+    ctrl: cliquenet::NetworkController,
+    recv: cliquenet::NetworkReceiver,
+    peers: Vec<PublicKey>,
+}
+
+struct Mesh {
+    nodes: Vec<MeshNode>,
+}
+
+async fn setup_mesh(n_nodes: usize) -> Mesh {
+    let keypairs: Vec<Keypair> = (0..n_nodes).map(|_| Keypair::generate().unwrap()).collect();
+    let pks: Vec<PublicKey> = keypairs.iter().map(|k| k.public_key()).collect();
+    let ports: Vec<u16> = (0..n_nodes).map(|_| reserve_port()).collect();
+
+    let mut nets = Vec::with_capacity(n_nodes);
+    for (i, kp) in keypairs.into_iter().enumerate() {
+        let parties: Vec<_> = (0..n_nodes)
+            .filter(|&j| j != i)
+            .map(|j| (pks[j], (Ipv4Addr::LOCALHOST, ports[j]).into()))
+            .collect();
+        let conf = Config::builder()
+            .name("bench")
+            .keypair(kp)
+            .bind((Ipv4Addr::LOCALHOST, ports[i]).into())
+            .parties(parties)
+            .max_message_size(NonZeroUsize::new(100 * MEBI).unwrap())
+            .receive_timeout(Duration::from_secs(60))
+            .retry_delays(vec![1, 3])
+            .max_retry_delay(Duration::from_secs(5))
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
+            .build();
+        nets.push(Network::create(conf).await.unwrap());
+    }
+
+    sleep(Duration::from_secs(3)).await;
+
+    let nodes = nets
+        .into_iter()
+        .enumerate()
+        .map(|(i, net)| {
+            let (ctrl, recv) = net.split_into();
+            let peers: Vec<PublicKey> = (0..n_nodes).filter(|&j| j != i).map(|j| pks[j]).collect();
+            MeshNode { ctrl, recv, peers }
+        })
+        .collect();
+
+    Mesh { nodes }
+}
+
+fn bench_mesh(c: &mut Criterion) {
+    const ROUNDS: usize = 10;
+    const NODES: usize = 10;
+
+    let rt = Runtime::new().unwrap();
+
+    let mut group = c.benchmark_group("mesh echos (10 nodes, 10 rounds)");
+    for &n in SIZES {
+        // Per iter we move NODES * (NODES - 1) * ROUNDS * n bytes total.
+        // Cap message size to keep iter time bounded.
+        if n > MEBI {
+            continue;
+        }
+        let mut mesh = rt.block_on(setup_mesh(NODES));
+        let total = (NODES * (NODES - 1) * ROUNDS * n) as u64;
+        group.throughput(Throughput::Bytes(total));
+        group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
+            let data = &DATA[&n];
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut set: JoinSet<MeshNode> = JoinSet::new();
+                    for node in mesh.nodes.drain(..) {
+                        let task_data = data.clone();
+                        set.spawn(async move {
+                            let MeshNode {
+                                mut ctrl,
+                                mut recv,
+                                peers,
+                            } = node;
+                            let n_recv = ROUNDS * peers.len();
+                            {
+                                let send = async {
+                                    for _ in 0..ROUNDS {
+                                        for &peer in &peers {
+                                            ctrl.unicast(Slot::MIN, peer, task_data.clone())
+                                                .unwrap();
+                                        }
+                                    }
+                                };
+                                let receive = async {
+                                    for _ in 0..n_recv {
+                                        let (src, msg) = recv.receive().await.unwrap();
+                                        debug_assert!(peers.contains(&src));
+                                        debug_assert_eq!(msg.len(), n);
+                                    }
+                                };
+                                tokio::join!(send, receive);
+                            }
+                            MeshNode { ctrl, recv, peers }
+                        });
+                    }
+                    while let Some(res) = set.join_next().await {
+                        mesh.nodes.push(res.unwrap());
+                    }
+                });
+            });
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("mesh echos (10 nodes, 10 rounds, no-retry)");
+    for &n in SIZES {
+        if n > MEBI {
+            continue;
+        }
+        let mut mesh = rt.block_on(setup_mesh(NODES));
+        let total = (NODES * (NODES - 1) * ROUNDS * n) as u64;
+        group.throughput(Throughput::Bytes(total));
+        group.bench_with_input(BenchmarkId::from_parameter(show(n)), &n, |b, &n| {
+            let data = &DATA[&n];
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut set: JoinSet<MeshNode> = JoinSet::new();
+                    for node in mesh.nodes.drain(..) {
+                        let task_data = data.clone();
+                        set.spawn(async move {
+                            let MeshNode {
+                                mut ctrl,
+                                mut recv,
+                                peers,
+                            } = node;
+                            let n_recv = ROUNDS * peers.len();
+                            {
+                                let send = async {
+                                    for _ in 0..ROUNDS {
+                                        for &peer in &peers {
+                                            let cmd = SendCommand::builder()
+                                                .slot(Slot::MIN)
+                                                .retry(RetryPolicy::NoRetry)
+                                                .action(SendAction::Unicast(
+                                                    peer,
+                                                    task_data.clone(),
+                                                ))
+                                                .build();
+                                            ctrl.send(cmd).unwrap();
+                                        }
+                                    }
+                                };
+                                let receive = async {
+                                    for _ in 0..n_recv {
+                                        let (src, msg) = recv.receive().await.unwrap();
+                                        debug_assert!(peers.contains(&src));
+                                        debug_assert_eq!(msg.len(), n);
+                                    }
+                                };
+                                tokio::join!(send, receive);
+                            }
+                            MeshNode { ctrl, recv, peers }
+                        });
+                    }
+                    while let Some(res) = set.join_next().await {
+                        mesh.nodes.push(res.unwrap());
+                    }
+                });
+            });
+        });
     }
     group.finish();
 }
@@ -370,5 +571,11 @@ fn show(size: usize) -> String {
     }
 }
 
-criterion_group!(benches, bench_tcp, bench_cliquenet, bench_bidirectional);
+criterion_group!(
+    benches,
+    bench_tcp,
+    bench_cliquenet,
+    bench_bidirectional,
+    bench_mesh
+);
 criterion_main!(benches);

--- a/crates/cliquenet/benches/bench1.rs
+++ b/crates/cliquenet/benches/bench1.rs
@@ -3,7 +3,8 @@ use std::{
 };
 
 use cliquenet::{
-    Config, NOISE_IK_25519_AESGCM_BLAKE2S, Network, RetryPolicy, SendAction, SendCommand, Slot,
+    Config, Network, RetryPolicy, SendAction, SendCommand, Slot,
+    noise::Protocol,
     x25519::{Keypair, PublicKey},
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -127,7 +128,7 @@ async fn setup_echo() -> Echo {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let conf_b = Config::builder()
@@ -139,7 +140,7 @@ async fn setup_echo() -> Echo {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let net_a = Network::create(conf_a).await.unwrap();
@@ -234,7 +235,7 @@ async fn setup_bidir() -> BiDir {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let conf_b = Config::builder()
@@ -246,7 +247,7 @@ async fn setup_bidir() -> BiDir {
         .receive_timeout(Duration::from_secs(60))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let net_a = Network::create(conf_a).await.unwrap();

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -13,6 +13,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
     time::{sleep, timeout},
+    try_join,
 };
 use tracing::{debug, warn};
 
@@ -39,78 +40,49 @@ type Prologue = Vec<u8>;
 
 impl Connection {
     pub async fn accept(conf: Arc<Config>, mut stream: TcpStream) -> Result<Self> {
-        if let Err(err) = stream.set_nodelay(true) {
-            warn!(
-                name = %conf.name,
-                node = %conf.keypair.public_key(),
-                %err,
-                "failed to enable NO_DELAY option"
-            )
-        }
-
-        let (version, prologue) = {
-            let action = select_version(&conf, &mut stream, false);
-            until(conf.handshake_timeout, action).await?
-        };
-
-        debug!(
-            name = %conf.name,
-            node = %conf.keypair.public_key(),
-            %version,
-            "negotiated version"
-        );
-
-        let params = conf
-            .noise_configs
-            .get(&version)
-            .expect("selected version has noise config");
-        let hs = Builder::new(params.clone())
-            .local_private_key(&conf.keypair.secret_key().as_bytes())
-            .expect("valid private key")
-            .prologue(&prologue)
-            .expect("1st time we set the prologue")
-            .build_responder()
-            .expect("valid noise params yield valid handshake state");
-
         let node = conf.keypair.public_key();
-        let addr = stream.peer_addr()?;
 
-        let state = {
-            let action = on_handshake(&mut stream, hs);
-            until(conf.handshake_timeout, action).await?
-        };
-
-        if let Some(key) = remote_static_key(&state) {
-            Ok(Self {
-                key,
-                addr,
-                stream,
-                state,
-            })
-        } else {
-            warn! {
-                name = %conf.name,
-                %node,
-                %addr,
-                "missing or invalid remote static key"
-            }
-            Err(NetworkError::InvalidHandshakeMessage)
+        if let Err(err) = stream.set_nodelay(true) {
+            warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option")
         }
+
+        until(conf.handshake_timeout, async move {
+            let (version, prologue) = select_version(&conf, &mut stream, false).await?;
+
+            debug!(name = %conf.name, %node, %version, "negotiated version");
+
+            let params = conf
+                .noise_configs
+                .get(&version)
+                .expect("selected version has noise config");
+
+            let hs = Builder::new(params.clone())
+                .local_private_key(&conf.keypair.secret_key().as_bytes())
+                .expect("valid private key")
+                .prologue(&prologue)
+                .expect("1st time we set the prologue")
+                .build_responder()
+                .expect("valid noise params yield valid handshake state");
+
+            let addr = stream.peer_addr()?;
+            let state = on_handshake(&mut stream, hs).await?;
+
+            if let Some(key) = remote_static_key(&state) {
+                Ok(Self {
+                    key,
+                    addr,
+                    stream,
+                    state,
+                })
+            } else {
+                warn!(name = %conf.name, %node, %addr, "invalid static key");
+                Err(NetworkError::InvalidHandshakeMessage)
+            }
+        })
+        .await
     }
 
     pub async fn connect(conf: Arc<Config>, peer: PublicKey, addr: NetAddr) -> Self {
-        let new_handshake_state = |prologue: &Prologue, params: &NoiseParams| {
-            Builder::new(params.clone())
-                .local_private_key(conf.keypair.secret_key().as_slice())
-                .expect("valid private key")
-                .remote_public_key(peer.as_slice())
-                .expect("valid remote pub key")
-                .prologue(prologue)
-                .expect("1st time we set the prologue")
-                .build_initiator()
-                .expect("valid noise params yield valid handshake state")
-        };
-
         let mut delays = once({
             if conf.random_connect_delay {
                 Duration::from_millis(rand::rng().random_range(0..1000))
@@ -136,111 +108,39 @@ impl Connection {
             } else {
                 sleep(delays.next().expect("delays iterator is infinite")).await;
             }
+
             debug!(name = %conf.name, %node, %peer, %addr, "connecting");
-            match until(conf.connect_timeout, TcpStream::connect(&addr)).await {
-                Ok(mut stream) => {
-                    let addr = match stream.peer_addr() {
-                        Ok(addr) => addr,
-                        Err(err) => {
-                            warn!(name = %conf.name, %node, %err, "failed to get peer address");
-                            continue;
-                        },
-                    };
-                    if let Err(err) = stream.set_nodelay(true) {
-                        warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option")
-                    }
-                    let action = select_version(&conf, &mut stream, true);
-                    let (version, prologue) = match until(conf.handshake_timeout, action).await {
-                        Ok((v, p)) => {
-                            debug!(name = %conf.name, %node, version = %v, "negotiated version");
-                            (v, p)
-                        },
-                        Err(err) => {
-                            warn!(name = %conf.name, %node, %err, "failed to negotiate version");
-                            continue;
-                        },
-                    };
-                    let params = conf
-                        .noise_configs
-                        .get(&version)
-                        .expect("selected version has noise config");
-                    let state = new_handshake_state(&prologue, params);
-                    match until(conf.handshake_timeout, handshake(&mut stream, state)).await {
-                        Ok(state) => {
-                            debug!(name = %conf.name, %node, %peer, %addr, "connected");
-                            match remote_static_key(&state) {
-                                Some(key) if key == peer => {
-                                    let mut conn = Self {
-                                        key,
-                                        addr,
-                                        stream,
-                                        state,
-                                    };
-                                    match conn
-                                        .exchange_hello(conf.handshake_timeout, Hello::Ok)
-                                        .await
-                                    {
-                                        Ok(h) if h.is_ok() => break conn,
-                                        Ok(h) => {
-                                            warn!(
-                                                name = %conf.name,
-                                                %node,
-                                                %peer,
-                                                remote = %key,
-                                                %addr,
-                                                "hello response was not ok"
-                                            );
-                                            backoff = h.backoff_duration();
-                                            continue;
-                                        },
-                                        Err(err) => {
-                                            warn!(
-                                                name = %conf.name,
-                                                %node,
-                                                %peer,
-                                                remote = %key,
-                                                %addr,
-                                                %err,
-                                                "failed to exchange hello"
-                                            );
-                                            continue;
-                                        },
-                                    }
-                                },
-                                Some(key) => {
-                                    warn!(
-                                        name = %conf.name,
-                                        %node,
-                                        %peer,
-                                        remote = %key,
-                                        %addr,
-                                        "remote static key mismatch"
-                                    )
-                                },
-                                None => {
-                                    warn!(
-                                        name = %conf.name,
-                                        %node,
-                                        %peer,
-                                        %addr,
-                                        "missing or invalid remote static key"
-                                    )
-                                },
-                            }
+
+            match try_connect(&conf, &peer, &addr).await {
+                Ok(mut conn) => {
+                    match conn.exchange_hello(conf.handshake_timeout, Hello::Ok).await {
+                        Ok(h) if h.is_ok() => break conn,
+                        Ok(h) => {
+                            warn!(
+                                name = %conf.name,
+                                %node,
+                                %peer,
+                                remote = %conn.key,
+                                %addr,
+                                "hello response was not ok"
+                            );
+                            backoff = h.backoff_duration();
                         },
                         Err(err) => {
                             warn!(
                                 name = %conf.name,
                                 %node,
                                 %peer,
+                                remote = %conn.key,
                                 %addr,
-                                %err, "handshake failure"
-                            )
+                                %err,
+                                "failed to exchange hello"
+                            );
                         },
                     }
                 },
                 Err(err) => {
-                    warn!(name = %conf.name, %node, %peer, %addr, %err, "connect failure");
+                    warn!(name = %conf.name, %node, %peer, %addr, %err, "connect/handshake error")
                 },
             }
         }
@@ -279,6 +179,61 @@ impl Connection {
     }
 }
 
+async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Connection> {
+    let new_handshake_state = |prologue: &Prologue, params: &NoiseParams| {
+        Builder::new(params.clone())
+            .local_private_key(conf.keypair.secret_key().as_slice())
+            .expect("valid private key")
+            .remote_public_key(peer.as_slice())
+            .expect("valid remote pub key")
+            .prologue(prologue)
+            .expect("1st time we set the prologue")
+            .build_initiator()
+            .expect("valid noise params yield valid handshake state")
+    };
+
+    let mut stream = until(conf.connect_timeout, TcpStream::connect(addr)).await?;
+
+    let node = conf.keypair.public_key();
+    let addr = stream.peer_addr()?;
+
+    debug!(name = %conf.name, %node, %peer, %addr, "tcp connection established");
+
+    if let Err(err) = stream.set_nodelay(true) {
+        warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option");
+    }
+
+    until(conf.handshake_timeout, async move {
+        let (version, prologue) = select_version(conf, &mut stream, true).await?;
+
+        debug!(name = %conf.name, %node, %peer, %addr, %version, "negotiated version");
+
+        let params = conf
+            .noise_configs
+            .get(&version)
+            .expect("selected version has noise config");
+
+        let state = handshake(&mut stream, new_handshake_state(&prologue, params)).await?;
+        match remote_static_key(&state) {
+            Some(key) if key == *peer => Ok(Connection {
+                key,
+                addr,
+                stream,
+                state,
+            }),
+            Some(key) => {
+                warn!(name = %conf.name, %node, %peer, remote = %key, %addr, "static key mismatch");
+                Err(NetworkError::InvalidHandshakeMessage)
+            },
+            None => {
+                warn!(name = %conf.name, %node, %peer, %addr, "invalid static key");
+                Err(NetworkError::InvalidHandshakeMessage)
+            },
+        }
+    })
+    .await
+}
+
 fn remote_static_key(state: &TransportState) -> Option<PublicKey> {
     let k = state.get_remote_static()?;
     PublicKey::try_from(k).ok()
@@ -305,24 +260,17 @@ async fn select_version(
     stream: &mut TcpStream,
     is_initiator: bool,
 ) -> Result<(Version, Prologue)> {
-    // NB that both ends send simultaneously before reading, hence the
-    // initial frame must fit into the socket's send buffer, i.e. be
-    // very small. Since we only send two u16 version numbers (= 4 bytes),
-    // that should not be a problem, but the init frame should better not
-    // grow.
     const INIT_PAYLOAD_LEN: usize = 4;
 
     let our_min = conf
         .noise_configs
-        .keys()
-        .min()
-        .copied()
+        .first_key_value()
+        .map(|(k, _)| *k)
         .expect("noise_configs is not empty");
     let our_max = conf
         .noise_configs
-        .keys()
-        .max()
-        .copied()
+        .last_key_value()
+        .map(|(k, _)| *k)
         .expect("noise_configs is not empty");
 
     let mut send_buf = [0u8; INIT_PAYLOAD_LEN];
@@ -331,8 +279,8 @@ async fn select_version(
     send_buf[0..2].copy_from_slice(&u16::from(our_min).to_be_bytes());
     send_buf[2..4].copy_from_slice(&u16::from(our_max).to_be_bytes());
 
-    stream.write_all(&send_buf).await?;
-    stream.read_exact(&mut recv_buf).await?;
+    let (mut r, mut w) = stream.split();
+    try_join!(w.write_all(&send_buf), r.read_exact(&mut recv_buf))?;
 
     let their_min = Version::from(u16::from_be_bytes([recv_buf[0], recv_buf[1]]));
     let their_max = Version::from(u16::from_be_bytes([recv_buf[2], recv_buf[3]]));

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -48,7 +48,10 @@ impl Connection {
             )
         }
 
-        let (version, prologue) = select_version(&conf, &mut stream, false).await?;
+        let (version, prologue) = {
+            let action = select_version(&conf, &mut stream, false);
+            until(conf.handshake_timeout, action).await?
+        };
 
         debug!(
             name = %conf.name,
@@ -71,26 +74,27 @@ impl Connection {
 
         let node = conf.keypair.public_key();
         let addr = stream.peer_addr()?;
-        match timeout(conf.handshake_timeout, on_handshake(&mut stream, hs)).await {
-            Ok(Ok(state)) => match remote_static_key(&state) {
-                Some(key) => Ok(Self {
-                    key,
-                    addr,
-                    stream,
-                    state,
-                }),
-                None => {
-                    warn! {
-                        name = %conf.name,
-                        %node,
-                        %addr,
-                        "missing or invalid remote static key"
-                    }
-                    Err(NetworkError::InvalidHandshakeMessage)
-                },
-            },
-            Ok(Err(e)) => Err(e),
-            Err(_) => Err(NetworkError::Timeout),
+
+        let state = {
+            let action = on_handshake(&mut stream, hs);
+            until(conf.handshake_timeout, action).await?
+        };
+
+        if let Some(key) = remote_static_key(&state) {
+            Ok(Self {
+                key,
+                addr,
+                stream,
+                state,
+            })
+        } else {
+            warn! {
+                name = %conf.name,
+                %node,
+                %addr,
+                "missing or invalid remote static key"
+            }
+            Err(NetworkError::InvalidHandshakeMessage)
         }
     }
 
@@ -101,7 +105,7 @@ impl Connection {
                 .expect("valid private key")
                 .remote_public_key(peer.as_slice())
                 .expect("valid remote pub key")
-                .prologue(&prologue)
+                .prologue(prologue)
                 .expect("1st time we set the prologue")
                 .build_initiator()
                 .expect("valid noise params yield valid handshake state")
@@ -133,8 +137,8 @@ impl Connection {
                 sleep(delays.next().expect("delays iterator is infinite")).await;
             }
             debug!(name = %conf.name, %node, %peer, %addr, "connecting");
-            match timeout(conf.connect_timeout, TcpStream::connect(&addr)).await {
-                Ok(Ok(mut stream)) => {
+            match until(conf.connect_timeout, TcpStream::connect(&addr)).await {
+                Ok(mut stream) => {
                     let addr = match stream.peer_addr() {
                         Ok(addr) => addr,
                         Err(err) => {
@@ -145,7 +149,8 @@ impl Connection {
                     if let Err(err) = stream.set_nodelay(true) {
                         warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option")
                     }
-                    let (version, prologue) = match select_version(&conf, &mut stream, true).await {
+                    let action = select_version(&conf, &mut stream, true);
+                    let (version, prologue) = match until(conf.handshake_timeout, action).await {
                         Ok((v, p)) => {
                             debug!(name = %conf.name, %node, version = %v, "negotiated version");
                             (v, p)
@@ -160,8 +165,8 @@ impl Connection {
                         .get(&version)
                         .expect("selected version has noise config");
                     let state = new_handshake_state(&prologue, params);
-                    match timeout(conf.handshake_timeout, handshake(&mut stream, state)).await {
-                        Ok(Ok(state)) => {
+                    match until(conf.handshake_timeout, handshake(&mut stream, state)).await {
+                        Ok(state) => {
                             debug!(name = %conf.name, %node, %peer, %addr, "connected");
                             match remote_static_key(&state) {
                                 Some(key) if key == peer => {
@@ -223,7 +228,7 @@ impl Connection {
                                 },
                             }
                         },
-                        Ok(Err(err)) => {
+                        Err(err) => {
                             warn!(
                                 name = %conf.name,
                                 %node,
@@ -232,16 +237,10 @@ impl Connection {
                                 %err, "handshake failure"
                             )
                         },
-                        Err(_) => {
-                            warn!(name = %conf.name, %node, %peer, %addr, "handshake timeout")
-                        },
                     }
                 },
-                Ok(Err(err)) => {
+                Err(err) => {
                     warn!(name = %conf.name, %node, %peer, %addr, %err, "connect failure");
-                },
-                Err(_) => {
-                    warn!(name = %conf.name, %node, %peer, %addr, "connect timeout");
                 },
             }
         }
@@ -283,6 +282,19 @@ impl Connection {
 fn remote_static_key(state: &TransportState) -> Option<PublicKey> {
     let k = state.get_remote_static()?;
     PublicKey::try_from(k).ok()
+}
+
+/// A variant of `timeout` that merges the timeout into the network error.
+async fn until<F, A, E>(t: Duration, fut: F) -> Result<A>
+where
+    F: Future<Output = std::result::Result<A, E>>,
+    E: Into<NetworkError>,
+{
+    match timeout(t, fut).await {
+        Ok(Ok(a)) => Ok(a),
+        Ok(Err(e)) => Err(e.into()),
+        Err(_) => Err(NetworkError::Timeout),
+    }
 }
 
 /// Select a version from the range that both sides support.

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -12,7 +12,7 @@ use snow::{Builder, HandshakeState, TransportState, params::NoiseParams};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
-    time::{sleep, timeout},
+    time::sleep,
     try_join,
 };
 use tracing::{debug, warn};
@@ -22,6 +22,7 @@ use crate::{
     addr::NetAddr,
     error::NetworkError,
     msg::{Header, MAX_NOISE_MESSAGE_SIZE, hello::Hello},
+    until,
     x25519::PublicKey,
 };
 
@@ -113,7 +114,11 @@ impl Connection {
 
             match try_connect(&conf, &peer, &addr).await {
                 Ok(mut conn) => {
-                    match conn.exchange_hello(conf.handshake_timeout, Hello::Ok).await {
+                    let hello_exchange = until(conf.handshake_timeout, async {
+                        conn.send_hello(Hello::Ok).await?;
+                        conn.recv_hello().await
+                    });
+                    match hello_exchange.await {
                         Ok(h) if h.is_ok() => break conn,
                         Ok(h) => {
                             warn!(
@@ -143,17 +148,6 @@ impl Connection {
                     warn!(name = %conf.name, %node, %peer, %addr, %err, "connect/handshake error")
                 },
             }
-        }
-    }
-
-    async fn exchange_hello(&mut self, d: Duration, h: Hello) -> Result<Hello> {
-        let future = async {
-            self.send_hello(h).await?;
-            self.recv_hello().await
-        };
-        match timeout(d, future).await {
-            Ok(re) => re,
-            Err(_) => Err(NetworkError::Timeout),
         }
     }
 
@@ -237,19 +231,6 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
 fn remote_static_key(state: &TransportState) -> Option<PublicKey> {
     let k = state.get_remote_static()?;
     PublicKey::try_from(k).ok()
-}
-
-/// A variant of `timeout` that merges the timeout into the network error.
-async fn until<F, A, E>(t: Duration, fut: F) -> Result<A>
-where
-    F: Future<Output = std::result::Result<A, E>>,
-    E: Into<NetworkError>,
-{
-    match timeout(t, fut).await {
-        Ok(Ok(a)) => Ok(a),
-        Ok(Err(e)) => Err(e.into()),
-        Err(_) => Err(NetworkError::Timeout),
-    }
 }
 
 /// Select a version from the range that both sides support.

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use rand::RngExt;
-use snow::{Builder, HandshakeState, TransportState, params::NoiseParams};
+use snow::{Builder, HandshakeState, StatelessTransportState, params::NoiseParams};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
@@ -34,7 +34,9 @@ pub struct Connection {
     pub key: PublicKey,
     pub addr: SocketAddr,
     pub stream: TcpStream,
-    pub state: TransportState,
+    pub state: StatelessTransportState,
+    pub recv_nonce: u64,
+    pub send_nonce: u64,
 }
 
 type Prologue = Vec<u8>;
@@ -47,7 +49,7 @@ impl Connection {
             warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option")
         }
 
-        until(conf.handshake_timeout, async move {
+        until(conf.handshake_timeout, "accept handshake", async move {
             let (version, prologue) = select_version(&conf, &mut stream, false).await?;
 
             debug!(name = %conf.name, %node, %version, "negotiated version");
@@ -74,6 +76,8 @@ impl Connection {
                     addr,
                     stream,
                     state,
+                    recv_nonce: 0,
+                    send_nonce: 0,
                 })
             } else {
                 warn!(name = %conf.name, %node, %addr, "invalid static key");
@@ -114,7 +118,7 @@ impl Connection {
 
             match try_connect(&conf, &peer, &addr).await {
                 Ok(mut conn) => {
-                    let hello_exchange = until(conf.handshake_timeout, async {
+                    let hello_exchange = until(conf.handshake_timeout, "hello exchange", async {
                         conn.send_hello(Hello::Ok).await?;
                         conn.recv_hello().await
                     });
@@ -154,9 +158,12 @@ impl Connection {
     /// Send a `Hello` frame.
     pub async fn send_hello(&mut self, h: Hello) -> Result<()> {
         let mut b = [0u8; 64];
-        let n = self
-            .state
-            .write_message(h.to_bytes().as_ref(), &mut b[Header::SIZE..])?;
+        let n = self.state.write_message(
+            self.send_nonce,
+            h.to_bytes().as_ref(),
+            &mut b[Header::SIZE..],
+        )?;
+        self.send_nonce += 1;
         let h = Header::data(n as u16);
         send_frame(&mut self.stream, h, &mut b[..Header::SIZE + n]).await?;
         Ok(())
@@ -167,7 +174,10 @@ impl Connection {
         let mut a = [0u8; 64];
         let h = recv_frame(&mut self.stream, &mut a).await?;
         let mut b = [0u8; 64];
-        let n = self.state.read_message(&a[..h.len().into()], &mut b)?;
+        let n = self
+            .state
+            .read_message(self.recv_nonce, &a[..h.len().into()], &mut b)?;
+        self.recv_nonce += 1;
         let h = Hello::from_bytes(&b[..n]).ok_or(NetworkError::InvalidHello)?;
         Ok(h)
     }
@@ -186,7 +196,12 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
             .expect("valid noise params yield valid handshake state")
     };
 
-    let mut stream = until(conf.connect_timeout, TcpStream::connect(addr)).await?;
+    let mut stream = until(
+        conf.connect_timeout,
+        "tcp connect",
+        TcpStream::connect(addr),
+    )
+    .await?;
 
     let node = conf.keypair.public_key();
     let addr = stream.peer_addr()?;
@@ -197,7 +212,7 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
         warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option");
     }
 
-    until(conf.handshake_timeout, async move {
+    until(conf.handshake_timeout, "connect handshake", async move {
         let (version, prologue) = select_version(conf, &mut stream, true).await?;
 
         debug!(name = %conf.name, %node, %peer, %addr, %version, "negotiated version");
@@ -215,6 +230,8 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
                 addr,
                 stream,
                 state,
+                recv_nonce: 0,
+                send_nonce: 0,
             }),
             Some(key) => {
                 warn!(name = %conf.name, %node, %peer, remote = %key, %addr, "static key mismatch");
@@ -229,7 +246,7 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
     .await
 }
 
-fn remote_static_key(state: &TransportState) -> Option<PublicKey> {
+fn remote_static_key(state: &StatelessTransportState) -> Option<PublicKey> {
     let k = state.get_remote_static()?;
     PublicKey::try_from(k).ok()
 }
@@ -293,7 +310,10 @@ async fn select_version(
 }
 
 /// Perform a noise handshake as initiator with the remote party.
-async fn handshake(stream: &mut TcpStream, mut hs: HandshakeState) -> Result<TransportState> {
+async fn handshake(
+    stream: &mut TcpStream,
+    mut hs: HandshakeState,
+) -> Result<StatelessTransportState> {
     let mut a = [0u8; MAX_NOISE_HANDSHAKE_SIZE];
     let n = hs.write_message(&[], &mut a[Header::SIZE..])?;
     let h = Header::data(n as u16);
@@ -304,11 +324,14 @@ async fn handshake(stream: &mut TcpStream, mut hs: HandshakeState) -> Result<Tra
         return Err(NetworkError::InvalidHandshakeMessage);
     }
     hs.read_message(&b[..h.len().into()], &mut a)?;
-    Ok(hs.into_transport_mode()?)
+    Ok(hs.into_stateless_transport_mode()?)
 }
 
 /// Perform a noise handshake as responder with a remote party.
-async fn on_handshake(stream: &mut TcpStream, mut hs: HandshakeState) -> Result<TransportState> {
+async fn on_handshake(
+    stream: &mut TcpStream,
+    mut hs: HandshakeState,
+) -> Result<StatelessTransportState> {
     let mut a = [0u8; MAX_NOISE_HANDSHAKE_SIZE];
     let h = recv_frame(stream, &mut a).await?;
     if !h.is_data() || h.is_partial() {
@@ -319,11 +342,11 @@ async fn on_handshake(stream: &mut TcpStream, mut hs: HandshakeState) -> Result<
     let n = hs.write_message(&[], &mut b[Header::SIZE..])?;
     let h = Header::data(n as u16);
     send_frame(stream, h, &mut b[..Header::SIZE + n]).await?;
-    Ok(hs.into_transport_mode()?)
+    Ok(hs.into_stateless_transport_mode()?)
 }
 
 /// Read a single frame (header + payload) from the remote.
-async fn recv_frame<R, const N: usize>(stream: &mut R, buf: &mut [u8; N]) -> io::Result<Header>
+pub async fn recv_frame<R, const N: usize>(stream: &mut R, buf: &mut [u8; N]) -> io::Result<Header>
 where
     R: AsyncReadExt + Unpin,
 {
@@ -343,7 +366,7 @@ where
 ///
 /// The header is serialised into the first 4 bytes of `msg`. It is the
 /// caller's responsibility to ensure there is room at the beginning.
-async fn send_frame<W>(stream: &mut W, hdr: Header, msg: &mut [u8]) -> io::Result<()>
+pub async fn send_frame<W>(stream: &mut W, hdr: Header, msg: &mut [u8]) -> io::Result<()>
 where
     W: AsyncWriteExt + Unpin,
 {

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -22,7 +22,7 @@ use crate::{
     addr::NetAddr,
     error::NetworkError,
     msg::{Header, MAX_NOISE_MESSAGE_SIZE, hello::Hello},
-    until,
+    util::until,
     x25519::PublicKey,
 };
 
@@ -52,12 +52,12 @@ impl Connection {
 
             debug!(name = %conf.name, %node, %version, "negotiated version");
 
-            let params = conf
-                .noise_configs
+            let noise_proto = conf
+                .noise_protocols
                 .get(&version)
                 .expect("selected version has noise config");
 
-            let hs = Builder::new(params.clone())
+            let hs = Builder::new(noise_proto.noise_params())
                 .local_private_key(&conf.keypair.secret_key().as_bytes())
                 .expect("valid private key")
                 .prologue(&prologue)
@@ -174,8 +174,8 @@ impl Connection {
 }
 
 async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Connection> {
-    let new_handshake_state = |prologue: &Prologue, params: &NoiseParams| {
-        Builder::new(params.clone())
+    let new_handshake_state = |prologue: &Prologue, params: NoiseParams| {
+        Builder::new(params)
             .local_private_key(conf.keypair.secret_key().as_slice())
             .expect("valid private key")
             .remote_public_key(peer.as_slice())
@@ -202,12 +202,13 @@ async fn try_connect(conf: &Config, peer: &PublicKey, addr: &str) -> Result<Conn
 
         debug!(name = %conf.name, %node, %peer, %addr, %version, "negotiated version");
 
-        let params = conf
-            .noise_configs
+        let noise_proto = conf
+            .noise_protocols
             .get(&version)
             .expect("selected version has noise config");
 
-        let state = handshake(&mut stream, new_handshake_state(&prologue, params)).await?;
+        let hshake = new_handshake_state(&prologue, noise_proto.noise_params());
+        let state = handshake(&mut stream, hshake).await?;
         match remote_static_key(&state) {
             Some(key) if key == *peer => Ok(Connection {
                 key,
@@ -244,12 +245,12 @@ async fn select_version(
     const INIT_PAYLOAD_LEN: usize = 4;
 
     let our_min = conf
-        .noise_configs
+        .noise_protocols
         .first_key_value()
         .map(|(k, _)| *k)
         .expect("noise_configs is not empty");
     let our_max = conf
-        .noise_configs
+        .noise_protocols
         .last_key_value()
         .map(|(k, _)| *k)
         .expect("noise_configs is not empty");
@@ -359,9 +360,7 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
 
     use super::{Prologue, Result, select_version};
-    use crate::{
-        Config, NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, NetworkError, Version, x25519::Keypair,
-    };
+    use crate::{Config, NetAddr, NetworkError, Version, noise::Protocol, x25519::Keypair};
 
     fn config<I, V>(versions: I) -> Config
     where
@@ -373,10 +372,10 @@ mod tests {
             .keypair(Keypair::generate().unwrap())
             .bind(NetAddr::from((Ipv4Addr::LOCALHOST, 0u16)))
             .parties([])
-            .noise_configs(
+            .noise_protocols(
                 versions
                     .into_iter()
-                    .map(|v| (v.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())),
+                    .map(|v| (v.into(), Protocol::IK_25519_AesGcm_Blake2s)),
             )
             .build()
     }

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -295,9 +295,9 @@ async fn select_version(
 ) -> Result<(Version, Prologue)> {
     // NB that both ends send simultaneously before reading, hence the
     // initial frame must fit into the socket's send buffer, i.e. be
-    // very small. Since we only send two u16 version numbers, that
-    // should not be a problem, but the init frame should better not
-    // grow.
+    // very small. Since we only send a header plus two u16 version
+    // numbers (= 8 bytes), that should not be a problem, but the init
+    // frame should better not grow.
     const INIT_PAYLOAD_LEN: usize = 4;
 
     let our_min = conf
@@ -415,4 +415,89 @@ where
     msg[..Header::SIZE].copy_from_slice(&hdr.to_bytes());
     stream.write_all(msg).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use tokio::net::{TcpListener, TcpStream};
+
+    use super::{Prologue, Result, select_version};
+    use crate::{
+        Config, NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, NetworkError, Version, x25519::Keypair,
+    };
+
+    fn config<I, V>(versions: I) -> Config
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<Version>,
+    {
+        Config::builder()
+            .name("test")
+            .keypair(Keypair::generate().unwrap())
+            .bind(NetAddr::from((Ipv4Addr::LOCALHOST, 0u16)))
+            .parties([])
+            .noise_configs(
+                versions
+                    .into_iter()
+                    .map(|v| (v.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())),
+            )
+            .build()
+    }
+
+    async fn negotiate(
+        a: &Config,
+        b: &Config,
+    ) -> (Result<(Version, Prologue)>, Result<(Version, Prologue)>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::join!(
+            async {
+                let mut s = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+                select_version(a, &mut s, true).await
+            },
+            async {
+                let (mut s, _) = listener.accept().await.unwrap();
+                select_version(b, &mut s, false).await
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn picks_min_of_maxes() {
+        let (ra, rb) = negotiate(&config([1, 2, 3]), &config([1, 2])).await;
+        let (va, pa) = ra.unwrap();
+        let (vb, pb) = rb.unwrap();
+        assert_eq!(va, 2.into());
+        assert_eq!(vb, 2.into());
+        assert_eq!(pa, pb);
+    }
+
+    #[tokio::test]
+    async fn higher_overlap_takes_higher() {
+        let (ra, rb) = negotiate(&config([2, 3, 4]), &config([1, 2, 3])).await;
+        let (va, pa) = ra.unwrap();
+        let (vb, pb) = rb.unwrap();
+        assert_eq!(va, 3.into());
+        assert_eq!(vb, 3.into());
+        assert_eq!(pa, pb);
+    }
+
+    #[tokio::test]
+    async fn single_version_match() {
+        let (ra, rb) = negotiate(&config([1]), &config([1])).await;
+        let (va, pa) = ra.unwrap();
+        let (vb, pb) = rb.unwrap();
+        assert_eq!(va, 1.into());
+        assert_eq!(vb, 1.into());
+        assert_eq!(pa, pb);
+    }
+
+    #[tokio::test]
+    async fn disjoint_ranges_fail() {
+        let (ra, rb) = negotiate(&config([1]), &config([2])).await;
+        assert!(matches!(ra, Err(NetworkError::IncompatibleVersions { .. })));
+        assert!(matches!(rb, Err(NetworkError::IncompatibleVersions { .. })));
+    }
 }

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -307,9 +307,9 @@ async fn select_version(
 ) -> Result<(Version, Prologue)> {
     // NB that both ends send simultaneously before reading, hence the
     // initial frame must fit into the socket's send buffer, i.e. be
-    // very small. Since we only send a header plus two u16 version
-    // numbers (= 8 bytes), that should not be a problem, but the init
-    // frame should better not grow.
+    // very small. Since we only send two u16 version numbers (= 4 bytes),
+    // that should not be a problem, but the init frame should better not
+    // grow.
     const INIT_PAYLOAD_LEN: usize = 4;
 
     let our_min = conf
@@ -325,20 +325,14 @@ async fn select_version(
         .copied()
         .expect("noise_configs is not empty");
 
-    let mut send_buf = [0u8; Header::SIZE + INIT_PAYLOAD_LEN];
+    let mut send_buf = [0u8; INIT_PAYLOAD_LEN];
     let mut recv_buf = [0u8; INIT_PAYLOAD_LEN];
 
-    let payload = &mut send_buf[Header::SIZE..];
-    payload[0..2].copy_from_slice(&u16::from(our_min).to_be_bytes());
-    payload[2..4].copy_from_slice(&u16::from(our_max).to_be_bytes());
+    send_buf[0..2].copy_from_slice(&u16::from(our_min).to_be_bytes());
+    send_buf[2..4].copy_from_slice(&u16::from(our_max).to_be_bytes());
 
-    let h = Header::init(INIT_PAYLOAD_LEN as u16);
-    send_frame(stream, h, &mut send_buf[..]).await?;
-
-    let h = recv_frame(stream, &mut recv_buf).await?;
-    if !h.is_init() || h.is_partial() || h.len() != INIT_PAYLOAD_LEN as u16 {
-        return Err(NetworkError::InvalidInit);
-    }
+    stream.write_all(&send_buf).await?;
+    stream.read_exact(&mut recv_buf).await?;
 
     let their_min = Version::from(u16::from_be_bytes([recv_buf[0], recv_buf[1]]));
     let their_max = Version::from(u16::from_be_bytes([recv_buf[2], recv_buf[3]]));
@@ -358,11 +352,11 @@ async fn select_version(
     let mut prologue = Vec::new();
     prologue.extend_from_slice(conf.name.as_bytes());
     if is_initiator {
-        prologue.extend_from_slice(&send_buf[Header::SIZE..]);
+        prologue.extend_from_slice(&send_buf);
         prologue.extend_from_slice(&recv_buf);
     } else {
         prologue.extend_from_slice(&recv_buf);
-        prologue.extend_from_slice(&send_buf[Header::SIZE..]);
+        prologue.extend_from_slice(&send_buf);
     }
 
     Ok((selected, prologue))

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -1,8 +1,9 @@
 use std::{
+    cmp::min,
     io,
     iter::{once, repeat},
     net::SocketAddr,
-    sync::{Arc, LazyLock},
+    sync::Arc,
     time::Duration,
 };
 
@@ -16,7 +17,7 @@ use tokio::{
 use tracing::{debug, warn};
 
 use crate::{
-    Config,
+    Config, Version,
     addr::NetAddr,
     error::NetworkError,
     msg::{Header, MAX_NOISE_MESSAGE_SIZE, hello::Hello},
@@ -24,12 +25,6 @@ use crate::{
 };
 
 const MAX_NOISE_HANDSHAKE_SIZE: usize = 1024;
-
-static NOISE_PARAMS: LazyLock<NoiseParams> = LazyLock::new(|| {
-    "Noise_IK_25519_AESGCM_BLAKE2s"
-        .parse()
-        .expect("valid noise params")
-});
 
 type Result<T> = std::result::Result<T, NetworkError>;
 
@@ -39,6 +34,8 @@ pub struct Connection {
     pub stream: TcpStream,
     pub state: TransportState,
 }
+
+type Prologue = Vec<u8>;
 
 impl Connection {
     pub async fn accept(conf: Arc<Config>, mut stream: TcpStream) -> Result<Self> {
@@ -50,13 +47,28 @@ impl Connection {
                 "failed to enable NO_DELAY option"
             )
         }
-        let hs = Builder::new(NOISE_PARAMS.clone())
+
+        let (version, prologue) = select_version(&conf, &mut stream, false).await?;
+
+        debug!(
+            name = %conf.name,
+            node = %conf.keypair.public_key(),
+            %version,
+            "negotiated version"
+        );
+
+        let params = conf
+            .noise_configs
+            .get(&version)
+            .expect("selected version has noise config");
+        let hs = Builder::new(params.clone())
             .local_private_key(&conf.keypair.secret_key().as_bytes())
             .expect("valid private key")
-            .prologue(conf.name.as_bytes())
+            .prologue(&prologue)
             .expect("1st time we set the prologue")
             .build_responder()
             .expect("valid noise params yield valid handshake state");
+
         let node = conf.keypair.public_key();
         let addr = stream.peer_addr()?;
         match timeout(conf.handshake_timeout, on_handshake(&mut stream, hs)).await {
@@ -83,13 +95,13 @@ impl Connection {
     }
 
     pub async fn connect(conf: Arc<Config>, peer: PublicKey, addr: NetAddr) -> Self {
-        let new_handshake_state = || {
-            Builder::new(NOISE_PARAMS.clone())
+        let new_handshake_state = |prologue: &Prologue, params: &NoiseParams| {
+            Builder::new(params.clone())
                 .local_private_key(conf.keypair.secret_key().as_slice())
                 .expect("valid private key")
                 .remote_public_key(peer.as_slice())
                 .expect("valid remote pub key")
-                .prologue(conf.name.as_bytes())
+                .prologue(&prologue)
                 .expect("1st time we set the prologue")
                 .build_initiator()
                 .expect("valid noise params yield valid handshake state")
@@ -133,7 +145,21 @@ impl Connection {
                     if let Err(err) = stream.set_nodelay(true) {
                         warn!(name = %conf.name, %node, %err, "failed to enable NO_DELAY option")
                     }
-                    let state = new_handshake_state();
+                    let (version, prologue) = match select_version(&conf, &mut stream, true).await {
+                        Ok((v, p)) => {
+                            debug!(name = %conf.name, %node, version = %v, "negotiated version");
+                            (v, p)
+                        },
+                        Err(err) => {
+                            warn!(name = %conf.name, %node, %err, "failed to negotiate version");
+                            continue;
+                        },
+                    };
+                    let params = conf
+                        .noise_configs
+                        .get(&version)
+                        .expect("selected version has noise config");
+                    let state = new_handshake_state(&prologue, params);
                     match timeout(conf.handshake_timeout, handshake(&mut stream, state)).await {
                         Ok(Ok(state)) => {
                             debug!(name = %conf.name, %node, %peer, %addr, "connected");
@@ -257,6 +283,77 @@ impl Connection {
 fn remote_static_key(state: &TransportState) -> Option<PublicKey> {
     let k = state.get_remote_static()?;
     PublicKey::try_from(k).ok()
+}
+
+/// Select a version from the range that both sides support.
+///
+/// This will be the minimum of the max. supported ones from both sides.
+async fn select_version(
+    conf: &Config,
+    stream: &mut TcpStream,
+    is_initiator: bool,
+) -> Result<(Version, Prologue)> {
+    // NB that both ends send simultaneously before reading, hence the
+    // initial frame must fit into the socket's send buffer, i.e. be
+    // very small. Since we only send two u16 version numbers, that
+    // should not be a problem, but the init frame should better not
+    // grow.
+    const INIT_PAYLOAD_LEN: usize = 4;
+
+    let our_min = conf
+        .noise_configs
+        .keys()
+        .min()
+        .copied()
+        .expect("noise_configs is not empty");
+    let our_max = conf
+        .noise_configs
+        .keys()
+        .max()
+        .copied()
+        .expect("noise_configs is not empty");
+
+    let mut send_buf = [0u8; Header::SIZE + INIT_PAYLOAD_LEN];
+    let mut recv_buf = [0u8; INIT_PAYLOAD_LEN];
+
+    let payload = &mut send_buf[Header::SIZE..];
+    payload[0..2].copy_from_slice(&u16::from(our_min).to_be_bytes());
+    payload[2..4].copy_from_slice(&u16::from(our_max).to_be_bytes());
+
+    let h = Header::init(INIT_PAYLOAD_LEN as u16);
+    send_frame(stream, h, &mut send_buf[..]).await?;
+
+    let h = recv_frame(stream, &mut recv_buf).await?;
+    if !h.is_init() || h.is_partial() || h.len() != INIT_PAYLOAD_LEN as u16 {
+        return Err(NetworkError::InvalidInit);
+    }
+
+    let their_min = Version::from(u16::from_be_bytes([recv_buf[0], recv_buf[1]]));
+    let their_max = Version::from(u16::from_be_bytes([recv_buf[2], recv_buf[3]]));
+
+    let selected = min(our_max, their_max);
+
+    if selected < their_min || selected < our_min {
+        return Err(NetworkError::IncompatibleVersions {
+            ours: (our_min, our_max),
+            theirs: (their_min, their_max),
+        });
+    }
+
+    // Construct the prologue so that both sides end up with the same value.
+    // We include the sent and received version ranges to ensure no one has
+    // tampered with those values as they were sent in plain text.
+    let mut prologue = Vec::new();
+    prologue.extend_from_slice(conf.name.as_bytes());
+    if is_initiator {
+        prologue.extend_from_slice(&send_buf[Header::SIZE..]);
+        prologue.extend_from_slice(&recv_buf);
+    } else {
+        prologue.extend_from_slice(&recv_buf);
+        prologue.extend_from_slice(&send_buf[Header::SIZE..]);
+    }
+
+    Ok((selected, prologue))
 }
 
 /// Perform a noise handshake as initiator with the remote party.

--- a/crates/cliquenet/src/error.rs
+++ b/crates/cliquenet/src/error.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use thiserror::Error;
 
-use crate::{Version, addr::NetAddr, msg::Header, x25519::PublicKey};
+use crate::{Version, addr::NetAddr, x25519::PublicKey};
 pub use crate::{addr::InvalidNetAddr, msg::InvalidHeader};
 
 /// The empty type has no values.
@@ -24,10 +24,6 @@ pub enum NetworkError {
     #[error("invalid frame header: {0}")]
     InvalidFrameHeader(#[from] InvalidHeader),
 
-    /// The received init frame is not valid.
-    #[error("invalid init frame")]
-    InvalidInit,
-
     /// The received message trailer is not valid.
     #[error("invalid message trailer")]
     InvalidTrailer,
@@ -43,10 +39,6 @@ pub enum NetworkError {
     /// The received frame has an unknown type.
     #[error("unknown frame type: {0}")]
     UnknownFrameType(u8),
-
-    /// The received frame is unexpected.
-    #[error("unexpected frame: {0}")]
-    UnexpectedFrame(Header),
 
     /// Version negotiation failed.
     #[error("version negotiation failed, ours = {ours:?}, theirs = {theirs:?}")]

--- a/crates/cliquenet/src/error.rs
+++ b/crates/cliquenet/src/error.rs
@@ -68,8 +68,8 @@ pub enum NetworkError {
     BudgetClosed,
 
     /// An operation timed out.
-    #[error("timeout")]
-    Timeout,
+    #[error("timeout: {0}")]
+    Timeout(&'static str),
 
     /// A peer's I/O processing has been interrupted.
     #[error("peer process interrupted")]
@@ -79,4 +79,7 @@ pub enum NetworkError {
     /// to the remote, meaning we can read fine, but not write properly.
     #[error("too many pending acks for peer {0}")]
     TooManyPendingAcks(PublicKey),
+
+    #[error("task {0}")]
+    Task(&'static str),
 }

--- a/crates/cliquenet/src/error.rs
+++ b/crates/cliquenet/src/error.rs
@@ -2,8 +2,8 @@ use std::io;
 
 use thiserror::Error;
 
+use crate::{Version, addr::NetAddr, msg::Header, x25519::PublicKey};
 pub use crate::{addr::InvalidNetAddr, msg::InvalidHeader};
-use crate::{addr::NetAddr, x25519::PublicKey};
 
 /// The empty type has no values.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -24,6 +24,10 @@ pub enum NetworkError {
     #[error("invalid frame header: {0}")]
     InvalidFrameHeader(#[from] InvalidHeader),
 
+    /// The received init frame is not valid.
+    #[error("invalid init frame")]
+    InvalidInit,
+
     /// The received message trailer is not valid.
     #[error("invalid message trailer")]
     InvalidTrailer,
@@ -39,6 +43,17 @@ pub enum NetworkError {
     /// The received frame has an unknown type.
     #[error("unknown frame type: {0}")]
     UnknownFrameType(u8),
+
+    /// The received frame is unexpected.
+    #[error("unexpected frame: {0}")]
+    UnexpectedFrame(Header),
+
+    /// Version negotiation failed.
+    #[error("version negotiation failed, ours = {ours:?}, theirs = {theirs:?}")]
+    IncompatibleVersions {
+        ours: (Version, Version),
+        theirs: (Version, Version),
+    },
 
     /// Generic Noise error.
     #[error("noise error: {0}")]

--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -5,17 +5,13 @@ mod msg;
 mod net;
 mod queue;
 mod time;
+mod util;
 
 pub mod error;
+pub mod noise;
 pub mod x25519;
 
-use std::{
-    collections::BTreeMap,
-    fmt,
-    num::NonZeroUsize,
-    sync::{Arc, LazyLock},
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt, num::NonZeroUsize, sync::Arc, time::Duration};
 
 pub use addr::NetAddr;
 use bon::Builder;
@@ -26,78 +22,79 @@ pub use net::{
     Network, NetworkController, NetworkReceiver, RetryPolicy, SendAction, SendCommand,
     SendCommandBuilder,
 };
-use snow::params::NoiseParams;
 
 use crate::x25519::{Keypair, PublicKey};
-
-pub static NOISE_IK_25519_AESGCM_BLAKE2S: LazyLock<NoiseParams> = LazyLock::new(|| {
-    "Noise_IK_25519_AESGCM_BLAKE2s"
-        .parse()
-        .expect("valid noise params")
-});
 
 #[derive(Builder)]
 #[non_exhaustive]
 pub struct Config {
     /// Network name.
     #[builder(with = |s: impl Into<String>| Arc::new(s.into()))]
-    pub name: Arc<String>,
+    name: Arc<String>,
 
-    #[builder(with = |xs: impl IntoIterator<Item = (Version, NoiseParams)>| {
+    /// The supported noise protocols.
+    ///
+    /// Nodes negotiate a common supported version which implies the exact
+    /// noise protocol parameters they are going to use for the subsequent
+    /// handshake.
+    ///
+    /// With this map, a node specifies the noise protocol names it supports
+    /// per version number.
+    #[builder(with = |xs: impl IntoIterator<Item = (Version, noise::Protocol)>| {
         let m = BTreeMap::from_iter(xs);
         assert! {
             !m.is_empty(),
-            "noise configs must not be empty"
+            "at least one noise protocol is required"
         }
         assert! {
             m.keys().zip(m.keys().skip(1)).all(|(a, b)| u16::from(*a) + 1 == u16::from(*b)),
-            "noise config versions must be consecutive"
+            "noise protocol versions must be consecutive"
         }
         m
     })]
-    noise_configs: BTreeMap<Version, NoiseParams>,
+    noise_protocols: BTreeMap<Version, noise::Protocol>,
 
     /// DH keypair
-    pub keypair: Keypair,
+    keypair: Keypair,
 
     /// Address to bind to.
-    pub bind: NetAddr,
+    bind: NetAddr,
 
     /// Network members with public key and network address.
     #[builder(with = <_>::from_iter)]
-    pub parties: Vec<(PublicKey, NetAddr)>,
+    parties: Vec<(PublicKey, NetAddr)>,
 
     #[builder(default = NonZeroUsize::new(100).expect("100 > 0"))]
-    pub peer_budget: NonZeroUsize,
+    peer_budget: NonZeroUsize,
 
     /// Max. number of bytes per message to send or receive.
     #[builder(default = NonZeroUsize::new(10485760).expect("10485760 > 0"))]
-    pub max_message_size: NonZeroUsize,
+    max_message_size: NonZeroUsize,
 
     /// Retry delays in seconds.
     #[builder(default = vec![1, 3, 5, 15, 30])]
-    pub retry_delays: Vec<u8>,
+    retry_delays: Vec<u8>,
 
     #[builder(default = Duration::from_secs(30))]
-    pub max_retry_delay: Duration,
+    max_retry_delay: Duration,
 
     /// Randomly delay the initial connect attempt between 0 and 1s.
     #[builder(default = true)]
-    pub random_connect_delay: bool,
+    random_connect_delay: bool,
 
     #[builder(default = Duration::from_secs(30))]
-    pub connect_timeout: Duration,
+    connect_timeout: Duration,
 
     #[builder(default = Duration::from_secs(10))]
-    pub handshake_timeout: Duration,
+    handshake_timeout: Duration,
 
     #[builder(default = Duration::from_secs(30))]
-    pub receive_timeout: Duration,
+    receive_timeout: Duration,
 
     #[builder(default = Duration::from_secs(30))]
-    pub backoff_duration: Duration,
+    backoff_duration: Duration,
 
-    pub metrics: Option<Arc<dyn Metrics>>,
+    metrics: Option<Arc<dyn Metrics>>,
 }
 
 impl fmt::Debug for Config {
@@ -123,6 +120,11 @@ impl fmt::Debug for Config {
 impl Config {
     pub fn public_key(&self) -> PublicKey {
         self.keypair.public_key()
+    }
+
+    pub fn with_metrics<M: Metrics + 'static>(mut self, m: M) -> Self {
+        self.metrics = Some(Arc::new(m));
+        self
     }
 }
 
@@ -171,18 +173,5 @@ impl From<Version> for u16 {
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-/// A variant of `timeout` that merges the timeout error into network error.
-async fn until<F, A, E>(t: Duration, fut: F) -> Result<A, NetworkError>
-where
-    F: Future<Output = Result<A, E>>,
-    E: Into<NetworkError>,
-{
-    match tokio::time::timeout(t, fut).await {
-        Ok(Ok(a)) => Ok(a),
-        Ok(Err(e)) => Err(e.into()),
-        Err(_) => Err(NetworkError::Timeout),
     }
 }

--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -9,7 +9,13 @@ mod time;
 pub mod error;
 pub mod x25519;
 
-use std::{fmt, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    num::NonZeroUsize,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 pub use addr::NetAddr;
 use bon::Builder;
@@ -20,8 +26,15 @@ pub use net::{
     Network, NetworkController, NetworkReceiver, RetryPolicy, SendAction, SendCommand,
     SendCommandBuilder,
 };
+use snow::params::NoiseParams;
 
 use crate::x25519::{Keypair, PublicKey};
+
+pub static NOISE_IK_25519_AESGCM_BLAKE2S: LazyLock<NoiseParams> = LazyLock::new(|| {
+    "Noise_IK_25519_AESGCM_BLAKE2s"
+        .parse()
+        .expect("valid noise params")
+});
 
 #[derive(Builder)]
 #[non_exhaustive]
@@ -29,6 +42,20 @@ pub struct Config {
     /// Network name.
     #[builder(with = |s: impl Into<String>| Arc::new(s.into()))]
     pub name: Arc<String>,
+
+    #[builder(with = |xs: impl IntoIterator<Item = (Version, NoiseParams)>| {
+        let m = BTreeMap::from_iter(xs);
+        assert! {
+            !m.is_empty(),
+            "noise configs must not be empty"
+        }
+        assert! {
+            m.keys().zip(m.keys().skip(1)).all(|(a, b)| u16::from(*a) + 1 == u16::from(*b)),
+            "noise config versions must be consecutive"
+        }
+        m
+    })]
+    noise_configs: BTreeMap<Version, NoiseParams>,
 
     /// DH keypair
     pub keypair: Keypair,
@@ -123,5 +150,26 @@ impl fmt::Display for Role {
             Self::Active => f.write_str("active"),
             Self::Passive => f.write_str("passive"),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Version(u16);
+
+impl From<u16> for Version {
+    fn from(v: u16) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Version> for u16 {
+    fn from(v: Version) -> Self {
+        v.0
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -173,3 +173,16 @@ impl fmt::Display for Version {
         self.0.fmt(f)
     }
 }
+
+/// A variant of `timeout` that merges the timeout error into network error.
+async fn until<F, A, E>(t: Duration, fut: F) -> Result<A, NetworkError>
+where
+    F: Future<Output = Result<A, E>>,
+    E: Into<NetworkError>,
+{
+    match tokio::time::timeout(t, fut).await {
+        Ok(Ok(a)) => Ok(a),
+        Ok(Err(e)) => Err(e.into()),
+        Err(_) => Err(NetworkError::Timeout),
+    }
+}

--- a/crates/cliquenet/src/msg/frame.rs
+++ b/crates/cliquenet/src/msg/frame.rs
@@ -51,7 +51,7 @@ impl Header {
         Self(n)
     }
 
-    /// Create an inital header with the given payload length.
+    /// Create an initial header with the given payload length.
     pub fn init(len: u16) -> Self {
         Self(len as u32)
     }

--- a/crates/cliquenet/src/msg/frame.rs
+++ b/crates/cliquenet/src/msg/frame.rs
@@ -19,8 +19,9 @@
 //!
 //! - Version (4 bits)
 //! - Type (4 bits)
-//!    - Data (0)
-//!    - Ack  (1)
+//!    - Init (0)
+//!    - Data (1)
+//!    - Ack  (2)
 //! - Partial (1 bit)
 //! - Reserved (7 bits)
 //! - Payload length (16 bits)
@@ -39,6 +40,7 @@ impl Header {
 
     pub fn new(ty: FrameType, len: u16) -> Self {
         match ty {
+            FrameType::Init => Self::init(len),
             FrameType::Data => Self::data(len),
             FrameType::Ack => Self::ack(len),
         }
@@ -49,21 +51,27 @@ impl Header {
         Self(n)
     }
 
+    /// Create an inital header with the given payload length.
+    pub fn init(len: u16) -> Self {
+        Self(len as u32)
+    }
+
     /// Create a data header with the given payload length.
     pub fn data(len: u16) -> Self {
-        Self(len as u32)
+        Self(0x1000000 | len as u32)
     }
 
     /// Create an ack header with the given payload length.
     pub fn ack(len: u16) -> Self {
-        Self(0x1000000 | len as u32)
+        Self(0x2000000 | len as u32)
     }
 
     /// The type of the frame following this header.
     pub fn frame_type(self) -> Result<FrameType, u8> {
         match (self.0 & 0xF000000) >> 24 {
-            0 => Ok(FrameType::Data),
-            1 => Ok(FrameType::Ack),
+            0 => Ok(FrameType::Init),
+            1 => Ok(FrameType::Data),
+            2 => Ok(FrameType::Ack),
             t => Err(t as u8),
         }
     }
@@ -73,14 +81,19 @@ impl Header {
         Self(self.0 | 0x800000)
     }
 
+    /// Is this an initial frame header?
+    pub fn is_init(self) -> bool {
+        self.0 & 0xF000000 == 0
+    }
+
     /// Is this a data frame header?
     pub fn is_data(self) -> bool {
-        self.0 & 0xF000000 == 0
+        self.0 & 0xF000000 == 0x1000000
     }
 
     /// Is this an ack frame header?
     pub fn is_ack(self) -> bool {
-        self.0 & 0xF000000 == 0x1000000
+        self.0 & 0xF000000 == 0x2000000
     }
 
     /// Is this a partial frame?
@@ -107,6 +120,7 @@ impl Header {
 /// The type of a frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameType {
+    Init,
     Data,
     Ack,
 }
@@ -138,6 +152,11 @@ mod tests {
     use super::{FrameType, Header};
 
     quickcheck! {
+        fn init(len: u16) -> bool {
+            let hdr = Header::init(len);
+            hdr.is_init() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Init)
+        }
+
         fn data(len: u16) -> bool {
             let hdr = Header::data(len);
             hdr.is_data() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Data)
@@ -148,12 +167,20 @@ mod tests {
             hdr.is_ack() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Ack)
         }
 
+        fn partial_init(len: u16) -> bool {
+            Header::init(len).partial().is_partial()
+        }
+
         fn partial_data(len: u16) -> bool {
             Header::data(len).partial().is_partial()
         }
 
         fn partial_ack(len: u16) -> bool {
             Header::ack(len).partial().is_partial()
+        }
+
+        fn init_len(len: u16) -> bool {
+            Header::init(len).len() == len
         }
 
         fn data_len(len: u16) -> bool {

--- a/crates/cliquenet/src/msg/frame.rs
+++ b/crates/cliquenet/src/msg/frame.rs
@@ -19,9 +19,8 @@
 //!
 //! - Version (4 bits)
 //! - Type (4 bits)
-//!    - Init (0)
-//!    - Data (1)
-//!    - Ack  (2)
+//!    - Data (0)
+//!    - Ack  (1)
 //! - Partial (1 bit)
 //! - Reserved (7 bits)
 //! - Payload length (16 bits)
@@ -40,7 +39,6 @@ impl Header {
 
     pub fn new(ty: FrameType, len: u16) -> Self {
         match ty {
-            FrameType::Init => Self::init(len),
             FrameType::Data => Self::data(len),
             FrameType::Ack => Self::ack(len),
         }
@@ -51,27 +49,21 @@ impl Header {
         Self(n)
     }
 
-    /// Create an initial header with the given payload length.
-    pub fn init(len: u16) -> Self {
-        Self(len as u32)
-    }
-
     /// Create a data header with the given payload length.
     pub fn data(len: u16) -> Self {
-        Self(0x1000000 | len as u32)
+        Self(len as u32)
     }
 
     /// Create an ack header with the given payload length.
     pub fn ack(len: u16) -> Self {
-        Self(0x2000000 | len as u32)
+        Self(0x1000000 | len as u32)
     }
 
     /// The type of the frame following this header.
     pub fn frame_type(self) -> Result<FrameType, u8> {
         match (self.0 & 0xF000000) >> 24 {
-            0 => Ok(FrameType::Init),
-            1 => Ok(FrameType::Data),
-            2 => Ok(FrameType::Ack),
+            0 => Ok(FrameType::Data),
+            1 => Ok(FrameType::Ack),
             t => Err(t as u8),
         }
     }
@@ -81,19 +73,14 @@ impl Header {
         Self(self.0 | 0x800000)
     }
 
-    /// Is this an initial frame header?
-    pub fn is_init(self) -> bool {
-        self.0 & 0xF000000 == 0
-    }
-
     /// Is this a data frame header?
     pub fn is_data(self) -> bool {
-        self.0 & 0xF000000 == 0x1000000
+        self.0 & 0xF000000 == 0
     }
 
     /// Is this an ack frame header?
     pub fn is_ack(self) -> bool {
-        self.0 & 0xF000000 == 0x2000000
+        self.0 & 0xF000000 == 0x1000000
     }
 
     /// Is this a partial frame?
@@ -120,7 +107,6 @@ impl Header {
 /// The type of a frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameType {
-    Init,
     Data,
     Ack,
 }
@@ -152,11 +138,6 @@ mod tests {
     use super::{FrameType, Header};
 
     quickcheck! {
-        fn init(len: u16) -> bool {
-            let hdr = Header::init(len);
-            hdr.is_init() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Init)
-        }
-
         fn data(len: u16) -> bool {
             let hdr = Header::data(len);
             hdr.is_data() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Data)
@@ -167,20 +148,12 @@ mod tests {
             hdr.is_ack() && !hdr.is_partial() && hdr.frame_type() == Ok(FrameType::Ack)
         }
 
-        fn partial_init(len: u16) -> bool {
-            Header::init(len).partial().is_partial()
-        }
-
         fn partial_data(len: u16) -> bool {
             Header::data(len).partial().is_partial()
         }
 
         fn partial_ack(len: u16) -> bool {
             Header::ack(len).partial().is_partial()
-        }
-
-        fn init_len(len: u16) -> bool {
-            Header::init(len).len() == len
         }
 
         fn data_len(len: u16) -> bool {

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -18,6 +18,7 @@ use std::{
 use bon::bon;
 use bytes::{Bytes, BytesMut};
 use delay::DelayQueue;
+use parking_lot::Mutex;
 use snow::StatelessTransportState;
 use tokio::{
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
@@ -60,7 +61,7 @@ pub struct Peer {
     msgs: Queue<(RetryPolicy, Bytes)>,
 
     /// Messages waiting to be retried if no ACK has been received.
-    retry: DelayQueue,
+    retry: Arc<Mutex<DelayQueue>>,
 
     /// Receive notifications about changes to the GC threshold
     next_slot: watch::Receiver<Slot>,
@@ -111,7 +112,7 @@ impl Peer {
             next_slot,
             lower_bound: Arc::new(AtomicU64::new(Slot::MIN.into())),
             tx: inbound,
-            retry: DelayQueue::new(config),
+            retry: Arc::new(Mutex::new(DelayQueue::new(config))),
             msgs: messages,
             metrics,
         }
@@ -128,27 +129,20 @@ impl Peer {
             return Err(NetworkError::PeerInterrupt);
         }
 
-        // ACKs received from remote.
-        //
-        // When receiving an ACK we remove the message from the retry buffer.
-        // The channel is unbounded because we can always remove an entry
-        // quickly.
-        let (ibound_acks_tx, mut ibound_acks_rx) = mpsc::unbounded_channel();
-
-        // ACKs to send to the remote.
-        //
-        // When we have received a message we need to send an ACK back.
-        // This channel is bounded. In case we accumulate too many ACKs we
-        // drop the connection as the sender task can not make progress.
-        let (obound_acks_tx, obound_acks_rx) = mpsc::channel(self.conf.peer_budget.get());
-
         // Messages to send to the remote.
         //
         // These are the plain bytes (plus retry policy) that the sending task
         // should deliver to the remote.
         let (message_tx, message_rx) = mpsc::unbounded_channel();
 
-        self.retry.reset();
+        // ACKs to send to the remote.
+        //
+        // When we have received a message we need to send an ACK back.
+        // This channel is bounded. In case we accumulate too many ACKs we
+        // drop the connection as the sender task can not make enough progress.
+        let (obound_acks_tx, obound_acks_rx) = mpsc::channel(self.conf.peer_budget.get());
+
+        self.retry.lock().reset();
 
         let Connection {
             key: peer,
@@ -178,7 +172,7 @@ impl Peer {
         let receiver = Receiver {
             budget: self.budget.clone(),
             countdown,
-            ibound_acks: ibound_acks_tx,
+            retry: self.retry.clone(),
             lower_bound: self.lower_bound.clone(),
             max_message_size: self.max_message_size,
             messages: self.tx.clone(),
@@ -203,23 +197,13 @@ impl Peer {
                 // has not sent yet. This is to prevent an attack were a
                 // malicious peer never sends ACKs, which would cause our
                 // retry queue to grow unbounded.
-                m = self.msgs.dequeue(), if self.retry.len() < self.conf.peer_budget.get() => {
+                m = self.msgs.dequeue(), if self.retry.lock().len() < self.conf.peer_budget.get() => {
                     trace!(name = %self.conf.name, %peer, %addr, "next outbound message");
                     let (slot, id, (policy, bytes)) = m;
                     if policy.is_retry() {
-                        self.retry.add(slot, id, bytes.clone());
+                        self.retry.lock().add(slot, id, bytes.clone());
                     }
                     message_tx.send((policy, bytes)).map_err(|_| NetworkError::ChannelClosed)?
-                }
-
-                // When an ACK has been received we can remove the message from the retry queue.
-                a = ibound_acks_rx.recv() => {
-                    let Some(ack) = a else {
-                        return Err(NetworkError::ChannelClosed)
-                    };
-                    trace!(name = %self.conf.name, %peer, %addr, ?ack, "ack received");
-                    let (s, i) = ack.into();
-                    self.retry.del(s, i);
                 }
 
                 // If requested, interrupt all I/O processing and return.
@@ -227,13 +211,6 @@ impl Peer {
                     trace!(name = %self.conf.name, %peer, %addr, "interrupt");
                     recv_task.abort();
                     send_task.abort();
-                    // Before returning we remove retry entries corresponding
-                    // to received ACKs. We do not want to send the messages
-                    // again since the remote has received it already.
-                    while let Ok(ack) = ibound_acks_rx.try_recv() {
-                        let (s, i) = ack.into();
-                        self.retry.del(s, i);
-                    }
                     return Err(NetworkError::PeerInterrupt)
                 }
 
@@ -245,7 +222,7 @@ impl Peer {
                     }
                     let s = *self.next_slot.borrow_and_update();
                     self.lower_bound.store(s.into(), Ordering::Relaxed);
-                    self.retry.gc(s);
+                    self.retry.lock().gc(s);
                 }
 
                 // Periodic maintenance:
@@ -253,10 +230,8 @@ impl Peer {
                 // - Retry messages
                 // - Update metrics
                 t = clock.tick() => {
-                    if !self.retry.is_empty() {
-                        trace!(name = %self.conf.name, %peer, %addr, "retry check");
-                        self.retry.check(t);
-                    }
+                    trace!(name = %self.conf.name, %peer, %addr, "retry check");
+                    self.retry.lock().check(t);
                     self.update_metrics(&peer)
                 }
 
@@ -265,8 +240,8 @@ impl Peer {
                 // This is separate from the retry check above because the check
                 // scans multiple items and here we just take the next one that
                 // is ready and go with it.
-                () = ready(()), if self.retry.is_ready() => {
-                    let Some(bytes) = self.retry.next() else {
+                () = ready(()), if self.retry.lock().is_ready() => {
+                    let Some(bytes) = self.retry.lock().next() else {
                         continue
                     };
                     trace!(name = %self.conf.name, %peer, %addr, "resending message");
@@ -316,7 +291,8 @@ impl Peer {
 
     fn update_metrics(&self, key: &PublicKey) {
         self.metrics.set(key, "outbound_messages", self.msgs.len());
-        self.metrics.set(key, "retrying_messages", self.retry.len());
+        self.metrics
+            .set(key, "retrying_messages", self.retry.lock().len());
         self.metrics
             .set(key, "remaining_budget", self.budget.remaining());
     }
@@ -386,9 +362,9 @@ struct Receiver {
     max_message_size: usize,
     stream: OwnedReadHalf,
     messages: UnboundedSender<PeerMessage>,
-    ibound_acks: UnboundedSender<Ack>,
     obound_acks: mpsc::Sender<Ack>,
     nonce: u64,
+    retry: Arc<Mutex<DelayQueue>>,
     state: Arc<StatelessTransportState>,
     lower_bound: Arc<AtomicU64>,
     countdown: Countdown,
@@ -420,10 +396,11 @@ impl Receiver {
                                 Ok(FrameType::Ack) => {
                                     let x = self.nonce();
                                     let n = self.state.read_message(x, &fbuf[.. h.len().into()], &mut *rbuf)?;
-                                    let Ok(a) = Ack::try_from(&rbuf[..n]) else {
+                                    let Ok(ack) = Ack::try_from(&rbuf[..n]) else {
                                         return Err(NetworkError::InvalidAck)
                                     };
-                                    self.ibound_acks.send(a).map_err(|_| NetworkError::ChannelClosed)?
+                                    let (s, i) = ack.into();
+                                    self.retry.lock().del(s, i);
                                 }
                                 Err(t) => return Err(NetworkError::UnknownFrameType(t))
                             }

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -560,6 +560,9 @@ impl Peer {
                                             self.retry.del(s, i);
                                             rstate = ReadState::Header { off: 0, buf: [0; _] };
                                         }
+                                        Ok(FrameType::Init) => {
+                                            return Err(NetworkError::UnexpectedFrame(*hdr))
+                                        }
                                         Err(t) => {
                                             return Err(NetworkError::UnknownFrameType(t))
                                         }

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -227,6 +227,13 @@ impl Peer {
                     trace!(name = %self.conf.name, %peer, %addr, "interrupt");
                     recv_task.abort();
                     send_task.abort();
+                    // Before returning we remove retry entries corresponding
+                    // to received ACKs. We do not want to send the messages
+                    // again since the remote has received it already.
+                    while let Ok(ack) = ibound_acks_rx.try_recv() {
+                        let (s, i) = ack.into();
+                        self.retry.del(s, i);
+                    }
                     return Err(NetworkError::PeerInterrupt)
                 }
 

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -394,6 +394,9 @@ impl Receiver {
                                     }
                                 }
                                 Ok(FrameType::Ack) => {
+                                    if h.is_partial() {
+                                        return Err(NetworkError::InvalidAck)
+                                    }
                                     let x = self.nonce();
                                     let n = self.state.read_message(x, &fbuf[.. h.len().into()], &mut *rbuf)?;
                                     let Ok(ack) = Ack::try_from(&rbuf[..n]) else {

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -458,8 +458,8 @@ impl Receiver {
 
             let permit = self
                 .budget
-                .clone()
                 .0
+                .clone()
                 .acquire_owned()
                 .await
                 .map_err(|_| NetworkError::BudgetClosed)?;

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -560,9 +560,6 @@ impl Peer {
                                             self.retry.del(s, i);
                                             rstate = ReadState::Header { off: 0, buf: [0; _] };
                                         }
-                                        Ok(FrameType::Init) => {
-                                            return Err(NetworkError::UnexpectedFrame(*hdr))
-                                        }
                                         Err(t) => {
                                             return Err(NetworkError::UnknownFrameType(t))
                                         }

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -4,25 +4,37 @@ mod delay;
 mod tests;
 
 use std::{
-    cmp::min, collections::VecDeque, future::ready, io, mem, net::SocketAddr, num::NonZeroUsize,
-    sync::Arc, time::Duration,
+    cmp::min,
+    future::ready,
+    mem,
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
 };
 
 use bon::bon;
 use bytes::{Bytes, BytesMut};
 use delay::DelayQueue;
-use snow::TransportState;
+use snow::StatelessTransportState;
 use tokio::{
-    select,
-    sync::{OwnedSemaphorePermit, Semaphore, mpsc::UnboundedSender, watch},
+    net::tcp::{OwnedReadHalf, OwnedWriteHalf},
+    select, spawn,
+    sync::{
+        Semaphore,
+        mpsc::{self, UnboundedReceiver, UnboundedSender, error::TrySendError},
+        watch,
+    },
     time::{MissedTickBehavior, interval},
 };
-use tokio_util::sync::CancellationToken;
-use tracing::{trace, warn};
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
+use tracing::{error, trace, warn};
 
 use crate::{
     Config, Metrics, PublicKey,
-    connection::Connection,
+    connection::{Connection, recv_frame, send_frame},
     error::{Empty, NetworkError},
     msg::{Ack, FrameType, Header, MAX_NOISE_MESSAGE_SIZE, MAX_PAYLOAD_SIZE, Slot, Trailer},
     net::{PeerMessage, RetryPolicy},
@@ -35,9 +47,6 @@ type Result<T> = std::result::Result<T, NetworkError>;
 
 /// A peer sends and receives messages over a connection with a remote.
 ///
-/// Peers are initialised with a [`Connection`], which can be replaced
-/// later, should it be necessary.
-///
 /// Messages sent are expected to be acknowledged, i.e. the remote needs to
 /// send back an ACK frame. Otherwise the message is resent after some time.
 pub struct Peer {
@@ -46,9 +55,6 @@ pub struct Peer {
 
     /// A budget limits how many message a peer can deliver to the application.
     budget: Budget,
-
-    /// The current TCP+Noise connection.
-    conn: Connection,
 
     /// Messages the application wants to be sent to the remote.
     msgs: Queue<(RetryPolicy, Bytes)>,
@@ -59,19 +65,11 @@ pub struct Peer {
     /// Receive notifications about changes to the GC threshold
     next_slot: watch::Receiver<Slot>,
 
-    /// Our current GC threshold.
-    lower_bound: Slot,
+    /// Our current GC threshold (slot number).
+    lower_bound: Arc<AtomicU64>,
 
     /// The channel over which to deliver inbound messages to the application.
     tx: UnboundedSender<PeerMessage>,
-
-    /// A healthcheck countdown.
-    ///
-    /// When dropped to 0 the connection should be replaced.
-    countdown: Countdown,
-
-    /// Token to interrupt processing.
-    cancel: CancellationToken,
 
     /// The true max. message size.
     ///
@@ -82,6 +80,7 @@ pub struct Peer {
 }
 
 /// A budget limits how many messages a peer can delivery to the application.
+#[derive(Clone)]
 pub struct Budget(Arc<Semaphore>);
 
 impl Budget {
@@ -103,7 +102,6 @@ impl Peer {
         messages: Queue<(RetryPolicy, Bytes)>,
         inbound: UnboundedSender<PeerMessage>,
         next_slot: watch::Receiver<Slot>,
-        connection: Connection,
         metrics: Arc<dyn Metrics>,
     ) -> Self {
         Self {
@@ -111,215 +109,135 @@ impl Peer {
             conf: config.clone(),
             budget: Budget::new(budget),
             next_slot,
-            lower_bound: Slot::MIN,
+            lower_bound: Arc::new(AtomicU64::new(Slot::MIN.into())),
             tx: inbound,
-            conn: connection,
             retry: DelayQueue::new(config),
             msgs: messages,
-            countdown: Countdown::new(),
-            cancel: CancellationToken::new(),
             metrics,
         }
     }
 
-    /// Replace the existing connection.
-    pub fn set_connection(&mut self, c: Connection) {
-        self.conn = c;
-        self.retry.reset();
-        self.cancel = CancellationToken::new()
-    }
-
-    /// Get a token to interrupt processing.
-    pub fn cancel_token(&self) -> CancellationToken {
-        self.cancel.clone()
-    }
-
-    /// Get the peer's public key.
-    pub fn public_key(&self) -> &PublicKey {
-        &self.conn.key
-    }
-
-    /// Get the peer's socket address.
-    pub fn socket_addr(&self) -> &SocketAddr {
-        &self.conn.addr
-    }
-
-    /// Start I/O with a connected peer.
+    /// Start I/O with a peer over the given connection.
     ///
     /// This method continues until an error occurs, after which callers may
     /// want to reconnect and resume peer operation with a new `Connection`.
-    pub async fn start(&mut self) -> Result<Empty> {
-        /// Messages are broken into frames and each frame has a header.
-        ///
-        /// The `ReadState` tracks what we have received from the remote.
-        enum ReadState<'a> {
-            Header {
-                off: usize,
-                buf: [u8; Header::SIZE],
-            },
-            Frame {
-                hdr: Header,
-                off: usize,
-                buf: &'a mut Vec<u8>,
-            },
-        }
-
-        /// This state tracks what we have sent to the remote. We currently
-        /// support either data or ACK frames. The offset and length values
-        /// are relative to the write buffer (see below).
-        enum WriteState {
-            /// No write operation is in progress.
-            Idle,
-            /// An ACK frame is sent.
-            Ack { off: usize, len: usize },
-            /// A data frame is sent.
-            Data { off: usize, len: usize },
-        }
-
-        impl WriteState {
-            fn is_idle(&self) -> bool {
-                matches!(self, Self::Idle)
-            }
-
-            /// Encrypt a single data frame with Noise.
-            fn data_frame(
-                data: &[u8],
-                is_partial: bool,
-                state: &mut TransportState,
-                buf: &mut NoiseBuf,
-            ) -> Result<Self> {
-                let n = state.write_message(data, &mut buf[Header::SIZE..])?;
-                let h = if is_partial {
-                    Header::data(n as u16).partial()
-                } else {
-                    Header::data(n as u16)
-                };
-                buf[..Header::SIZE].copy_from_slice(&h.to_bytes());
-                Ok(Self::Data {
-                    off: 0,
-                    len: n + Header::SIZE,
-                })
-            }
-
-            /// Encrypt a single ACK frame with Noise.
-            fn ack_frame(a: Ack, state: &mut TransportState, buf: &mut NoiseBuf) -> Result<Self> {
-                let n = state.write_message(&a.0, &mut buf[Header::SIZE..])?;
-                let h = Header::ack(n as u16);
-                buf[..Header::SIZE].copy_from_slice(&h.to_bytes());
-                Ok(Self::Ack {
-                    off: 0,
-                    len: n + Header::SIZE,
-                })
-            }
-        }
-
+    pub async fn start(&mut self, conn: Connection, cancel: CancellationToken) -> Result<Empty> {
         // Early check if we already got cancelled which can happen with many
         // simultaneous connects where we need to drop connections.
-        if self.cancel.is_cancelled() {
+        if cancel.is_cancelled() {
             return Err(NetworkError::PeerInterrupt);
         }
 
-        // Noise packages are limited to 64KiB.
+        // ACKs received from remote.
         //
-        // We retain one such buffer for reading and one for writing.
-        let mut rbuf = NoiseBuf::new([0; _]);
-        let mut wbuf = NoiseBuf::new([0; _]);
+        // When receiving an ACK we remove the message from the retry buffer.
+        // The channel is unbounded because we can always remove an entry
+        // quickly.
+        let (ibound_acks_tx, mut ibound_acks_rx) = mpsc::unbounded_channel();
 
-        // A frame buffer for reading before it is decrypted.
-        let mut fbuf = Vec::new();
+        // ACKs to send to the remote.
+        //
+        // When we have received a message we need to send an ACK back.
+        // This channel is bounded. In case we accumulate too many ACKs we
+        // drop the connection as the sender task can not make progress.
+        let (obound_acks_tx, obound_acks_rx) = mpsc::channel(self.conf.peer_budget.get());
 
-        // An incoming message that is assembled from its frames.
-        let mut ibound_msg = BytesMut::new();
+        // Messages to send to the remote.
+        //
+        // These are the plain bytes (plus retry policy) that the sending task
+        // should deliver to the remote.
+        let (message_tx, message_rx) = mpsc::unbounded_channel();
 
-        // An outgoing message. The integer tracks the chunk size as we need
-        // to break the message into frames that fit into a noise package.
-        let mut obound_msg: Option<(RetryPolicy, Bytes, usize)> = None;
+        self.retry.reset();
 
-        // Pending outbound ACK messages. This is appended when we received a
-        // message and picked up and interleaved when sending frames or else
-        // at the start of the loop (see below).
-        let mut obound_acks: VecDeque<Ack> = VecDeque::new();
+        let Connection {
+            key: peer,
+            addr,
+            stream,
+            state,
+            recv_nonce,
+            send_nonce,
+        } = conn;
 
-        // Track write and read states:
-        let mut wstate = WriteState::Idle;
-        let mut rstate = ReadState::Header {
-            off: 0,
-            buf: [0; _],
+        let state = Arc::new(state);
+
+        let (read_half, write_half) = stream.into_split();
+
+        let countdown = Countdown::new();
+
+        let sender = Sender {
+            acks: obound_acks_rx,
+            conf: self.conf.clone(),
+            countdown: countdown.clone(),
+            messages: message_rx,
+            nonce: send_nonce,
+            state: state.clone(),
+            stream: write_half,
         };
 
-        // Each read needs a permit taken from our budget in order to deliver
-        // to the application.
-        let mut read_permit: Option<OwnedSemaphorePermit> = None;
+        let receiver = Receiver {
+            budget: self.budget.clone(),
+            countdown,
+            ibound_acks: ibound_acks_tx,
+            lower_bound: self.lower_bound.clone(),
+            max_message_size: self.max_message_size,
+            messages: self.tx.clone(),
+            nonce: recv_nonce,
+            obound_acks: obound_acks_tx,
+            peer,
+            state,
+            stream: read_half,
+        };
 
-        // Measure time.
-        //
-        // Used to trigger resends of messages that have not been ACKed yet.
+        let mut send_task = AbortOnDropHandle::new(spawn(sender.start()));
+        let mut recv_task = AbortOnDropHandle::new(spawn(receiver.start()));
+
         let mut clock = interval(Duration::from_secs(1));
         clock.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        // Ensure any previously fired countdown is reset.
-        self.countdown.stop();
-
         loop {
-            trace!(
-                name     = %self.conf.name,
-                peer     = %self.conn.key,
-                addr     = %self.conn.addr,
-                writing  = %!wstate.is_idle(),
-                acks     = %obound_acks.len(),
-                retries  = %self.retry.len(),
-                can_read = %read_permit.is_some(),
-                "entering event loop"
-            );
-
             select! {
-                // Wait for the next message if no write is in progress.
+                // Wait for the next message.
                 //
                 // We limit writing if we expect too many ACKs that the remote
                 // has not sent yet. This is to prevent an attack were a
                 // malicious peer never sends ACKs, which would cause our
-                // delay queue to grow unbounded.
-                m = self.msgs.dequeue(), if wstate.is_idle() && self.retry.len() < self.conf.peer_budget.get() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "next outbound message");
+                // retry queue to grow unbounded.
+                m = self.msgs.dequeue(), if self.retry.len() < self.conf.peer_budget.get() => {
+                    trace!(name = %self.conf.name, %peer, %addr, "next outbound message");
                     let (slot, id, (policy, bytes)) = m;
                     if policy.is_retry() {
                         self.retry.add(slot, id, bytes.clone());
                     }
-                    let chunk = min(bytes.len(), MAX_PAYLOAD_SIZE);
-                    wstate = WriteState::data_frame(
-                        &bytes[..chunk],
-                        chunk < bytes.len(),
-                        &mut self.conn.state,
-                        &mut wbuf
-                    )?;
-                    obound_msg = Some((policy, bytes, chunk))
+                    message_tx.send((policy, bytes)).map_err(|_| NetworkError::ChannelClosed)?
                 }
 
-                // Pick up an ACK and send it if possible.
-                () = ready(()), if wstate.is_idle() && !obound_acks.is_empty() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "next outbound ack");
-                    let ack = obound_acks.pop_front().expect("obound_acks is not empty");
-                    wstate = WriteState::ack_frame(ack, &mut self.conn.state, &mut wbuf)?
+                // When an ACK has been received we can remove the message from the retry queue.
+                a = ibound_acks_rx.recv() => {
+                    let Some(ack) = a else {
+                        return Err(NetworkError::ChannelClosed)
+                    };
+                    trace!(name = %self.conf.name, %peer, %addr, ?ack, "ack received");
+                    let (s, i) = ack.into();
+                    self.retry.del(s, i);
                 }
 
-                // If requested, interrupt all I/O processing.
-                //
-                // Once a peer has been interrupted, its connection needs to be
-                // replaced before calling start again.
-                _ = self.cancel.cancelled() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "interrupt");
+                // If requested, interrupt all I/O processing and return.
+                _ = cancel.cancelled() => {
+                    trace!(name = %self.conf.name, %peer, %addr, "interrupt");
+                    recv_task.abort();
+                    send_task.abort();
                     return Err(NetworkError::PeerInterrupt)
                 }
 
                 // Wait for a slot change, signaling GC.
                 r = self.next_slot.changed() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "gc");
+                    trace!(name = %self.conf.name, %peer, %addr, "gc");
                     if r.is_err() {
                         return Err(NetworkError::ChannelClosed)
                     }
                     let s = *self.next_slot.borrow_and_update();
-                    debug_assert!(s > self.lower_bound);
-                    self.lower_bound = s;
+                    self.lower_bound.store(s.into(), Ordering::Relaxed);
                     self.retry.gc(s);
                 }
 
@@ -329,10 +247,10 @@ impl Peer {
                 // - Update metrics
                 t = clock.tick() => {
                     if !self.retry.is_empty() {
-                        trace!(name = %self.conf.name, peer = %self.conn.key, "retry check");
+                        trace!(name = %self.conf.name, %peer, %addr, "retry check");
                         self.retry.check(t);
                     }
-                    self.update_metrics()
+                    self.update_metrics(&peer)
                 }
 
                 // If messages should be re-sent and we can do so, send it:
@@ -340,235 +258,48 @@ impl Peer {
                 // This is separate from the retry check above because the check
                 // scans multiple items and here we just take the next one that
                 // is ready and go with it.
-                () = ready(()), if self.retry.is_ready() && wstate.is_idle() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "resending message");
+                () = ready(()), if self.retry.is_ready() => {
                     let Some(bytes) = self.retry.next() else {
                         continue
                     };
-                    let chunk = min(bytes.len(), MAX_PAYLOAD_SIZE);
-                    wstate = WriteState::data_frame(
-                        &bytes[..chunk],
-                        chunk < bytes.len(),
-                        &mut self.conn.state,
-                        &mut wbuf
-                    )?;
-                    obound_msg = Some((RetryPolicy::Default, bytes, chunk))
+                    trace!(name = %self.conf.name, %peer, %addr, "resending message");
+                    message_tx
+                        .send((RetryPolicy::Default, bytes))
+                        .map_err(|_| NetworkError::ChannelClosed)?
                 }
 
-                // Continue an ongoing write operation.
-                r = self.conn.stream.writable(), if !wstate.is_idle() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "continue writing");
-                    if let Err(e) = r {
-                        return Err(e.into())
+                // Check that our send task has not terminated.
+                r = &mut send_task => match r {
+                    Ok(Err(err)) => {
+                        warn!(name = %self.conf.name, %peer, %addr, %err, "send task error");
+                        recv_task.abort();
+                        return Err(err)
                     }
-                    match &mut wstate {
-                        WriteState::Ack { off, len } => {
-                            match self.conn.stream.try_write(&wbuf[*off..*len]) {
-                                Ok(n) => {
-                                    *off += n;
-                                    if *off < *len {
-                                        continue
-                                    }
-                                    if let Some((policy, bytes, chunk)) = &mut obound_msg {
-                                        if *chunk < bytes.len() {
-                                            let end = min(*chunk + MAX_PAYLOAD_SIZE, bytes.len());
-                                            wstate = WriteState::data_frame(
-                                                &bytes[*chunk..end],
-                                                end < bytes.len(),
-                                                &mut self.conn.state,
-                                                &mut wbuf
-                                            )?;
-                                            *chunk = end;
-                                        } else {
-                                            if policy.is_retry() {
-                                                self.countdown.start(self.conf.receive_timeout)
-                                            }
-                                            obound_msg = None;
-                                            wstate = WriteState::Idle;
-                                        }
-                                    } else {
-                                        wstate = WriteState::Idle;
-                                    }
-                                }
-                                Err(e) => if e.kind() != io::ErrorKind::WouldBlock {
-                                    return Err(e.into())
-                                }
-                            }
+                    Err(err) => {
+                        recv_task.abort();
+                        return if err.is_cancelled() {
+                            Err(NetworkError::Task("cancelled"))
+                        } else {
+                            error!(name = %self.conf.name, %peer, %addr, %err, "send task panic");
+                            Err(NetworkError::Task("send panic"))
                         }
-                        WriteState::Data { off, len } => {
-                            match self.conn.stream.try_write(&wbuf[*off..*len]) {
-                                Ok(n) => {
-                                    *off += n;
-                                    if *off < *len {
-                                        continue
-                                    }
-                                    if let Some(ack) = obound_acks.pop_front() {
-                                        wstate = WriteState::ack_frame(ack, &mut self.conn.state, &mut wbuf)?
-                                    } else if let Some((policy, bytes, chunk)) = &mut obound_msg {
-                                        if *chunk < bytes.len() {
-                                            let end = min(*chunk + MAX_PAYLOAD_SIZE, bytes.len());
-                                            wstate = WriteState::data_frame(
-                                                &bytes[*chunk..end],
-                                                end < bytes.len(),
-                                                &mut self.conn.state,
-                                                &mut wbuf
-                                            )?;
-                                            *chunk = end;
-                                        } else {
-                                            if policy.is_retry() {
-                                                self.countdown.start(self.conf.receive_timeout)
-                                            }
-                                            obound_msg = None;
-                                            wstate = WriteState::Idle;
-                                        }
-                                    } else {
-                                        wstate = WriteState::Idle;
-                                    }
-                                }
-                                Err(e) => if e.kind() != io::ErrorKind::WouldBlock {
-                                    return Err(e.into())
-                                }
-                            }
-                        },
-                        WriteState::Idle => { /* unreachable!() */ }
                     }
-                }
+                },
 
-                // Wait for the healthcheck countdown to finish.
-                //
-                // The countdown is started after writing a message and reset
-                // when we received a frame.
-                () = &mut self.countdown => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "read timeout");
-                    return Err(NetworkError::Timeout)
-                }
-
-                // Await the next read permit.
-                //
-                // If our budget is used up, we need to wait for capacity to become
-                // available before we can continue to read from the socket (and
-                // eventually deliver the message to the application).
-                p = self.budget.0.clone().acquire_owned(), if read_permit.is_none() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "next read permit");
-                    read_permit = Some(p.map_err(|_| NetworkError::BudgetClosed)?);
-                }
-
-                // Continue reading from the socket if possible.
-                //
-                // NB that we require the ACKs that we have appended before to
-                // picked up. This should be very fast as writing interleaves
-                // ACKs in between frames. We do this to exercise backpressure
-                // because if the remote does not or can not read what we write
-                // but keeps sending us data we would accumulate ACKs without
-                // bound.
-                r = self.conn.stream.readable(), if read_permit.is_some() => {
-                    trace!(name = %self.conf.name, peer = %self.conn.key, "continue reading");
-                    if let Err(e) = r {
-                        return Err(e.into())
+                // Check that our receive task has not terminated.
+                r = &mut recv_task => match r {
+                    Ok(Err(err)) => {
+                        warn!(name = %self.conf.name, %peer, %addr, %err, "receive task error");
+                        send_task.abort();
+                        return Err(err)
                     }
-                    if obound_acks.len() > self.conf.peer_budget.get() {
-                        return Err(NetworkError::TooManyPendingAcks(self.conn.key))
-                    }
-                    match &mut rstate {
-                        ReadState::Header { off, buf } => {
-                            match self.conn.stream.try_read(&mut buf[*off..]) {
-                                Ok(0) => {
-                                    let e = io::ErrorKind::UnexpectedEof.into();
-                                    return Err(NetworkError::Io(e))
-                                }
-                                Ok(n) => {
-                                    self.countdown.stop();
-                                    *off += n;
-                                    if *off < buf.len() {
-                                        continue
-                                    }
-                                    let hdr = Header::unvalidated(u32::from_be_bytes(*buf));
-                                    fbuf.resize(hdr.len().into(), 0);
-                                    rstate = ReadState::Frame { hdr, off: 0, buf: &mut fbuf }
-                                }
-                                Err(e) => if e.kind() != io::ErrorKind::WouldBlock {
-                                    return Err(e.into())
-                                }
-                            }
-                        }
-                        ReadState::Frame { hdr, off, buf } => {
-                            match self.conn.stream.try_read(&mut buf[*off..]) {
-                                Ok(0) => {
-                                    let e = io::ErrorKind::UnexpectedEof.into();
-                                    return Err(NetworkError::Io(e))
-                                }
-                                Ok(n) => {
-                                    self.countdown.stop();
-                                    *off += n;
-                                    if *off < buf.len() {
-                                        continue
-                                    }
-                                    match hdr.frame_type() {
-                                        Ok(FrameType::Data) => {
-                                            let n = self.conn.state.read_message(buf, &mut *rbuf)?;
-                                            ibound_msg.extend_from_slice(&rbuf[..n]);
-                                            if ibound_msg.len() > self.max_message_size {
-                                                return Err(NetworkError::MessageTooLarge)
-                                            }
-                                            if !hdr.is_partial() { // message complete
-                                                let mut msg = mem::take(&mut ibound_msg).freeze();
-                                                let Some(t) = Trailer::from_bytes(&mut msg) else {
-                                                    warn!(
-                                                        name = %self.conf.name,
-                                                        node = %self.conf.keypair.public_key(),
-                                                        peer = %self.conn.key,
-                                                        addr = %self.conn.addr,
-                                                        "invalid trailer"
-                                                    );
-                                                    return Err(NetworkError::InvalidTrailer);
-                                                };
-                                                let slot = match t {
-                                                    Trailer::Std { slot, id } => {
-                                                        obound_acks.push_back(Ack::from((slot, id)));
-                                                        Some(slot)
-                                                    }
-                                                    Trailer::NoAck { slot } => Some(slot),
-                                                    Trailer::Unknown => None
-                                                };
-                                                if let Some(s) = slot && s < self.lower_bound {
-                                                    continue
-                                                }
-                                                let p = read_permit.take();
-                                                debug_assert!(p.is_some());
-                                                if self.tx.send((self.conn.key, msg, p)).is_err() {
-                                                    return Err(NetworkError::ChannelClosed)
-                                                }
-                                                trace!(
-                                                    name = %self.conf.name,
-                                                    node = %self.conf.keypair.public_key(),
-                                                    peer = %self.conn.key,
-                                                    addr = %self.conn.addr,
-                                                    "message delivered"
-                                                );
-                                            }
-                                            rstate = ReadState::Header { off: 0, buf: [0; _] };
-                                        }
-                                        Ok(FrameType::Ack) if hdr.is_partial() => {
-                                            return Err(NetworkError::InvalidAck)
-                                        }
-                                        Ok(FrameType::Ack) => {
-                                            let n = self.conn.state.read_message(buf, &mut *rbuf)?;
-                                            let Ok(a) = Ack::try_from(&rbuf[..n]) else {
-                                                return Err(NetworkError::InvalidAck)
-                                            };
-                                            let (s, i) = a.into();
-                                            self.retry.del(s, i);
-                                            rstate = ReadState::Header { off: 0, buf: [0; _] };
-                                        }
-                                        Err(t) => {
-                                            return Err(NetworkError::UnknownFrameType(t))
-                                        }
-                                    }
-                                }
-                                Err(e) => if e.kind() != io::ErrorKind::WouldBlock {
-                                    return Err(e.into())
-                                }
-                            }
+                    Err(err) => {
+                        send_task.abort();
+                        return if err.is_cancelled() {
+                            Err(NetworkError::Task("cancelled"))
+                        } else {
+                            error!(name = %self.conf.name, %peer, %addr, %err, "receive task panic");
+                            Err(NetworkError::Task("receive panic"))
                         }
                     }
                 }
@@ -576,12 +307,172 @@ impl Peer {
         }
     }
 
-    fn update_metrics(&self) {
+    fn update_metrics(&self, key: &PublicKey) {
+        self.metrics.set(key, "outbound_messages", self.msgs.len());
+        self.metrics.set(key, "retrying_messages", self.retry.len());
         self.metrics
-            .set(&self.conn.key, "outbound_messages", self.msgs.len());
-        self.metrics
-            .set(&self.conn.key, "retrying_messages", self.retry.len());
-        self.metrics
-            .set(&self.conn.key, "remaining_budget", self.budget.remaining());
+            .set(key, "remaining_budget", self.budget.remaining());
+    }
+}
+
+struct Sender {
+    conf: Arc<Config>,
+    stream: OwnedWriteHalf,
+    messages: UnboundedReceiver<(RetryPolicy, Bytes)>,
+    acks: mpsc::Receiver<Ack>,
+    state: Arc<StatelessTransportState>,
+    nonce: u64,
+    countdown: Countdown,
+}
+
+impl Sender {
+    async fn start(mut self) -> Result<Empty> {
+        let mut buf = NoiseBuf::new([0; _]);
+        let mut msg = Bytes::new();
+        let mut pol = RetryPolicy::default();
+        loop {
+            select! {
+                Some((p, m)) = self.messages.recv(), if msg.is_empty() => {
+                    msg = m;
+                    pol = p
+                }
+
+                Some(ack) = self.acks.recv() => {
+                    let x = self.nonce();
+                    let n = self.state.write_message(x, &ack.0, &mut buf[Header::SIZE..])?;
+                    let h = Header::ack(n as u16);
+                    send_frame(&mut self.stream, h, &mut buf[..Header::SIZE + n]).await?
+                }
+
+                // We split messages into frames in this separate select branch
+                // to interleave the sending of data frames with ACK frames from
+                // the branch above.
+                () = ready(()), if !msg.is_empty() => {
+                    let b = msg.split_to(min(msg.len(), MAX_PAYLOAD_SIZE));
+                    let x = self.nonce();
+                    let n = self.state.write_message(x, &b, &mut buf[Header::SIZE..])?;
+                    let h = if msg.is_empty() {
+                        Header::data(n as u16)
+                    } else {
+                        Header::data(n as u16).partial()
+                    };
+                    send_frame(&mut self.stream, h, &mut buf[..Header::SIZE + n]).await?;
+                    if msg.is_empty() && pol.is_retry() {
+                        self.countdown.start(self.conf.receive_timeout)
+                    }
+                }
+                else => return Err(NetworkError::ChannelClosed)
+            }
+        }
+    }
+
+    fn nonce(&mut self) -> u64 {
+        let n = self.nonce;
+        self.nonce += 1;
+        n
+    }
+}
+
+struct Receiver {
+    peer: PublicKey,
+    budget: Budget,
+    max_message_size: usize,
+    stream: OwnedReadHalf,
+    messages: UnboundedSender<PeerMessage>,
+    ibound_acks: UnboundedSender<Ack>,
+    obound_acks: mpsc::Sender<Ack>,
+    nonce: u64,
+    state: Arc<StatelessTransportState>,
+    lower_bound: Arc<AtomicU64>,
+    countdown: Countdown,
+}
+
+impl Receiver {
+    async fn start(mut self) -> Result<Empty> {
+        let mut fbuf = NoiseBuf::new([0; _]); // frame buffer (raw data)
+        let mut rbuf = NoiseBuf::new([0; _]); // read buffer (decrypted)
+        let mut msg = BytesMut::new();
+        loop {
+            loop {
+                select! {
+                    h = recv_frame(&mut self.stream, &mut fbuf) => match h {
+                        Ok(h) => {
+                            self.countdown.stop();
+                            match h.frame_type() {
+                                Ok(FrameType::Data) => {
+                                    let x = self.nonce();
+                                    let n = self.state.read_message(x, &fbuf[.. h.len().into()], &mut *rbuf)?;
+                                    msg.extend_from_slice(&rbuf[..n]);
+                                    if msg.len() > self.max_message_size {
+                                        return Err(NetworkError::MessageTooLarge)
+                                    }
+                                    if !h.is_partial() {
+                                        break
+                                    }
+                                }
+                                Ok(FrameType::Ack) => {
+                                    let x = self.nonce();
+                                    let n = self.state.read_message(x, &fbuf[.. h.len().into()], &mut *rbuf)?;
+                                    let Ok(a) = Ack::try_from(&rbuf[..n]) else {
+                                        return Err(NetworkError::InvalidAck)
+                                    };
+                                    self.ibound_acks.send(a).map_err(|_| NetworkError::ChannelClosed)?
+                                }
+                                Err(t) => return Err(NetworkError::UnknownFrameType(t))
+                            }
+                        }
+                        Err(err) => return Err(err.into())
+                    },
+                    () = &mut self.countdown => {
+                        return Err(NetworkError::Timeout("receiving from peer"))
+                    }
+                }
+            }
+
+            let mut msg = mem::take(&mut msg).freeze();
+
+            let Some(t) = Trailer::from_bytes(&mut msg) else {
+                return Err(NetworkError::InvalidTrailer);
+            };
+
+            let slot = match t {
+                Trailer::Std { slot, id } => {
+                    match self.obound_acks.try_send(Ack::from((slot, id))) {
+                        Ok(()) => {},
+                        Err(TrySendError::Full(_)) => {
+                            return Err(NetworkError::TooManyPendingAcks(self.peer));
+                        },
+                        Err(TrySendError::Closed(_)) => return Err(NetworkError::ChannelClosed),
+                    }
+                    Some(slot)
+                },
+                Trailer::NoAck { slot } => Some(slot),
+                Trailer::Unknown => None,
+            };
+
+            if let Some(s) = slot
+                && u64::from(s) < self.lower_bound.load(Ordering::Relaxed)
+            {
+                continue;
+            }
+
+            let permit = self
+                .budget
+                .clone()
+                .0
+                .acquire_owned()
+                .await
+                .map_err(|_| NetworkError::BudgetClosed)?;
+
+            if self.messages.send((self.peer, msg, Some(permit))).is_err() {
+                return Err(NetworkError::ChannelClosed);
+            }
+        }
+    }
+
+    fn nonce(&mut self) -> u64 {
+        let n = self.nonce;
+        self.nonce += 1;
+        n
     }
 }

--- a/crates/cliquenet/src/net/peer/delay.rs
+++ b/crates/cliquenet/src/net/peer/delay.rs
@@ -40,10 +40,6 @@ impl DelayQueue {
         self.items.len()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
     pub fn is_ready(&self) -> bool {
         !self.ready.is_empty()
     }

--- a/crates/cliquenet/src/net/peer/tests.rs
+++ b/crates/cliquenet/src/net/peer/tests.rs
@@ -6,6 +6,7 @@ use tokio::{
     sync::{OwnedSemaphorePermit, mpsc, watch},
     time::timeout,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     Config, Keypair, PublicKey,
@@ -73,7 +74,6 @@ fn payload(slot: Slot, id: MsgId, data: &[u8]) -> (RetryPolicy, Bytes) {
 /// Create a `Peer` and its inbound message receiver + outbox + slot sender.
 fn make_peer(
     conf: Arc<Config>,
-    conn: Connection,
     budget: usize,
 ) -> (Peer, Rx, Queue<(RetryPolicy, Bytes)>, watch::Sender<Slot>) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -85,7 +85,6 @@ fn make_peer(
         .messages(outbox.clone())
         .inbound(tx)
         .next_slot(slot_rx)
-        .connection(conn)
         .metrics(Arc::new(NoMetrics))
         .build();
     (peer, rx, outbox, slot_tx)
@@ -106,15 +105,15 @@ async fn send_receive() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let slot = Slot::new(1);
     let id = MsgId::new(1);
     outbox_a.enqueue(slot, id, payload(slot, id, b"hello"));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (src, data, _permit) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -140,8 +139,8 @@ async fn send_multiple() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let n = 10u64;
     let slot = Slot::new(1);
@@ -151,8 +150,8 @@ async fn send_multiple() {
         outbox_a.enqueue(slot, id, payload(slot, id, msg.as_bytes()));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     for i in 0..n {
         let (_, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
@@ -179,8 +178,8 @@ async fn bidirectional() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, mut rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, mut rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let slot = Slot::new(1);
     for i in 0..5u64 {
@@ -189,8 +188,8 @@ async fn bidirectional() {
         outbox_b.enqueue(slot, id, payload(slot, id, b"from-b"));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     for _ in 0..5 {
         let (src, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
@@ -226,16 +225,16 @@ async fn large_message() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let big: Vec<u8> = (0..200 * 1024).map(|i| (i % 251) as u8).collect();
     let slot = Slot::new(1);
     let id = MsgId::new(0);
     outbox_a.enqueue(slot, id, payload(slot, id, &big));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(10), rx_b.recv())
         .await
@@ -260,8 +259,8 @@ async fn slow_receiver() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 1);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 1);
 
     let slot = Slot::new(1);
     for i in 0..3u64 {
@@ -270,8 +269,8 @@ async fn slow_receiver() {
         outbox_a.enqueue(slot, id, payload(slot, id, msg.as_bytes()));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     for i in 0..3u64 {
         let (_, data, permit) = timeout(Duration::from_secs(5), rx_b.recv())
@@ -298,8 +297,8 @@ async fn slot_gc() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, slot_b) = make_peer(conf_b, 10);
 
     // Slot 3 (below threshold) — should be discarded by B.
     let old_slot = Slot::new(3);
@@ -316,8 +315,8 @@ async fn slot_gc() {
     slot_b.send(Slot::new(5)).unwrap();
     outbox_a.gc(Slot::new(5));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -357,7 +356,6 @@ async fn receive_timeout() {
         .messages(outbox.clone())
         .inbound(tx)
         .next_slot(slot_rx)
-        .connection(conn_a)
         .metrics(Arc::new(NoMetrics))
         .build();
 
@@ -365,13 +363,22 @@ async fn receive_timeout() {
     let id = MsgId::new(0);
     outbox.enqueue(slot, id, payload(slot, id, b"ping"));
 
-    let result = timeout(Duration::from_secs(5), peer_a.start())
-        .await
-        .expect("test itself timed out");
+    let result = timeout(
+        Duration::from_secs(5),
+        peer_a.start(conn_a, CancellationToken::new()),
+    )
+    .await
+    .expect("test itself timed out");
 
+    // When Receiver returns Timeout, its `obound_acks_tx` drops; Sender then
+    // sees its `acks` channel close and returns ChannelClosed. Whichever
+    // subtask the coordinator's `select!` reaps first determines the error.
     assert!(
-        matches!(result, Err(NetworkError::Timeout)),
-        "expected Timeout, got {result:?}"
+        matches!(
+            result,
+            Err(NetworkError::Timeout(_)) | Err(NetworkError::ChannelClosed)
+        ),
+        "expected Timeout or ChannelClosed, got {result:?}"
     );
 }
 
@@ -387,16 +394,16 @@ async fn threshold_advance_mid_flight() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let s1 = Slot::new(1);
     let s3 = Slot::new(3);
     outbox_a.enqueue(s1, MsgId::new(0), payload(s1, MsgId::new(0), b"old"));
     outbox_a.enqueue(s3, MsgId::new(0), payload(s3, MsgId::new(0), b"new"));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data1, _) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -438,7 +445,7 @@ async fn channel_closed() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
 
     let (tx_b, rx_b) = mpsc::unbounded_channel();
     let (_slot_tx, slot_rx) = watch::channel(Slot::MIN);
@@ -448,7 +455,6 @@ async fn channel_closed() {
         .messages(Queue::new())
         .inbound(tx_b)
         .next_slot(slot_rx)
-        .connection(conn_b)
         .metrics(Arc::new(NoMetrics))
         .build();
     drop(rx_b);
@@ -457,10 +463,13 @@ async fn channel_closed() {
     let id = MsgId::new(0);
     outbox_a.enqueue(slot, id, payload(slot, id, b"data"));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let result = timeout(Duration::from_secs(5), peer_b.start())
-        .await
-        .expect("test itself timed out");
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let result = timeout(
+        Duration::from_secs(5),
+        peer_b.start(conn_b, CancellationToken::new()),
+    )
+    .await
+    .expect("test itself timed out");
 
     assert!(
         matches!(result, Err(NetworkError::ChannelClosed)),
@@ -490,19 +499,28 @@ async fn connection_reset() {
         .messages(Queue::new())
         .inbound(tx)
         .next_slot(slot_rx)
-        .connection(conn_a)
         .metrics(Arc::new(NoMetrics))
         .build();
 
     drop(conn_b);
 
-    let result = timeout(Duration::from_secs(5), peer_a.start())
-        .await
-        .expect("test itself timed out");
+    let result = timeout(
+        Duration::from_secs(5),
+        peer_a.start(conn_a, CancellationToken::new()),
+    )
+    .await
+    .expect("test itself timed out");
 
+    // The Receiver hits Io when recv_frame sees the peer's FIN/EOF; that drops
+    // its `obound_acks_tx`, which can cause the Sender to return ChannelClosed
+    // first. Either error correctly indicates a broken connection — which one
+    // the coordinator returns depends on which subtask its `select!` reaps first.
     assert!(
-        matches!(result, Err(NetworkError::Io(_))),
-        "expected Io error, got {result:?}"
+        matches!(
+            result,
+            Err(NetworkError::Io(_)) | Err(NetworkError::ChannelClosed)
+        ),
+        "expected Io or ChannelClosed, got {result:?}"
     );
 }
 
@@ -518,15 +536,15 @@ async fn empty_payload() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let slot = Slot::new(1);
     let id = MsgId::new(0);
     outbox_a.enqueue(slot, id, payload(slot, id, b""));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -551,8 +569,8 @@ async fn interleaved_acks() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, mut rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, mut rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let big_a: Vec<u8> = (0..100 * 1024).map(|i| (i % 251) as u8).collect();
     let big_b: Vec<u8> = (0..100 * 1024).map(|i| (i % 241) as u8).collect();
@@ -564,8 +582,8 @@ async fn interleaved_acks() {
         outbox_b.enqueue(slot, id, payload(slot, id, &big_b));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     for _ in 0..3 {
         let (_, data, _) = timeout(Duration::from_secs(10), rx_b.recv())
@@ -599,8 +617,8 @@ async fn duplicate_message_id() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
     let slot = Slot::new(1);
     let id = MsgId::new(0);
@@ -608,8 +626,8 @@ async fn duplicate_message_id() {
     outbox_a.enqueue(slot, id, payload(slot, id, b"first"));
     outbox_a.enqueue(slot, id, payload(slot, id, b"second"));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -641,8 +659,8 @@ async fn threshold_exact_boundary() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, slot_b) = make_peer(conf_b, conn_b, 10);
+    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, slot_b) = make_peer(conf_b, 10);
 
     let s4 = Slot::new(4);
     outbox_a.enqueue(s4, MsgId::new(0), payload(s4, MsgId::new(0), b"below"));
@@ -658,8 +676,8 @@ async fn threshold_exact_boundary() {
     slot_b.send(Slot::new(5)).unwrap();
     outbox_a.gc(Slot::new(5));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let mut received = Vec::new();
     for _ in 0..2 {
@@ -695,8 +713,8 @@ async fn many_small_messages() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, conn_a, 500);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 500);
+    let (mut peer_a, _rx_a, outbox_a, slot_a) = make_peer(conf_a, 500);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 500);
 
     let msgs_per_slot = 50u64;
     let num_slots = 100u64;
@@ -709,8 +727,8 @@ async fn many_small_messages() {
         outbox_a.enqueue(slot, id, payload(slot, id, &msg));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let mut values = Vec::with_capacity(count as usize);
     for n in 0..count {
@@ -762,18 +780,18 @@ async fn retry_delivers_on_late_start() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
 
     let slot = Slot::new(1);
     let id = MsgId::new(0);
     outbox_a.enqueue(slot, id, payload(slot, id, b"retried"));
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
 
     tokio::time::sleep(Duration::from_millis(1500)).await;
 
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 10);
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(5), rx_b.recv())
         .await
@@ -806,7 +824,6 @@ async fn retry_after_reconnect() {
         .messages(outbox_a.clone())
         .inbound(tx_a)
         .next_slot(slot_rx)
-        .connection(conn_a1)
         .metrics(Arc::new(NoMetrics))
         .build();
 
@@ -816,19 +833,21 @@ async fn retry_after_reconnect() {
 
     drop(conn_b1);
 
-    let result = peer_a.start().await;
+    let result = peer_a.start(conn_a1, CancellationToken::new()).await;
     assert!(
-        matches!(result, Err(NetworkError::Io(_))),
-        "expected Io error, got {result:?}"
+        matches!(
+            result,
+            Err(NetworkError::Io(_)) | Err(NetworkError::ChannelClosed)
+        ),
+        "expected Io or ChannelClosed, got {result:?}"
     );
 
     let (conn_a2, conn_b2) = connection_pair(conf_a, pkb, conf_b.clone()).await;
-    peer_a.set_connection(conn_a2);
 
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b2, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 10);
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a2, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b2, CancellationToken::new()).await });
 
     let (_, data, _) = timeout(Duration::from_secs(10), rx_b.recv())
         .await
@@ -864,8 +883,8 @@ async fn backpressure_on_unacked() {
 
     let (conn_a, conn_b) = connection_pair(conf_a.clone(), pkb, conf_b.clone()).await;
 
-    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, conn_a, 10);
-    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, conn_b, 1);
+    let (mut peer_a, _rx_a, outbox_a, _slot_a) = make_peer(conf_a, 10);
+    let (mut peer_b, mut rx_b, _outbox_b, _slot_b) = make_peer(conf_b, 1);
 
     let slot = Slot::new(1);
     for i in 0..5u64 {
@@ -874,8 +893,8 @@ async fn backpressure_on_unacked() {
         outbox_a.enqueue(slot, id, payload(slot, id, msg.as_bytes()));
     }
 
-    let ha = tokio::spawn(async move { peer_a.start().await });
-    let hb = tokio::spawn(async move { peer_b.start().await });
+    let ha = tokio::spawn(async move { peer_a.start(conn_a, CancellationToken::new()).await });
+    let hb = tokio::spawn(async move { peer_b.start(conn_b, CancellationToken::new()).await });
 
     let mut received = Vec::new();
     for _ in 0..3 {

--- a/crates/cliquenet/src/net/peer/tests.rs
+++ b/crates/cliquenet/src/net/peer/tests.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 use crate::{
-    Config, Keypair, PublicKey,
+    Config, Keypair, NOISE_IK_25519_AESGCM_BLAKE2S, PublicKey,
     addr::NetAddr,
     connection::Connection,
     error::NetworkError,
@@ -32,6 +32,7 @@ fn config(kp: Keypair, recv_timeout: Duration) -> Arc<Config> {
             .receive_timeout(recv_timeout)
             .retry_delays(vec![2, 5])
             .max_retry_delay(Duration::from_secs(10))
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build(),
     )
 }
@@ -743,6 +744,7 @@ fn config_with_retry(kp: Keypair, recv_timeout: Duration, retry_delays: Vec<u8>)
             .receive_timeout(recv_timeout)
             .retry_delays(retry_delays)
             .max_retry_delay(Duration::from_secs(10))
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build(),
     )
 }
@@ -854,6 +856,7 @@ async fn backpressure_on_unacked() {
             .receive_timeout(Duration::from_secs(5))
             .retry_delays(vec![30])
             .max_retry_delay(Duration::from_secs(30))
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build(),
     );
     let conf_b = config(kb.clone(), Duration::from_secs(5));

--- a/crates/cliquenet/src/net/peer/tests.rs
+++ b/crates/cliquenet/src/net/peer/tests.rs
@@ -8,13 +8,14 @@ use tokio::{
 };
 
 use crate::{
-    Config, Keypair, NOISE_IK_25519_AESGCM_BLAKE2S, PublicKey,
+    Config, Keypair, PublicKey,
     addr::NetAddr,
     connection::Connection,
     error::NetworkError,
     metrics::NoMetrics,
     msg::{MsgId, Slot, Trailer, hello::Hello},
     net::{RetryPolicy, peer::Peer},
+    noise::Protocol,
     queue::Queue,
 };
 
@@ -32,7 +33,7 @@ fn config(kp: Keypair, recv_timeout: Duration) -> Arc<Config> {
             .receive_timeout(recv_timeout)
             .retry_delays(vec![2, 5])
             .max_retry_delay(Duration::from_secs(10))
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
 }
@@ -744,7 +745,7 @@ fn config_with_retry(kp: Keypair, recv_timeout: Duration, retry_delays: Vec<u8>)
             .receive_timeout(recv_timeout)
             .retry_delays(retry_delays)
             .max_retry_delay(Duration::from_secs(10))
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
 }
@@ -856,7 +857,7 @@ async fn backpressure_on_unacked() {
             .receive_timeout(Duration::from_secs(5))
             .retry_delays(vec![30])
             .max_retry_delay(Duration::from_secs(30))
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     );
     let conf_b = config(kb.clone(), Duration::from_secs(5));

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -379,7 +379,6 @@ impl Server {
                                 name = %self.conf.name,
                                 node = %self.key,
                                 peer = %key,
-                                //addr = %peer.socket_addr(),
                                 "party has been removed"
                             );
                             continue
@@ -701,17 +700,10 @@ impl Server {
         let name = self.conf.name.clone();
         let metrics = self.metrics.clone();
         self.peer_tasks.spawn(key, async move {
-            let _addr = conn.addr;
+            let addr = conn.addr;
             let Err(err) = peer.start(conn, cancel).await;
             if !matches!(err, NetworkError::PeerInterrupt) {
-                warn!(
-                    %name,
-                    %node,
-                    peer = %key,
-                    addr = %_addr,
-                    %err,
-                    "peer failure"
-                );
+                warn!(%name, %node, peer = %key, %addr, %err, "peer failure");
                 metrics.add(&key, "errors", 1)
             }
             peer

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -699,19 +699,20 @@ impl Server {
         );
         let node = self.key;
         let name = self.conf.name.clone();
-        //let metrics = self.metrics.clone();
+        let metrics = self.metrics.clone();
         self.peer_tasks.spawn(key, async move {
+            let _addr = conn.addr;
             let Err(err) = peer.start(conn, cancel).await;
             if !matches!(err, NetworkError::PeerInterrupt) {
                 warn!(
                     %name,
                     %node,
-                    //peer = %peer.public_key(),
-                    //addr = %peer.socket_addr(),
+                    peer = %key,
+                    addr = %_addr,
                     %err,
                     "peer failure"
                 );
-                //metrics.add(peer.public_key(), "errors", 1)
+                metrics.add(&key, "errors", 1)
             }
             peer
         });

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -248,18 +248,18 @@ impl Server {
                                     .next_slot(self.next_slot.clone())
                                     .inbound(self.ibound.clone())
                                     .messages(party.outbox.clone())
-                                    .connection(conn)
                                     .metrics(self.metrics.clone())
                                     .build();
-                                party.peer = PeerState::Connected(peer.cancel_token());
-                                self.spawn_peer(key, peer);
+                                let cancel = CancellationToken::new();
+                                party.peer = PeerState::Connected(cancel.clone());
+                                self.spawn_peer(key, peer, conn, cancel);
                             }
-                            PeerState::Reconnect(mut peer) => {
+                            PeerState::Reconnect(peer) => {
                                 self.connect_tasks.abort(&conn.key);
                                 let key = conn.key;
-                                peer.set_connection(conn);
-                                party.peer = PeerState::Connected(peer.cancel_token());
-                                self.spawn_peer(key, peer);
+                                let cancel = CancellationToken::new();
+                                party.peer = PeerState::Connected(cancel.clone());
+                                self.spawn_peer(key, peer, conn, cancel);
                             }
                             PeerState::Connected(cancel) => {
                                 if conn.key > self.key {
@@ -324,17 +324,17 @@ impl Server {
                                     .next_slot(self.next_slot.clone())
                                     .inbound(self.ibound.clone())
                                     .messages(party.outbox.clone())
-                                    .connection(conn)
                                     .metrics(self.metrics.clone())
                                     .build();
-                                party.peer = PeerState::Connected(peer.cancel_token());
-                                self.spawn_peer(key, peer);
+                                let cancel = CancellationToken::new();
+                                party.peer = PeerState::Connected(cancel.clone());
+                                self.spawn_peer(key, peer, conn, cancel);
                             }
-                            PeerState::Reconnect(mut peer) => {
+                            PeerState::Reconnect(peer) => {
                                 let key = conn.key;
-                                peer.set_connection(conn);
-                                party.peer = PeerState::Connected(peer.cancel_token());
-                                self.spawn_peer(key, peer);
+                                let cancel = CancellationToken::new();
+                                party.peer = PeerState::Connected(cancel.clone());
+                                self.spawn_peer(key, peer, conn, cancel);
                             }
                             PeerState::Connected(cancel) => {
                                 if conn.key < self.key {
@@ -370,25 +370,25 @@ impl Server {
                 },
 
                 Some(p) = self.peer_tasks.join_next() => match p {
-                    (key, Ok(mut peer)) => {
+                    (key, Ok(peer)) => {
                         if self.ibound.is_closed() {
                             return
                         }
-                        let Some(party) = self.parties.get_mut(peer.public_key()) else {
+                        let Some(party) = self.parties.get_mut(&key) else {
                             debug!(
                                 name = %self.conf.name,
                                 node = %self.key,
-                                peer = %peer.public_key(),
-                                addr = %peer.socket_addr(),
+                                peer = %key,
+                                //addr = %peer.socket_addr(),
                                 "party has been removed"
                             );
                             continue
                         };
                         if let PeerState::Replace(conn) = party.peer.take() {
                             let key = conn.key;
-                            peer.set_connection(conn);
-                            party.peer = PeerState::Connected(peer.cancel_token());
-                            self.spawn_peer(key, peer);
+                            let cancel = CancellationToken::new();
+                            party.peer = PeerState::Connected(cancel.clone());
+                            self.spawn_peer(key, peer, conn, cancel);
                         } else {
                             let addr = party.addr.clone();
                             party.peer = PeerState::Reconnect(peer);
@@ -672,7 +672,7 @@ impl Server {
         self.hello_tasks.abort(&conn.key);
         self.hello_tasks.spawn(
             conn.key,
-            until(self.conf.handshake_timeout, async move {
+            until(self.conf.handshake_timeout, "hello exchange", async move {
                 let theirs = conn.recv_hello().await?;
                 conn.send_hello(ours.clone()).await?;
                 Ok::<_, NetworkError>((ours, conn, theirs))
@@ -683,29 +683,35 @@ impl Server {
             .set(&self.key, "hello_tasks", self.hello_tasks.len());
     }
 
-    fn spawn_peer(&mut self, key: PublicKey, mut peer: Peer) {
+    fn spawn_peer(
+        &mut self,
+        key: PublicKey,
+        mut peer: Peer,
+        conn: Connection,
+        cancel: CancellationToken,
+    ) {
         debug!(
             name = %self.conf.name,
             node = %self.key,
-            peer = %peer.public_key(),
-            addr = %peer.socket_addr(),
+            peer = %conn.key,
+            addr = %conn.addr,
             "spawning peer task"
         );
         let node = self.key;
         let name = self.conf.name.clone();
-        let metrics = self.metrics.clone();
+        //let metrics = self.metrics.clone();
         self.peer_tasks.spawn(key, async move {
-            let Err(err) = peer.start().await;
+            let Err(err) = peer.start(conn, cancel).await;
             if !matches!(err, NetworkError::PeerInterrupt) {
                 warn!(
                     %name,
                     %node,
-                    peer = %peer.public_key(),
-                    addr = %peer.socket_addr(),
+                    //peer = %peer.public_key(),
+                    //addr = %peer.socket_addr(),
                     %err,
                     "peer failure"
                 );
-                metrics.add(peer.public_key(), "errors", 1)
+                //metrics.add(peer.public_key(), "errors", 1)
             }
             peer
         });

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -9,7 +9,6 @@ use tokio::{
         watch,
     },
     task::{JoinHandle, JoinSet},
-    time::timeout,
 };
 use tokio_util::{sync::CancellationToken, task::JoinMap};
 use tracing::{debug, error, info, trace, warn};
@@ -22,6 +21,7 @@ use crate::{
     msg::{MsgId, Slot, Trailer, hello::Hello},
     net::{Command, PeerCommand, PeerMessage, RetryPolicy, SendAction, peer::Peer},
     queue::Queue,
+    until,
 };
 
 pub struct Server {
@@ -667,21 +667,18 @@ impl Server {
             "spawning hello task"
         );
 
-        let duration = self.conf.handshake_timeout;
-
         self.metrics.add(&conn.key, "hellos", 1);
+
         self.hello_tasks.abort(&conn.key);
-        self.hello_tasks.spawn(conn.key, async move {
-            let future = async {
+        self.hello_tasks.spawn(
+            conn.key,
+            until(self.conf.handshake_timeout, async move {
                 let theirs = conn.recv_hello().await?;
                 conn.send_hello(ours.clone()).await?;
-                Ok((ours, conn, theirs))
-            };
-            match timeout(duration, future).await {
-                Ok(re) => re,
-                Err(_) => Err(NetworkError::Timeout),
-            }
-        });
+                Ok::<_, NetworkError>((ours, conn, theirs))
+            }),
+        );
+
         self.metrics
             .set(&self.key, "hello_tasks", self.hello_tasks.len());
     }

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -143,7 +143,7 @@ impl Server {
                             name = %self.conf.name,
                             node = %self.key,
                             %addr,
-                            "accepted new connection"
+                            "accepted new tcp connection"
                         );
                         self.spawn_accept(stream)
                     }
@@ -152,7 +152,7 @@ impl Server {
                             name = %self.conf.name,
                             node = %self.key,
                             %err,
-                            "error accepting connection"
+                            "error accepting tcp connection"
                         )
                     }
                 },
@@ -513,7 +513,7 @@ impl Server {
                                         name = %self.conf.name,
                                         node = %self.key,
                                         peer = %k,
-                                        role = ?role,
+                                        role = %role,
                                         "peer to assign role to not found"
                                     );
                                 }

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -21,7 +21,7 @@ use crate::{
     msg::{MsgId, Slot, Trailer, hello::Hello},
     net::{Command, PeerCommand, PeerMessage, RetryPolicy, SendAction, peer::Peer},
     queue::Queue,
-    until,
+    util::until,
 };
 
 pub struct Server {

--- a/crates/cliquenet/src/noise.rs
+++ b/crates/cliquenet/src/noise.rs
@@ -1,0 +1,41 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use snow::params::NoiseParams;
+
+static NOISE_PARAMS: LazyLock<HashMap<Protocol, NoiseParams>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        (
+            Protocol::IK_25519_AesGcm_Blake2s,
+            "Noise_IK_25519_AESGCM_BLAKE2s"
+                .parse()
+                .expect("valid noise params"),
+        ),
+        (
+            Protocol::IK_25519_ChaChaPoly_Blake2s,
+            "Noise_IK_25519_ChaChaPoly_BLAKE2s"
+                .parse()
+                .expect("valid noise params"),
+        ),
+    ])
+});
+
+/// Supported noise protocol names.
+///
+/// A protocol name contains the handshake pattern, DH, cipher, and
+/// hash function names. See https://noiseprotocol.org for details.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(non_camel_case_types)]
+#[non_exhaustive]
+pub enum Protocol {
+    IK_25519_AesGcm_Blake2s,
+    IK_25519_ChaChaPoly_Blake2s,
+}
+
+impl Protocol {
+    pub(crate) fn noise_params(self) -> NoiseParams {
+        NOISE_PARAMS
+            .get(&self)
+            .cloned()
+            .expect("All protocol names are in NOISE_PARAMS.")
+    }
+}

--- a/crates/cliquenet/src/time.rs
+++ b/crates/cliquenet/src/time.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
 };
 
 use parking_lot::Mutex;
@@ -20,6 +20,9 @@ struct Inner {
 
     // Is this countdown running?
     stopped: bool,
+
+    /// Waker to call when a stopped `Countdown` should be polled again.
+    waker: Option<Waker>,
 }
 
 impl Default for Countdown {
@@ -37,6 +40,7 @@ impl Countdown {
             inner: Arc::new(Mutex::new(Inner {
                 sleep: Box::pin(sleep(Duration::from_secs(1))),
                 stopped: true,
+                waker: None,
             })),
         }
     }
@@ -46,13 +50,21 @@ impl Countdown {
     /// Once started, a countdown can not be started again, unless
     /// `Countdown::stop` is invoked first.
     pub fn start(&self, timeout: Duration) {
-        let mut inner = self.inner.lock();
-        if !inner.stopped {
-            // The countdown is already running.
-            return;
+        // Take the waker and drop the lock before calling `wake`
+        // to avoid holding it across scheduling.
+        let waker = {
+            let mut inner = self.inner.lock();
+            if !inner.stopped {
+                // The countdown is already running.
+                return;
+            }
+            inner.stopped = false;
+            inner.sleep.as_mut().reset(Instant::now() + timeout);
+            inner.waker.take()
+        };
+        if let Some(w) = waker {
+            w.wake();
         }
-        inner.stopped = false;
-        inner.sleep.as_mut().reset(Instant::now() + timeout);
     }
 
     /// Stop this countdown.
@@ -67,8 +79,16 @@ impl Future for Countdown {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut inner = self.inner.lock();
         if inner.stopped {
+            if let Some(w) = inner.waker.as_mut() {
+                if !w.will_wake(cx.waker()) {
+                    w.clone_from(cx.waker())
+                }
+            } else {
+                inner.waker = Some(cx.waker().clone())
+            }
             return Poll::Pending;
         }
+        debug_assert!(inner.waker.is_none());
         inner.sleep.as_mut().poll(cx)
     }
 }

--- a/crates/cliquenet/src/time.rs
+++ b/crates/cliquenet/src/time.rs
@@ -1,14 +1,20 @@
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
+use parking_lot::Mutex;
 use tokio::time::{Duration, Instant, Sleep, sleep};
 
 /// A countdown timer that can be reset.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Countdown {
+    inner: Arc<Mutex<Inner>>,
+}
+#[derive(Debug)]
+struct Inner {
     // The actual future to await.
     sleep: Pin<Box<Sleep>>,
 
@@ -28,8 +34,10 @@ impl Countdown {
     /// When ready, use `Countdown::start` to begin.
     pub fn new() -> Self {
         Self {
-            sleep: Box::pin(sleep(Duration::from_secs(1))),
-            stopped: true,
+            inner: Arc::new(Mutex::new(Inner {
+                sleep: Box::pin(sleep(Duration::from_secs(1))),
+                stopped: true,
+            })),
         }
     }
 
@@ -37,29 +45,31 @@ impl Countdown {
     ///
     /// Once started, a countdown can not be started again, unless
     /// `Countdown::stop` is invoked first.
-    pub fn start(&mut self, timeout: Duration) {
-        if !self.stopped {
+    pub fn start(&self, timeout: Duration) {
+        let mut inner = self.inner.lock();
+        if !inner.stopped {
             // The countdown is already running.
             return;
         }
-        self.stopped = false;
-        self.sleep.as_mut().reset(Instant::now() + timeout);
+        inner.stopped = false;
+        inner.sleep.as_mut().reset(Instant::now() + timeout);
     }
 
     /// Stop this countdown.
-    pub fn stop(&mut self) {
-        self.stopped = true
+    pub fn stop(&self) {
+        self.inner.lock().stopped = true
     }
 }
 
 impl Future for Countdown {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.stopped {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.inner.lock();
+        if inner.stopped {
             return Poll::Pending;
         }
-        self.as_mut().sleep.as_mut().poll(cx)
+        inner.sleep.as_mut().poll(cx)
     }
 }
 

--- a/crates/cliquenet/src/util.rs
+++ b/crates/cliquenet/src/util.rs
@@ -1,0 +1,16 @@
+use std::time::Duration;
+
+use crate::NetworkError;
+
+/// A variant of `timeout` that merges the timeout error into network error.
+pub(crate) async fn until<F, A, E>(t: Duration, fut: F) -> Result<A, NetworkError>
+where
+    F: Future<Output = Result<A, E>>,
+    E: Into<NetworkError>,
+{
+    match tokio::time::timeout(t, fut).await {
+        Ok(Ok(a)) => Ok(a),
+        Ok(Err(e)) => Err(e.into()),
+        Err(_) => Err(NetworkError::Timeout),
+    }
+}

--- a/crates/cliquenet/src/util.rs
+++ b/crates/cliquenet/src/util.rs
@@ -3,14 +3,18 @@ use std::time::Duration;
 use crate::NetworkError;
 
 /// A variant of `timeout` that merges the timeout error into network error.
-pub(crate) async fn until<F, A, E>(t: Duration, fut: F) -> Result<A, NetworkError>
+pub(crate) async fn until<F, A, E>(
+    timeout: Duration,
+    context: &'static str,
+    action: F,
+) -> Result<A, NetworkError>
 where
     F: Future<Output = Result<A, E>>,
     E: Into<NetworkError>,
 {
-    match tokio::time::timeout(t, fut).await {
+    match tokio::time::timeout(timeout, action).await {
         Ok(Ok(a)) => Ok(a),
         Ok(Err(e)) => Err(e.into()),
-        Err(_) => Err(NetworkError::Timeout),
+        Err(_) => Err(NetworkError::Timeout(context)),
     }
 }

--- a/crates/cliquenet/tests/frame-handling.rs
+++ b/crates/cliquenet/tests/frame-handling.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::Ipv4Addr};
 
 use bytes::Bytes;
-use cliquenet::{Config, NetAddr, Network, Slot, x25519::Keypair};
+use cliquenet::{Config, NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, Network, Slot, x25519::Keypair};
 use rand::Rng;
 
 /// Send and receive 5 MiB messages.
@@ -28,6 +28,7 @@ async fn multiple_frames() {
                     .keypair(k)
                     .bind(a)
                     .parties(parties.iter().map(|(k, a)| (k.public_key(), a.clone())))
+                    .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
                     .build(),
             )
             .await

--- a/crates/cliquenet/tests/frame-handling.rs
+++ b/crates/cliquenet/tests/frame-handling.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::Ipv4Addr};
 
 use bytes::Bytes;
-use cliquenet::{Config, NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, Network, Slot, x25519::Keypair};
+use cliquenet::{Config, NetAddr, Network, Slot, noise::Protocol, x25519::Keypair};
 use rand::Rng;
 
 /// Send and receive 5 MiB messages.
@@ -28,7 +28,7 @@ async fn multiple_frames() {
                     .keypair(k)
                     .bind(a)
                     .parties(parties.iter().map(|(k, a)| (k.public_key(), a.clone())))
-                    .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+                    .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
                     .build(),
             )
             .await

--- a/crates/cliquenet/tests/network.rs
+++ b/crates/cliquenet/tests/network.rs
@@ -2,7 +2,7 @@ use std::{net::Ipv4Addr, time::Duration};
 
 use bytes::Bytes;
 use cliquenet::{
-    Config, Network, Role, Slot,
+    Config, NOISE_IK_25519_AESGCM_BLAKE2S, Network, Role, Slot,
     error::NetworkError,
     x25519::{Keypair, PublicKey},
 };
@@ -51,6 +51,7 @@ fn make_config(node: &Node, all: &[&Node]) -> Config {
         .receive_timeout(Duration::from_secs(5))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build()
 }
 
@@ -586,6 +587,7 @@ async fn unknown_peer_backs_off() {
             .retry_delays(vec![1])
             .max_retry_delay(Duration::from_secs(1))
             .backoff_duration(Duration::from_secs(60))
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build(),
     )
     .await
@@ -603,6 +605,7 @@ async fn unknown_peer_backs_off() {
             .receive_timeout(Duration::from_secs(5))
             .retry_delays(vec![1])
             .max_retry_delay(Duration::from_secs(1))
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build(),
     )
     .await

--- a/crates/cliquenet/tests/network.rs
+++ b/crates/cliquenet/tests/network.rs
@@ -2,8 +2,9 @@ use std::{net::Ipv4Addr, time::Duration};
 
 use bytes::Bytes;
 use cliquenet::{
-    Config, NOISE_IK_25519_AESGCM_BLAKE2S, Network, Role, Slot,
+    Config, Network, Role, Slot,
     error::NetworkError,
+    noise::Protocol,
     x25519::{Keypair, PublicKey},
 };
 use tokio::time::{sleep, timeout};
@@ -51,7 +52,7 @@ fn make_config(node: &Node, all: &[&Node]) -> Config {
         .receive_timeout(Duration::from_secs(5))
         .retry_delays(vec![1, 3])
         .max_retry_delay(Duration::from_secs(5))
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build()
 }
 
@@ -587,7 +588,7 @@ async fn unknown_peer_backs_off() {
             .retry_delays(vec![1])
             .max_retry_delay(Duration::from_secs(1))
             .backoff_duration(Duration::from_secs(60))
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
     .await
@@ -605,7 +606,7 @@ async fn unknown_peer_backs_off() {
             .receive_timeout(Duration::from_secs(5))
             .retry_delays(vec![1])
             .max_retry_delay(Duration::from_secs(1))
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
     .await

--- a/crates/hotshot/new-protocol/src/network/cliquenet.rs
+++ b/crates/hotshot/new-protocol/src/network/cliquenet.rs
@@ -1,12 +1,8 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
 pub use cliquenet::Config as CliquenetConfig;
 use cliquenet::{
-    NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, NetworkError as CliquenetError, Role, Slot,
-    x25519::PublicKey,
+    NetAddr, NetworkError as CliquenetError, Role, Slot, noise::Protocol, x25519::PublicKey,
 };
 use hotshot_types::{
     PeerConnectInfo,
@@ -60,7 +56,7 @@ impl<T: NodeType> Cliquenet<T> {
                     .values()
                     .map(|info| (info.x25519_key.into(), info.p2p_addr.clone())),
             )
-            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+            .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build();
 
         Self::create_with_config(signing_key, upgrade_lock, cfg, parties, metrics).await
@@ -69,7 +65,7 @@ impl<T: NodeType> Cliquenet<T> {
     pub(crate) async fn create_with_config<P>(
         signing_key: T::SignatureKey,
         upgrade_lock: UpgradeLock<T>,
-        mut config: cliquenet::Config,
+        config: cliquenet::Config,
         parties: P,
         metrics: Box<dyn Metrics>,
     ) -> Result<Self, NetworkError>
@@ -77,9 +73,8 @@ impl<T: NodeType> Cliquenet<T> {
         P: IntoIterator<Item = (T::SignatureKey, PeerConnectInfo)>,
     {
         let public_key = config.public_key();
-        assert!(config.metrics.is_none());
-        config.metrics = Some(Arc::new(CliquenetMetrics::new(metrics)));
-        let network = cliquenet::Network::create(config)
+        let metrics = CliquenetMetrics::new(metrics);
+        let network = cliquenet::Network::create(config.with_metrics(metrics))
             .await
             .map_err(to_network_error)?;
 

--- a/crates/hotshot/new-protocol/src/network/cliquenet.rs
+++ b/crates/hotshot/new-protocol/src/network/cliquenet.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 pub use cliquenet::Config as CliquenetConfig;
-use cliquenet::{NetAddr, NetworkError as CliquenetError, Role, Slot, x25519::PublicKey};
+use cliquenet::{
+    NOISE_IK_25519_AESGCM_BLAKE2S, NetAddr, NetworkError as CliquenetError, Role, Slot,
+    x25519::PublicKey,
+};
 use hotshot_types::{
     PeerConnectInfo,
     data::{EpochNumber, ViewNumber},
@@ -57,6 +60,7 @@ impl<T: NodeType> Cliquenet<T> {
                     .values()
                     .map(|info| (info.x25519_key.into(), info.p2p_addr.clone())),
             )
+            .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
             .build();
 
         Self::create_with_config(signing_key, upgrade_lock, cfg, parties, metrics).await

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -6,6 +6,7 @@ use std::{
 
 use async_broadcast::Sender;
 use bon::Builder;
+use cliquenet::NOISE_IK_25519_AESGCM_BLAKE2S;
 use committable::Committable;
 use hotshot::types::{BLSPubKey, Event, EventType};
 use hotshot_example_types::{node_types::TestTypes, storage_types::TestStorage};
@@ -544,6 +545,7 @@ async fn create_network(
                 .iter()
                 .map(|(_, info)| (info.x25519_key.into(), info.p2p_addr.clone())),
         )
+        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
         .build();
 
     let met = Box::new(NoMetrics);

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -6,7 +6,7 @@ use std::{
 
 use async_broadcast::Sender;
 use bon::Builder;
-use cliquenet::NOISE_IK_25519_AESGCM_BLAKE2S;
+use cliquenet::noise::Protocol;
 use committable::Committable;
 use hotshot::types::{BLSPubKey, Event, EventType};
 use hotshot_example_types::{node_types::TestTypes, storage_types::TestStorage};
@@ -545,7 +545,7 @@ async fn create_network(
                 .iter()
                 .map(|(_, info)| (info.x25519_key.into(), info.p2p_addr.clone())),
         )
-        .noise_configs([(1.into(), NOISE_IK_25519_AESGCM_BLAKE2S.clone())])
+        .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
     let met = Box::new(NoMetrics);


### PR DESCRIPTION
Replaces the single-task `select!` event loop in `peer.rs` with a three-task topology -- the peer task owning retry/dequeue/GC/clock, plus a `Sender` and `Receiver` each owning their respective TCP stream half and running in separate tasks each. Noise state is `Arc<StatelessTransportState>` with per-direction `send_nonce`/`recv_nonce` owned by their respective tasks, so encryption and decryption run on different runtime workers without a mutex, i.e. we do not need to share the state via `Arc<Mutex<TransportState>>`.

- `Connection` carries explicit `send_nonce` / `recv_nonce`; `Peer` no longer owns the `Connection`.
- `Peer::start(conn, cancel)` takes the connection and cancellation token as arguments; `set_connection` and the internal cancel field are gone.
- Peer task <-> `Sender` task /`Receiver` task communication uses three channels (outbound messages, outbound ACKs, inbound ACKs); the previous local `VecDeque<Ack>` is replaced by these.
- `Countdown` is now `Clone` so the `Sender` can `start()` it on the last frame of a retry-policy send and the `Receiver` can `stop()` it on incoming bytes.

The design, which goes back a little to the original implementation, allows send and receive operations to run in parallel on different cores which improves full duplex throughput.