### PR TITLE
fix(light-client): persist used_x25519_keys in stake table storage

### DIFF
--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -263,13 +263,14 @@ impl StakeTableState {
         validator_exits: HashSet<Address>,
         used_bls_keys: HashSet<BLSPubKey>,
         used_schnorr_keys: HashSet<SchnorrPubKey>,
+        used_x25519_keys: HashSet<x25519::PublicKey>,
     ) -> Self {
         Self {
             validators,
             validator_exits,
             used_bls_keys,
             used_schnorr_keys,
-            used_x25519_keys: HashSet::new(),
+            used_x25519_keys,
         }
     }
 

--- a/crates/hotshot/types/src/x25519.rs
+++ b/crates/hotshot/types/src/x25519.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use cliquenet::x25519::{InvalidKeypair, InvalidPublicKey, InvalidSecretKey};
 use rand::{Rng, SeedableRng};
@@ -195,6 +195,14 @@ impl TryFrom<PublicKey> for TaggedBase64 {
 
     fn try_from(k: PublicKey) -> Result<Self, Self::Error> {
         TaggedBase64::new(X25519_PUBLIC_KEY, &k.as_bytes()[..])
+    }
+}
+
+impl FromStr for PublicKey {
+    type Err = Tb64Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s.parse::<TaggedBase64>()?)
     }
 }
 

--- a/light-client/migrations/01_init_schema.sql
+++ b/light-client/migrations/01_init_schema.sql
@@ -53,6 +53,16 @@ CREATE TABLE stake_table_schnorr_key (
 );
 CREATE INDEX stake_table_schnorr_key_epoch ON stake_table_schnorr_key (epoch);
 
+-- This table tracks used x25519 keys for each stake table.
+--
+-- It is cumulative, meaning each key is only added once, with the epoch number where it is first
+-- used, but it belongs to the `used_x25519_keys` set in each stake table after that epoch as well.
+CREATE TABLE stake_table_x25519_key (
+    key   TEXT   PRIMARY KEY,
+    epoch BIGINT NOT NULL
+);
+CREATE INDEX stake_table_x25519_key_epoch ON stake_table_x25519_key (epoch);
+
 -- This table tracks exiting validators for each stake table.
 --
 -- It is cumulative, meaning each address is only added once, with the epoch number where it first

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -1486,7 +1486,16 @@ mod test {
         used_schnorr.insert(complete.state_ver_key.clone());
         used_schnorr.insert(incomplete.state_ver_key.clone());
 
-        let state = StakeTableState::new(validators, Default::default(), used_bls, used_schnorr);
+        let mut used_x25519 = HashSet::default();
+        used_x25519.insert(complete.x25519_key.unwrap());
+
+        let state = StakeTableState::new(
+            validators,
+            Default::default(),
+            used_bls,
+            used_schnorr,
+            used_x25519,
+        );
 
         let epoch = genesis.first_epoch_with_dynamic_stake_table + 1;
         db.insert_stake_table(epoch, &state, CLIQUENET_VERSION, CLIQUENET_VERSION)

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -1059,6 +1059,31 @@ mod test {
         assert_eq!(loaded_next_version, EPOCH_VERSION);
     }
 
+    /// Regression: storage previously dropped `used_x25519_keys` on round trip,
+    /// so a reloaded `StakeTableState::commit()` diverged from the proposer's
+    /// hash once any V3 events had been applied.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_stake_table_x25519_keys_round_trip() {
+        use committable::Committable;
+
+        let db = SqliteStorage::default().await.unwrap();
+        let epoch = EpochNumber::new(1);
+        let state = random_stake_table();
+        assert!(
+            !state.used_x25519_keys().is_empty(),
+            "random_stake_table must populate used_x25519_keys for this test to be meaningful"
+        );
+
+        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION, CLIQUENET_VERSION)
+            .await
+            .unwrap();
+        let (_, loaded, ..) = db.stake_table_lower_bound(epoch).await.unwrap().unwrap();
+
+        assert_eq!(loaded.used_x25519_keys(), state.used_x25519_keys());
+        assert_eq!(loaded.commit(), state.commit());
+    }
+
     /// Make a stake table state with all fields populated.
     fn random_stake_table() -> StakeTableState {
         let validator = random_validator();

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -14,7 +14,7 @@ use hotshot_query_service_types::{
     HeightIndexed,
     availability::{BlockId, LeafId, LeafQueryData},
 };
-use hotshot_types::{data::EpochNumber, light_client::StateVerKey};
+use hotshot_types::{data::EpochNumber, light_client::StateVerKey, x25519};
 use serde::Serialize;
 use serde_json::Value;
 use sqlx::{
@@ -442,6 +442,16 @@ impl Storage for SqliteStorage {
                 .await
                 .context(format!("loading Schnorr keys for epoch {epoch}"))?;
 
+        let used_x25519_keys =
+            query_as::<_, (String,)>("SELECT key FROM stake_table_x25519_key WHERE epoch <= $1")
+                .bind(epoch)
+                .fetch(tx.as_mut())
+                .map_err(anyhow::Error::new)
+                .and_then(|(s,)| async move { Ok(x25519::PublicKey::from_str(&s)?) })
+                .try_collect()
+                .await
+                .context(format!("loading x25519 keys for epoch {epoch}"))?;
+
         Ok(Some((
             EpochNumber::new(epoch as u64),
             StakeTableState::new(
@@ -449,6 +459,7 @@ impl Storage for SqliteStorage {
                 validator_exits,
                 used_bls_keys,
                 used_schnorr_keys,
+                used_x25519_keys,
             ),
             epoch_root_protocol_version,
             next_epoch_root_protocol_version,
@@ -525,6 +536,23 @@ impl Storage for SqliteStorage {
             .context(format!(
                 "inserting newly used Schnorr keys for epoch {epoch}"
             ))?;
+
+        // Insert only newly used x25519 keys.
+        if !stake_table.used_x25519_keys().is_empty() {
+            QueryBuilder::new("INSERT INTO stake_table_x25519_key (epoch, key) ")
+                .push_values(stake_table.used_x25519_keys(), |mut q, key| {
+                    q.push_bind(epoch).push_bind(key.to_string());
+                })
+                // If we insert keys out of order, make sure `epoch` reflects the earliest time
+                // when this key was added to the state.
+                .push(" ON CONFLICT (key) DO UPDATE SET epoch = min(epoch, excluded.epoch)")
+                .build()
+                .execute(tx.as_mut())
+                .await
+                .context(format!(
+                    "inserting newly used x25519 keys for epoch {epoch}"
+                ))?;
+        }
 
         // Insert only the new validator exits.
         if !stake_table.validator_exits().is_empty() {
@@ -1035,6 +1063,8 @@ mod test {
     fn random_stake_table() -> StakeTableState {
         let validator = random_validator();
         let candidate: RegisteredValidator<PubKey> = validator.clone().into();
+        let x25519_key =
+            x25519::PublicKey::try_from(rand::random::<[u8; 32]>().as_slice()).unwrap();
         StakeTableState::new(
             [(candidate.account, candidate.clone())]
                 .into_iter()
@@ -1042,6 +1072,7 @@ mod test {
             [Address::random()].into_iter().collect(),
             [candidate.stake_table_key].into_iter().collect(),
             [candidate.state_ver_key].into_iter().collect(),
+            [x25519_key].into_iter().collect(),
         )
     }
 
@@ -1050,6 +1081,8 @@ mod test {
         let new_validator = random_validator();
         let new_candidate: RegisteredValidator<PubKey> = new_validator.clone().into();
         let new_exit = Address::random();
+        let new_x25519 =
+            x25519::PublicKey::try_from(rand::random::<[u8; 32]>().as_slice()).unwrap();
         StakeTableState::new(
             state
                 .validators()
@@ -1073,6 +1106,12 @@ mod test {
                 .used_schnorr_keys()
                 .iter()
                 .chain([&new_candidate.state_ver_key])
+                .cloned()
+                .collect(),
+            state
+                .used_x25519_keys()
+                .iter()
+                .chain([&new_x25519])
                 .cloned()
                 .collect(),
         )

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -450,6 +450,7 @@ impl InnerTestClient {
             Default::default(),
             used_bls_keys,
             used_schnorr_keys,
+            HashSet::default(),
         );
         state.commit()
     }


### PR DESCRIPTION
- Add stake_table_x25519_key table to the schema, mirroring BLS/Schnorr
- Insert/load used_x25519_keys in SqliteStorage::{insert,lower_bound}
- Extend StakeTableState::new to take used_x25519_keys
- Add FromStr impl on hotshot_types::x25519::PublicKey (TaggedBase64)

Without this the LC reconstructs the stake table from an empty x25519 set on DB resume, so commit() diverges from the proposer's cumulative hash once any V3 events have been processed.
