### PR TITLE
[backport release 1.2 #4356] fix(light-client): persist used_x25519_keys in stake table storage

### DIFF
--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -280,13 +280,14 @@ impl StakeTableState {
         validator_exits: HashSet<Address>,
         used_bls_keys: HashSet<BLSPubKey>,
         used_schnorr_keys: HashSet<SchnorrPubKey>,
+        used_x25519_keys: HashSet<x25519::PublicKey>,
     ) -> Self {
         Self {
             validators,
             validator_exits,
             used_bls_keys,
             used_schnorr_keys,
-            used_x25519_keys: HashSet::new(),
+            used_x25519_keys,
         }
     }
 

--- a/crates/hotshot/types/src/x25519.rs
+++ b/crates/hotshot/types/src/x25519.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use cliquenet::x25519::{InvalidKeypair, InvalidPublicKey, InvalidSecretKey};
 use rand::{Rng, SeedableRng};
@@ -195,6 +195,14 @@ impl TryFrom<PublicKey> for TaggedBase64 {
 
     fn try_from(k: PublicKey) -> Result<Self, Self::Error> {
         TaggedBase64::new(X25519_PUBLIC_KEY, &k.as_bytes()[..])
+    }
+}
+
+impl FromStr for PublicKey {
+    type Err = Tb64Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s.parse::<TaggedBase64>()?)
     }
 }
 

--- a/light-client/migrations/01_init_schema.sql
+++ b/light-client/migrations/01_init_schema.sql
@@ -8,13 +8,20 @@ CREATE TABLE leaf (
 );
 CREATE INDEX leaf_payload_hash_height ON leaf (payload_hash, height);
 
--- This table just keeps track of which epochs we have a stake table for, and the protocol
--- version in effect when that stake table was cached. Storing the version with each snapshot
--- lets cache hits apply the correct active-set selection rules without re-fetching the epoch
--- root header.
+-- This table just keeps track of which epochs we have a stake table for, and two protocol
+-- versions:
+--
+--   * `epoch_root_protocol_version` is the version of the epoch root header in epoch `e-2`,
+--     under whose rules this epoch's active validator set was selected. Storing it lets cache
+--     hits apply the correct active-set selection rules without re-fetching the root.
+--
+--   * `next_epoch_root_protocol_version` is the version of the epoch root header in epoch
+--     `e-1`, which is the snapshot for `e+1`. Storing it lets a catchup that starts from this
+--     row seed iter 1's filter version without re-fetching that root.
 CREATE TABLE stake_table_epoch (
-    epoch            BIGINT PRIMARY KEY,
-    protocol_version TEXT   NOT NULL
+    epoch                            BIGINT PRIMARY KEY,
+    epoch_root_protocol_version      TEXT   NOT NULL,
+    next_epoch_root_protocol_version TEXT   NOT NULL
 );
 
 -- This table holds the actual entries for each stake table.

--- a/light-client/migrations/01_init_schema.sql
+++ b/light-client/migrations/01_init_schema.sql
@@ -46,6 +46,16 @@ CREATE TABLE stake_table_schnorr_key (
 );
 CREATE INDEX stake_table_schnorr_key_epoch ON stake_table_schnorr_key (epoch);
 
+-- This table tracks used x25519 keys for each stake table.
+--
+-- It is cumulative, meaning each key is only added once, with the epoch number where it is first
+-- used, but it belongs to the `used_x25519_keys` set in each stake table after that epoch as well.
+CREATE TABLE stake_table_x25519_key (
+    key   TEXT   PRIMARY KEY,
+    epoch BIGINT NOT NULL
+);
+CREATE INDEX stake_table_x25519_key_epoch ON stake_table_x25519_key (epoch);
+
 -- This table tracks exiting validators for each stake table.
 --
 -- It is cumulative, meaning each address is only added once, with the epoch number where it first

--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -256,29 +256,6 @@ impl StakeTablePair for (Arc<StakeTable>, Arc<StakeTable>) {
     }
 }
 
-/// A `StakeTablePair` that promises only the previous-epoch stake table will be consulted.
-///
-/// Use when verifying a header whose QC cannot be an epoch-transition QC (i.e. the cert will not
-/// carry a `next_epoch_qc`), such as an epoch root header. If `next_epoch_stake_table` is ever
-/// consulted, this returns an error rather than silently returning the wrong table.
-pub struct PrevOnly(
-    /// The previous-epoch stake table.
-    pub Arc<StakeTable>,
-);
-
-impl StakeTablePair for PrevOnly {
-    async fn stake_table(&self) -> Result<Arc<StakeTable>> {
-        Ok(self.0.clone())
-    }
-
-    async fn next_epoch_stake_table(&self) -> Result<Arc<StakeTable>> {
-        bail!(
-            "next_epoch_stake_table consulted for a header asserted to be a non-epoch-transition \
-             block"
-        )
-    }
-}
-
 /// A quorum based on a [`StakeTablePair`] for a particular epoch.
 #[derive(Clone, Debug)]
 pub struct StakeTableQuorum<T> {
@@ -507,21 +484,5 @@ mod test {
             .await
             .unwrap();
         assert_eq!(version, leaves[0].header().version());
-    }
-
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    async fn prev_only_returns_prev() {
-        let st: Arc<StakeTable> = Arc::new(Vec::<StakeTableEntry<PubKey>>::new().into());
-        let pair = PrevOnly(st.clone());
-        let got = pair.stake_table().await.unwrap();
-        assert_eq!(*got, *st);
-    }
-
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
-    async fn prev_only_next_errors() {
-        let st: Arc<StakeTable> = Arc::new(Vec::<StakeTableEntry<PubKey>>::new().into());
-        let pair = PrevOnly(st);
-        let err = pair.next_epoch_stake_table().await.unwrap_err();
-        assert!(err.to_string().contains("next_epoch_stake_table"));
     }
 }

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -23,7 +23,7 @@ use crate::{
     client::Client,
     consensus::{
         leaf::LeafProofHint,
-        quorum::{PrevOnly, Quorum, StakeTable, StakeTablePair, StakeTableQuorum},
+        quorum::{Quorum, StakeTable, StakeTablePair, StakeTableQuorum},
     },
     storage::{LeafRequest, Storage},
 };
@@ -574,29 +574,55 @@ where
             }
         }
 
-        // If we didn't find the exact stake table we are looking for in cache, look for it in our
-        // local database, or an earlier one we can catch up from.
-        let (lower_bound, mut stake_table, mut prev_quorum) =
-            if let Some((lower_bound, stake_table, protocol_version)) =
+        // Look up an earlier stake table we can catch up from, in cache or DB.
+        //
+        // `epoch_root_protocol_version` is the version of the snapshot root header (root in epoch
+        // `k-2` for the epoch `k` we are computing). On DB load we seed it from the stored
+        // `next_snapshot_version` of `lower_bound`, which is the snapshot for `lower_bound + 1`
+        // (= iter 1's target). On genesis we fetch the root at `first_dynamic - 2` (signed by
+        // the genesis stake table) and use its version.
+        let (lower_bound, mut stake_table, mut prev_quorum, mut epoch_root_protocol_version) =
+            if let Some((lower_bound, stake_table, stored_version, next_stored_version)) =
                 self.db.stake_table_lower_bound(epoch).await?
             {
                 if lower_bound == epoch {
-                    // We have the exact quorum we requested already in our database. Add it to cache
-                    // and return it.
                     tracing::debug!(%epoch, "found stake table in database");
-                    let quorum = stake_table_state_to_quorum(&stake_table, protocol_version)?;
+                    let quorum = stake_table_state_to_quorum(&stake_table, stored_version)?;
                     return Ok(self.cache_stake_table(epoch, Arc::new(quorum)).await);
                 }
 
-                let quorum = stake_table_state_to_quorum(&stake_table, protocol_version)?;
-                (lower_bound, stake_table, Arc::new(quorum))
+                let quorum = stake_table_state_to_quorum(&stake_table, stored_version)?;
+                (
+                    lower_bound,
+                    stake_table,
+                    Arc::new(quorum),
+                    next_stored_version,
+                )
             } else {
                 // We don't have any stake table earlier than `epoch` as a starting point, so we must
                 // start from the genesis state.
+                let bootstrap_epoch = (*self.first_epoch_with_dynamic_stake_table)
+                    .checked_sub(2)
+                    .context(
+                        "first_epoch_with_dynamic_stake_table must be >= 2 for genesis catchup",
+                    )?;
+                let bootstrap_height = root_block_in_epoch(bootstrap_epoch, self.epoch_height);
+                let bootstrap_quorum = (
+                    self.genesis_stake_table.clone(),
+                    self.genesis_stake_table.clone(),
+                );
+                let bootstrap_root = self
+                    .fetch_header_with_quorum(
+                        BlockId::Number(bootstrap_height as usize),
+                        move |_epoch| StakeTableQuorum::new(bootstrap_quorum, self.epoch_height),
+                    )
+                    .await
+                    .context("fetching snapshot root header for genesis catchup")?;
                 (
                     self.first_epoch_with_dynamic_stake_table - 1,
                     StakeTableState::default(),
                     self.genesis_stake_table.clone(),
+                    bootstrap_root.version(),
                 )
             };
         tracing::info!(from = %lower_bound, to = %epoch, "performing stake table catchup");
@@ -615,14 +641,24 @@ where
                 }
             }
 
+            let next_quorum = Arc::new(stake_table_state_to_quorum(
+                &stake_table,
+                epoch_root_protocol_version,
+            )?);
+
             let root_height = root_block_in_epoch(epoch - 1, self.epoch_height);
-            let root = self
-                .fetch_header_with_quorum(BlockId::Number(root_height as usize), |_| {
-                    StakeTableQuorum::new(PrevOnly(prev_quorum.clone()), self.epoch_height)
-                })
+            let root = {
+                let prev_quorum = prev_quorum.clone();
+                let next_quorum = next_quorum.clone();
+                self.fetch_header_with_quorum(
+                    BlockId::Number(root_height as usize),
+                    move |_epoch| {
+                        StakeTableQuorum::new((prev_quorum, next_quorum), self.epoch_height)
+                    },
+                )
                 .await
-                .context(format!("fetching epoch root for {epoch}"))?;
-            let next_quorum = Arc::new(stake_table_state_to_quorum(&stake_table, root.version())?);
+                .context(format!("fetching epoch root for {epoch}"))?
+            };
             if let Some(hash) = root.next_stake_table_hash() {
                 ensure!(
                     hash == stake_table.commit(),
@@ -645,10 +681,18 @@ where
                 bail!("epoch {epoch} root {root_height} does not have next stake table hash");
             }
 
-            // Cache the reconstructed stake table in the database.
+            // Cache the reconstructed stake table in the database. We store
+            // `epoch_root_protocol_version` (snapshot for this epoch, used by cache hits) and
+            // `root.version()` (snapshot for `epoch + 1`, used to seed iter 1 of a future
+            // catchup that resumes from this row).
             if let Err(err) = self
                 .db
-                .insert_stake_table(EpochNumber::new(epoch), &stake_table, root.version())
+                .insert_stake_table(
+                    EpochNumber::new(epoch),
+                    &stake_table,
+                    epoch_root_protocol_version,
+                    root.version(),
+                )
                 .await
             {
                 // If this fails, we can continue with the stake table that we have in memory right
@@ -657,6 +701,7 @@ where
             }
 
             prev_quorum = next_quorum;
+            epoch_root_protocol_version = root.version();
         }
 
         Ok(self.cache_stake_table(epoch, prev_quorum).await)
@@ -1246,13 +1291,173 @@ mod test {
         );
     }
 
-    /// At CLIQUENET_VERSION, validators missing x25519_key or p2p_addr must be filtered out of
-    /// the active set. Drives the cache-hit path of `quorum_for_epoch`: we pre-populate the DB
-    /// with a state at CLIQUENET_VERSION containing a mix of complete and incomplete validators,
-    /// and verify that the returned quorum contains only the complete ones.
+    /// Regression: epoch-root leaf proofs must locate a 2-chain when views immediately after
+    /// the root are non-contiguous. Alternates failed view (gap) and ok view past the root.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_fetch_stake_table_catchup_with_view_gaps_after_root() {
+        let client = TestClient::with_epoch_height(10);
+        let genesis = client.genesis().await;
+        let lc = LightClient::from_genesis(
+            SqliteStorage::default().await.unwrap(),
+            client.clone(),
+            genesis.clone(),
+        );
+
+        let target_epoch = genesis.first_epoch_with_dynamic_stake_table + 1;
+        let root_height = root_block_in_epoch(*target_epoch - 1, 10) as usize;
+        for i in [0, 2, 4] {
+            client.add_view_gap_after(root_height + i).await;
+        }
+
+        let expected = client.quorum_for_epoch(target_epoch).await.into();
+        assert_eq!(*lc.quorum_for_epoch(target_epoch).await.unwrap(), expected);
+    }
+
+    /// Regression: epoch-transition QC verification must actually check `next_epoch_qc`
+    /// against the next epoch's quorum.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_fetch_stake_table_catchup_rejects_tampered_next_epoch_qc() {
+        let client = TestClient::with_epoch_height(10);
+        let genesis = client.genesis().await;
+        let lc = LightClient::from_genesis(
+            SqliteStorage::default().await.unwrap(),
+            client.clone(),
+            genesis.clone(),
+        );
+
+        let target_epoch = genesis.first_epoch_with_dynamic_stake_table + 1;
+        let root_height = root_block_in_epoch(*target_epoch - 1, 10) as usize;
+        client.add_view_gap_after(root_height).await;
+        client.corrupt_next_epoch_qc().await;
+
+        let err = lc.quorum_for_epoch(target_epoch).await.unwrap_err();
+        assert!(
+            err.to_string().contains("verifying next epoch QC")
+                || err
+                    .chain()
+                    .any(|e| e.to_string().contains("verifying next epoch QC")),
+            "{err:#}"
+        );
+    }
+
+    /// Regression: from-genesis catchup must seed the snapshot version by fetching the root at
+    /// `first_dynamic - 2` (verified by the genesis stake table), not by reusing the version of
+    /// the root in epoch `first_dynamic - 1`. Upgrades the root at `first_dynamic - 1` to
+    /// CLIQUENET so it differs from the bootstrap root at `first_dynamic - 2`.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_fetch_stake_table_catchup_genesis_bootstrap_version() {
+        let client = TestClient::with_epoch_height(10);
+        let genesis = client.genesis().await;
+        let db = SqliteStorage::default().await.unwrap();
+        let lc = LightClient::from_genesis(db.clone(), client.clone(), genesis.clone());
+
+        let epoch = genesis.first_epoch_with_dynamic_stake_table;
+        let root_height = root_block_in_epoch(*epoch - 1, 10);
+        client.set_upgrade(root_height, CLIQUENET_VERSION).await;
+
+        lc.quorum_for_epoch(epoch).await.unwrap();
+
+        let (cached_epoch, _, cached_version, _) =
+            db.stake_table_lower_bound(epoch).await.unwrap().unwrap();
+        assert_eq!(cached_epoch, epoch);
+        assert_eq!(cached_version, DRB_AND_HEADER_UPGRADE_VERSION);
+    }
+
+    /// Regression: iter 1 of DB-load catchup must seed from `next_stored_version`, not
+    /// `stored_version`.
     ///
-    /// Regression guard for: version not threaded to selection, filter not version-gated,
-    /// stored version ignored on lookup.
+    /// - insert stake table for `lower_bound_epoch` with `stored_version` = V4 and
+    ///   `next_stored_version` = CLIQUENET
+    /// - activate the upgrade at `target_epoch_root`
+    /// - request quorum for `target_epoch`
+    /// - fix: seed = `next_stored_version` = CLIQUENET, filter drops all validators, errors
+    /// - previous bug: seed = `stored_version` = V4, no filter, catchup wrongly succeeds
+    ///
+    /// Brittle: asserts that an error happens, not the filter version. Avoids x25519/p2p
+    /// plumbing in the shared test client.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_fetch_stake_table_catchup_db_load_advances_snapshot_version() {
+        use crate::client::Client;
+
+        let client = TestClient::with_epoch_height(10);
+        let genesis = client.genesis().await;
+        let db = SqliteStorage::default().await.unwrap();
+        let lc = LightClient::from_genesis(db.clone(), client.clone(), genesis.clone());
+
+        let lower_bound_epoch = genesis.first_epoch_with_dynamic_stake_table;
+        let target_epoch = lower_bound_epoch + 1;
+        let target_epoch_root = root_block_in_epoch(*target_epoch - 2, 10);
+
+        let mut prev_state = StakeTableState::default();
+        for event in client.stake_table_events(lower_bound_epoch).await.unwrap() {
+            prev_state.apply_event(event).unwrap().unwrap();
+        }
+        db.insert_stake_table(
+            lower_bound_epoch,
+            &prev_state,
+            DRB_AND_HEADER_UPGRADE_VERSION,
+            CLIQUENET_VERSION,
+        )
+        .await
+        .unwrap();
+
+        client
+            .set_upgrade(target_epoch_root, CLIQUENET_VERSION)
+            .await;
+
+        let err = lc.quorum_for_epoch(target_epoch).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("No validators met the minimum criteria")
+                || err.chain().any(|e| e
+                    .to_string()
+                    .contains("No validators met the minimum criteria")),
+            "{err:#}"
+        );
+    }
+
+    /// Regression: catchup filtered the candidate active set at `root.version()` (root in
+    /// epoch `e-1`) instead of the snapshot root's version (epoch `e-2`). When those versions
+    /// differ across CLIQUENET, the LC diverges from the espresso node.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_fetch_stake_table_catchup_uses_snapshot_root_version() {
+        use crate::client::Client;
+
+        let client = TestClient::with_epoch_height(10);
+        let genesis = client.genesis().await;
+        let db = SqliteStorage::default().await.unwrap();
+        let lc = LightClient::from_genesis(db.clone(), client.clone(), genesis.clone());
+
+        let prev_epoch = genesis.first_epoch_with_dynamic_stake_table;
+        let target_epoch = prev_epoch + 1;
+        let root_height = root_block_in_epoch(*target_epoch - 1, 10);
+
+        let mut prev_state = StakeTableState::default();
+        for event in client.stake_table_events(prev_epoch).await.unwrap() {
+            prev_state.apply_event(event).unwrap().unwrap();
+        }
+        db.insert_stake_table(
+            prev_epoch,
+            &prev_state,
+            DRB_AND_HEADER_UPGRADE_VERSION,
+            DRB_AND_HEADER_UPGRADE_VERSION,
+        )
+        .await
+        .unwrap();
+
+        client.set_upgrade(root_height, CLIQUENET_VERSION).await;
+
+        let expected = client.quorum_for_epoch(target_epoch).await.into();
+        assert_eq!(*lc.quorum_for_epoch(target_epoch).await.unwrap(), expected);
+    }
+
+    /// Regression: CLIQUENET active-set filter must run on the cache-hit path using the stored
+    /// version, dropping validators missing x25519/p2p.
     #[tokio::test]
     #[test_log::test]
     async fn test_fetch_stake_table_cliquenet_filter() {
@@ -1293,7 +1498,7 @@ mod test {
         );
 
         let epoch = genesis.first_epoch_with_dynamic_stake_table + 1;
-        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION)
+        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION, CLIQUENET_VERSION)
             .await
             .unwrap();
 
@@ -1311,20 +1516,8 @@ mod test {
         assert_eq!(pre_cliquenet.active_validators().len(), 2);
     }
 
-    /// Reconstruction-from-events counterpart to `test_fetch_stake_table_cliquenet_filter`.
-    ///
-    /// Drives the catchup path of `quorum_for_epoch`: no DB entry exists for `epoch`, so the
-    /// light client must replay events from the server, fetch the epoch root header, and select
-    /// the active set at the root's protocol version. We assert that:
-    /// 1. Reconstruction succeeds (i.e. version is threaded all the way through to selection).
-    /// 2. The cached entry written by the catchup carries the root header's protocol version.
-    ///
-    /// TODO: Exercising the CLIQUENET-specific filter on the reconstruction path requires
-    /// `TestClient` to (a) generate epoch root headers at CLIQUENET_VERSION (currently hardcoded
-    /// to DRB_AND_HEADER_UPGRADE_VERSION in `InnerTestClient::leaf`) and (b) emit
-    /// `RegisterV3`/`X25519KeyUpdate`/`P2pAddrUpdate` events for some validators while leaving
-    /// others incomplete. Until then, this test only proves the plumbing; the cache-hit test
-    /// `test_fetch_stake_table_cliquenet_filter` covers the filter semantics.
+    /// Regression: catchup must thread the snapshot version end-to-end through reconstruction
+    /// and cache it with each replayed epoch.
     #[tokio::test]
     #[test_log::test]
     async fn test_fetch_stake_table_cliquenet_filter_reconstruction() {
@@ -1333,19 +1526,13 @@ mod test {
         let genesis = client.genesis().await;
         let lc = LightClient::from_genesis(db.clone(), client.clone(), genesis.clone());
 
-        // Sanity: nothing cached yet for the requested epoch.
         let epoch = genesis.first_epoch_with_dynamic_stake_table + 2;
         assert!(db.stake_table_lower_bound(epoch).await.unwrap().is_none());
 
-        // Trigger the reconstruction path. This will replay events for each epoch up to `epoch`,
-        // fetch the epoch root header, and use the root's `version()` to select the active set.
         let expected = client.quorum_for_epoch(epoch).await.into();
         assert_eq!(*lc.quorum_for_epoch(epoch).await.unwrap(), expected);
 
-        // The catchup should have written each replayed epoch into the DB tagged with the root
-        // header's protocol version. TestClient currently produces DRB_AND_HEADER_UPGRADE_VERSION
-        // headers, so that is what we expect to see in storage.
-        let (cached_epoch, _, cached_version) =
+        let (cached_epoch, _, cached_version, _) =
             db.stake_table_lower_bound(epoch).await.unwrap().unwrap();
         assert_eq!(cached_epoch, epoch);
         assert_eq!(cached_version, DRB_AND_HEADER_UPGRADE_VERSION);

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -1281,7 +1281,16 @@ mod test {
         used_schnorr.insert(complete.state_ver_key.clone());
         used_schnorr.insert(incomplete.state_ver_key.clone());
 
-        let state = StakeTableState::new(validators, Default::default(), used_bls, used_schnorr);
+        let mut used_x25519 = HashSet::default();
+        used_x25519.insert(complete.x25519_key.unwrap());
+
+        let state = StakeTableState::new(
+            validators,
+            Default::default(),
+            used_bls,
+            used_schnorr,
+            used_x25519,
+        );
 
         let epoch = genesis.first_epoch_with_dynamic_stake_table + 1;
         db.insert_stake_table(epoch, &state, CLIQUENET_VERSION)

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -77,26 +77,32 @@ pub trait Storage: Sized + Send + Sync + 'static {
 
     /// Get the stake table for the latest epoch which is not later than `epoch`.
     ///
-    /// If such a stake table is available in the database, returns the ordered entries, the
-    /// epoch number of the stake table that was loaded, and the protocol version in effect when
-    /// that stake table was cached.
+    /// If such a stake table is available in the database, returns the loaded epoch number, the
+    /// stake table state, the protocol version of the epoch root header under whose rules that
+    /// stake table's active set was selected, and the protocol version of the epoch root header
+    /// in the next epoch (used to seed iter 1 of a catchup that resumes from this row).
     fn stake_table_lower_bound(
         &self,
         epoch: EpochNumber,
-    ) -> impl Send + Future<Output = Result<Option<(EpochNumber, StakeTableState, Version)>>>;
+    ) -> impl Send + Future<Output = Result<Option<(EpochNumber, StakeTableState, Version, Version)>>>;
 
     /// Add a stake table to the cache.
     ///
-    /// `protocol_version` is the protocol version in effect at the epoch root header, used so
-    /// that future cache hits can apply the correct active-set selection rules without
-    /// re-fetching the root.
+    /// `epoch_root_protocol_version` is the protocol version of the epoch root header in epoch
+    /// `e-2` (the snapshot point), used so that future cache hits can apply the same active-set
+    /// selection rules without re-fetching the root.
+    ///
+    /// `next_epoch_root_protocol_version` is the protocol version of the epoch root header in
+    /// epoch `e-1` (the snapshot point for `e+1`), used so that a future catchup resuming from
+    /// this row can seed iter 1's filter version without re-fetching that root.
     ///
     /// This may result in an older stake table being removed.
     fn insert_stake_table(
         &self,
         epoch: EpochNumber,
         stake_table: &StakeTableState,
-        protocol_version: Version,
+        epoch_root_protocol_version: Version,
+        next_epoch_root_protocol_version: Version,
     ) -> impl Send + Future<Output = Result<()>>;
 }
 
@@ -361,23 +367,35 @@ impl Storage for SqliteStorage {
     async fn stake_table_lower_bound(
         &self,
         epoch: EpochNumber,
-    ) -> Result<Option<(EpochNumber, StakeTableState, Version)>> {
+    ) -> Result<Option<(EpochNumber, StakeTableState, Version, Version)>> {
         let mut tx = self.pool.begin().await?;
 
-        let Some((epoch, protocol_version)) = query_as::<_, (i64, String)>(
-            "SELECT epoch, protocol_version FROM stake_table_epoch WHERE epoch <= $1 ORDER BY \
-             epoch DESC LIMIT 1",
-        )
-        .bind(*epoch as i64)
-        .fetch_optional(tx.as_mut())
-        .await
-        .context("loading epoch lower bound")?
+        let Some((epoch, epoch_root_protocol_version, next_epoch_root_protocol_version)) =
+            query_as::<_, (i64, String, String)>(
+                "SELECT epoch, epoch_root_protocol_version, next_epoch_root_protocol_version FROM \
+                 stake_table_epoch WHERE epoch <= $1 ORDER BY epoch DESC LIMIT 1",
+            )
+            .bind(*epoch as i64)
+            .fetch_optional(tx.as_mut())
+            .await
+            .context("loading epoch lower bound")?
         else {
             return Ok(None);
         };
-        let protocol_version = versions::parse_version(&protocol_version).with_context(|| {
-            format!("parsing stored protocol version {protocol_version:?} for epoch {epoch}")
-        })?;
+        let epoch_root_protocol_version = versions::parse_version(&epoch_root_protocol_version)
+            .with_context(|| {
+                format!(
+                    "parsing stored epoch root protocol version {epoch_root_protocol_version:?} \
+                     for epoch {epoch}"
+                )
+            })?;
+        let next_epoch_root_protocol_version =
+            versions::parse_version(&next_epoch_root_protocol_version).with_context(|| {
+                format!(
+                    "parsing stored next epoch root protocol version \
+                     {next_epoch_root_protocol_version:?} for epoch {epoch}"
+                )
+            })?;
 
         let validators = query_as::<_, (Value,)>(
             "SELECT data FROM stake_table_validator WHERE epoch = $1 ORDER BY idx",
@@ -442,7 +460,8 @@ impl Storage for SqliteStorage {
                 used_schnorr_keys,
                 used_x25519_keys,
             ),
-            protocol_version,
+            epoch_root_protocol_version,
+            next_epoch_root_protocol_version,
         )))
     }
 
@@ -450,22 +469,28 @@ impl Storage for SqliteStorage {
         &self,
         epoch: EpochNumber,
         stake_table: &StakeTableState,
-        protocol_version: Version,
+        epoch_root_protocol_version: Version,
+        next_epoch_root_protocol_version: Version,
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
-        // Record that the stake table for this epoch is available, along with the protocol
-        // version in effect when it was selected.
+        // Record that the stake table for this epoch is available, along with the versions of
+        // the epoch root headers in epochs `e-2` and `e-1` (snapshot points for `e` and `e+1`).
         let epoch = i64::try_from(*epoch).context("epoch overflow")?;
-        let protocol_version_str = protocol_version.to_string();
-        query("INSERT INTO stake_table_epoch (epoch, protocol_version) VALUES ($1, $2)")
-            .bind(epoch)
-            .bind(&protocol_version_str)
-            .execute(tx.as_mut())
-            .await
-            .context(format!(
-                "recording stake table availability for epoch {epoch}"
-            ))?;
+        let epoch_root_protocol_version_str = epoch_root_protocol_version.to_string();
+        let next_epoch_root_protocol_version_str = next_epoch_root_protocol_version.to_string();
+        query(
+            "INSERT INTO stake_table_epoch (epoch, epoch_root_protocol_version, \
+             next_epoch_root_protocol_version) VALUES ($1, $2, $3)",
+        )
+        .bind(epoch)
+        .bind(&epoch_root_protocol_version_str)
+        .bind(&next_epoch_root_protocol_version_str)
+        .execute(tx.as_mut())
+        .await
+        .context(format!(
+            "recording stake table availability for epoch {epoch}"
+        ))?;
 
         // Insert validators for the new stake table.
         let validators = stake_table
@@ -862,12 +887,12 @@ mod test {
 
         let epoch = EpochNumber::new(1);
         let state = random_stake_table();
-        db.insert_stake_table(epoch, &state, EPOCH_VERSION)
+        db.insert_stake_table(epoch, &state, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
         assert_eq!(
             db.stake_table_lower_bound(epoch).await.unwrap().unwrap(),
-            (epoch, state, EPOCH_VERSION)
+            (epoch, state, EPOCH_VERSION, EPOCH_VERSION)
         );
     }
 
@@ -878,7 +903,7 @@ mod test {
 
         let epoch = EpochNumber::new(1);
         let state = random_stake_table();
-        db.insert_stake_table(epoch, &state, EPOCH_VERSION)
+        db.insert_stake_table(epoch, &state, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
         assert_eq!(
@@ -886,7 +911,7 @@ mod test {
                 .await
                 .unwrap()
                 .unwrap(),
-            (epoch, state, EPOCH_VERSION)
+            (epoch, state, EPOCH_VERSION, EPOCH_VERSION)
         );
     }
 
@@ -897,10 +922,10 @@ mod test {
 
         let state1 = random_stake_table();
         let state2 = chain_stake_table(&state1);
-        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
-        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
 
@@ -909,7 +934,7 @@ mod test {
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(2), state2, EPOCH_VERSION)
+            (EpochNumber::new(2), state2, EPOCH_VERSION, EPOCH_VERSION)
         );
     }
 
@@ -917,9 +942,14 @@ mod test {
     #[test_log::test]
     async fn test_stake_table_lower_bound_not_found() {
         let db = SqliteStorage::default().await.unwrap();
-        db.insert_stake_table(EpochNumber::new(2), &random_stake_table(), EPOCH_VERSION)
-            .await
-            .unwrap();
+        db.insert_stake_table(
+            EpochNumber::new(2),
+            &random_stake_table(),
+            EPOCH_VERSION,
+            EPOCH_VERSION,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             db.stake_table_lower_bound(EpochNumber::new(1))
                 .await
@@ -942,13 +972,13 @@ mod test {
         let state1 = random_stake_table();
         let state2 = chain_stake_table(&state1);
         let state3 = chain_stake_table(&state2);
-        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
-        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
-        db.insert_stake_table(EpochNumber::new(3), &state3, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(3), &state3, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
 
@@ -957,21 +987,26 @@ mod test {
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(1), state1.clone(), EPOCH_VERSION)
+            (
+                EpochNumber::new(1),
+                state1.clone(),
+                EPOCH_VERSION,
+                EPOCH_VERSION
+            )
         );
         assert_eq!(
             db.stake_table_lower_bound(EpochNumber::new(2))
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(1), state1, EPOCH_VERSION)
+            (EpochNumber::new(1), state1, EPOCH_VERSION, EPOCH_VERSION)
         );
         assert_eq!(
             db.stake_table_lower_bound(EpochNumber::new(3))
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(3), state3, EPOCH_VERSION)
+            (EpochNumber::new(3), state3, EPOCH_VERSION, EPOCH_VERSION)
         );
     }
 
@@ -982,10 +1017,10 @@ mod test {
 
         let state1 = random_stake_table();
         let state2 = chain_stake_table(&state1);
-        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(2), &state2, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
-        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION)
+        db.insert_stake_table(EpochNumber::new(1), &state1, EPOCH_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
 
@@ -994,32 +1029,33 @@ mod test {
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(1), state1, EPOCH_VERSION)
+            (EpochNumber::new(1), state1, EPOCH_VERSION, EPOCH_VERSION)
         );
         assert_eq!(
             db.stake_table_lower_bound(EpochNumber::new(2))
                 .await
                 .unwrap()
                 .unwrap(),
-            (EpochNumber::new(2), state2, EPOCH_VERSION)
+            (EpochNumber::new(2), state2, EPOCH_VERSION, EPOCH_VERSION)
         );
     }
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_stake_table_protocol_version_roundtrip() {
+    async fn test_stake_table_epoch_root_protocol_version_roundtrip() {
         let db = SqliteStorage::default().await.unwrap();
 
         let epoch = EpochNumber::new(1);
         let state = random_stake_table();
-        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION)
+        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION, EPOCH_VERSION)
             .await
             .unwrap();
-        let (loaded_epoch, loaded_state, loaded_protocol_version) =
+        let (loaded_epoch, loaded_state, loaded_version, loaded_next_version) =
             db.stake_table_lower_bound(epoch).await.unwrap().unwrap();
         assert_eq!(loaded_epoch, epoch);
         assert_eq!(loaded_state, state);
-        assert_eq!(loaded_protocol_version, CLIQUENET_VERSION);
+        assert_eq!(loaded_version, CLIQUENET_VERSION);
+        assert_eq!(loaded_next_version, EPOCH_VERSION);
     }
 
     /// Regression: storage previously dropped `used_x25519_keys` on round trip,

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -14,7 +14,7 @@ use hotshot_query_service_types::{
     HeightIndexed,
     availability::{BlockId, LeafId, LeafQueryData},
 };
-use hotshot_types::{data::EpochNumber, light_client::StateVerKey};
+use hotshot_types::{data::EpochNumber, light_client::StateVerKey, x25519};
 use serde_json::Value;
 use sqlx::{
     QueryBuilder, SqlitePool, query, query_as,
@@ -423,6 +423,16 @@ impl Storage for SqliteStorage {
                 .await
                 .context(format!("loading Schnorr keys for epoch {epoch}"))?;
 
+        let used_x25519_keys =
+            query_as::<_, (String,)>("SELECT key FROM stake_table_x25519_key WHERE epoch <= $1")
+                .bind(epoch)
+                .fetch(tx.as_mut())
+                .map_err(anyhow::Error::new)
+                .and_then(|(s,)| async move { Ok(x25519::PublicKey::from_str(&s)?) })
+                .try_collect()
+                .await
+                .context(format!("loading x25519 keys for epoch {epoch}"))?;
+
         Ok(Some((
             EpochNumber::new(epoch as u64),
             StakeTableState::new(
@@ -430,6 +440,7 @@ impl Storage for SqliteStorage {
                 validator_exits,
                 used_bls_keys,
                 used_schnorr_keys,
+                used_x25519_keys,
             ),
             protocol_version,
         )))
@@ -499,6 +510,23 @@ impl Storage for SqliteStorage {
             .context(format!(
                 "inserting newly used Schnorr keys for epoch {epoch}"
             ))?;
+
+        // Insert only newly used x25519 keys.
+        if !stake_table.used_x25519_keys().is_empty() {
+            QueryBuilder::new("INSERT INTO stake_table_x25519_key (epoch, key) ")
+                .push_values(stake_table.used_x25519_keys(), |mut q, key| {
+                    q.push_bind(epoch).push_bind(key.to_string());
+                })
+                // If we insert keys out of order, make sure `epoch` reflects the earliest time
+                // when this key was added to the state.
+                .push(" ON CONFLICT (key) DO UPDATE SET epoch = min(epoch, excluded.epoch)")
+                .build()
+                .execute(tx.as_mut())
+                .await
+                .context(format!(
+                    "inserting newly used x25519 keys for epoch {epoch}"
+                ))?;
+        }
 
         // Insert only the new validator exits.
         if !stake_table.validator_exits().is_empty() {
@@ -994,10 +1022,37 @@ mod test {
         assert_eq!(loaded_protocol_version, CLIQUENET_VERSION);
     }
 
+    /// Regression: storage previously dropped `used_x25519_keys` on round trip,
+    /// so a reloaded `StakeTableState::commit()` diverged from the proposer's
+    /// hash once any V3 events had been applied.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_stake_table_x25519_keys_round_trip() {
+        use committable::Committable;
+
+        let db = SqliteStorage::default().await.unwrap();
+        let epoch = EpochNumber::new(1);
+        let state = random_stake_table();
+        assert!(
+            !state.used_x25519_keys().is_empty(),
+            "random_stake_table must populate used_x25519_keys for this test to be meaningful"
+        );
+
+        db.insert_stake_table(epoch, &state, CLIQUENET_VERSION, CLIQUENET_VERSION)
+            .await
+            .unwrap();
+        let (_, loaded, ..) = db.stake_table_lower_bound(epoch).await.unwrap().unwrap();
+
+        assert_eq!(loaded.used_x25519_keys(), state.used_x25519_keys());
+        assert_eq!(loaded.commit(), state.commit());
+    }
+
     /// Make a stake table state with all fields populated.
     fn random_stake_table() -> StakeTableState {
         let validator = random_validator();
         let candidate: RegisteredValidator<PubKey> = validator.clone().into();
+        let x25519_key =
+            x25519::PublicKey::try_from(rand::random::<[u8; 32]>().as_slice()).unwrap();
         StakeTableState::new(
             [(candidate.account, candidate.clone())]
                 .into_iter()
@@ -1005,6 +1060,7 @@ mod test {
             [Address::random()].into_iter().collect(),
             [candidate.stake_table_key].into_iter().collect(),
             [candidate.state_ver_key].into_iter().collect(),
+            [x25519_key].into_iter().collect(),
         )
     }
 
@@ -1013,6 +1069,8 @@ mod test {
         let new_validator = random_validator();
         let new_candidate: RegisteredValidator<PubKey> = new_validator.clone().into();
         let new_exit = Address::random();
+        let new_x25519 =
+            x25519::PublicKey::try_from(rand::random::<[u8; 32]>().as_slice()).unwrap();
         StakeTableState::new(
             state
                 .validators()
@@ -1036,6 +1094,12 @@ mod test {
                 .used_schnorr_keys()
                 .iter()
                 .chain([&new_candidate.state_ver_key])
+                .cloned()
+                .collect(),
+            state
+                .used_x25519_keys()
+                .iter()
+                .chain([&new_x25519])
                 .cloned()
                 .collect(),
         )

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -431,6 +431,7 @@ impl InnerTestClient {
             Default::default(),
             used_bls_keys,
             used_schnorr_keys,
+            HashSet::default(),
         );
         state.commit()
     }

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -31,7 +31,9 @@ use hotshot_types::{
     message::UpgradeLock,
     signature_key::SchnorrPubKey,
     simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2, UpgradeCertificate},
-    simple_vote::{NextEpochQuorumData2, QuorumData2, UpgradeProposalData, VersionedVoteData},
+    simple_vote::{
+        NextEpochQuorumData2, QuorumData2, UpgradeProposalData, VersionedVoteData, Vote2Data,
+    },
     stake_table::{StakeTableEntry, supermajority_threshold},
     traits::{
         block_contents::EncodeBytes,
@@ -46,7 +48,10 @@ use jf_merkle_tree_compat::{
 };
 use rand::RngCore;
 use vbs::version::{StaticVersionType, Version};
-use versions::{DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_VERSION, FEE_VERSION, Upgrade, version};
+use versions::{
+    DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_VERSION, FEE_VERSION, NEW_PROTOCOL_VERSION, Upgrade,
+    version,
+};
 
 use crate::{
     client::Client,
@@ -379,9 +384,23 @@ struct InnerTestClient {
     missing_quorums: HashSet<u64>,
     invalid_quorums: HashSet<u64>,
     mock_block_height: Option<u64>,
+    view_gaps: HashSet<usize>,
+    corrupt_next_epoch_qc: bool,
+    /// `(height, target)`: leaves at heights `>= height` use `target`; earlier use
+    /// `DRB_AND_HEADER_UPGRADE_VERSION`.
+    upgrade: Option<(u64, Version)>,
+    /// `Certificate2` finality proofs for new-protocol leaves, by height.
+    cert2s: HashMap<usize, Certificate2<SeqTypes>>,
 }
 
 impl InnerTestClient {
+    fn version_at(&self, height: u64) -> Version {
+        match self.upgrade {
+            Some((h, target)) if height >= h => target,
+            _ => DRB_AND_HEADER_UPGRADE_VERSION,
+        }
+    }
+
     fn quorum_for_epoch(&mut self, epoch: u64) -> &[(PrivKey, AuthenticatedValidator<PubKey>)] {
         // For testing purposes, we will say that one new node joins the quorum each epoch. The
         // static stake table used before the first epoch with dynamic stake is the same as the
@@ -454,9 +473,10 @@ impl InnerTestClient {
 
         for i in self.leaves.len()..=height {
             let epoch = EpochNumber::new(epoch_from_block_number(i as u64, epoch_height));
-            let view_number = ViewNumber::new(i as u64);
+            let view_offset = self.view_gaps.iter().filter(|&&g| g < i).count() as u64;
+            let view_number = ViewNumber::new(i as u64 + view_offset);
 
-            let upgrade = Upgrade::trivial(DRB_AND_HEADER_UPGRADE_VERSION);
+            let upgrade = Upgrade::trivial(self.version_at(i as u64));
             let node_state = NodeState::mock_v3().with_genesis_version(upgrade.base);
             let (justify_qc, mt) = if i == 0 {
                 (
@@ -493,6 +513,55 @@ impl InnerTestClient {
             {
                 assert!(block_header.set_next_stake_table_hash(self.stake_table_hash(*epoch + 1)));
             }
+            let next_epoch_justify_qc = if i > 0 && is_epoch_transition(i as u64, epoch_height) {
+                let parent_qc = self.leaves[i - 1].qc().clone();
+                let data: NextEpochQuorumData2<SeqTypes> = parent_qc.data.into();
+                let versioned_commit = VersionedVoteData::new_infallible(
+                    data.clone(),
+                    parent_qc.view_number,
+                    &UpgradeLock::<SeqTypes>::new(upgrade),
+                )
+                .commit();
+                let commit_bytes: [u8; 32] = versioned_commit.into();
+
+                let (next_keys, next_validators): (Vec<_>, Vec<_>) =
+                    self.quorum_for_epoch(*epoch + 1).iter().cloned().unzip();
+                let mut next_entries = vec![];
+                let mut next_total = U256::ZERO;
+                for validator in &next_validators {
+                    next_entries.push(StakeTableEntry {
+                        stake_key: validator.stake_table_key,
+                        stake_amount: validator.stake,
+                    });
+                    next_total += validator.stake;
+                }
+                let next_pp =
+                    PubKey::public_parameter(&next_entries, supermajority_threshold(next_total));
+                let sign_bytes: [u8; 32] = if self.corrupt_next_epoch_qc {
+                    [0xCC; 32]
+                } else {
+                    *versioned_commit.as_ref()
+                };
+                let next_sigs = next_keys
+                    .iter()
+                    .map(|key| PubKey::sign(key, &sign_bytes).unwrap())
+                    .collect::<Vec<_>>();
+                let next_signature = PubKey::assemble(
+                    &next_pp,
+                    &std::iter::repeat_n(true, next_keys.len()).collect::<BitVec>(),
+                    &next_sigs,
+                );
+
+                Some(NextEpochQuorumCertificate2::new(
+                    data,
+                    Commitment::from_raw(commit_bytes),
+                    parent_qc.view_number,
+                    Some(next_signature),
+                    Default::default(),
+                ))
+            } else {
+                None
+            };
             let quorum_proposal = QuorumProposalWrapper::<SeqTypes> {
                 proposal: QuorumProposal2::<SeqTypes> {
                     epoch: Some(epoch),
@@ -502,7 +571,7 @@ impl InnerTestClient {
                     upgrade_certificate: None,
                     view_change_evidence: None,
                     next_drb_result: None,
-                    next_epoch_justify_qc: None,
+                    next_epoch_justify_qc,
                     state_cert: None,
                 },
             };
@@ -533,6 +602,39 @@ impl InnerTestClient {
                 assembled,
                 view_number,
             );
+
+            // New-protocol finality uses a `Certificate2` over `Vote2Data` instead of a
+            // HotStuff2 2-chain.
+            if upgrade.base >= NEW_PROTOCOL_VERSION {
+                let vote2_data = Vote2Data {
+                    leaf_commit: leaf.commit(),
+                    epoch,
+                    block_number: i as u64,
+                };
+                let vote2_data_comm = VersionedVoteData::new_infallible(
+                    vote2_data.clone(),
+                    view_number,
+                    &UpgradeLock::<SeqTypes>::new(upgrade),
+                )
+                .commit();
+                let cert2_sigs = quorum
+                    .iter()
+                    .map(|key| PubKey::sign(key, vote2_data_comm.as_ref()).unwrap())
+                    .collect::<Vec<_>>();
+                let cert2_assembled = PubKey::assemble(
+                    &pp,
+                    &std::iter::repeat_n(true, quorum.len()).collect::<BitVec>(),
+                    &cert2_sigs,
+                );
+                let cert2 = Certificate2::<SeqTypes>::create_signed_certificate(
+                    vote2_data_comm,
+                    vote2_data,
+                    cert2_assembled,
+                    view_number,
+                );
+                self.cert2s.insert(i, cert2);
+            }
+
             let leaf = LeafQueryData::new(leaf, qc).unwrap();
             self.leaf_hashes.insert(leaf.hash(), i);
             self.block_hashes.insert(leaf.block_hash(), i);
@@ -574,6 +676,27 @@ impl InnerTestClient {
 }
 
 impl TestClient {
+    pub fn with_epoch_height(epoch_height: u64) -> Self {
+        Self {
+            inner: Default::default(),
+            epoch_height,
+        }
+    }
+
+    pub async fn add_view_gap_after(&self, height: usize) {
+        self.inner.lock().await.view_gaps.insert(height);
+    }
+
+    pub async fn corrupt_next_epoch_qc(&self) {
+        self.inner.lock().await.corrupt_next_epoch_qc = true;
+    }
+
+    /// Upgrade leaves at `height` and above to `target`. Must be set before those leaves are
+    /// generated.
+    pub async fn set_upgrade(&self, height: u64, target: Version) {
+        self.inner.lock().await.upgrade = Some((height, target));
+    }
+
     pub async fn genesis(&self) -> Genesis {
         let mut inner = self.inner.lock().await;
         Genesis {
@@ -702,7 +825,7 @@ impl Client for TestClient {
         let leaf = inner.leaf(height, self.epoch_height).await;
 
         let mut proof = LeafProof::default();
-        proof.push(leaf);
+        proof.push(leaf.clone());
         if let Some(finalized) = finalized {
             ensure!(
                 finalized > (height as u64),
@@ -718,8 +841,31 @@ impl Client for TestClient {
             }
         }
 
-        proof.push(inner.leaf(height + 1, self.epoch_height).await);
-        assert!(proof.push(inner.leaf(height + 2, self.epoch_height).await));
+        // For new-protocol leaves, finality is a single `Certificate2` rather than a QC chain.
+        if leaf.leaf().block_header().version() >= NEW_PROTOCOL_VERSION {
+            let cert2 = inner
+                .cert2s
+                .get(&height)
+                .with_context(|| format!("missing cert2 for new-protocol leaf {height}"))?
+                .clone();
+            proof.add_certificate(Arc::new(cert2), leaf.qc().clone());
+            return Ok(proof);
+        }
+
+        const MAX_PROOF_LEAVES: usize = 16;
+        let mut next = height + 1;
+        loop {
+            let leaf = inner.leaf(next, self.epoch_height).await;
+            next += 1;
+            if proof.push(leaf) {
+                break;
+            }
+            ensure!(
+                next < height + MAX_PROOF_LEAVES,
+                "could not assemble finality proof for leaf {height} within {MAX_PROOF_LEAVES} \
+                 leaves; add a higher bound or fewer view gaps"
+            );
+        }
 
         Ok(proof)
     }


### PR DESCRIPTION
Automatic backport of #4346 failed.

mergiraf was able to resolve conflicts
