### PR TITLE
[Backport release-mainnet-1.1.0-rc] Use CDN with keep alive and additional logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,8 +2732,9 @@ dependencies = [
 [[package]]
 name = "cdn-broker"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
+ "anyhow",
  "cdn-proto",
  "clap 4.6.0",
  "console-subscriber",
@@ -2745,6 +2746,7 @@ dependencies = [
  "portpicker",
  "prometheus",
  "rand 0.8.5",
+ "reqwest 0.12.28",
  "rkyv",
  "tokio",
  "tracing",
@@ -2754,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.6.2"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "cdn-proto",
  "clap 4.6.0",
@@ -2770,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "cdn-proto",
  "clap 4.6.0",
@@ -2783,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
@@ -2805,6 +2807,7 @@ dependencies = [
  "rkyv",
  "rustls 0.23.37",
  "rustls-pki-types",
+ "socket2 0.6.3",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,11 @@ byteorder = { version = "1" }
 bytes = { version = "1.11.0", features = ["serde"] }
 bytesize = "1.3"
 cbor4ii = { version = "1.0", features = ["serde1"] }
-cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.6.2-bcompat-patch2", package = "cdn-broker", features = ["global-permits"] }
-cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.6.2-bcompat-patch2", package = "cdn-client" }
-cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "0.6.2-bcompat-patch2", package = "cdn-marshal" }
+cdn-broker = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260519-keep-alive", package = "cdn-broker", features = [
+    "global-permits",
+] }
+cdn-client = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260519-keep-alive", package = "cdn-client" }
+cdn-marshal = { git = "https://github.com/EspressoSystems/Push-CDN", tag = "20260519-keep-alive", package = "cdn-marshal" }
 chrono = { version = "0.4", features = ["serde"] }
 circular-buffer = "0.1.9"
 clap = { version = "4.5", features = ["derive", "env", "string"] }

--- a/crates/espresso/node/src/bin/cdn-broker.rs
+++ b/crates/espresso/node/src/bin/cdn-broker.rs
@@ -33,7 +33,7 @@ struct Args {
     /// The user-facing endpoint in `IP:port` form to advertise
     #[arg(
         long,
-        default_value = "local_ip:1738",
+        default_value = "public_ip:1738",
         env = "ESPRESSO_CDN_BROKER_PUBLIC_ADVERTISE_ENDPOINT"
     )]
     public_advertise_endpoint: String,

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -523,7 +523,7 @@ processes:
 
   # A broker is the main message-routing unit of the CDN
   broker_0:
-    command: cdn-broker -d "redis://:changeme!@localhost:6379" -m 127.0.0.1:9091
+    command: cdn-broker -d "redis://:changeme!@localhost:6379" -m 127.0.0.1:9091 --public-advertise-endpoint local_ip:1738
     depends_on:
       keydb:
         condition: process_healthy


### PR DESCRIPTION
Backport of https://github.com/EspressoSystems/espresso-network/pull/4274 to release-mainnet-1.1.0-rc.