### PR TITLE
CI: remove deployment info PR trigger (#4361)

### DIFF
--- a/.github/workflows/deployment-info.yml
+++ b/.github/workflows/deployment-info.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   schedule:
     - cron: "0 6 * * *" # daily at 6am UTC
   workflow_dispatch:


### PR DESCRIPTION
The job sometimes fails due to rate limits.

It runs on main an schedule which should be enough.

(cherry picked from commit 174023437dbadfa5eec55f651193172264365254)
