### PR TITLE
[backport release-mainnet-1.2.0-rc #4360] ci(docker): retry transient ghcr.io failures, don't fail-fast 

### DIFF
--- a/.github/workflows/benchmark-build.yaml
+++ b/.github/workflows/benchmark-build.yaml
@@ -146,15 +146,23 @@ jobs:
           path: target/arm64/release
 
       - name: Setup Docker BuildKit (buildx)
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Login to Github Container Repo
-        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate espresso-node docker metadata
         uses: docker/metadata-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
     name: Build ${{ matrix.binary }} AMD
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - binary: espresso-node
@@ -107,6 +108,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - binary: espresso-node
@@ -169,6 +171,7 @@ jobs:
     needs: build-amd
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         service:
           - bridge
@@ -200,15 +203,23 @@ jobs:
           merge-multiple: true
 
       - name: Setup Docker BuildKit (buildx)
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Login to Github Container Repo
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate ${{ matrix.service }} docker metadata
         uses: docker/metadata-action@v5
@@ -222,15 +233,20 @@ jobs:
       #   - On main: push to the registry and fetch from the registry to run the demo test.
       - name: Build docker image and export to file (on PRs)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v4
+        env:
+          LABELS: ${{ steps.metadata.outputs.labels }}
+          TAGS: ${{ steps.metadata.outputs.tags }}
         with:
-          context: .
-          file: ./docker/${{ matrix.service }}.Dockerfile
-          labels: ${{ steps.metadata.outputs.labels  }}
-          # Note the tag is used later to run the demo test
-          tags: ${{ steps.metadata.outputs.tags }}
-          platforms: linux/amd64
-          outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.service }}.tar
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            scripts/ci-docker-buildx \
+              --file ./docker/${{ matrix.service }}.Dockerfile \
+              --platform linux/amd64 \
+              --output type=docker,dest=${{ runner.temp }}/${{ matrix.service }}.tar \
+              .
 
       - name: Upload docker image artifact (on PRs)
         if: github.event_name == 'pull_request'
@@ -243,15 +259,20 @@ jobs:
 
       - name: Build and push docker (non-PR)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
-        id: build
+        uses: nick-fields/retry@v4
+        env:
+          LABELS: ${{ steps.metadata.outputs.labels }}
         with:
-          context: .
-          file: ./docker/${{ matrix.service }}.Dockerfile
-          labels: ${{ steps.metadata.outputs.labels  }}
-          # Note: the final multiarch image will receive the tag
-          platforms: linux/amd64
-          outputs: type=image,name=ghcr.io/espressosystems/espresso-network/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            scripts/ci-docker-buildx \
+              --file ./docker/${{ matrix.service }}.Dockerfile \
+              --platform linux/amd64 \
+              --output type=image,name=ghcr.io/espressosystems/espresso-network/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true \
+              --metadata-file ${{ runner.temp }}/metadata.json \
+              .
 
       - name: Export docker image digest
         if: github.event_name != 'pull_request'
@@ -260,7 +281,7 @@ jobs:
           set -x
           digest_dir="${{ runner.temp }}/digests"
           mkdir -p "${digest_dir}"
-          digest="${{ steps.build.outputs.digest }}"
+          digest=$(jq -r '."containerimage.digest"' "${{ runner.temp }}/metadata.json")
           touch "${digest_dir}/${digest#sha256:}"
           ls -lah "${digest_dir}"
 
@@ -279,6 +300,7 @@ jobs:
     needs: build-arm
     runs-on: ubuntu-24.04-arm
     strategy:
+      fail-fast: false
       matrix:
         service:
           - bridge
@@ -310,14 +332,22 @@ jobs:
           merge-multiple: true
 
       - name: Setup Docker BuildKit (buildx)
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Login to Github Container Repo
-        uses: docker/login-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate ${{ matrix.service }} docker metadata
         uses: docker/metadata-action@v5
@@ -326,16 +356,20 @@ jobs:
           images: ghcr.io/espressosystems/espresso-network/${{ matrix.service }}
 
       - name: Build and push docker
-        uses: docker/build-push-action@v6
-        id: build
+        uses: nick-fields/retry@v4
+        env:
+          LABELS: ${{ steps.metadata.outputs.labels }}
         with:
-          context: .
-          file: ./docker/${{ matrix.service }}.Dockerfile
-          labels: ${{ steps.metadata.outputs.labels  }}
-          # Note: the final multiarch image will receive the tag
-          platforms: linux/arm64
-          outputs: type=image,name=ghcr.io/espressosystems/espresso-network/${{  matrix.service }},push-by-digest=true,name-canonical=true,push=true
-
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            scripts/ci-docker-buildx \
+              --file ./docker/${{ matrix.service }}.Dockerfile \
+              --platform linux/arm64 \
+              --output type=image,name=ghcr.io/espressosystems/espresso-network/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true \
+              --metadata-file ${{ runner.temp }}/metadata.json \
+              .
 
       - name: Export docker image digest
         shell: bash
@@ -343,7 +377,7 @@ jobs:
           set -x
           digest_dir="${{ runner.temp }}/digests"
           mkdir -p "${digest_dir}"
-          digest="${{ steps.build.outputs.digest }}"
+          digest=$(jq -r '."containerimage.digest"' "${{ runner.temp }}/metadata.json")
           touch "${digest_dir}/${digest#sha256:}"
           ls -lah "${digest_dir}"
 
@@ -364,6 +398,7 @@ jobs:
     needs: [build-dockers-amd, build-dockers-arm]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         service:
           - bridge
@@ -388,14 +423,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Login to Github Container Repo
-        uses: docker/login-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner  }}
-          password: ${{ secrets.GITHUB_TOKEN  }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -445,15 +488,20 @@ jobs:
       # Consumers should migrate to ghcr.io/espressosystems/espresso-network/espresso-node.
       - name: Build and push legacy sequencer image with old binary names
         if: matrix.service == 'espresso-node'
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v4
+        env:
+          TAGS: ghcr.io/espressosystems/espresso-sequencer/sequencer:${{ steps.meta.outputs.version }}
         with:
-          context: .
-          file: ./docker/espresso-node-legacy.Dockerfile
-          build-args: |
-            BASE_IMAGE=ghcr.io/espressosystems/espresso-network/espresso-node:${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/espressosystems/espresso-sequencer/sequencer:${{ steps.meta.outputs.version }}
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            scripts/ci-docker-buildx \
+              --file ./docker/espresso-node-legacy.Dockerfile \
+              --build-arg BASE_IMAGE=ghcr.io/espressosystems/espresso-network/espresso-node:${{ steps.meta.outputs.version }} \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              .
 
   test-demo-pr:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/promote-docker-tag.yml
+++ b/.github/workflows/promote-docker-tag.yml
@@ -42,14 +42,22 @@ jobs:
           fi
 
       - name: Login to Github Container Repo
-        uses: docker/login-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Verify source image exists
         env:
@@ -101,6 +109,7 @@ jobs:
     # TODO: re-enable after testing
     # environment: release
     strategy:
+      fail-fast: false
       matrix:
         service:
           - bridge
@@ -120,14 +129,22 @@ jobs:
           - submit-transactions
     steps:
       - name: Login to Github Container Repo
-        uses: docker/login-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: docker/setup-buildx-action@v3
+          attempt_limit: 3
+          attempt_delay: 10000
 
       - name: Re-tag image
         env:

--- a/scripts/ci-docker-buildx
+++ b/scripts/ci-docker-buildx
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DOCKER:=docker}"
+: "${LABELS:=}"
+: "${TAGS:=}"
+
+args=()
+
+while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
+  args+=(--label "${line}")
+done <<< "${LABELS}"
+
+while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
+  args+=(--tag "${line}")
+done <<< "${TAGS}"
+
+exec "${DOCKER}" buildx build "${args[@]}" "$@"


### PR DESCRIPTION
* ci(docker): retry transient ghcr.io failures, don't fail-fast

- Wrap docker/setup-buildx-action, docker/login-action, and docker/build-push-action with Wandalen/wretry.action (3 attempts, 10s delay) to survive transient 502s and timeouts from ghcr.io
- Set fail-fast: false on all docker-related matrix strategies so one flaky service doesn't cancel the others
- Update steps.build.outputs.digest references to read through wretry's nested outputs map via fromJSON
- Align one stray docker/build-push-action@v5 to @v6

* ci(build): skip heavy build on PRs targeting release-* branches

- Add branches-ignore: release-* under pull_request
- Push trigger still covers release-* branches directly, so the workflow runs on merge into release branches

* Revert "ci(build): skip heavy build on PRs targeting release-* branches"

This reverts commit 65f7f19e34fa6b720617dcc029a1955f89a6a421.

* fix(ci): drop wretry on docker/build-push-action

- The multi-line labels output from docker/metadata-action breaks wretry's nested with: | parser: continuation lines start at column 0 and look like new top-level keys
- Revert build-push-action invocations to direct usage; keep wretry on setup-buildx-action and login-action which have only scalar inputs and were the failure modes observed in the login timeout log

* ci(docker): retry build via nick-fields/retry + raw buildx

- Add scripts/ci-docker-buildx wrapper that converts the multi-line LABELS and TAGS outputs from docker/metadata-action into individual --label/--tag flags
- Replace the four docker/build-push-action invocations with nick-fields/retry@v4 wrapping the wrapper. 3 attempts, 10s wait, 30 min timeout. This handles transient ghcr.io 502s when fetching the base image during the build itself
- Read the pushed image digest from buildx's --metadata-file (containerimage.digest) instead of relying on docker/build-push- action's outputs

(cherry picked from commit 614415e95e529658cb8b215ed6647431076196be)
