### PR TITLE
Some small optimisations.

### DIFF
--- a/crates/cliquenet/src/msg.rs
+++ b/crates/cliquenet/src/msg.rs
@@ -12,7 +12,10 @@ pub use trailer::Trailer;
 pub const MAX_NOISE_MESSAGE_SIZE: usize = 64 * 1024;
 
 /// Max. number of bytes for payload data.
-pub const MAX_PAYLOAD_SIZE: usize = MAX_NOISE_MESSAGE_SIZE - 32;
+pub const MAX_PAYLOAD_SIZE: usize = MAX_NOISE_MESSAGE_SIZE - RESERVED_TAG_SIZE;
+
+/// Space reserved for the AEAD tag (16 are required, we add some extra margin).
+pub(crate) const RESERVED_TAG_SIZE: usize = 32;
 
 /// Slots contain messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/cliquenet/src/net.rs
+++ b/crates/cliquenet/src/net.rs
@@ -166,6 +166,14 @@ impl Network {
         &mut self.recv
     }
 
+    pub fn split(&self) -> (&NetworkController, &NetworkReceiver) {
+        (&self.ctrl, &self.recv)
+    }
+
+    pub fn split_mut(&mut self) -> (&mut NetworkController, &mut NetworkReceiver) {
+        (&mut self.ctrl, &mut self.recv)
+    }
+
     pub fn split_into(self) -> (NetworkController, NetworkReceiver) {
         (self.ctrl, self.recv)
     }
@@ -195,11 +203,16 @@ impl NetworkReceiver {
     /// The returned public key denotes the source where the message came from.
     pub async fn receive(&mut self) -> Option<(PublicKey, Bytes)> {
         let (k, b, _) = self.rx.recv().await?;
+        debug!(peer = %k, len = b.len(), "message received");
         Some((k, b))
     }
 }
 
 impl NetworkController {
+    pub fn config(&self) -> &Config {
+        &self.conf
+    }
+
     /// Iterate over all parties.
     pub fn parties(&self) -> impl Iterator<Item = (&PublicKey, &Role)> {
         self.parties.iter()
@@ -207,8 +220,11 @@ impl NetworkController {
 
     /// Send a message to a party, identified by the given public key.
     pub fn unicast(&mut self, s: Slot, to: PublicKey, msg: Vec<u8>) -> Result<(), NetworkError> {
-        debug!(slot = %s, %to, "unicast");
+        debug!(slot = %s, %to, len = msg.len(), "unicast");
         self.length_check(&msg)?;
+        if self.lt_lower_bound(s) {
+            return Ok(());
+        }
         let cmd = SendCommand::builder()
             .slot(s)
             .action(SendAction::Unicast(to, msg))
@@ -220,8 +236,11 @@ impl NetworkController {
 
     /// Send a message to all parties.
     pub fn broadcast(&mut self, s: Slot, msg: Vec<u8>) -> Result<(), NetworkError> {
-        debug!(slot = %s, "broadcast");
+        debug!(slot = %s, len = msg.len(), "broadcast");
         self.length_check(&msg)?;
+        if self.lt_lower_bound(s) {
+            return Ok(());
+        }
         let cmd = SendCommand::builder()
             .slot(s)
             .action(SendAction::Broadcast(msg))
@@ -236,8 +255,11 @@ impl NetworkController {
     where
         P: IntoIterator<Item = PublicKey>,
     {
-        debug!(slot = %s, "multicast");
+        debug!(slot = %s, len = msg.len(), "multicast");
         self.length_check(&msg)?;
+        if self.lt_lower_bound(s) {
+            return Ok(());
+        }
         let cmd = SendCommand::builder()
             .slot(s)
             .action(SendAction::Multicast(to.into_iter().collect(), msg))
@@ -249,8 +271,12 @@ impl NetworkController {
 
     /// General send operation, supporting custom retry policies.
     pub fn send(&mut self, cmd: SendCommand) -> Result<(), NetworkError> {
-        debug!(slot = %cmd.slot, "send");
-        self.length_check(msg_bytes(&cmd))?;
+        let bytes = msg_bytes(&cmd);
+        debug!(slot = %cmd.slot, len = %bytes.len(), "send");
+        self.length_check(bytes)?;
+        if self.lt_lower_bound(cmd.slot) {
+            return Ok(());
+        }
         self.tx
             .send(Command::Send(cmd))
             .map_err(|_| NetworkError::ChannelClosed)
@@ -341,6 +367,21 @@ impl NetworkController {
             return Err(NetworkError::MessageTooLarge);
         }
         Ok(())
+    }
+
+    /// Check if the given slot is less than our lower bound.
+    fn lt_lower_bound(&self, s: Slot) -> bool {
+        if s < self.lower_bound {
+            warn!(
+                name = %self.conf.name,
+                node = %self.node,
+                slot = %s,
+                lower_bound = %self.lower_bound,
+                "slot below lower bound"
+            );
+            return true;
+        }
+        false
     }
 }
 

--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -24,7 +24,10 @@ use crate::{
     Config, Metrics, PublicKey,
     connection::Connection,
     error::{Empty, NetworkError},
-    msg::{Ack, FrameType, Header, MAX_NOISE_MESSAGE_SIZE, MAX_PAYLOAD_SIZE, Slot, Trailer},
+    msg::{
+        Ack, FrameType, Header, MAX_NOISE_MESSAGE_SIZE, MAX_PAYLOAD_SIZE, RESERVED_TAG_SIZE, Slot,
+        Trailer,
+    },
     net::{PeerMessage, RetryPolicy},
     queue::Queue,
     time::Countdown,
@@ -107,7 +110,10 @@ impl Peer {
         metrics: Arc<dyn Metrics>,
     ) -> Self {
         Self {
-            max_message_size: config.max_message_size.get() + Trailer::MAX_SIZE,
+            max_message_size: config
+                .max_message_size
+                .get()
+                .saturating_add(Trailer::MAX_SIZE),
             conf: config.clone(),
             budget: Budget::new(budget),
             next_slot,
@@ -159,6 +165,7 @@ impl Peer {
             },
             Frame {
                 hdr: Header,
+                typ: FrameType,
                 off: usize,
                 buf: &'a mut Vec<u8>,
             },
@@ -219,11 +226,11 @@ impl Peer {
             return Err(NetworkError::PeerInterrupt);
         }
 
-        // Noise packages are limited to 64KiB.
-        //
-        // We retain one such buffer for reading and one for writing.
-        let mut rbuf = NoiseBuf::new([0; _]);
+        // Write buffer (Noise packages are limited to 64KiB).
         let mut wbuf = NoiseBuf::new([0; _]);
+
+        // Ack buffer.
+        let mut abuf = [0; size_of::<Ack>() + RESERVED_TAG_SIZE];
 
         // A frame buffer for reading before it is decrypted.
         let mut fbuf = Vec::new();
@@ -483,15 +490,45 @@ impl Peer {
                                         continue
                                     }
                                     let hdr = Header::unvalidated(u32::from_be_bytes(*buf));
+                                    let typ = match hdr.frame_type() {
+                                        Ok(FrameType::Data) => FrameType::Data,
+                                        Ok(FrameType::Ack) => {
+                                            if hdr.is_partial() {
+                                                warn!(
+                                                    name = %self.conf.name,
+                                                    node = %self.conf.keypair.public_key(),
+                                                    peer = %self.conn.key,
+                                                    addr = %self.conn.addr,
+                                                    "ACK header marked as partial"
+                                                );
+                                                return Err(NetworkError::InvalidAck)
+                                            }
+                                            if hdr.len() as usize > abuf.len() {
+                                                warn!(
+                                                    name = %self.conf.name,
+                                                    node = %self.conf.keypair.public_key(),
+                                                    peer = %self.conn.key,
+                                                    addr = %self.conn.addr,
+                                                    len  = %hdr.len(),
+                                                    "ACK header length too large"
+                                                );
+                                                return Err(NetworkError::InvalidAck)
+                                            }
+                                            FrameType::Ack
+                                        }
+                                        Err(typ) => {
+                                            return Err(NetworkError::UnknownFrameType(typ))
+                                        }
+                                    };
                                     fbuf.resize(hdr.len().into(), 0);
-                                    rstate = ReadState::Frame { hdr, off: 0, buf: &mut fbuf }
+                                    rstate = ReadState::Frame { hdr, typ, off: 0, buf: &mut fbuf }
                                 }
                                 Err(e) => if e.kind() != io::ErrorKind::WouldBlock {
                                     return Err(e.into())
                                 }
                             }
                         }
-                        ReadState::Frame { hdr, off, buf } => {
+                        ReadState::Frame { hdr, typ, off, buf } => {
                             match self.conn.stream.try_read(&mut buf[*off..]) {
                                 Ok(0) => {
                                     let e = io::ErrorKind::UnexpectedEof.into();
@@ -503,13 +540,19 @@ impl Peer {
                                     if *off < buf.len() {
                                         continue
                                     }
-                                    match hdr.frame_type() {
-                                        Ok(FrameType::Data) => {
-                                            let n = self.conn.state.read_message(buf, &mut *rbuf)?;
-                                            ibound_msg.extend_from_slice(&rbuf[..n]);
+                                    match typ {
+                                        FrameType::Data => {
+                                            let n = buf.len();
+                                            let i = ibound_msg.len();
+                                            ibound_msg.resize(i + n, 0);
+
+                                            let n = self.conn.state.read_message(buf, &mut ibound_msg[i..])?;
+                                            ibound_msg.truncate(i + n);
+
                                             if ibound_msg.len() > self.max_message_size {
                                                 return Err(NetworkError::MessageTooLarge)
                                             }
+
                                             if !hdr.is_partial() { // message complete
                                                 let mut msg = mem::take(&mut ibound_msg).freeze();
                                                 let Some(t) = Trailer::from_bytes(&mut msg) else {
@@ -531,6 +574,7 @@ impl Peer {
                                                     Trailer::Unknown => None
                                                 };
                                                 if let Some(s) = slot && s < self.lower_bound {
+                                                    rstate = ReadState::Header { off: 0, buf: [0; _] };
                                                     continue
                                                 }
                                                 let p = read_permit.take();
@@ -548,20 +592,14 @@ impl Peer {
                                             }
                                             rstate = ReadState::Header { off: 0, buf: [0; _] };
                                         }
-                                        Ok(FrameType::Ack) if hdr.is_partial() => {
-                                            return Err(NetworkError::InvalidAck)
-                                        }
-                                        Ok(FrameType::Ack) => {
-                                            let n = self.conn.state.read_message(buf, &mut *rbuf)?;
-                                            let Ok(a) = Ack::try_from(&rbuf[..n]) else {
+                                        FrameType::Ack => {
+                                            let n = self.conn.state.read_message(buf, &mut abuf)?;
+                                            let Ok(a) = Ack::try_from(&abuf[..n]) else {
                                                 return Err(NetworkError::InvalidAck)
                                             };
                                             let (s, i) = a.into();
                                             self.retry.del(s, i);
                                             rstate = ReadState::Header { off: 0, buf: [0; _] };
-                                        }
-                                        Err(t) => {
-                                            return Err(NetworkError::UnknownFrameType(t))
                                         }
                                     }
                                 }


### PR DESCRIPTION
1. Remove `rbuf` (read buffer). Rather than decrypting into `rbuf` and copying the data into the inbound message, we now resize inbound message and decrypt directly into it.
2. Small ACK buffer. With `rbuf` gone we need a buffer to decrypt the ACK frame. We allocate a small buffer on the stack.
3. Early frame type validation. Instead of reading the header and the frame data before validating the header we now eagerly check the expected header invariants (e.g. that the type is known, an ACK header is not marked partial and the frame length does not exceed the expected size, etc.)
4. Improve debug logs. In `net.rs` we now include the message length in the debug logs and add a log when receiving a message.
5. Do not enqueue messages below the lower bound. We now check on message submission that the slot this message belongs to has not been garbage collected yet.
6. BUGFIX: Reset read state. When receiving a message below the GC cutoff point we did not reset the read state.