### PR TITLE
Add send retry delays.

### DIFF
--- a/crates/cliquenet/benches/bench1.rs
+++ b/crates/cliquenet/benches/bench1.rs
@@ -126,8 +126,8 @@ async fn setup_echo() -> Echo {
         .parties([(pkb, addr_b.into())])
         .max_message_size(NonZeroUsize::new(100 * MEBI).unwrap())
         .receive_timeout(Duration::from_secs(60))
-        .retry_delays(vec![1, 3])
-        .max_retry_delay(Duration::from_secs(5))
+        .connect_retry_delays(vec![1, 3])
+        .send_retry_delays(vec![1, 3])
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
@@ -138,8 +138,8 @@ async fn setup_echo() -> Echo {
         .parties([(pka, addr_a.into())])
         .max_message_size(NonZeroUsize::new(100 * MEBI).unwrap())
         .receive_timeout(Duration::from_secs(60))
-        .retry_delays(vec![1, 3])
-        .max_retry_delay(Duration::from_secs(5))
+        .connect_retry_delays(vec![1, 3])
+        .send_retry_delays(vec![1, 3])
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
@@ -233,8 +233,8 @@ async fn setup_bidir() -> BiDir {
         .parties([(pkb, addr_b.into())])
         .max_message_size(NonZeroUsize::new(100 * MEBI).unwrap())
         .receive_timeout(Duration::from_secs(60))
-        .retry_delays(vec![1, 3])
-        .max_retry_delay(Duration::from_secs(5))
+        .connect_retry_delays(vec![1, 3])
+        .send_retry_delays(vec![1, 3])
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 
@@ -245,8 +245,8 @@ async fn setup_bidir() -> BiDir {
         .parties([(pka, addr_a.into())])
         .max_message_size(NonZeroUsize::new(100 * MEBI).unwrap())
         .receive_timeout(Duration::from_secs(60))
-        .retry_delays(vec![1, 3])
-        .max_retry_delay(Duration::from_secs(5))
+        .connect_retry_delays(vec![1, 3])
+        .send_retry_delays(vec![1, 3])
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build();
 

--- a/crates/cliquenet/src/connection.rs
+++ b/crates/cliquenet/src/connection.rs
@@ -92,11 +92,14 @@ impl Connection {
             }
         })
         .chain(
-            conf.retry_delays
+            conf.connect_retry_delays
                 .iter()
                 .map(|&d| Duration::from_secs(d.into())),
         )
-        .chain(repeat(conf.max_retry_delay));
+        .chain(repeat({
+            let d = *conf.connect_retry_delays.last();
+            Duration::from_secs(d.into())
+        }));
 
         let addr = addr.to_string();
         let node = conf.keypair.public_key();
@@ -244,16 +247,8 @@ async fn select_version(
 ) -> Result<(Version, Prologue)> {
     const INIT_PAYLOAD_LEN: usize = 4;
 
-    let our_min = conf
-        .noise_protocols
-        .first_key_value()
-        .map(|(k, _)| *k)
-        .expect("noise_configs is not empty");
-    let our_max = conf
-        .noise_protocols
-        .last_key_value()
-        .map(|(k, _)| *k)
-        .expect("noise_configs is not empty");
+    let our_min = *conf.noise_protocols.first().0;
+    let our_max = *conf.noise_protocols.last().0;
 
     let mut send_buf = [0u8; INIT_PAYLOAD_LEN];
     let mut recv_buf = [0u8; INIT_PAYLOAD_LEN];

--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -23,9 +23,13 @@ pub use net::{
     SendCommandBuilder,
 };
 
-use crate::x25519::{Keypair, PublicKey};
+use crate::{
+    util::nonempty::NonEmpty,
+    x25519::{Keypair, PublicKey},
+};
 
 #[derive(Builder)]
+#[builder(finish_fn(vis = "", name = "internal_build"))]
 #[non_exhaustive]
 pub struct Config {
     /// Network name.
@@ -40,19 +44,10 @@ pub struct Config {
     ///
     /// With this map, a node specifies the noise protocol names it supports
     /// per version number.
-    #[builder(with = |xs: impl IntoIterator<Item = (Version, noise::Protocol)>| {
-        let m = BTreeMap::from_iter(xs);
-        assert! {
-            !m.is_empty(),
-            "at least one noise protocol is required"
-        }
-        assert! {
-            m.keys().zip(m.keys().skip(1)).all(|(a, b)| u16::from(*a) + 1 == u16::from(*b)),
-            "noise protocol versions must be consecutive"
-        }
-        m
+    #[builder(with = |it: impl IntoIterator<Item = (Version, noise::Protocol)>| {
+        NonEmpty::assert_non_empty_map(it)
     })]
-    noise_protocols: BTreeMap<Version, noise::Protocol>,
+    noise_protocols: NonEmpty<BTreeMap<Version, noise::Protocol>>,
 
     /// DH keypair
     keypair: Keypair,
@@ -71,30 +66,61 @@ pub struct Config {
     #[builder(default = NonZeroUsize::new(10485760).expect("10485760 > 0"))]
     max_message_size: NonZeroUsize,
 
-    /// Retry delays in seconds.
-    #[builder(default = vec![1, 3, 5, 15, 30])]
-    retry_delays: Vec<u8>,
+    /// Connect retry delays in seconds.
+    #[builder(
+        default = NonEmpty::new(1, [3, 5, 15, 30]),
+        with = |it: impl IntoIterator<Item = u8>| NonEmpty::assert_non_empty_vec(it)
+    )]
+    connect_retry_delays: NonEmpty<Vec<u8>>,
 
-    #[builder(default = Duration::from_secs(30))]
-    max_retry_delay: Duration,
+    /// Send retry delays in seconds.
+    #[builder(
+        default = NonEmpty::new(5, [15, 30]),
+        with = |it: impl IntoIterator<Item = u8>| NonEmpty::assert_non_empty_vec(it)
+    )]
+    send_retry_delays: NonEmpty<Vec<u8>>,
 
     /// Randomly delay the initial connect attempt between 0 and 1s.
     #[builder(default = true)]
     random_connect_delay: bool,
 
+    /// How long to wait to establish a TCP connection?
     #[builder(default = Duration::from_secs(30))]
     connect_timeout: Duration,
 
+    /// How long to wait for a noise handshake to complete?
     #[builder(default = Duration::from_secs(10))]
     handshake_timeout: Duration,
 
+    /// After sending a message we expect to hear back from the peer.
+    ///
+    /// If we do not receive anything for this duration we reconnect.
     #[builder(default = Duration::from_secs(30))]
     receive_timeout: Duration,
 
+    /// If a party is not known we tell it to back off for this amount of time.
+    ///
+    /// This may happen when not all peers have a consistent configuration.
     #[builder(default = Duration::from_secs(30))]
     backoff_duration: Duration,
 
+    /// Optional metrics implementation.
     metrics: Option<Arc<dyn Metrics>>,
+}
+
+impl<S: config_builder::IsComplete> ConfigBuilder<S> {
+    pub fn build(self) -> Config {
+        let conf = self.internal_build();
+
+        let v1 = conf.noise_protocols.iter().map(|(k, _)| k);
+        let v2 = conf.noise_protocols.iter().map(|(k, _)| k).skip(1);
+        assert! {
+            v1.zip(v2).all(|(a, b)| u16::from(*a) + 1 == u16::from(*b)),
+            "cliquenet configuration requires consecutive noise protocol versions"
+        }
+
+        conf
+    }
 }
 
 impl fmt::Debug for Config {
@@ -106,8 +132,8 @@ impl fmt::Debug for Config {
             .field("parties", &self.parties)
             .field("peer_budget", &self.peer_budget)
             .field("max_message_size", &self.max_message_size)
-            .field("retry_delays", &self.retry_delays)
-            .field("max_retry_delay", &self.max_retry_delay)
+            .field("connect_retry_delays", &self.connect_retry_delays)
+            .field("send_retry_delays", &self.send_retry_delays)
             .field("random_connect_delay", &self.random_connect_delay)
             .field("connect_timeout", &self.connect_timeout)
             .field("handshake_timeout", &self.handshake_timeout)

--- a/crates/cliquenet/src/metrics.rs
+++ b/crates/cliquenet/src/metrics.rs
@@ -1,11 +1,18 @@
 use crate::x25519::PublicKey;
 
+/// Type that records metrics.
 pub trait Metrics: Send + Sync {
+    /// Set a peer gauge to the given value.
     fn set(&self, key: &PublicKey, label: &str, val: usize);
+
+    /// Add to a peer counter the given value.
     fn add(&self, key: &PublicKey, label: &str, val: usize);
+
+    /// Remove all peer metrics.
     fn del(&self, key: &PublicKey);
 }
 
+/// A no-op [`Metrics`] implementation.
 pub(crate) struct NoMetrics;
 
 impl Metrics for NoMetrics {

--- a/crates/cliquenet/src/net/peer/delay.rs
+++ b/crates/cliquenet/src/net/peer/delay.rs
@@ -105,11 +105,10 @@ impl DelayQueue {
 }
 
 fn timeout(conf: &Config, at: usize) -> Instant {
-    let d = conf
-        .retry_delays
+    let d = *conf
+        .send_retry_delays
         .get(at)
-        .copied()
-        .map(|d| Duration::from_secs(d.into()))
-        .unwrap_or(conf.max_retry_delay);
-    Instant::now() + d
+        .unwrap_or_else(|| conf.send_retry_delays.last());
+
+    Instant::now() + Duration::from_secs(d.into())
 }

--- a/crates/cliquenet/src/net/peer/tests.rs
+++ b/crates/cliquenet/src/net/peer/tests.rs
@@ -31,8 +31,8 @@ fn config(kp: Keypair, recv_timeout: Duration) -> Arc<Config> {
             .bind(NetAddr::from((std::net::Ipv4Addr::LOCALHOST, 0u16)))
             .parties(std::iter::empty::<(PublicKey, NetAddr)>())
             .receive_timeout(recv_timeout)
-            .retry_delays(vec![2, 5])
-            .max_retry_delay(Duration::from_secs(10))
+            .connect_retry_delays(vec![2, 5])
+            .send_retry_delays(vec![2, 5])
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
@@ -743,8 +743,8 @@ fn config_with_retry(kp: Keypair, recv_timeout: Duration, retry_delays: Vec<u8>)
             .bind(NetAddr::from((std::net::Ipv4Addr::LOCALHOST, 0u16)))
             .parties(std::iter::empty::<(PublicKey, NetAddr)>())
             .receive_timeout(recv_timeout)
-            .retry_delays(retry_delays)
-            .max_retry_delay(Duration::from_secs(10))
+            .connect_retry_delays(retry_delays.clone())
+            .send_retry_delays(retry_delays)
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )
@@ -855,8 +855,8 @@ async fn backpressure_on_unacked() {
             .parties(std::iter::empty::<(PublicKey, NetAddr)>())
             .peer_budget(NonZeroUsize::new(3).unwrap())
             .receive_timeout(Duration::from_secs(5))
-            .retry_delays(vec![30])
-            .max_retry_delay(Duration::from_secs(30))
+            .connect_retry_delays(vec![30])
+            .send_retry_delays(vec![30])
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     );

--- a/crates/cliquenet/src/util.rs
+++ b/crates/cliquenet/src/util.rs
@@ -1,3 +1,5 @@
+pub(crate) mod nonempty;
+
 use std::time::Duration;
 
 use crate::NetworkError;

--- a/crates/cliquenet/src/util/nonempty.rs
+++ b/crates/cliquenet/src/util/nonempty.rs
@@ -1,0 +1,79 @@
+use std::{collections::BTreeMap, iter::once};
+
+/// Small helper to ensure some container type is not empty.
+#[derive(Debug)]
+pub(crate) struct NonEmpty<T: Container>(T::Element, T);
+
+pub(crate) trait Container {
+    type Element;
+}
+
+impl<A> Container for Vec<A> {
+    type Element = A;
+}
+
+impl<K: Ord, V> Container for BTreeMap<K, V> {
+    type Element = (K, V);
+}
+
+impl<A> NonEmpty<Vec<A>> {
+    pub(crate) fn new<I>(fst: A, rest: I) -> Self
+    where
+        I: IntoIterator<Item = A>,
+    {
+        Self(fst, rest.into_iter().collect())
+    }
+
+    pub(crate) fn assert_non_empty_vec<I>(it: I) -> Self
+    where
+        I: IntoIterator<Item = A>,
+    {
+        let mut it = it.into_iter();
+        let fst = it.next().expect("non empty vector");
+        Self(fst, it.collect())
+    }
+
+    pub(crate) fn last(&self) -> &A {
+        self.1.as_slice().last().unwrap_or(&self.0)
+    }
+
+    pub(crate) fn get(&self, i: usize) -> Option<&A> {
+        match i {
+            0 => Some(&self.0),
+            _ => self.1.get(i - 1),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &A> {
+        once(&self.0).chain(self.1.as_slice().iter())
+    }
+}
+
+impl<K: Ord, V> NonEmpty<BTreeMap<K, V>> {
+    pub(crate) fn assert_non_empty_map<I>(it: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut m = BTreeMap::from_iter(it);
+        let fst = m.pop_first().expect("non empty map");
+        Self(fst, m)
+    }
+
+    pub(crate) fn first(&self) -> (&K, &V) {
+        (&self.0.0, &self.0.1)
+    }
+
+    pub(crate) fn last(&self) -> (&K, &V) {
+        self.1.last_key_value().unwrap_or((&self.0.0, &self.0.1))
+    }
+
+    pub(crate) fn get(&self, k: &K) -> Option<&V> {
+        (&self.0.0 == k)
+            .then_some(&self.0.1)
+            .or_else(|| self.1.get(k))
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        once((&self.0.0, &self.0.1)).chain(self.1.iter())
+    }
+}

--- a/crates/cliquenet/tests/network.rs
+++ b/crates/cliquenet/tests/network.rs
@@ -50,8 +50,8 @@ fn make_config(node: &Node, all: &[&Node]) -> Config {
         .bind(node.addr().into())
         .parties(all.iter().map(|n| (n.key, n.addr().into())))
         .receive_timeout(Duration::from_secs(5))
-        .retry_delays(vec![1, 3])
-        .max_retry_delay(Duration::from_secs(5))
+        .connect_retry_delays(vec![1, 3])
+        .send_retry_delays(vec![1, 3])
         .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
         .build()
 }
@@ -585,8 +585,8 @@ async fn unknown_peer_backs_off() {
             .bind(a.addr().into())
             .parties([(a.key, a.addr().into())])
             .receive_timeout(Duration::from_secs(5))
-            .retry_delays(vec![1])
-            .max_retry_delay(Duration::from_secs(1))
+            .connect_retry_delays(vec![1])
+            .send_retry_delays(vec![1])
             .backoff_duration(Duration::from_secs(60))
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
@@ -604,8 +604,8 @@ async fn unknown_peer_backs_off() {
             .bind(c.addr().into())
             .parties([(a.key, a.addr().into()), (c.key, c.addr().into())])
             .receive_timeout(Duration::from_secs(5))
-            .retry_delays(vec![1])
-            .max_retry_delay(Duration::from_secs(1))
+            .connect_retry_delays(vec![1])
+            .send_retry_delays(vec![1])
             .noise_protocols([(1.into(), Protocol::IK_25519_AesGcm_Blake2s)])
             .build(),
     )


### PR DESCRIPTION
Currently there is only one retry delay config, but connection retries and delivery retries may want to use different delays.

Also enforce some constraints on type level, i.e. the non-emptiness of delays and noise configs.