### PR TITLE
[new-protocol]  Fix cert2 mismatch in leaf catchup by fetching cert2 at exact height

### DIFF
--- a/crates/espresso/node/api/catchup.toml
+++ b/crates/espresso/node/api/catchup.toml
@@ -87,10 +87,9 @@ PATH = ["/:height/cert2"]
 ":height" = "Integer"
 DOC = """
 
-Fetches the earliest cert2 whose finalized block height is
-at or above `:height`.
+Fetches the cert2 stored at exactly `:height`, if one exists.
 
-Returns 404 if no cert2 with height >= `:height` is available
+Returns 404 if no cert2 is stored at exactly `:height`.
 """
 
 [route.reward_account]

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -965,7 +965,7 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence, D: CatchupStorage + S
         &self,
         height: u64,
     ) -> anyhow::Result<Option<espresso_types::Certificate2<SeqTypes>>> {
-        self.inner().load_earliest_cert2(height).await
+        self.inner().load_cert2(height).await
     }
 
     #[tracing::instrument(skip(self, instance))]

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -282,9 +282,9 @@ pub(crate) trait CatchupDataSource: Sync {
         height: u64,
     ) -> impl Send + Future<Output = anyhow::Result<Vec<Leaf2>>>;
 
-    /// Load the earliest cert2 whose finalized block height is at or above `height`.
+    /// Load the cert2 stored at exactly `height`, if one exists.
     ///
-    /// Returns `None` when no cert2 height >= `height` is locally available
+    /// Returns `None` when no cert2 is stored at exactly `height`.
     fn get_cert2(
         &self,
         _height: u64,

--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -789,7 +789,7 @@ impl CatchupStorage for SqlStorage {
             .clone();
 
         // New protocol: cert2 alone proves finality. Return the leaf range up to the finalizing
-        // cert2's height
+        // cert2's height.
         if leaf.block_header().version() >= NEW_PROTOCOL_VERSION {
             let cert2: espresso_types::Certificate2<SeqTypes> =
                 tx.load_earliest_cert2(height).await?.context(format!(
@@ -845,7 +845,7 @@ impl CatchupStorage for SqlStorage {
         Ok(chain)
     }
 
-    async fn load_earliest_cert2(
+    async fn load_cert2(
         &self,
         height: u64,
     ) -> anyhow::Result<Option<espresso_types::Certificate2<SeqTypes>>> {
@@ -853,7 +853,7 @@ impl CatchupStorage for SqlStorage {
             .read()
             .await
             .context("opening transaction to fetch cert2")?;
-        Ok(tx.load_earliest_cert2(height).await?)
+        Ok(tx.load_cert2(height).await?)
     }
 
     async fn get_leaf(&self, height: u64) -> anyhow::Result<Leaf2> {
@@ -1005,11 +1005,11 @@ impl CatchupStorage for DataSource {
         self.as_ref().get_leaf_chain(height).await
     }
 
-    async fn load_earliest_cert2(
+    async fn load_cert2(
         &self,
         height: u64,
     ) -> anyhow::Result<Option<espresso_types::Certificate2<SeqTypes>>> {
-        self.as_ref().load_earliest_cert2(height).await
+        self.as_ref().load_cert2(height).await
     }
 
     async fn get_leaf(&self, height: u64) -> anyhow::Result<Leaf2> {

--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -392,16 +392,23 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
         if first.block_header().version() >= NEW_PROTOCOL_VERSION {
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(NEW_PROTOCOL_VERSION));
+
+            // The chain terminates at the leaf the cert2 finalizes, so fetch that cert2 by its
+            // exact height
+            let cert2_height = leaf_chain
+                .last()
+                .ok_or_else(|| anyhow!("empty leaf chain returned for height {height}"))?
+                .height();
             let cert2 = self
                 .fetch(retry, |client| async move {
                     let cert2 = client
-                        .get::<Certificate2<SeqTypes>>(&format!("catchup/{height}/cert2"))
+                        .get::<Certificate2<SeqTypes>>(&format!("catchup/{cert2_height}/cert2"))
                         .send()
                         .await?;
                     anyhow::Ok(cert2)
                 })
                 .await
-                .with_context(|| format!("failed to fetch cert2 for height {height}"))?;
+                .with_context(|| format!("failed to fetch cert2 for height {cert2_height}"))?;
 
             verify_leaf_chain_with_cert2(
                 leaf_chain,
@@ -645,11 +652,8 @@ pub(crate) trait CatchupStorage: Sync {
         }
     }
 
-    /// Load the earliest cert2 whose finalized block height is at or above `height`.
-    ///
-    /// "Earliest" means the cert2 with the smallest finalized block height that is still greater
-    /// than or equal to the requested `height`.
-    fn load_earliest_cert2(
+    /// Load the cert2 stored at exactly `height`, if one exists.
+    fn load_cert2(
         &self,
         _height: u64,
     ) -> impl Send + Future<Output = anyhow::Result<Option<Certificate2<SeqTypes>>>> {
@@ -726,11 +730,8 @@ where
         self.inner().get_leaf_chain(height).await
     }
 
-    async fn load_earliest_cert2(
-        &self,
-        height: u64,
-    ) -> anyhow::Result<Option<Certificate2<SeqTypes>>> {
-        self.inner().load_earliest_cert2(height).await
+    async fn load_cert2(&self, height: u64) -> anyhow::Result<Option<Certificate2<SeqTypes>>> {
+        self.inner().load_cert2(height).await
     }
 
     async fn get_leaf(&self, height: u64) -> anyhow::Result<Leaf2> {

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -272,17 +272,26 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
             // New protocol: pair the leaf range with its finalizing cert2 for verification.
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(NEW_PROTOCOL_VERSION));
+            // The chain terminates at the leaf the cert2 finalizes, so request that cert2 by its
+            // exact height rather than the earliest cert2 at or above `height`. The earliest query
+            // is not stable across requests: concurrent consensus progress can shift it to a cert2
+            // finalizing a different leaf than the one ending the chain we already fetched
+            // ("cert2 does not match the newest leaf").
+            let cert2_height = leaf_chain
+                .last()
+                .ok_or_else(|| anyhow::anyhow!("empty leaf chain for height {height}"))?
+                .height();
             let cert2 = self
                 .request_indefinitely(
-                    Request::Cert2(height),
+                    Request::Cert2(cert2_height),
                     RequestType::Batched,
                     move |_request: &Request, response: Response| async move {
                         let Response::Cert2(cert2) = response else {
                             return Err(anyhow::anyhow!("expected cert2 response"));
                         };
-                        if cert2.data.block_number < height {
+                        if cert2.data.block_number != cert2_height {
                             return Err(anyhow::anyhow!(
-                                "received cert2 at height {} below requested height {height}",
+                                "received cert2 at height {} but expected exactly {cert2_height}",
                                 cert2.data.block_number
                             ));
                         }
@@ -290,7 +299,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
                     },
                 )
                 .await
-                .with_context(|| format!("failed to request cert2 at or above height {height}"))?;
+                .with_context(|| format!("failed to request cert2 at height {cert2_height}"))?;
 
             verify_leaf_chain_with_cert2(
                 leaf_chain,

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -273,10 +273,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(NEW_PROTOCOL_VERSION));
             // The chain terminates at the leaf the cert2 finalizes, so request that cert2 by its
-            // exact height rather than the earliest cert2 at or above `height`. The earliest query
-            // is not stable across requests: concurrent consensus progress can shift it to a cert2
-            // finalizing a different leaf than the one ending the chain we already fetched
-            // ("cert2 does not match the newest leaf").
+            // exact height
             let cert2_height = leaf_chain
                 .last()
                 .ok_or_else(|| anyhow::anyhow!("empty leaf chain for height {height}"))?

--- a/crates/espresso/node/src/request_response/data_source.rs
+++ b/crates/espresso/node/src/request_response/data_source.rs
@@ -313,7 +313,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
             Request::Cert2(height) => {
                 let cert2 = match &self.storage {
                     Some(Storage::Sql(storage)) => storage
-                        .load_earliest_cert2(*height)
+                        .load_cert2(*height)
                         .await
                         .with_context(|| "failed to load cert2 from sql storage")?,
                     Some(Storage::Fs(_)) => bail!("fs storage not supported for cert2"),
@@ -322,7 +322,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
 
                 match cert2 {
                     Some(cert2) => Ok(Response::Cert2(cert2)),
-                    None => bail!("no cert2 available for height {height}"),
+                    None => bail!("no cert2 available at height {height}"),
                 }
             },
             Request::RewardMerkleTreeV2(height, view) => {


### PR DESCRIPTION
Catchup failed with "cert2 does not match the newest leaf in the chain" because the client requested the cert2 at the wrong height. This fixes it by fetching the cert2 at the exact height of the chain's last leaf