### PR TITLE
Introduce `GcScope`.

### DIFF
--- a/crates/cliquenet/src/net/peer.rs
+++ b/crates/cliquenet/src/net/peer.rs
@@ -62,9 +62,6 @@ pub struct Peer {
     /// Receive notifications about changes to the GC threshold
     next_slot: watch::Receiver<Slot>,
 
-    /// Our current GC threshold.
-    lower_bound: Slot,
-
     /// The channel over which to deliver inbound messages to the application.
     tx: UnboundedSender<PeerMessage>,
 
@@ -117,7 +114,6 @@ impl Peer {
             conf: config.clone(),
             budget: Budget::new(budget),
             next_slot,
-            lower_bound: Slot::MIN,
             tx: inbound,
             conn: connection,
             retry: DelayQueue::new(config),
@@ -325,8 +321,6 @@ impl Peer {
                         return Err(NetworkError::ChannelClosed)
                     }
                     let s = *self.next_slot.borrow_and_update();
-                    debug_assert!(s > self.lower_bound);
-                    self.lower_bound = s;
                     self.retry.gc(s);
                 }
 
@@ -565,17 +559,11 @@ impl Peer {
                                                     );
                                                     return Err(NetworkError::InvalidTrailer);
                                                 };
-                                                let slot = match t {
-                                                    Trailer::Std { slot, id } => {
-                                                        obound_acks.push_back(Ack::from((slot, id)));
-                                                        Some(slot)
-                                                    }
-                                                    Trailer::NoAck { slot } => Some(slot),
-                                                    Trailer::Unknown => None
-                                                };
-                                                if let Some(s) = slot && s < self.lower_bound {
-                                                    rstate = ReadState::Header { off: 0, buf: [0; _] };
-                                                    continue
+                                                match t {
+                                                    Trailer::Std { slot, id } =>
+                                                        obound_acks.push_back(Ack::from((slot, id))),
+                                                    Trailer::NoAck { slot: _ } => (),
+                                                    Trailer::Unknown => ()
                                                 }
                                                 let p = read_permit.take();
                                                 debug_assert!(p.is_some());

--- a/crates/hotshot/new-protocol/src/client.rs
+++ b/crates/hotshot/new-protocol/src/client.rs
@@ -100,14 +100,12 @@ impl<T: NodeType> ClientApi<T> {
 
     pub async fn send_external_message(
         &self,
-        view: ViewNumber,
         payload: Vec<u8>,
         recipient: T::SignatureKey,
     ) -> Result<(), QueryError> {
         let (respond, rx) = oneshot::channel();
         self.call(
             ClientRequest::SendExternalMessage {
-                view,
                 payload,
                 recipient,
                 respond,
@@ -222,7 +220,6 @@ pub(crate) enum ClientRequest<T: NodeType> {
         respond: oneshot::Sender<Result<SignedProposal<T, Proposal<T>>, QueryError>>,
     },
     SendExternalMessage {
-        view: ViewNumber,
         payload: Vec<u8>,
         recipient: T::SignatureKey,
         respond: oneshot::Sender<Result<(), QueryError>>,
@@ -278,24 +275,24 @@ impl<T: NodeType> ClientLeafFetcherNetwork<T> {
 impl<T: NodeType> LeafFetcherNetwork<T> for ClientLeafFetcherNetwork<T> {
     async fn send_leaf_request(
         &self,
-        view: ViewNumber,
+        _: ViewNumber,
         payload: Vec<u8>,
         recipient: T::SignatureKey,
     ) -> anyhow::Result<()> {
         self.client
-            .send_external_message(view, payload, recipient)
+            .send_external_message(payload, recipient)
             .await?;
         Ok(())
     }
 
     async fn send_leaf_response(
         &self,
-        view: ViewNumber,
+        _: ViewNumber,
         payload: Vec<u8>,
         recipient: T::SignatureKey,
     ) -> anyhow::Result<()> {
         self.client
-            .send_external_message(view, payload, recipient)
+            .send_external_message(payload, recipient)
             .await?;
         Ok(())
     }

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -39,6 +39,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     block::BlockAndHeaderRequest,
+    coordinator::GcScope,
     helpers::proposal_commitment,
     logging::KeyPrefix,
     message::{
@@ -652,24 +653,35 @@ impl<T: NodeType> Consensus<T> {
         self.signed_proposals.get(view)
     }
 
-    pub fn gc(&mut self, view: ViewNumber, _epoch: EpochNumber) {
-        self.proposed_views = self.proposed_views.split_off(&view);
-        self.states_verified = self.states_verified.split_off(&view);
-        self.blocks_reconstructed = self.blocks_reconstructed.split_off(&view);
-        self.blocks = self.blocks.split_off(&view);
-        self.certs = self.certs.split_off(&view);
-        self.certs2 = self.certs2.split_off(&view);
-        self.pending_certs1 = self.pending_certs1.split_off(&view);
-        self.pending_certs2 = self.pending_certs2.split_off(&view);
-        self.timeout_certs = self.timeout_certs.split_off(&view);
-        self.headers
-            .retain(|(header_view, _), _| *header_view >= view);
-        self.leaves = self.leaves.split_off(&view);
-        self.proposals = self.proposals.split_off(&view);
-        self.signed_proposals = self.signed_proposals.split_off(&view);
-        self.vid_shares = self.vid_shares.split_off(&view);
-        self.voted_1_views = self.voted_1_views.split_off(&view);
-        self.voted_2_views = self.voted_2_views.split_off(&view);
+    pub fn gc(&mut self, scope: GcScope) {
+        match scope {
+            GcScope::Local(view) => {
+                self.headers
+                    .retain(|(header_view, _), _| *header_view >= view);
+                self.proposed_views = self.proposed_views.split_off(&view);
+                self.states_verified = self.states_verified.split_off(&view);
+                self.timeout_certs = self.timeout_certs.split_off(&view);
+                self.voted_1_views = self.voted_1_views.split_off(&view);
+                self.voted_2_views = self.voted_2_views.split_off(&view);
+            },
+            GcScope::Decided(view) => {
+                self.blocks = self.blocks.split_off(&view);
+                self.blocks_reconstructed = self.blocks_reconstructed.split_off(&view);
+                self.certs = self.certs.split_off(&view);
+                self.certs2 = self.certs2.split_off(&view);
+                self.leaves = self.leaves.split_off(&view);
+                self.pending_certs1 = self.pending_certs1.split_off(&view);
+                self.pending_certs2 = self.pending_certs2.split_off(&view);
+                self.proposals = self.proposals.split_off(&view);
+                self.signed_proposals = self.signed_proposals.split_off(&view);
+                self.vid_shares = self.vid_shares.split_off(&view);
+                if let Some(epoch) = self.current_epoch {
+                    let epoch = EpochNumber::new(epoch.saturating_sub(1));
+                    self.drb_results = self.drb_results.split_off(&epoch);
+                    self.state_certs = self.state_certs.split_off(&epoch);
+                }
+            },
+        }
     }
 
     /// Test-only: forcibly replace the proposal stored at `view`.

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -615,7 +615,10 @@ where
                         ProposalMessage::validated(proposal.clone()),
                     )),
                 };
-                if let Err(err) = self.network.broadcast(self.view(&message), &message) {
+                if let Err(err) = self
+                    .network
+                    .broadcast(self.consensus.current_view(), &message)
+                {
                     let err = CoordinatorError::from(err).context("proposal broadcast");
                     if err.severity == Severity::Critical {
                         return Err(err);
@@ -634,7 +637,7 @@ where
                     };
                     if let Err(err) =
                         self.network
-                            .unicast(self.view(&message), &recipient, &message)
+                            .unicast(self.consensus.current_view(), &recipient, &message)
                     {
                         let err = CoordinatorError::from(err).context("vid share unicast");
                         if err.severity == Severity::Critical {
@@ -655,7 +658,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(self.view(&message), &message)
+                    .broadcast(self.consensus.current_view(), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast timeout vote"))?
             },
             ConsensusOutput::SendTimeoutCertificate(tc, view, epoch) => {
@@ -672,7 +675,7 @@ where
                         )),
                     };
                     self.network
-                        .unicast(self.view(&message), &leader, &message)
+                        .unicast(self.consensus.current_view(), &leader, &message)
                         .map_err(|e| CoordinatorError::from(e).context("timeout certificate"))?;
                 }
             },
@@ -688,7 +691,7 @@ where
                     message_type: MessageType::Consensus(ConsensusMessage::Vote1(vote1)),
                 };
                 self.network
-                    .broadcast(self.view(&message), &message)
+                    .broadcast(self.consensus.current_view(), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast vote1"))?
             },
             ConsensusOutput::SendVote2(vote2) => {
@@ -698,7 +701,7 @@ where
                     message_type: MessageType::Consensus(ConsensusMessage::Vote2(vote2)),
                 };
                 self.network
-                    .broadcast(self.view(&message), &message)
+                    .broadcast(self.consensus.current_view(), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast vote2"))?
             },
             ConsensusOutput::SendEpochChange(epoch_change) => {
@@ -715,7 +718,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(self.view(&message), &message)
+                    .broadcast(self.consensus.current_view(), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast epoch change"))?
             },
             ConsensusOutput::SendCertificate1(cert1) => {
@@ -733,7 +736,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(self.view(&message), &message)
+                    .broadcast(self.consensus.current_view(), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast certificate1"))?
             },
             ConsensusOutput::ProposalValidated { proposal, sender } => {
@@ -967,8 +970,11 @@ where
                             Box::new(proposal),
                         )),
                     };
-
-                    if let Err(err) = self.network.unicast(view, &message.sender, &response) {
+                    if let Err(err) = self.network.unicast(
+                        self.consensus.current_view(),
+                        &message.sender,
+                        &response,
+                    ) {
                         let err = CoordinatorError::from(err).context("proposal response");
                         warn!(%node, %err, "network error while sending proposal response");
                     }
@@ -1081,7 +1087,7 @@ where
             message_type: MessageType::Block(msg),
         };
         self.network
-            .unicast(self.view(&message), &leader, &message)
+            .unicast(self.consensus.current_view(), &leader, &message)
             .map_err(|e| CoordinatorError::from(e).context("leader unicast"))
     }
 
@@ -1166,7 +1172,7 @@ where
                     };
 
                     self.network
-                        .broadcast(self.view(&message), &message)
+                        .broadcast(self.consensus.current_view(), &message)
                         .map_err(|err| {
                             CoordinatorError::from(err).context("broadcast proposal request")
                         })?;
@@ -1185,7 +1191,7 @@ where
                 };
                 let result = self
                     .network
-                    .unicast(self.view(&message), &recipient, &message)
+                    .unicast(self.consensus.current_view(), &recipient, &message)
                     .map_err(|err| {
                         CoordinatorError::from(err)
                             .context("send external message")
@@ -1278,7 +1284,10 @@ where
                         message::TimeoutVoteMessage { vote, lock: None },
                     )),
                 };
-                if let Err(err) = self.network.broadcast(self.view(&message), &message) {
+                if let Err(err) = self
+                    .network
+                    .broadcast(self.consensus.current_view(), &message)
+                {
                     tracing::warn!(%err, "failed to rebroadcast bridged timeout vote");
                 }
                 let _ = respond.send(());
@@ -1373,6 +1382,8 @@ where
                 self.block_builder.gc(view);
                 self.cached_validated_proposals = self.cached_validated_proposals.split_off(&view);
                 self.cached_vid_shares = self.cached_vid_shares.split_off(&view);
+                // When we enter a new view, we do not want to GC enqueued messages
+                // for the previous view yet:
                 self.network.gc(view.saturating_sub(1).into())?;
                 self.timeout_collector.gc(view, epoch);
                 self.timeout_one_honest_collector.gc(view, epoch);
@@ -1390,12 +1401,6 @@ where
             },
         }
         Ok(())
-    }
-
-    /// Use the message view number if available, or the current one otherwise.
-    fn view<U>(&self, m: &Message<T, U>) -> ViewNumber {
-        m.view_number()
-            .unwrap_or_else(|| self.consensus.current_view())
     }
 }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -572,12 +572,12 @@ where
                 if let Some(cert2) = cert2 {
                     self.storage.append_cert2(cert2.view_number, cert2.clone());
                 }
-                // `leaves` is ordered newest first
-                //  garbage collect the data for views < decided view
+                // `leaves` is ordered newest first.
+                //  Garbage collect the data for views < decided view
                 if let Some(newest) = leaves.first() {
                     let gc_view = newest.view_number();
                     let gc_epoch = newest.justify_qc().epoch().unwrap_or_default();
-                    self.gc(gc_view, gc_epoch);
+                    self.gc(gc_view, gc_epoch)?;
                 }
                 for leaf in leaves {
                     self.epoch_manager.handle_leaf_decided(leaf);
@@ -615,7 +615,7 @@ where
                         ProposalMessage::validated(proposal.clone()),
                     )),
                 };
-                if let Err(err) = self.network.broadcast(message.view_number(), &message) {
+                if let Err(err) = self.network.broadcast(self.view(&message), &message) {
                     let err = CoordinatorError::from(err).context("proposal broadcast");
                     if err.severity == Severity::Critical {
                         return Err(err);
@@ -634,7 +634,7 @@ where
                     };
                     if let Err(err) =
                         self.network
-                            .unicast(message.view_number(), &recipient, &message)
+                            .unicast(self.view(&message), &recipient, &message)
                     {
                         let err = CoordinatorError::from(err).context("vid share unicast");
                         if err.severity == Severity::Critical {
@@ -655,7 +655,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(message.view_number(), &message)
+                    .broadcast(self.view(&message), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast timeout vote"))?
             },
             ConsensusOutput::SendTimeoutCertificate(tc, view, epoch) => {
@@ -672,7 +672,7 @@ where
                         )),
                     };
                     self.network
-                        .unicast(message.view_number(), &leader, &message)
+                        .unicast(self.view(&message), &leader, &message)
                         .map_err(|e| CoordinatorError::from(e).context("timeout certificate"))?;
                 }
             },
@@ -688,7 +688,7 @@ where
                     message_type: MessageType::Consensus(ConsensusMessage::Vote1(vote1)),
                 };
                 self.network
-                    .broadcast(message.view_number(), &message)
+                    .broadcast(self.view(&message), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast vote1"))?
             },
             ConsensusOutput::SendVote2(vote2) => {
@@ -698,7 +698,7 @@ where
                     message_type: MessageType::Consensus(ConsensusMessage::Vote2(vote2)),
                 };
                 self.network
-                    .broadcast(message.view_number(), &message)
+                    .broadcast(self.view(&message), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast vote2"))?
             },
             ConsensusOutput::SendEpochChange(epoch_change) => {
@@ -715,7 +715,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(message.view_number(), &message)
+                    .broadcast(self.view(&message), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast epoch change"))?
             },
             ConsensusOutput::SendCertificate1(cert1) => {
@@ -733,7 +733,7 @@ where
                     )),
                 };
                 self.network
-                    .broadcast(message.view_number(), &message)
+                    .broadcast(self.view(&message), &message)
                     .map_err(|e| CoordinatorError::from(e).context("broadcast certificate1"))?
             },
             ConsensusOutput::ProposalValidated { proposal, sender } => {
@@ -1080,7 +1080,7 @@ where
             message_type: MessageType::Block(msg),
         };
         self.network
-            .unicast(message.view_number(), &leader, &message)
+            .unicast(self.view(&message), &leader, &message)
             .map_err(|e| CoordinatorError::from(e).context("leader unicast"))
     }
 
@@ -1165,7 +1165,7 @@ where
                     };
 
                     self.network
-                        .broadcast(message.view_number(), &message)
+                        .broadcast(self.view(&message), &message)
                         .map_err(|err| {
                             CoordinatorError::from(err).context("broadcast proposal request")
                         })?;
@@ -1174,7 +1174,6 @@ where
                     .push(view, leaf_commitment, respond);
             },
             ClientRequest::SendExternalMessage {
-                view,
                 payload,
                 recipient,
                 respond,
@@ -1185,7 +1184,7 @@ where
                 };
                 let result = self
                     .network
-                    .unicast(view, &recipient, &message)
+                    .unicast(self.view(&message), &recipient, &message)
                     .map_err(|err| {
                         CoordinatorError::from(err)
                             .context("send external message")
@@ -1278,7 +1277,7 @@ where
                         message::TimeoutVoteMessage { vote, lock: None },
                     )),
                 };
-                if let Err(err) = self.network.broadcast(message.view_number(), &message) {
+                if let Err(err) = self.network.broadcast(self.view(&message), &message) {
                     tracing::warn!(%err, "failed to rebroadcast bridged timeout vote");
                 }
                 let _ = respond.send(());
@@ -1366,10 +1365,10 @@ where
             ));
     }
 
-    fn gc(&mut self, view: ViewNumber, epoch: EpochNumber) {
+    fn gc(&mut self, view: ViewNumber, epoch: EpochNumber) -> Result<(), CoordinatorError> {
         info!(node = %self.node_id, %view, "garbage collecting");
         self.consensus.gc(view, epoch);
-        let _ = self.network.gc(view); // TODO
+        self.network.gc(view)?;
         self.state_manager.gc(view);
         self.vid_disperser.gc(view);
         self.vid_reconstructor.gc(view);
@@ -1384,6 +1383,12 @@ where
         self.storage.gc(view);
         self.cached_validated_proposals = self.cached_validated_proposals.split_off(&view);
         self.cached_vid_shares = self.cached_vid_shares.split_off(&view);
+        Ok(())
+    }
+
+    fn view<U>(&self, m: &Message<T, U>) -> ViewNumber {
+        m.view_number()
+            .unwrap_or_else(|| self.consensus.current_view())
     }
 }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -577,7 +577,7 @@ where
                 if let Some(newest) = leaves.first() {
                     let gc_view = newest.view_number();
                     let gc_epoch = newest.justify_qc().epoch().unwrap_or_default();
-                    self.gc(gc_view, gc_epoch)?;
+                    self.gc(gc_epoch, GcScope::Decided(gc_view))?;
                 }
                 for leaf in leaves {
                     self.epoch_manager.handle_leaf_decided(leaf);
@@ -748,6 +748,7 @@ where
                 info!(%node, %view, %epoch, "view changed");
                 self.consensus.set_view(view, epoch);
                 self.timer.reset_with_epoch(view, epoch);
+                self.gc(epoch, GcScope::Local(view))?;
                 let txns = self.block_builder.on_view_changed(view, epoch);
                 if !txns.is_empty() {
                     let next_view = view + 1;
@@ -1365,31 +1366,46 @@ where
             ));
     }
 
-    fn gc(&mut self, view: ViewNumber, epoch: EpochNumber) -> Result<(), CoordinatorError> {
-        info!(node = %self.node_id, %view, "garbage collecting");
-        self.consensus.gc(view, epoch);
-        self.network.gc(view)?;
-        self.state_manager.gc(view);
-        self.vid_disperser.gc(view);
-        self.vid_reconstructor.gc(view);
-        self.vote1_collector.gc(view, epoch);
-        self.vote2_collector.gc(view, epoch);
-        self.timeout_collector.gc(view, epoch);
-        self.timeout_one_honest_collector.gc(view, epoch);
-        self.epoch_root_collector.gc(view, epoch);
-        self.epoch_manager.gc(epoch);
-        self.block_builder.gc(view);
-        self.pending_proposal_fetches.gc(view);
-        self.storage.gc(view);
-        self.cached_validated_proposals = self.cached_validated_proposals.split_off(&view);
-        self.cached_vid_shares = self.cached_vid_shares.split_off(&view);
+    fn gc(&mut self, epoch: EpochNumber, scope: GcScope) -> Result<(), CoordinatorError> {
+        self.consensus.gc(scope);
+        match scope {
+            GcScope::Local(view) => {
+                self.block_builder.gc(view);
+                self.cached_validated_proposals = self.cached_validated_proposals.split_off(&view);
+                self.cached_vid_shares = self.cached_vid_shares.split_off(&view);
+                self.network.gc(view.saturating_sub(1).into())?;
+                self.timeout_collector.gc(view, epoch);
+                self.timeout_one_honest_collector.gc(view, epoch);
+                self.vid_disperser.gc(view);
+                self.vote1_collector.gc(view, epoch);
+                self.vote2_collector.gc(view, epoch);
+            },
+            GcScope::Decided(view) => {
+                self.epoch_manager.gc(epoch);
+                self.epoch_root_collector.gc(view, epoch);
+                self.pending_proposal_fetches.gc(view);
+                self.state_manager.gc(view);
+                self.storage.gc(view);
+                self.vid_reconstructor.gc(view);
+            },
+        }
         Ok(())
     }
 
+    /// Use the message view number if available, or the current one otherwise.
     fn view<U>(&self, m: &Message<T, U>) -> ViewNumber {
         m.view_number()
             .unwrap_or_else(|| self.consensus.current_view())
     }
+}
+
+/// Garbage collection scope.
+#[derive(Debug, Clone, Copy)]
+pub enum GcScope {
+    /// GC is invoked on local view changes.
+    Local(ViewNumber),
+    /// GC is invoked on local decided views.
+    Decided(ViewNumber),
 }
 
 fn check_payload_commitment<T: NodeType>(

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -274,15 +274,6 @@ impl<T: NodeType, S> Message<T, S> {
         matches!(self.message_type, MessageType::External(_))
     }
 
-    pub fn view_number(&self) -> Option<ViewNumber> {
-        match &self.message_type {
-            MessageType::Consensus(consensus_message) => Some(consensus_message.view_number()),
-            MessageType::Block(block_message) => Some(block_message.view_number()),
-            MessageType::ProposalFetch(message) => Some(message.view_number()),
-            MessageType::External(_) => None,
-        }
-    }
-
     #[cfg(test)]
     pub fn into_unchecked(self) -> Message<T, Unchecked> {
         Message {

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -274,6 +274,15 @@ impl<T: NodeType, S> Message<T, S> {
         matches!(self.message_type, MessageType::External(_))
     }
 
+    pub fn view_number(&self) -> Option<ViewNumber> {
+        match &self.message_type {
+            MessageType::Consensus(consensus_message) => Some(consensus_message.view_number()),
+            MessageType::Block(block_message) => Some(block_message.view_number()),
+            MessageType::ProposalFetch(message) => Some(message.view_number()),
+            MessageType::External(_) => None,
+        }
+    }
+
     #[cfg(test)]
     pub fn into_unchecked(self) -> Message<T, Unchecked> {
         Message {
@@ -289,7 +298,7 @@ impl<T: NodeType, S> HasViewNumber for Message<T, S> {
             MessageType::Consensus(consensus_message) => consensus_message.view_number(),
             MessageType::Block(block_message) => block_message.view_number(),
             MessageType::ProposalFetch(message) => message.view_number(),
-            MessageType::External(_) => ViewNumber::new(0), // TODO: This can become a problem
+            MessageType::External(_) => ViewNumber::new(1), // TODO: This can become a problem
         }
     }
 }

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -101,6 +101,15 @@ enum Pending<T: NodeType> {
     Header(HeaderRequest<T>),
 }
 
+impl<T: NodeType> Pending<T> {
+    fn view(&self) -> ViewNumber {
+        match self {
+            Pending::State(r) => r.view,
+            Pending::Header(r) => r.view,
+        }
+    }
+}
+
 enum Completed<T: NodeType> {
     State {
         response: StateResponse<T>,
@@ -370,13 +379,28 @@ impl<T: NodeType> StateManager<T> {
     pub fn gc(&mut self, view_number: ViewNumber) {
         self.validated_states
             .retain(|_, entry| entry.leaf.view_number() >= view_number);
+
         for (task, view) in self.state_requests.values() {
             if *view < view_number {
                 task.abort();
             }
         }
+
         self.state_requests
             .retain(|_, (_, view)| *view >= view_number);
+
+        self.header_requests.retain(|(view, _), handle| {
+            let keep = *view >= view_number;
+            if !keep {
+                handle.abort();
+            }
+            keep
+        });
+
+        self.pending_requests.retain(|_, pending| {
+            pending.retain(|p| p.view() >= view_number);
+            !pending.is_empty()
+        });
     }
 
     fn start_pending(&mut self, finished_commitment: Commitment<Leaf2<T>>) {

--- a/crates/hotshot/types/src/message.rs
+++ b/crates/hotshot/types/src/message.rs
@@ -166,8 +166,7 @@ impl<TYPES: NodeType> ViewMessage<TYPES> for MessageKind<TYPES> {
                 ResponseMessage::Found(m) => m.view_number(),
                 ResponseMessage::NotFound | ResponseMessage::Denied => ViewNumber::new(1),
             },
-            // TODO: change this once cliquenet has a Slot::MAX for external messages that is not garbage collected
-            MessageKind::External(_) => ViewNumber::new(u64::MAX),
+            MessageKind::External(_) => ViewNumber::new(1),
         }
     }
 }


### PR DESCRIPTION
1. **Cliquenet no longer suppresses inbound messages below its own GC threshold**. The slot is a local value and no assumptions should be made that peers agree on the value.
2. **Revert the view number of external messages to 1 and ignore it**. Instead send external messages with the current view. The changes in 1. ensure they are delivered when received and this change ensures they are sent because they do not sit below the GC threshold.
3. **Add `GcScope`**. Some collections can (and should) be pruned on local view changes, others have to be kept around until a view has been decided. This enum encodes the distinction and `Coordinator::gc` and `Consensus::gc` are changed to clean as soon as possible.
4. **Always use the current view number for sending**. This ensures that every message we intend to send is not ignored because it sits below our own GC threshold which is especially relevant for replying to received messages as the remote's message view may be below our own.