### PR TITLE
Fix misleading `orchestrator client` error level log

### DIFF
--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -460,7 +460,10 @@ where
                 .wait_for_all_nodes_ready(peer_config)
                 .await;
         } else {
-            tracing::error!("Cannot get info from orchestrator client");
+            // the network config was loaded from storage or fetched from
+            // peers, so there is no orchestrated start to wait for. This is the normal path
+            // for a node rejoining an existing network.
+            tracing::info!("no orchestrator configured");
         }
         tracing::warn!("starting consensus");
         self.consensus_handle.start_consensus().await;

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -461,8 +461,8 @@ where
                 .await;
         } else {
             // the network config was loaded from storage or fetched from
-            // peers, so there is no orchestrated start to wait for. This is the normal path
-            // for a node rejoining an existing network.
+            // peers, so there is no need of orchestrator
+            // This is the normal path for a node rejoining an existing network.
             tracing::info!("no orchestrator configured");
         }
         tracing::warn!("starting consensus");


### PR DESCRIPTION
For an existing network, we don't use orchestrator because we may already have the config or we have fetched from peers. 