### PR TITLE
[new-protocol] seed reconstructed blocks from anchor leaf and saved proposals after restart

### DIFF
--- a/crates/hotshot/new-protocol/bench/src/node.rs
+++ b/crates/hotshot/new-protocol/bench/src/node.rs
@@ -175,7 +175,7 @@ async fn build_coordinator(
         genesis_state,
         Leaf2::from(genesis_proposal.clone()),
     );
-    consensus.seed_parent(genesis_cert1, genesis_proposal);
+    consensus.seed_parent(genesis_cert1, genesis_proposal, std::iter::empty());
 
     let proposal_validator =
         ProposalValidator::new(membership.clone(), epoch_height, upgrade_lock.clone());

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -279,27 +279,25 @@ impl<T: NodeType> Consensus<T> {
     /// Sets the locked certificate and current epoch. After calling this, a
     /// subsequent `apply` that triggers `maybe_propose` will find the
     /// parent cert and proposal it needs.
-    pub fn seed_parent(&mut self, cert1: Certificate1<T>, proposal: Proposal<T>) {
+    ///
+    /// `reconstructed` are `(view, V2 commitment)` pairs to record as
+    /// already reconstructed blocks. During normal operation this set is
+    /// populated as VID shares arrive; on restart it starts empty, but the
+    /// persisted leaf and proposals correspond to blocks this node had already
+    /// reconstructed in the previous process. Seeding them lets a restarted
+    /// leader satisfy the `parent_block_reconstructed` check for its first
+    /// proposal/vote instead of stalling.
+    pub fn seed_parent(
+        &mut self,
+        cert1: Certificate1<T>,
+        proposal: Proposal<T>,
+        reconstructed: impl IntoIterator<Item = (ViewNumber, VidCommitment2)>,
+    ) {
         self.current_epoch = Some(proposal.epoch);
         self.certs.insert(cert1.view_number(), cert1.clone());
         self.locked_cert = Some(cert1);
         self.proposals.insert(proposal.view_number, proposal);
-    }
-
-    /// Insert `(view, V2 commitment)` pairs into the set of blocks whose payload
-    /// has been reconstructed from VID shares.
-    ///
-    /// During normal operation this set is populated as shares arrive.
-    /// On restart that in memory set
-    /// is empty, but a node's persisted leaf and proposals correspond to blocks
-    /// it had already reconstructed in the previous process. Seeding them lets a
-    /// restarted leader satisfy the `parent_block_reconstructed` check for
-    /// its first proposal/vote instead of stalling
-    pub fn seed_reconstructed_blocks(
-        &mut self,
-        blocks: impl IntoIterator<Item = (ViewNumber, VidCommitment2)>,
-    ) {
-        for (view, commitment) in blocks {
+        for (view, commitment) in reconstructed {
             self.blocks_reconstructed.insert((view, commitment));
         }
     }

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -286,6 +286,24 @@ impl<T: NodeType> Consensus<T> {
         self.proposals.insert(proposal.view_number, proposal);
     }
 
+    /// Insert `(view, V2 commitment)` pairs into the set of blocks whose payload
+    /// has been reconstructed from VID shares.
+    ///
+    /// During normal operation this set is populated as shares arrive.
+    /// On restart that in memory set
+    /// is empty, but a node's persisted leaf and proposals correspond to blocks
+    /// it had already reconstructed in the previous process. Seeding them lets a
+    /// restarted leader satisfy the `parent_block_reconstructed` check for
+    /// its first proposal/vote instead of stalling
+    pub fn seed_reconstructed_blocks(
+        &mut self,
+        blocks: impl IntoIterator<Item = (ViewNumber, VidCommitment2)>,
+    ) {
+        for (view, commitment) in blocks {
+            self.blocks_reconstructed.insert((view, commitment));
+        }
+    }
+
     /// Apply a [`PreCutoverSeed`] to bridge legacy state into the new
     /// protocol. Performs the four operations the seed describes
     /// atomically: anchor the decided view, install the undecided

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -172,6 +172,22 @@ where
         consensus.seed_parent(cert1, parent_proposal);
         consensus.set_view(anchor_view, anchor_epoch);
 
+        // The anchor leaf and persisted proposals are blocks this node had
+        // reconstructed before it went down, so treat them as reconstructed on
+        // restart
+        let seeded_blocks = std::iter::once((anchor_view, anchor_leaf.block_header().clone()))
+            .chain(
+                initializer
+                    .saved_proposals
+                    .iter()
+                    .map(|(view, p)| (*view, p.data.block_header().clone())),
+            )
+            .filter_map(|(view, header)| match header.payload_commitment() {
+                VidCommitment::V2(commitment) => Some((view, commitment)),
+                _ => None,
+            });
+        consensus.seed_reconstructed_blocks(seeded_blocks);
+
         let lock = upgrade_lock.clone();
         Self::builder()
             .consensus(consensus)

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -169,24 +169,23 @@ where
             initializer.anchor_state.clone(),
             anchor_leaf.clone(),
         );
-        consensus.seed_parent(cert1, parent_proposal);
-        consensus.set_view(anchor_view, anchor_epoch);
-
         // The anchor leaf and persisted proposals are blocks this node had
         // reconstructed before it went down, so treat them as reconstructed on
         // restart
-        let seeded_blocks = std::iter::once((anchor_view, anchor_leaf.block_header().clone()))
-            .chain(
-                initializer
-                    .saved_proposals
-                    .iter()
-                    .map(|(view, p)| (*view, p.data.block_header().clone())),
-            )
-            .filter_map(|(view, header)| match header.payload_commitment() {
-                VidCommitment::V2(commitment) => Some((view, commitment)),
-                _ => None,
-            });
-        consensus.seed_reconstructed_blocks(seeded_blocks);
+        let reconstructed_blocks =
+            std::iter::once((anchor_view, anchor_leaf.block_header().clone()))
+                .chain(
+                    initializer
+                        .saved_proposals
+                        .iter()
+                        .map(|(view, p)| (*view, p.data.block_header().clone())),
+                )
+                .filter_map(|(view, header)| match header.payload_commitment() {
+                    VidCommitment::V2(commitment) => Some((view, commitment)),
+                    _ => None,
+                });
+        consensus.seed_parent(cert1, parent_proposal, reconstructed_blocks);
+        consensus.set_view(anchor_view, anchor_epoch);
 
         let lock = upgrade_lock.clone();
         Self::builder()

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -118,7 +118,11 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
         genesis_state,
         Leaf2::from(genesis_proposal.clone()),
     );
-    consensus.seed_parent(genesis_cert1.clone(), genesis_proposal.clone());
+    consensus.seed_parent(
+        genesis_cert1.clone(),
+        genesis_proposal.clone(),
+        std::iter::empty(),
+    );
 
     if let Some(seed) = pre_cutover_seed {
         consensus.apply_pre_cutover_seed(seed);

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -275,7 +275,7 @@ async fn build_cutover_coordinator(
         genesis_state,
         Leaf2::from(genesis_proposal.clone()),
     );
-    consensus.seed_parent(genesis_cert1, genesis_proposal);
+    consensus.seed_parent(genesis_cert1, genesis_proposal, std::iter::empty());
 
     let block_builder = BlockBuilder::new(
         instance.clone(),


### PR DESCRIPTION
Seed the `blocks_reconstructed` set from the anchor leaf and saved proposals on restart so a restarted leader can satisfy the `parent_block_reconstructed` check instead of stalling.