### PR TITLE
ci(claude-review): add backport-correctness review mode

### DIFF
--- a/.github/claude/review-backport.md
+++ b/.github/claude/review-backport.md
@@ -1,0 +1,9 @@
+This PR is a backport. The original PR number is in `./tmp/is-backport`.
+
+Perform a BACKPORT-CORRECTNESS review. Do not perform a general code review.
+
+- `./tmp/original.diff` is the original PR's diff; `./tmp/backport.diff` is this PR's diff. Compare them and confirm the
+  backport faithfully reproduces the original change, adapted correctly to the target branch (API/type differences
+  between branches, conflict-resolution edits, dropped or extra hunks).
+- `./tmp/original-pr-comments.json` holds the original PR's review comments. Do NOT re-flag anything already raised
+  there. Only flag problems introduced by the backport itself (bad merge, lost hunk, wrong adaptation).

--- a/.github/claude/review-common.md
+++ b/.github/claude/review-common.md
@@ -1,0 +1,16 @@
+Before reviewing, read existing comments from `./tmp/pr-review-comments.json`.
+
+- Do not duplicate feedback already given by any reviewer.
+- For your own unresolved review threads: respond to any changes or replies, then resolve if the issue is fixed,
+  explained, or answered satisfactorily.
+  `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'`
+- Only resolve your own threads, never others'.
+
+Do NOT comment on:
+
+- `todo!()` or `// TODO` -- these are intentional, just factor them into your understanding
+- Unnecessary clones or clone optimization suggestions
+- Unused code, fields, or parameters -- clippy catches these, and `_` prefixed names are intentionally unused
+
+Provide detailed feedback using inline comments for specific issues. Use top-level comments for general observations or
+praise.

--- a/.github/claude/review-standard.md
+++ b/.github/claude/review-standard.md
@@ -1,0 +1,26 @@
+Perform a comprehensive code review with the following focus areas:
+
+1. **Code Quality**
+   - Clean code principles and best practices
+   - Proper error handling and edge cases
+   - Code readability and maintainability
+
+2. **Security**
+   - Check for potential security vulnerabilities
+   - Validate input sanitization
+   - Review authentication/authorization logic
+
+3. **Performance**
+   - Identify potential performance bottlenecks
+   - Review database queries for efficiency
+   - Check for memory leaks or resource issues
+
+4. **Testing**
+   - Verify adequate test coverage
+   - Review test quality and edge cases
+   - Check for missing test scenarios
+
+5. **Documentation**
+   - Ensure code is properly documented
+   - Verify README updates for new features
+   - Check API documentation accuracy

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,6 +35,28 @@ jobs:
             "${{ github.event.pull_request.number }}" \
             > ./tmp/pr-review-comments.json
 
+      - name: Prepare backport context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Backport PRs use the branch name backport-<original>-to-<target>,
+          # created by both scripts/backport-dispatch and korthout/backport-action.
+          if [[ ! "$HEAD_REF" =~ ^backport-([0-9]+)-to- ]]; then
+            echo "not a backport branch ($HEAD_REF); skipping"
+            exit 0
+          fi
+          orig="${BASH_REMATCH[1]}"
+          echo "$orig" > ./tmp/is-backport
+          scripts/fetch-pr-team-comments "$OWNER" "$REPO" "$orig" \
+            > ./tmp/original-pr-comments.json
+          gh pr diff "$orig" > ./tmp/original.diff
+          gh pr diff "$PR_NUMBER" > ./tmp/backport.diff
+
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
@@ -44,7 +66,21 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Perform a comprehensive code review with the following focus areas:
+            If `./tmp/is-backport` exists, this PR is a backport of the original PR
+            whose number is in that file. Perform a BACKPORT-CORRECTNESS review instead
+            of the standard review below:
+            - `./tmp/original.diff` is the original PR's diff; `./tmp/backport.diff` is
+              this PR's diff. Compare them and confirm the backport faithfully reproduces
+              the original change, adapted correctly to the target branch (API/type
+              differences between branches, conflict-resolution edits, dropped or extra
+              hunks).
+            - `./tmp/original-pr-comments.json` holds the original PR's review comments.
+              Do NOT re-flag anything already raised there. Only flag problems introduced
+              by the backport itself (bad merge, lost hunk, wrong adaptation).
+            - Skip the same exclusions listed below.
+            Then stop; do not run the standard review.
+
+            Otherwise, perform a comprehensive code review with the following focus areas:
 
             1. **Code Quality**
                - Clean code principles and best practices

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -57,69 +57,39 @@ jobs:
           gh pr diff "$orig" > ./tmp/original.diff
           gh pr diff "$PR_NUMBER" > ./tmp/backport.diff
 
+      - name: Build review prompt
+        id: prompt
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Prompt bodies live in .github/claude/*.md (not under .github/workflows)
+          # so editing them does not trip claude-code-action's workflow-change guard.
+          # Read from PR head, so PR-author controllable. Fine: fork PRs need manual
+          # approval to run, and Claude only adds advisory review, never approves/merges.
+          if [[ -f ./tmp/is-backport ]]; then
+            focus=.github/claude/review-backport.md
+          else
+            focus=.github/claude/review-standard.md
+          fi
+          {
+            echo "text<<__PROMPT_EOF__"
+            echo "REPO: $REPO"
+            echo "PR NUMBER: $PR_NUMBER"
+            echo
+            cat "$focus"
+            echo
+            cat .github/claude/review-common.md
+            echo "__PROMPT_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            If `./tmp/is-backport` exists, this PR is a backport of the original PR
-            whose number is in that file. Perform a BACKPORT-CORRECTNESS review instead
-            of the standard review below:
-            - `./tmp/original.diff` is the original PR's diff; `./tmp/backport.diff` is
-              this PR's diff. Compare them and confirm the backport faithfully reproduces
-              the original change, adapted correctly to the target branch (API/type
-              differences between branches, conflict-resolution edits, dropped or extra
-              hunks).
-            - `./tmp/original-pr-comments.json` holds the original PR's review comments.
-              Do NOT re-flag anything already raised there. Only flag problems introduced
-              by the backport itself (bad merge, lost hunk, wrong adaptation).
-            - Skip the same exclusions listed below.
-            Then stop; do not run the standard review.
-
-            Otherwise, perform a comprehensive code review with the following focus areas:
-
-            1. **Code Quality**
-               - Clean code principles and best practices
-               - Proper error handling and edge cases
-               - Code readability and maintainability
-
-            2. **Security**
-               - Check for potential security vulnerabilities
-               - Validate input sanitization
-               - Review authentication/authorization logic
-
-            3. **Performance**
-               - Identify potential performance bottlenecks
-               - Review database queries for efficiency
-               - Check for memory leaks or resource issues
-
-            4. **Testing**
-               - Verify adequate test coverage
-               - Review test quality and edge cases
-               - Check for missing test scenarios
-
-            5. **Documentation**
-               - Ensure code is properly documented
-               - Verify README updates for new features
-               - Check API documentation accuracy
-
-            Before reviewing, read existing comments from `./tmp/pr-review-comments.json`.
-            - Do not duplicate feedback already given by any reviewer.
-            - For your own unresolved review threads: respond to any changes or replies, then resolve if the issue is fixed, explained, or answered satisfactorily.
-              `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'`
-            - Only resolve your own threads, never others'.
-
-            Do NOT comment on:
-            - `todo!()` or `// TODO` -- these are intentional, just factor them into your understanding
-            - Unnecessary clones or clone optimization suggestions
-            - Unused code, fields, or parameters -- clippy catches these, and `_` prefixed names are intentionally unused
-
-            Provide detailed feedback using inline comments for specific issues.
-            Use top-level comments for general observations or praise.
+          prompt: ${{ steps.prompt.outputs.text }}
           # Allowed tools (minimal permissions):
           #   mcp__github_inline_comment__create_inline_comment - post inline code comments
           #   gh pr comment  - post top-level PR comments


### PR DESCRIPTION
Problem: claude's review on backports is just noise right now.

- detect backports via `backport-<n>-to-<target>` branch name
- fetch original PR comments and both diffs into ./tmp
- prompt reviews backport fidelity, skips issues already raised on original
