### PR TITLE
[Fast Finality] Gate Votes and Proposal by Relevant Storage

### DIFF
--- a/crates/hotshot/example-types/src/storage_types.rs
+++ b/crates/hotshot/example-types/src/storage_types.rs
@@ -17,7 +17,7 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use hotshot_types::{
     data::{
-        DaProposal, DaProposal2, EpochNumber, QuorumProposal, QuorumProposal2,
+        DaProposal, DaProposal2, EpochNumber, Leaf2, QuorumProposal, QuorumProposal2,
         QuorumProposalWrapper, VidCommitment, VidDisperseShare, ViewNumber,
     },
     drb::{DrbInput, DrbResult},
@@ -61,6 +61,7 @@ pub struct TestStorageState<TYPES: NodeType> {
     drb_inputs: BTreeMap<u64, DrbInput>,
     epoch_roots: BTreeMap<EpochNumber, TYPES::BlockHeader>,
     restart_view: ViewNumber,
+    anchor_leaf: Option<(Leaf2<TYPES>, QuorumCertificate2<TYPES>)>,
 }
 
 impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
@@ -84,6 +85,7 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
             drb_inputs: BTreeMap::new(),
             epoch_roots: BTreeMap::new(),
             restart_view: ViewNumber::genesis(),
+            anchor_leaf: None,
         }
     }
 }
@@ -148,6 +150,25 @@ impl<TYPES: NodeType> TestStorage<TYPES> {
 
     pub async fn restart_view(&self) -> ViewNumber {
         self.inner.read().await.restart_view
+    }
+
+    /// Record the newest decided leaf and the QC certifying it, keeping the
+    /// pair with the highest view. Plays the role of the application-level
+    /// anchor persistence (e.g. `append_decided_leaves` in the sequencer);
+    /// the anchor is what a restarted node resumes consensus from.
+    pub async fn update_anchor_leaf(&self, leaf: Leaf2<TYPES>, qc: QuorumCertificate2<TYPES>) {
+        let mut inner = self.inner.write().await;
+        if inner
+            .anchor_leaf
+            .as_ref()
+            .is_none_or(|(anchor, _)| leaf.view_number() > anchor.view_number())
+        {
+            inner.anchor_leaf = Some((leaf, qc));
+        }
+    }
+
+    pub async fn anchor_leaf(&self) -> Option<(Leaf2<TYPES>, QuorumCertificate2<TYPES>)> {
+        self.inner.read().await.anchor_leaf.clone()
     }
 
     pub async fn last_actioned_epoch(&self) -> Option<EpochNumber> {

--- a/crates/hotshot/example-types/src/storage_types.rs
+++ b/crates/hotshot/example-types/src/storage_types.rs
@@ -54,6 +54,7 @@ pub struct TestStorageState<TYPES: NodeType> {
     next_epoch_high_qc2:
         Option<hotshot_types::simple_certificate::NextEpochQuorumCertificate2<TYPES>>,
     action: ViewNumber,
+    action_log: Vec<(ViewNumber, HotShotAction)>,
     epoch: Option<EpochNumber>,
     state_certs: BTreeMap<EpochNumber, LightClientStateUpdateCertificateV2<TYPES>>,
     drb_results: BTreeMap<EpochNumber, DrbResult>,
@@ -76,6 +77,7 @@ impl<TYPES: NodeType> Default for TestStorageState<TYPES> {
             eqc: None,
             next_epoch_high_qc2: None,
             action: ViewNumber::genesis(),
+            action_log: Vec::new(),
             epoch: None,
             state_certs: BTreeMap::new(),
             drb_results: BTreeMap::new(),
@@ -137,6 +139,11 @@ impl<TYPES: NodeType> TestStorage<TYPES> {
 
     pub async fn last_actioned_view(&self) -> ViewNumber {
         self.inner.read().await.action
+    }
+
+    /// Every action successfully recorded, in call order.
+    pub async fn action_log(&self) -> Vec<(ViewNumber, HotShotAction)> {
+        self.inner.read().await.action_log.clone()
     }
 
     pub async fn restart_view(&self) -> ViewNumber {
@@ -264,6 +271,7 @@ impl<TYPES: NodeType> Storage<TYPES> for TestStorage<TYPES> {
             bail!("Failed to append Action to storage");
         }
         let mut inner = self.inner.write().await;
+        inner.action_log.push((view, action));
         if matches!(
             action,
             HotShotAction::Vote | HotShotAction::Propose | HotShotAction::TimeoutVote

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -48,6 +48,7 @@ use crate::{
     },
     outbox::Outbox,
     state::{StateRequest, StateResponse},
+    storage::{ActionKind, StorageOutput},
 };
 
 /// Inputs to [`Consensus::apply_pre_cutover_seed`].
@@ -103,6 +104,7 @@ pub enum ConsensusInput<T: NodeType> {
     ),
     StateValidated(StateResponse<T>),
     StateValidationFailed(StateResponse<T>),
+    Stored(StorageOutput<T>),
     Timeout(ViewNumber, EpochNumber),
     TimeoutCertificate(TimeoutCertificate2<T>),
     TimeoutOneHonest(ViewNumber, EpochNumber),
@@ -115,6 +117,12 @@ pub enum ConsensusOutput<T: NodeType> {
     RequestBlockAndHeader(BlockAndHeaderRequest<T>),
     RequestState(StateRequest<T>),
     RequestDrbResult(EpochNumber),
+    /// Durably record that this node acted (voted or proposed) in a view.
+    /// The corresponding send is held in a pending map until the matching
+    /// `ConsensusInput::Stored` confirmation arrives.
+    RecordAction(ViewNumber, Option<EpochNumber>, ActionKind),
+    /// Durably store this node's own proposal before it is broadcast.
+    PersistProposal(SignedProposal<T, Proposal<T>>),
     SendProposal(SignedProposal<T, Proposal<T>>),
     SendVidShares(Vec<VidShareMessage<T>>),
     SendTimeoutVote(TimeoutVote2<T>, Option<Certificate1<T>>),
@@ -175,6 +183,18 @@ pub struct Consensus<T: NodeType> {
 
     voted_1_views: BTreeSet<ViewNumber>,
     voted_2_views: BTreeSet<ViewNumber>,
+
+    /// Storage confirmations; sends are gated on these facts.
+    stored_proposals: BTreeMap<ViewNumber, Vec<Commitment<Leaf2<T>>>>,
+    stored_vids: BTreeSet<ViewNumber>,
+    stored_actions: BTreeSet<(ViewNumber, ActionKind)>,
+    requested_actions: BTreeSet<(ViewNumber, ActionKind)>,
+
+    /// Messages constructed and accounted for in `voted_*_views` /
+    /// `proposed_views`, awaiting their storage confirmations.
+    pending_vote1: BTreeMap<ViewNumber, Vote1<T>>,
+    pending_vote2: BTreeMap<ViewNumber, Vote2<T>>,
+    pending_proposal: BTreeMap<ViewNumber, SignedProposal<T, Proposal<T>>>,
 
     /// Skipped by `maybe_vote_2_and_update_lock` (V1 AvidM dispersal).
     pre_cutover_views: BTreeSet<ViewNumber>,
@@ -263,6 +283,13 @@ impl<T: NodeType> Consensus<T> {
             stake_table_coordinator: membership_coordinator,
             voted_1_views: BTreeSet::new(),
             voted_2_views: BTreeSet::new(),
+            stored_proposals: BTreeMap::new(),
+            stored_vids: BTreeSet::new(),
+            stored_actions: BTreeSet::new(),
+            requested_actions: BTreeSet::new(),
+            pending_vote1: BTreeMap::new(),
+            pending_vote2: BTreeMap::new(),
+            pending_proposal: BTreeMap::new(),
             pre_cutover_views: BTreeSet::new(),
             pending_certs1: BTreeMap::new(),
             pending_certs2: BTreeMap::new(),
@@ -532,6 +559,11 @@ impl<T: NodeType> Consensus<T> {
                 self.headers.insert((view, commitment), header);
                 Protocol::Continue
             },
+            ConsensusInput::Stored(stored) => {
+                debug!(?stored, "apply: stored");
+                self.handle_stored(stored, outbox);
+                Protocol::Continue
+            },
             ConsensusInput::StateValidationFailed(state_response) => {
                 let view = state_response.view;
                 let stored_proposal = self.proposals.get(&view);
@@ -708,6 +740,14 @@ impl<T: NodeType> Consensus<T> {
                 self.proposals = self.proposals.split_off(&view);
                 self.signed_proposals = self.signed_proposals.split_off(&view);
                 self.vid_shares = self.vid_shares.split_off(&view);
+                self.stored_proposals = self.stored_proposals.split_off(&view);
+                self.stored_vids = self.stored_vids.split_off(&view);
+                self.stored_actions = self.stored_actions.split_off(&(view, ActionKind::Vote));
+                self.requested_actions =
+                    self.requested_actions.split_off(&(view, ActionKind::Vote));
+                self.pending_vote1 = self.pending_vote1.split_off(&view);
+                self.pending_vote2 = self.pending_vote2.split_off(&view);
+                self.pending_proposal = self.pending_proposal.split_off(&view);
                 if let Some(epoch) = self.current_epoch {
                     let epoch = EpochNumber::new(epoch.saturating_sub(1));
                     self.drb_results = self.drb_results.split_off(&epoch);
@@ -1404,7 +1444,9 @@ impl<T: NodeType> Consensus<T> {
         };
 
         self.proposed_views.insert(view);
-        outbox.push_back(ConsensusOutput::SendProposal(message));
+        outbox.push_back(ConsensusOutput::PersistProposal(message.clone()));
+        self.request_action(view, Some(proposal_epoch), ActionKind::Propose, outbox);
+        self.pending_proposal.insert(view, message);
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1543,6 +1585,87 @@ impl<T: NodeType> Consensus<T> {
             auth_root,
             signed_state_digest,
         })
+    }
+
+    fn handle_stored(&mut self, stored: StorageOutput<T>, outbox: &mut Outbox<ConsensusOutput<T>>) {
+        let view = stored.view_number();
+        match stored {
+            StorageOutput::Proposal(view, commitment) => {
+                self.stored_proposals
+                    .entry(view)
+                    .or_default()
+                    .push(commitment);
+            },
+            StorageOutput::Vid(view) => {
+                self.stored_vids.insert(view);
+            },
+            StorageOutput::Action(view, kind) => {
+                self.stored_actions.insert((view, kind));
+            },
+        }
+        self.release_vote1(view, outbox);
+        self.release_vote2(view, outbox);
+        self.release_proposal(view, outbox);
+    }
+
+    fn release_vote1(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
+        let Some(vote1) = self.pending_vote1.get(&view) else {
+            return;
+        };
+        if !self.stored_actions.contains(&(view, ActionKind::Vote))
+            || !self.is_proposal_stored(view, &vote1.vote.data.leaf_commit)
+        {
+            return;
+        }
+        let vote1 = self.pending_vote1.remove(&view).expect("checked above");
+        if view <= self.timeout_view {
+            debug!(%view, "dropping pending vote1 for timed-out view");
+            return;
+        }
+        outbox.push_back(ConsensusOutput::SendVote1(vote1));
+    }
+
+    fn release_vote2(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
+        if !self.stored_actions.contains(&(view, ActionKind::Vote))
+            || !self.stored_vids.contains(&view)
+        {
+            return;
+        }
+        let Some(vote2) = self.pending_vote2.remove(&view) else {
+            return;
+        };
+        outbox.push_back(ConsensusOutput::SendVote2(vote2));
+    }
+
+    fn release_proposal(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
+        let Some(message) = self.pending_proposal.get(&view) else {
+            return;
+        };
+        if !self.stored_actions.contains(&(view, ActionKind::Propose))
+            || !self.is_proposal_stored(view, &proposal_commitment(&message.data))
+        {
+            return;
+        }
+        let message = self.pending_proposal.remove(&view).expect("checked above");
+        outbox.push_back(ConsensusOutput::SendProposal(message));
+    }
+
+    fn is_proposal_stored(&self, view: ViewNumber, commitment: &Commitment<Leaf2<T>>) -> bool {
+        self.stored_proposals
+            .get(&view)
+            .is_some_and(|commitments| commitments.contains(commitment))
+    }
+
+    fn request_action(
+        &mut self,
+        view: ViewNumber,
+        epoch: Option<EpochNumber>,
+        kind: ActionKind,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) {
+        if self.requested_actions.insert((view, kind)) {
+            outbox.push_back(ConsensusOutput::RecordAction(view, epoch, kind));
+        }
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1699,8 +1822,15 @@ impl<T: NodeType> Consensus<T> {
             vid_share: vid_share.clone(),
             state_vote,
         };
-        outbox.push_back(ConsensusOutput::SendVote1(vote));
         self.voted_1_views.insert(view);
+        if self.stored_actions.contains(&(view, ActionKind::Vote))
+            && self.is_proposal_stored(view, &proposal_commit)
+        {
+            outbox.push_back(ConsensusOutput::SendVote1(vote));
+        } else {
+            self.request_action(view, Some(epoch), ActionKind::Vote, outbox);
+            self.pending_vote1.insert(view, vote);
+        }
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1793,8 +1923,15 @@ impl<T: NodeType> Consensus<T> {
                 return;
             },
         };
-        outbox.push_back(ConsensusOutput::SendVote2(vote));
         self.voted_2_views.insert(view);
+        if self.stored_actions.contains(&(view, ActionKind::Vote))
+            && self.stored_vids.contains(&view)
+        {
+            outbox.push_back(ConsensusOutput::SendVote2(vote));
+        } else {
+            self.request_action(view, Some(proposal_epoch), ActionKind::Vote, outbox);
+            self.pending_vote2.insert(view, vote);
+        }
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -2098,6 +2235,7 @@ impl<T: NodeType> ConsensusInput<T> {
             ConsensusInput::ProposalWithVidShare(_, prop, _) => prop.view_number(),
             ConsensusInput::StateValidated(response) => response.view,
             ConsensusInput::StateValidationFailed(request) => request.view,
+            ConsensusInput::Stored(stored) => stored.view_number(),
             ConsensusInput::Timeout(view, _) => *view,
             ConsensusInput::TimeoutOneHonest(view, _) => *view,
             ConsensusInput::TimeoutCertificate(cert) => {

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -117,11 +117,7 @@ pub enum ConsensusOutput<T: NodeType> {
     RequestBlockAndHeader(BlockAndHeaderRequest<T>),
     RequestState(StateRequest<T>),
     RequestDrbResult(EpochNumber),
-    /// Durably record that this node acted (voted or proposed) in a view.
-    /// The corresponding send is held in a pending map until the matching
-    /// `ConsensusInput::Stored` confirmation arrives.
     RecordAction(ViewNumber, Option<EpochNumber>, ActionKind),
-    /// Durably store this node's own proposal before it is broadcast.
     PersistProposal(SignedProposal<T, Proposal<T>>),
     SendProposal(SignedProposal<T, Proposal<T>>),
     SendVidShares(Vec<VidShareMessage<T>>),

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -696,6 +696,18 @@ impl<T: NodeType> Consensus<T> {
         self.current_epoch = Some(epoch);
     }
 
+    /// Forward-only jump used on restart. Raising `timeout_view` keeps the
+    /// node from voting in views it may already have acted in before it
+    /// went down.
+    pub fn skip_to_view(&mut self, view: ViewNumber) {
+        if view > self.timeout_view {
+            self.timeout_view = view;
+        }
+        if view > self.current_view {
+            self.current_view = view;
+        }
+    }
+
     pub fn wants_proposal_for_view(&self, view: &ViewNumber) -> bool {
         let locked_too_new = self
             .locked_cert

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -696,15 +696,28 @@ impl<T: NodeType> Consensus<T> {
         self.current_epoch = Some(epoch);
     }
 
-    /// Forward-only jump used on restart. Raising `timeout_view` keeps the
-    /// node from voting in views it may already have acted in before it
-    /// went down.
-    pub fn skip_to_view(&mut self, view: ViewNumber) {
-        if view > self.timeout_view {
-            self.timeout_view = view;
+    /// Position the view state on restart at the first view this node may
+    /// act in: past the decided anchor, no earlier than the view it was in
+    /// at shutdown, and past any view it recorded an action for. Raising
+    /// `timeout_view` bars voting and proposing in everything earlier.
+    ///
+    /// `current_view` lands one view before the first allowed view because
+    /// `Coordinator::start` enters `current_view + 1` through the normal
+    /// `ViewChanged` path, which arms the timer and kicks off the leader's
+    /// block request. Forward-only: never regresses either view.
+    pub fn resume_from_restart(
+        &mut self,
+        anchor_view: ViewNumber,
+        restart_view: ViewNumber,
+        last_actioned_view: ViewNumber,
+    ) {
+        let first_allowed = max(anchor_view + 1, max(restart_view, last_actioned_view + 1));
+        let last_barred = first_allowed - 1;
+        if last_barred > self.timeout_view {
+            self.timeout_view = last_barred;
         }
-        if view > self.current_view {
-            self.current_view = view;
+        if last_barred > self.current_view {
+            self.current_view = last_barred;
         }
     }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -3,6 +3,7 @@ mod metrics;
 pub mod timer;
 
 use std::{
+    cmp::max,
     collections::{BTreeMap, HashMap},
     sync::Arc,
     time::Duration,
@@ -186,6 +187,13 @@ where
                 });
         consensus.seed_parent(cert1, parent_proposal, reconstructed_blocks);
         consensus.set_view(anchor_view, anchor_epoch);
+        // Never re-enter a view this node may have voted or proposed in
+        // before it went down.
+        let start_view = max(
+            anchor_view + 1,
+            max(initializer.start_view, initializer.last_actioned_view + 1),
+        );
+        consensus.skip_to_view(start_view - 1);
         if let Some(state_cert) = initializer.state_cert.clone() {
             consensus.seed_state_cert(state_cert);
         }
@@ -294,19 +302,19 @@ where
         if let Some(leader) = self.leader(next_view, epoch)
             && leader == self.public_key
         {
-            let parent_proposal = self
-                .consensus
-                .proposal_at(cur_view)
-                .expect("parent proposal must be seeded before start()")
-                .clone();
-            self.outbox
-                .push_back(ConsensusOutput::RequestBlockAndHeader(
-                    BlockAndHeaderRequest {
-                        view: next_view,
-                        epoch,
-                        parent_proposal,
-                    },
-                ));
+            // No parent proposal when restarting past the anchor view: the
+            // node cannot propose off the anchor for a later view; the
+            // timeout path takes over instead.
+            if let Some(parent_proposal) = self.consensus.proposal_at(cur_view).cloned() {
+                self.outbox
+                    .push_back(ConsensusOutput::RequestBlockAndHeader(
+                        BlockAndHeaderRequest {
+                            view: next_view,
+                            epoch,
+                            parent_proposal,
+                        },
+                    ));
+            }
         }
     }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -3,7 +3,6 @@ mod metrics;
 pub mod timer;
 
 use std::{
-    cmp::max,
     collections::{BTreeMap, HashMap},
     sync::Arc,
     time::Duration,
@@ -185,15 +184,16 @@ where
                     VidCommitment::V2(commitment) => Some((view, commitment)),
                     _ => None,
                 });
+        // `seed_parent` sets the current epoch from the anchor proposal;
+        // `resume_from_restart` positions the view so the node never
+        // re-enters a view it may have voted or proposed in before it went
+        // down.
         consensus.seed_parent(cert1, parent_proposal, reconstructed_blocks);
-        consensus.set_view(anchor_view, anchor_epoch);
-        // Never re-enter a view this node may have voted or proposed in
-        // before it went down.
-        let start_view = max(
-            anchor_view + 1,
-            max(initializer.start_view, initializer.last_actioned_view + 1),
+        consensus.resume_from_restart(
+            anchor_view,
+            initializer.start_view,
+            initializer.last_actioned_view,
         );
-        consensus.skip_to_view(start_view - 1);
         if let Some(state_cert) = initializer.state_cert.clone() {
             consensus.seed_state_cert(state_cert);
         }

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -512,6 +512,10 @@ where
                         return Err(CoordinatorError::unspecified().context("vid reconstruction"))
                     }
                 },
+                Some(stored) = self.storage.next() => {
+                    finish_measurement(next_input);
+                    return Ok(ConsensusInput::Stored(stored))
+                },
                 Some(result) = self.epoch_manager.next() => match result {
                     Ok(EpochRootResult::DrbResult(epoch, drb_result)) => {
                         finish_measurement(next_input);
@@ -638,11 +642,13 @@ where
                 );
                 self.block_builder.request_block(request);
             },
-            ConsensusOutput::SendProposal(proposal) => {
+            ConsensusOutput::RecordAction(view, epoch, kind) => {
+                debug!(%node, %view, ?kind, "record action");
+                self.storage.record_action(view, epoch, kind);
+            },
+            ConsensusOutput::PersistProposal(proposal) => {
                 let view = proposal.data.view_number;
-                let epoch = proposal.data.epoch;
-                let block = proposal.data.block_header.block_number();
-                info!(%node, %view, %epoch, %block, "send proposal");
+                debug!(%node, %view, "persist proposal");
                 self.storage.append_proposal(proposal.data.clone());
                 // Two blocks can be built for one view. Here we know which one
                 // wins and we persist just that one:
@@ -659,9 +665,12 @@ where
                         warn!(%node, %view, "no payload for proposed block");
                     }
                 }
-                // TODO: This may be done async in network so we do not spend
-                // too much time here in this loop.
-
+            },
+            ConsensusOutput::SendProposal(proposal) => {
+                let view = proposal.data.view_number;
+                let epoch = proposal.data.epoch;
+                let block = proposal.data.block_header.block_number();
+                info!(%node, %view, %epoch, %block, "send proposal");
                 let message = Message {
                     sender: self.public_key.clone(),
                     message_type: MessageType::Consensus(ConsensusMessage::Proposal(

--- a/crates/hotshot/new-protocol/src/storage.rs
+++ b/crates/hotshot/new-protocol/src/storage.rs
@@ -1,22 +1,30 @@
 use std::{collections::BTreeMap, marker::PhantomData, time::Duration};
 
 use async_trait::async_trait;
+use committable::Commitment;
 use hotshot::{traits::BlockPayload, types::SignatureKey};
 use hotshot_example_types::storage_types::TestStorage;
 use hotshot_types::{
     data::{
-        DaProposal2, EpochNumber, QuorumProposal2, QuorumProposalWrapper, VidCommitment,
+        DaProposal2, EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, VidCommitment,
         VidDisperseShare, VidDisperseShare2, ViewChangeEvidence2, ViewNumber,
     },
+    event::HotShotAction,
     message::Proposal as SignedProposal,
     simple_certificate::LightClientStateUpdateCertificateV2,
     traits::{EncodeBytes, node_implementation::NodeType, storage::Storage as StorageTrait},
     utils::EpochTransitionIndicator,
 };
-use tokio::{spawn, task::JoinHandle, time::sleep};
+use tokio::{
+    task::{AbortHandle, JoinSet},
+    time::sleep,
+};
 use tracing::{error, warn};
 
-use crate::message::{Certificate2, Proposal};
+use crate::{
+    helpers::proposal_commitment,
+    message::{Certificate2, Proposal},
+};
 
 const RETRY_DELAY: Duration = Duration::from_millis(300);
 
@@ -26,10 +34,41 @@ pub trait NewProtocolStorage<T: NodeType>: StorageTrait<T> {
     async fn append_cert2(&self, view: ViewNumber, cert: Certificate2<T>) -> anyhow::Result<()>;
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ActionKind {
+    Vote,
+    Propose,
+}
+
+impl From<ActionKind> for HotShotAction {
+    fn from(kind: ActionKind) -> Self {
+        match kind {
+            ActionKind::Vote => HotShotAction::Vote,
+            ActionKind::Propose => HotShotAction::Propose,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StorageOutput<T: NodeType> {
+    Proposal(ViewNumber, Commitment<Leaf2<T>>),
+    Vid(ViewNumber),
+    Action(ViewNumber, ActionKind),
+}
+
+impl<T: NodeType> StorageOutput<T> {
+    pub fn view_number(&self) -> ViewNumber {
+        match self {
+            Self::Proposal(view, _) | Self::Vid(view) | Self::Action(view, _) => *view,
+        }
+    }
+}
+
 pub struct Storage<T: NodeType, S> {
     storage: S,
     private_key: <T::SignatureKey as SignatureKey>::PrivateKey,
-    handles: BTreeMap<ViewNumber, Vec<JoinHandle<()>>>,
+    tasks: JoinSet<Option<StorageOutput<T>>>,
+    handles: BTreeMap<ViewNumber, Vec<AbortHandle>>,
 }
 
 impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
@@ -37,6 +76,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
         Self {
             storage,
             private_key,
+            tasks: JoinSet::new(),
             handles: BTreeMap::new(),
         }
     }
@@ -45,15 +85,15 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
         let view = vid_share.view_number;
         let storage = self.storage.clone();
         let private_key = self.private_key.clone();
-        let handle = spawn(async move {
+        let handle = self.tasks.spawn(async move {
             let share: VidDisperseShare<T> = VidDisperseShare::V2(vid_share);
             let Some(proposal) = share.to_proposal(&private_key) else {
                 error!("failed to sign VID share for storage");
-                return;
+                return None;
             };
             loop {
                 match storage.append_vid(&proposal).await {
-                    Ok(()) => return,
+                    Ok(()) => return Some(StorageOutput::Vid(view)),
                     Err(err) => {
                         warn!(%err, "failed to append VID share, retrying");
                         sleep(RETRY_DELAY).await;
@@ -74,7 +114,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
     ) {
         let storage = self.storage.clone();
         let private_key = self.private_key.clone();
-        let handle = spawn(async move {
+        let handle = self.tasks.spawn(async move {
             let data = DaProposal2 {
                 encoded_transactions: block_payload.encode(),
                 metadata,
@@ -84,7 +124,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
             };
             let Ok(signature) = T::SignatureKey::sign(&private_key, &[]) else {
                 error!("failed to sign DA proposal for storage");
-                return;
+                return None;
             };
             let proposal = SignedProposal {
                 data,
@@ -93,7 +133,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
             };
             loop {
                 match storage.append_da2(&proposal, vid_commit).await {
-                    Ok(()) => return,
+                    Ok(()) => return None,
                     Err(err) => {
                         warn!(%err, "failed to append DA proposal, retrying");
                         sleep(RETRY_DELAY).await;
@@ -106,10 +146,10 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
 
     pub fn append_cert2(&mut self, view: ViewNumber, cert2: Certificate2<T>) {
         let storage = self.storage.clone();
-        let handle = spawn(async move {
+        let handle = self.tasks.spawn(async move {
             loop {
                 match storage.append_cert2(view, cert2.clone()).await {
-                    Ok(()) => return,
+                    Ok(()) => return None,
                     Err(err) => {
                         warn!(%err, %view, "failed to append cert2, retrying");
                         sleep(RETRY_DELAY).await;
@@ -126,10 +166,10 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
         state_cert: LightClientStateUpdateCertificateV2<T>,
     ) {
         let storage = self.storage.clone();
-        let handle = spawn(async move {
+        let handle = self.tasks.spawn(async move {
             loop {
                 match storage.update_state_cert(state_cert.clone()).await {
-                    Ok(()) => return,
+                    Ok(()) => return None,
                     Err(err) => {
                         warn!(%err, epoch = %state_cert.epoch, "failed to append state cert, retrying");
                         sleep(RETRY_DELAY).await;
@@ -142,9 +182,10 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
 
     pub fn append_proposal(&mut self, proposal: Proposal<T>) {
         let view = proposal.view_number;
+        let commitment = proposal_commitment(&proposal);
         let storage = self.storage.clone();
         let private_key = self.private_key.clone();
-        let handle = spawn(async move {
+        let handle = self.tasks.spawn(async move {
             let data = QuorumProposalWrapper {
                 proposal: QuorumProposal2 {
                     block_header: proposal.block_header,
@@ -162,7 +203,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
             };
             let Ok(signature) = T::SignatureKey::sign(&private_key, &[]) else {
                 error!("failed to sign quorum proposal for storage");
-                return;
+                return None;
             };
             let signed = SignedProposal {
                 data,
@@ -171,7 +212,7 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
             };
             loop {
                 match storage.append_proposal_wrapper(&signed).await {
-                    Ok(()) => return,
+                    Ok(()) => return Some(StorageOutput::Proposal(view, commitment)),
                     Err(err) => {
                         warn!(%err, "failed to append proposal, retrying");
                         sleep(RETRY_DELAY).await;
@@ -180,6 +221,36 @@ impl<T: NodeType, S: NewProtocolStorage<T>> Storage<T, S> {
             }
         });
         self.handles.entry(view).or_default().push(handle);
+    }
+
+    pub fn record_action(
+        &mut self,
+        view: ViewNumber,
+        epoch: Option<EpochNumber>,
+        kind: ActionKind,
+    ) {
+        let storage = self.storage.clone();
+        let handle = self.tasks.spawn(async move {
+            loop {
+                match storage.record_action(view, epoch, kind.into()).await {
+                    Ok(()) => return Some(StorageOutput::Action(view, kind)),
+                    Err(err) => {
+                        warn!(%err, %view, ?kind, "failed to record action, retrying");
+                        sleep(RETRY_DELAY).await;
+                    },
+                }
+            }
+        });
+        self.handles.entry(view).or_default().push(handle);
+    }
+
+    pub async fn next(&mut self) -> Option<StorageOutput<T>> {
+        loop {
+            match self.tasks.join_next().await? {
+                Ok(Some(output)) => return Some(output),
+                Ok(None) | Err(_) => continue,
+            }
+        }
     }
 
     pub fn gc(&mut self, view_number: ViewNumber) {

--- a/crates/hotshot/new-protocol/src/tests.rs
+++ b/crates/hotshot/new-protocol/src/tests.rs
@@ -10,4 +10,5 @@ mod integration;
 mod legacy_cutover;
 mod restarts;
 mod state;
+mod storage;
 mod vid;

--- a/crates/hotshot/new-protocol/src/tests/common/assertions.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/assertions.rs
@@ -38,6 +38,14 @@ pub(crate) fn is_request_block_and_header(output: &ConsensusOutput<TestTypes>) -
     matches!(output, ConsensusOutput::RequestBlockAndHeader(_))
 }
 
+pub(crate) fn is_record_action(output: &ConsensusOutput<TestTypes>) -> bool {
+    matches!(output, ConsensusOutput::RecordAction(..))
+}
+
+pub(crate) fn is_persist_proposal(output: &ConsensusOutput<TestTypes>) -> bool {
+    matches!(output, ConsensusOutput::PersistProposal(_))
+}
+
 pub(crate) fn is_request_vid_disperse(output: &ConsensusOutput<TestTypes>) -> bool {
     matches!(output, ConsensusOutput::RequestVidDisperse { .. })
 }

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -131,7 +131,7 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
     // Restarted nodes must not act again in views they acted in before.
     let restart_view = storage.restart_view().await;
     let last_actioned_view = storage.last_actioned_view().await;
-    consensus.skip_to_view(std::cmp::max(restart_view, last_actioned_view + 1) - 1);
+    consensus.resume_from_restart(ViewNumber::genesis(), restart_view, last_actioned_view);
 
     let genesis_wrapper = QuorumProposalWrapper::<TestTypes> {
         proposal: QuorumProposal2 {

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -128,6 +128,11 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
         consensus.apply_pre_cutover_seed(seed);
     }
 
+    // Restarted nodes must not act again in views they acted in before.
+    let restart_view = storage.restart_view().await;
+    let last_actioned_view = storage.last_actioned_view().await;
+    consensus.skip_to_view(std::cmp::max(restart_view, last_actioned_view + 1) - 1);
+
     let genesis_wrapper = QuorumProposalWrapper::<TestTypes> {
         proposal: QuorumProposal2 {
             block_header: genesis_leaf.block_header().clone(),

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -8,12 +8,15 @@ use hotshot_example_types::{
     storage_types::TestStorage,
 };
 use hotshot_types::{
-    data::{EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, ViewNumber},
+    data::{
+        EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, VidCommitment,
+        ViewChangeEvidence2, ViewNumber,
+    },
     epoch_membership::EpochMembershipCoordinator,
     light_client::StateKeyPair,
     message::Proposal as SignedProposal,
     simple_vote::QuorumData2,
-    traits::{signature_key::SignatureKey, storage::Storage as _},
+    traits::{block_contents::BlockHeader, signature_key::SignatureKey, storage::Storage as _},
 };
 
 use crate::{
@@ -63,6 +66,16 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
     let genesis_leaf =
         Leaf2::<TestTypes>::genesis(&genesis_state, &instance, TEST_VERSIONS.test.base).await;
 
+    // A node restarting with persistent storage resumes from its persisted
+    // decided anchor (mirroring production's `Coordinator::maker`, which
+    // gets the anchor from the `HotShotInitializer`); otherwise it starts
+    // from genesis.
+    let restart_anchor = storage.anchor_leaf().await;
+    let initial_leaf = restart_anchor
+        .as_ref()
+        .map(|(leaf, _)| leaf.clone())
+        .unwrap_or_else(|| genesis_leaf.clone());
+
     let mut consensus = Consensus::new(
         membership.clone(),
         public_key,
@@ -70,7 +83,7 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
         state_private_key,
         10,
         upgrade_lock.clone(),
-        genesis_leaf.clone(),
+        initial_leaf,
         epoch_height,
     );
 
@@ -108,21 +121,74 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
     // Build a genesis cert1 and proposal so consensus can self-start.
     let genesis_cert1 = build_genesis_cert1(&genesis_leaf);
     let genesis_proposal = build_genesis_proposal(&genesis_leaf, &genesis_cert1);
-    // The synthetic genesis proposal carries the genesis cert1 as its
-    // justify_qc, so the leaf derived from it has a different commitment than
-    // `genesis_leaf` (which has a null justify_qc). `request_header` for view 1
-    // looks up the parent state by the proposal's leaf commitment, so seed the
-    // genesis state under that commitment too.
-    state_manager.seed_state(
-        ViewNumber::genesis(),
-        genesis_state,
-        Leaf2::from(genesis_proposal.clone()),
-    );
-    consensus.seed_parent(
-        genesis_cert1.clone(),
-        genesis_proposal.clone(),
-        std::iter::empty(),
-    );
+
+    let anchor_view = if let Some((anchor_leaf, anchor_cert)) = restart_anchor {
+        // Seed the persisted anchor as the parent, exactly as production's
+        // `Coordinator::maker` does from the initializer: rebuild the parent
+        // proposal from the anchor leaf, seed a sparse state for it, and
+        // treat the anchor plus persisted proposals as already-reconstructed
+        // blocks so the first leader after restart is not stalled by the
+        // `parent_block_reconstructed` check.
+        let anchor_view = anchor_leaf.view_number();
+        let anchor_proposal = Proposal {
+            block_header: anchor_leaf.block_header().clone(),
+            view_number: anchor_view,
+            epoch: anchor_leaf
+                .epoch(epoch_height)
+                .unwrap_or(EpochNumber::genesis()),
+            justify_qc: anchor_leaf.justify_qc(),
+            next_epoch_justify_qc: None,
+            upgrade_certificate: anchor_leaf.upgrade_certificate(),
+            view_change_evidence: anchor_leaf
+                .view_change_evidence
+                .clone()
+                .and_then(|e| match e {
+                    ViewChangeEvidence2::Timeout(tc) => Some(tc),
+                    ViewChangeEvidence2::ViewSync(_) => None,
+                }),
+            next_drb_result: anchor_leaf.next_drb_result,
+            state_cert: None,
+        };
+        let anchor_state = <TestValidatedState as hotshot_types::traits::states::ValidatedState<
+            TestTypes,
+        >>::from_header(anchor_leaf.block_header());
+        state_manager.seed_state(anchor_view, Arc::new(anchor_state), anchor_leaf.clone());
+        let reconstructed: Vec<_> =
+            std::iter::once((anchor_view, anchor_leaf.block_header().clone()))
+                .chain(
+                    storage
+                        .proposals_cloned()
+                        .await
+                        .into_iter()
+                        .map(|(view, p)| (view, p.data.block_header().clone())),
+                )
+                .filter_map(|(view, header)| {
+                    match BlockHeader::<TestTypes>::payload_commitment(&header) {
+                        VidCommitment::V2(commitment) => Some((view, commitment)),
+                        _ => None,
+                    }
+                })
+                .collect();
+        consensus.seed_parent(anchor_cert, anchor_proposal, reconstructed);
+        anchor_view
+    } else {
+        // The synthetic genesis proposal carries the genesis cert1 as its
+        // justify_qc, so the leaf derived from it has a different commitment than
+        // `genesis_leaf` (which has a null justify_qc). `request_header` for view 1
+        // looks up the parent state by the proposal's leaf commitment, so seed the
+        // genesis state under that commitment too.
+        state_manager.seed_state(
+            ViewNumber::genesis(),
+            genesis_state,
+            Leaf2::from(genesis_proposal.clone()),
+        );
+        consensus.seed_parent(
+            genesis_cert1.clone(),
+            genesis_proposal.clone(),
+            std::iter::empty(),
+        );
+        ViewNumber::genesis()
+    };
 
     if let Some(seed) = pre_cutover_seed {
         consensus.apply_pre_cutover_seed(seed);
@@ -131,7 +197,14 @@ pub async fn build_test_coordinator<N: Network<TestTypes>>(
     // Restarted nodes must not act again in views they acted in before.
     let restart_view = storage.restart_view().await;
     let last_actioned_view = storage.last_actioned_view().await;
-    consensus.resume_from_restart(ViewNumber::genesis(), restart_view, last_actioned_view);
+    consensus.resume_from_restart(anchor_view, restart_view, last_actioned_view);
+
+    // A leader proposing on an epoch-root parent QC right after restart
+    // needs the persisted light-client state cert (as in production, where
+    // it arrives via `HotShotInitializer::state_cert`).
+    if let Some(state_cert) = storage.state_cert_cloned().await {
+        consensus.seed_state_cert(state_cert);
+    }
 
     let genesis_wrapper = QuorumProposalWrapper::<TestTypes> {
         proposal: QuorumProposal2 {

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -211,6 +211,25 @@ impl TestHarness {
         inputs
     }
 
+    /// Process events from the coordinator until the collected outputs
+    /// satisfy `predicate`. Use for outputs that are gated on storage
+    /// confirmations (votes, proposals) and thus need extra loop turns
+    /// after their triggering input has been observed.
+    pub async fn process_until_output<P>(&mut self, pred: P)
+    where
+        P: Fn(&Outbox<ConsensusOutput<TestTypes>>) -> bool,
+    {
+        while !pred(&self.outputs) {
+            match self.coordinator.next_consensus_input().await {
+                Ok(input) => self.apply_and_process(input).await,
+                Err(err) if err.severity == Severity::Critical => {
+                    panic!("Critical coordinator error: {err}")
+                },
+                Err(_err) => {},
+            }
+        }
+    }
+
     pub fn outputs(&self) -> &Outbox<ConsensusOutput<TestTypes>> {
         &self.outputs
     }

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -92,6 +92,22 @@ pub struct TestRunner {
     #[builder(default)]
     expected_failed_views: BTreeSet<ViewNumber>,
 
+    /// Views excluded from correctness verification entirely.  Used by
+    /// full-restart tests where whether a view in the crash/recovery window
+    /// decides or times out is nondeterministic.
+    #[builder(default)]
+    tolerated_failed_views: BTreeSet<ViewNumber>,
+
+    /// Reuse each node's `TestStorage` across `NodeAction::Restart` instead
+    /// of starting from blank storage.
+    #[builder(default)]
+    persistent_storage: bool,
+
+    /// Per-node storage, created at the start of `run()`.  Exposed so tests
+    /// can inspect persisted state (e.g. the action log) after a run.
+    #[builder(skip)]
+    node_storages: Vec<TestStorage<TestTypes>>,
+
     /// Node indices that are offline for the entire test.  Down nodes do
     /// not run a coordinator.  Views where a down node is leader are
     /// expected to timeout.
@@ -222,9 +238,16 @@ impl TestRunner {
         result
     }
 
+    pub fn node_storages(&self) -> &[TestStorage<TestTypes>] {
+        &self.node_storages
+    }
+
     pub async fn run(&mut self) -> Result<(), TestError> {
         crate::logging::init_test_logging();
 
+        self.node_storages = (0..self.num_nodes)
+            .map(|_| TestStorage::default())
+            .collect();
         let initially_down = self.initially_down_nodes();
         let mut node_handles: Vec<Option<JoinHandle<()>>> = Vec::with_capacity(self.num_nodes);
         let mut generations: Vec<u64> = vec![0; self.num_nodes];
@@ -251,8 +274,12 @@ impl TestRunner {
         for (i, (_, public_key, _)) in parties.iter().enumerate() {
             let network = create_network(i, &parties, &self.upgrade_lock).await;
 
-            let (membership, storage, client, external_events_tx) =
-                mock_membership_with_client(self.num_nodes, self.epoch_height, *public_key);
+            let (membership, storage, client, external_events_tx) = mock_membership_with_client(
+                self.num_nodes,
+                self.epoch_height,
+                *public_key,
+                self.node_storages[i].clone(),
+            );
 
             let coord = build_test_coordinator(
                 i as u64,
@@ -370,12 +397,16 @@ impl TestRunner {
                                 // Create a fresh coordinator from genesis.
                                 let net =
                                     create_network(change.idx, &parties, &self.upgrade_lock).await;
+                                if !self.persistent_storage {
+                                    self.node_storages[change.idx] = TestStorage::default();
+                                }
                                 let (membership, storage, client, external_events_tx) = {
                                     let k = parties[change.idx].1;
                                     mock_membership_with_client(
                                         self.num_nodes,
                                         self.epoch_height,
                                         k,
+                                        self.node_storages[change.idx].clone(),
                                     )
                                 };
                                 let coord = build_test_coordinator(
@@ -456,6 +487,7 @@ impl TestRunner {
             &node_commits,
             &node_timeouts,
             &all_expected_failures,
+            &self.tolerated_failed_views,
             self.target_decisions,
             &currently_down,
         )
@@ -469,6 +501,7 @@ impl TestRunner {
         node_commits: &[BTreeMap<ViewNumber, [u8; 32]>],
         node_timeouts: &[BTreeSet<ViewNumber>],
         expected_failed_views: &BTreeSet<ViewNumber>,
+        tolerated_failed_views: &BTreeSet<ViewNumber>,
         target_decisions: usize,
         down_nodes: &BTreeSet<usize>,
     ) -> Result<(), TestError> {
@@ -479,6 +512,9 @@ impl TestRunner {
         let last_view = expected_failed_views.len() + target_decisions;
         for v in 1..=last_view {
             let view = ViewNumber::new(v.try_into().unwrap());
+            if tolerated_failed_views.contains(&view) {
+                continue;
+            }
             if expected_failed_views.contains(&view) {
                 let mut timeout_count = 0;
                 for (i, commits) in node_commits.iter().enumerate() {

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -52,8 +52,10 @@ pub struct NodeChange {
 /// Actions that can be applied to a node during a test.
 #[derive(Clone, Debug)]
 pub enum NodeAction {
-    /// Restart: shut down the node and create a fresh coordinator from
-    /// genesis (blank state).
+    /// Restart: shut down the node and create a fresh coordinator. With
+    /// `persistent_storage` the node resumes from its persisted decided
+    /// anchor and action records; otherwise it starts from genesis
+    /// (blank state).
     Restart,
     /// Start: bring a node that was initially offline into the network
     /// with a fresh coordinator from genesis.
@@ -314,6 +316,7 @@ impl TestRunner {
                 }
                 Some(tokio::spawn(run_node(
                     coord,
+                    self.node_storages[i].clone(),
                     tx,
                     i,
                     generation,
@@ -394,7 +397,9 @@ impl TestRunner {
                                     handle.abort();
                                     let _ = handle.await;
                                 }
-                                // Create a fresh coordinator from genesis.
+                                // Create a fresh coordinator; it resumes
+                                // from the persisted anchor when storage is
+                                // persistent, from genesis otherwise.
                                 let net =
                                     create_network(change.idx, &parties, &self.upgrade_lock).await;
                                 if !self.persistent_storage {
@@ -432,6 +437,7 @@ impl TestRunner {
                                 let initial_commits = BTreeMap::new();
                                 node_handles[change.idx] = Some(tokio::spawn(run_node(
                                     coord,
+                                    self.node_storages[change.idx].clone(),
                                     tx,
                                     change.idx,
                                     generation,
@@ -607,8 +613,10 @@ async fn create_network(
         .unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_node<N: Network<TestTypes>>(
     mut coord: Coordinator<TestTypes, N, TestStorage<TestTypes>>,
+    storage: TestStorage<TestTypes>,
     output_tx: UnboundedSender<TaggedEvent>,
     idx: usize,
     generation: u64,
@@ -643,7 +651,16 @@ async fn run_node<N: Network<TestTypes>>(
         }
 
         while let Some(output) = coord.outbox_mut().pop_front() {
-            if let ConsensusOutput::LeafDecided { leaves, .. } = &output {
+            if let ConsensusOutput::LeafDecided { leaves, cert1, .. } = &output {
+                // Persist the decided anchor the way the application's
+                // persistence layer does in production: the newest decided
+                // leaf and the QC certifying it. A node restarted with
+                // persistent storage resumes consensus from this anchor.
+                if let Some(newest) = leaves.first() {
+                    storage
+                        .update_anchor_leaf(newest.clone(), cert1.clone())
+                        .await;
+                }
                 for leaf in leaves {
                     let commit: [u8; 32] = leaf.commit().into();
                     let view = leaf.view_number();

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -59,6 +59,7 @@ use crate::{
     },
     outbox::Outbox,
     state::StateResponse,
+    storage::StorageOutput,
 };
 
 /// DRB result used by `TestData` for epoch transition proposals.
@@ -889,6 +890,20 @@ impl ConsensusHarness {
     /// actions that consensus expects feedback for.
     pub async fn apply(&mut self, input: ConsensusInput<TestTypes>) {
         let mut outbox = Outbox::new();
+        // The coordinator persists incoming proposals and VID shares before
+        // consensus sees them; simulate those storage confirmations.
+        if let ConsensusInput::ProposalWithVidShare(_, msg, vid_share) = &input {
+            let view = msg.proposal.data.view_number;
+            let commitment = proposal_commitment(&msg.proposal.data);
+            self.consensus.apply(
+                ConsensusInput::Stored(StorageOutput::Proposal(view, commitment)),
+                &mut outbox,
+            );
+            self.consensus.apply(
+                ConsensusInput::Stored(StorageOutput::Vid(vid_share.view_number)),
+                &mut outbox,
+            );
+        }
         self.consensus.apply(input, &mut outbox);
         self.drain_outbox(&mut outbox).await;
     }
@@ -909,6 +924,20 @@ impl ConsensusHarness {
             ConsensusOutput::RequestState(req) => {
                 let input = state_verified_input(&req.proposal, req.view);
                 self.consensus.apply(input, outbox);
+            },
+            ConsensusOutput::RecordAction(view, _, kind) => {
+                self.consensus.apply(
+                    ConsensusInput::Stored(StorageOutput::Action(*view, *kind)),
+                    outbox,
+                );
+            },
+            ConsensusOutput::PersistProposal(proposal) => {
+                let view = proposal.data.view_number;
+                let commitment = proposal_commitment(&proposal.data);
+                self.consensus.apply(
+                    ConsensusInput::Stored(StorageOutput::Proposal(view, commitment)),
+                    outbox,
+                );
             },
             ConsensusOutput::RequestBlockAndHeader(req) => {
                 let mock_block = MockBlock::new();

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -575,7 +575,7 @@ pub fn mock_membership_with_num_nodes(
     CoordinatorClient<TestTypes>,
 ) {
     let (coord, storage, client, _external_events_tx) =
-        mock_membership_with_client(num_nodes, epoch_height, public_key);
+        mock_membership_with_client(num_nodes, epoch_height, public_key, TestStorage::default());
     (coord, storage, client)
 }
 
@@ -583,6 +583,7 @@ pub fn mock_membership_with_client(
     num_nodes: usize,
     epoch_height: u64,
     public_key: BLSPubKey,
+    storage: TestStorage<TestTypes>,
 ) -> (
     EpochMembershipCoordinator<TestTypes>,
     TestStorage<TestTypes>,
@@ -596,6 +597,7 @@ pub fn mock_membership_with_client(
         epoch_height,
         leaf_fetcher_network,
         public_key,
+        storage,
     );
     (coord, storage, client, external_events_tx)
 }
@@ -607,6 +609,7 @@ pub fn mock_membership_with_leaf_fetcher_network(
         dyn hotshot_types::traits::leaf_fetcher_network::LeafFetcherNetwork<TestTypes>,
     >,
     public_key: BLSPubKey,
+    storage: TestStorage<TestTypes>,
 ) -> (
     EpochMembershipCoordinator<TestTypes>,
     TestStorage<TestTypes>,
@@ -618,7 +621,6 @@ pub fn mock_membership_with_leaf_fetcher_network(
         &TestNodeStakes::default(),
     )
     .0;
-    let storage = TestStorage::<TestTypes>::default();
     let membership = StrictMembership::<TestTypes, StaticStakeTable<BLSPubKey, SchnorrPubKey>>::new(
         members.clone(),
         members.clone(),

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -13,18 +13,19 @@ use hotshot_types::{
 
 use super::common::utils::TestData;
 use crate::{
-    consensus::ConsensusInput,
+    consensus::{ConsensusInput, ConsensusOutput},
     helpers::proposal_commitment,
     message::Proposal,
     outbox::Outbox,
     state::StateResponse,
+    storage::{ActionKind, StorageOutput},
     tests::common::{
         assertions::{
-            any, count_matching, is_leaf_decided, is_proposal, is_request_block_and_header,
-            is_request_state, is_send_timeout_cert, is_send_timeout_vote, is_view_changed,
-            is_vote1, is_vote2, node_index_for_key,
+            any, count_matching, is_leaf_decided, is_persist_proposal, is_proposal,
+            is_record_action, is_request_block_and_header, is_request_state, is_send_timeout_cert,
+            is_send_timeout_vote, is_view_changed, is_vote1, is_vote2, node_index_for_key,
         },
-        utils::{ConsensusHarness, MockBlock},
+        utils::{ConsensusHarness, MockBlock, state_verified_input},
     },
 };
 
@@ -894,5 +895,172 @@ async fn test_stale_timeout_certificate_ignored() {
     assert!(
         any(harness.outputs(), is_send_timeout_cert),
         "timeout certificate over the current view must still be forwarded"
+    );
+}
+
+/// Vote1 is held until the Vote action and the proposal are durably stored,
+/// and the action record is requested exactly once.
+#[tokio::test]
+async fn test_vote1_gated_on_storage() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(2).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let view = ViewNumber::new(1);
+    let commit = proposal_commitment(&test_data.views[0].proposal.data);
+    let consensus = &mut harness.consensus;
+    let mut outbox = Outbox::new();
+
+    consensus.apply(
+        test_data.views[0].proposal_input_consensus(&node_key),
+        &mut outbox,
+    );
+    consensus.apply(
+        state_verified_input(&test_data.views[0].proposal.data, view),
+        &mut outbox,
+    );
+
+    assert!(!any(&outbox, is_vote1), "vote1 must wait for storage");
+    assert_eq!(count_matching(&outbox, is_record_action), 1);
+
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Action(view, ActionKind::Vote)),
+        &mut outbox,
+    );
+    assert!(!any(&outbox, is_vote1), "vote1 must wait for the proposal");
+
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Proposal(view, commit)),
+        &mut outbox,
+    );
+    assert_eq!(count_matching(&outbox, is_vote1), 1);
+
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Proposal(view, commit)),
+        &mut outbox,
+    );
+    assert_eq!(
+        count_matching(&outbox, is_vote1),
+        1,
+        "re-delivered confirmations must not double-send"
+    );
+}
+
+/// The lock update and view change fire as soon as cert1 is valid, but
+/// vote2 is held until the node's own VID share is durably stored.  Vote1
+/// and vote2 for the same view share a single action record.
+#[tokio::test]
+async fn test_vote2_gated_on_vid_storage() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(3).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let view = ViewNumber::new(1);
+    let commit = proposal_commitment(&test_data.views[0].proposal.data);
+    let consensus = &mut harness.consensus;
+    let mut outbox = Outbox::new();
+
+    consensus.apply(
+        test_data.views[0].proposal_input_consensus(&node_key),
+        &mut outbox,
+    );
+    consensus.apply(
+        state_verified_input(&test_data.views[0].proposal.data, view),
+        &mut outbox,
+    );
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Action(view, ActionKind::Vote)),
+        &mut outbox,
+    );
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Proposal(view, commit)),
+        &mut outbox,
+    );
+    assert_eq!(count_matching(&outbox, is_vote1), 1);
+
+    consensus.apply(test_data.views[0].block_reconstructed_input(), &mut outbox);
+    consensus.apply(test_data.views[0].cert1_input(), &mut outbox);
+
+    assert!(any(&outbox, is_view_changed), "lock update is not gated");
+    assert!(!any(&outbox, is_vote2), "vote2 must wait for the VID share");
+
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Vid(view)),
+        &mut outbox,
+    );
+    assert_eq!(count_matching(&outbox, is_vote2), 1);
+    assert_eq!(
+        count_matching(&outbox, is_record_action),
+        1,
+        "vote1 and vote2 share one action record per view"
+    );
+}
+
+/// A pending vote1 is dropped if its view times out before the storage
+/// confirmations arrive.
+#[tokio::test]
+async fn test_pending_vote1_dropped_on_timeout() {
+    let mut harness = ConsensusHarness::new(0).await;
+    let test_data = TestData::new(2).await;
+    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+    let view = ViewNumber::new(1);
+    let commit = proposal_commitment(&test_data.views[0].proposal.data);
+    let consensus = &mut harness.consensus;
+    let mut outbox = Outbox::new();
+
+    consensus.apply(
+        test_data.views[0].proposal_input_consensus(&node_key),
+        &mut outbox,
+    );
+    consensus.apply(
+        state_verified_input(&test_data.views[0].proposal.data, view),
+        &mut outbox,
+    );
+    assert_eq!(count_matching(&outbox, is_record_action), 1);
+
+    consensus.apply(
+        ConsensusInput::Timeout(view, EpochNumber::genesis()),
+        &mut outbox,
+    );
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Action(view, ActionKind::Vote)),
+        &mut outbox,
+    );
+    consensus.apply(
+        ConsensusInput::Stored(StorageOutput::Proposal(view, commit)),
+        &mut outbox,
+    );
+    assert!(
+        !any(&outbox, is_vote1),
+        "vote1 for a timed-out view must not be released"
+    );
+}
+
+/// SendProposal is released only after the proposal is persisted and the
+/// Propose action is recorded.
+#[tokio::test]
+async fn test_proposal_release_follows_storage() {
+    let test_data = TestData::new(4).await;
+    let leader_for_view_2 = test_data.views[1].leader_public_key;
+    let leader_index = node_index_for_key(&leader_for_view_2);
+    let mut harness = ConsensusHarness::new(leader_index).await;
+
+    harness
+        .apply(test_data.views[0].proposal_input_consensus(&leader_for_view_2))
+        .await;
+    harness.apply(test_data.views[0].cert1_input()).await;
+
+    let outputs: Vec<_> = harness.outputs().iter().cloned().collect();
+    let send = outputs.iter().position(is_proposal).expect("proposal sent");
+    let persist = outputs
+        .iter()
+        .position(is_persist_proposal)
+        .expect("proposal persisted");
+    let action = outputs
+        .iter()
+        .position(|o| matches!(o, ConsensusOutput::RecordAction(_, _, ActionKind::Propose)))
+        .expect("propose action recorded");
+    assert!(persist < send, "proposal must be persisted before sending");
+    assert!(
+        action < send,
+        "propose action must be recorded before sending"
     );
 }

--- a/crates/hotshot/new-protocol/src/tests/cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/cutover.rs
@@ -204,8 +204,12 @@ async fn upgrade_certificate_cutover() {
     );
 
     let public_key = BLSPubKey::generated_from_seed_indexed([0u8; 32], 0).0;
-    let (membership, ..) =
-        crate::tests::common::utils::mock_membership_with_client(num_nodes, 100, public_key);
+    let (membership, ..) = crate::tests::common::utils::mock_membership_with_client(
+        num_nodes,
+        100,
+        public_key,
+        Default::default(),
+    );
     let epoch_membership = membership
         .membership_for_epoch(Some(EpochNumber::genesis()))
         .unwrap();

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -119,6 +119,9 @@ async fn test_sequential_vote1() {
             count_matching(inputs, is_state_validated) >= 2
         })
         .await;
+    harness
+        .process_until_output(|outputs| count_matching(outputs, is_vote1) >= 2)
+        .await;
 
     assert_eq!(
         count_matching(harness.outputs(), is_vote1),
@@ -138,14 +141,9 @@ async fn test_cert1_formed_and_vote2_sent() {
     // View 1: proposal + Vote1 messages → CPU forms cert1 + reconstructs block
     send_proposal_and_vote1s(&mut harness, &test_data, 0, &node_key).await;
 
-    assert!(
-        any(harness.outputs(), is_vote1),
-        "Vote1 should be sent for proposal"
-    );
-    assert!(
-        any(harness.outputs(), is_vote2),
-        "Vote2 should be sent for proposal"
-    );
+    harness
+        .process_until_output(|outputs| any(outputs, is_vote1) && any(outputs, is_vote2))
+        .await;
 }
 
 /// Full decide path: Certificate1, Certificate2, and block reconstruction
@@ -168,8 +166,9 @@ async fn test_full_decide() {
     send_proposal_and_vote1s(&mut harness, &test_data, 1, &node_key).await;
     send_vote2s(&mut harness, &test_data, 1).await;
 
-    assert!(any(harness.outputs(), is_vote1), "Vote1 should be sent");
-    assert!(any(harness.outputs(), is_vote2), "Vote2 should be sent");
+    harness
+        .process_until_output(|outputs| any(outputs, is_vote1) && any(outputs, is_vote2))
+        .await;
 
     assert!(
         any(harness.outputs(), is_send_cert1),
@@ -225,10 +224,9 @@ async fn test_leader_proposal() {
 
     // SendProposal proves the CPU VidDisperseTask computed the VID
     // disperse — consensus cannot send a proposal without it.
-    assert!(
-        any(harness.outputs(), is_proposal),
-        "Leader should send proposal (requires CPU VID disperse)"
-    );
+    harness
+        .process_until_output(|outputs| any(outputs, is_proposal))
+        .await;
 }
 
 /// Multi-view chain: certificates are formed for each view, leading to
@@ -321,10 +319,10 @@ async fn test_leader_proposes_after_timeout() {
         any(harness.outputs(), is_request_vid_disperse),
         "Leader should request VID disperse after TC"
     );
-    assert!(
-        any(harness.outputs(), is_proposal),
-        "Leader should send proposal with timeout view change evidence"
-    );
+    // Proposal with timeout view change evidence, released once stored.
+    harness
+        .process_until_output(|outputs| any(outputs, is_proposal))
+        .await;
 }
 
 // ---------------------------------------------------------------------------
@@ -507,11 +505,11 @@ async fn test_leader_proposes_with_computed_drb_in_epoch3() {
     harness
         .process_until(|inputs| any(inputs, |i| is_header_created_for_view(i, 28)))
         .await;
-    assert!(
-        any(harness.outputs(), |o| is_proposal_for_view(o, 28)),
-        "Leader should propose view 28 in epoch 3's transition window using the DRB result \
-         computed in epoch 1"
-    );
+    // Leader proposes view 28 in epoch 3's transition window using the DRB
+    // result computed in epoch 1.
+    harness
+        .process_until_output(|outputs| any(outputs, |o| is_proposal_for_view(o, 28)))
+        .await;
 }
 
 /// Same three-epoch setup but from a non-leader node's perspective:
@@ -558,10 +556,11 @@ async fn test_node_votes_with_computed_drb_in_epoch3() {
     // this proposal using the DRB result computed by the EpochManager.
     run_views_integration(&mut harness, &test_data, &node_key, 26..27).await;
 
-    assert!(
-        count_matching(harness.outputs(), is_vote1) > vote_count_before,
-        "Node should vote on epoch 3 transition-window proposal with the computed DRB result"
-    );
+    // The node votes on the epoch 3 transition-window proposal with the
+    // computed DRB result.
+    harness
+        .process_until_output(|outputs| count_matching(outputs, is_vote1) > vote_count_before)
+        .await;
 }
 
 /// f+1 timeout votes (OneHonestThreshold) trigger a TimeoutOneHonest input,

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -401,7 +401,7 @@ async fn spawn_node(
 ) -> NodeState {
     let network = build_new_protocol_network(i, parties, new_proto_lock).await;
     let (membership, storage, client, external_events_tx) =
-        mock_membership_with_client(num_nodes, EPOCH_HEIGHT, parties[i].1);
+        mock_membership_with_client(num_nodes, EPOCH_HEIGHT, parties[i].1, Default::default());
 
     let coord = build_cutover_coordinator(
         i as u64,

--- a/crates/hotshot/new-protocol/src/tests/restarts.rs
+++ b/crates/hotshot/new-protocol/src/tests/restarts.rs
@@ -74,15 +74,17 @@ async fn restart_f_nodes_with_epochs() {
 
 /// 5 nodes all crash at view ~5 and restart with their persisted storage.
 ///
-/// Decided state is not yet persisted (the chain re-grows from the genesis
-/// anchor), but the persisted action records must keep every node out of
-/// the views it acted in before the crash: views resume past the crash and
-/// no node records a Vote or Propose action twice for any view.
+/// Each node resumes from its persisted decided anchor (the newest decided
+/// leaf at crash time) instead of re-growing the chain from genesis, and
+/// the persisted action records keep every node out of the views it acted
+/// in before the crash: views resume past the crash and no node records a
+/// Vote or Propose action twice for any view.
 /// The crash/recovery window is nondeterministic, so those views are
 /// excluded from the usual per-view verification.
 #[tokio::test(flavor = "multi_thread")]
 async fn restart_all_nodes_with_storage() {
     let num_nodes = 5;
+    let crash_view = 5;
     let mut runner = TestRunner::builder()
         .num_nodes(num_nodes)
         .target_decisions(35)
@@ -90,7 +92,7 @@ async fn restart_all_nodes_with_storage() {
         .persistent_storage(true)
         .tolerated_failed_views(views(1..=30))
         .node_changes(vec![(
-            5,
+            crash_view,
             (0..num_nodes)
                 .map(|idx| NodeChange {
                     idx,
@@ -110,6 +112,16 @@ async fn restart_all_nodes_with_storage() {
                  had already acted in"
             );
         }
+
+        let (anchor, _) = storage
+            .anchor_leaf()
+            .await
+            .unwrap_or_else(|| panic!("node {idx} has no persisted anchor"));
+        assert!(
+            *anchor.view_number() > crash_view,
+            "node {idx} anchor stuck at view {} — it did not keep deciding after the restart",
+            anchor.view_number()
+        );
     }
 }
 

--- a/crates/hotshot/new-protocol/src/tests/restarts.rs
+++ b/crates/hotshot/new-protocol/src/tests/restarts.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use crate::tests::common::{
     runner::{NodeAction, NodeChange, TestRunner},
@@ -72,33 +72,46 @@ async fn restart_f_nodes_with_epochs() {
         .unwrap();
 }
 
-// TODO: This test currently builds a brand-new chain from genesis after
-// the restart because there is no persistent storage.  Once storage is
-// implemented the restarted nodes should resume from their last decided
-// state instead of starting a fresh chain.
-//
-// #[tokio::test(flavor = "multi_thread")]
-// async fn restart_all_nodes_with_epochs() {
-//     TestRunner {
-//         num_nodes: 5,
-//         target_decisions: 30,
-//         max_runtime: Duration::from_secs(300),
-//         epoch_height: 10,
-//         node_changes: vec![(
-//             15,
-//             (0..5)
-//                 .map(|i| NodeChange {
-//                     idx: i,
-//                     action: NodeAction::Restart,
-//                 })
-//                 .collect(),
-//         )],
-//         ..Default::default()
-//     }
-//     .run::<MemoryTestNetwork>()
-//     .await
-//     .unwrap();
-// }
+/// 5 nodes all crash at view ~5 and restart with their persisted storage.
+///
+/// Decided state is not yet persisted (the chain re-grows from the genesis
+/// anchor), but the persisted action records must keep every node out of
+/// the views it acted in before the crash: views resume past the crash and
+/// no node records a Vote or Propose action twice for any view.
+/// The crash/recovery window is nondeterministic, so those views are
+/// excluded from the usual per-view verification.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_all_nodes_with_storage() {
+    let num_nodes = 5;
+    let mut runner = TestRunner::builder()
+        .num_nodes(num_nodes)
+        .target_decisions(35)
+        .epoch_height(10)
+        .persistent_storage(true)
+        .tolerated_failed_views(views(1..=30))
+        .node_changes(vec![(
+            5,
+            (0..num_nodes)
+                .map(|idx| NodeChange {
+                    idx,
+                    action: NodeAction::Restart,
+                })
+                .collect(),
+        )])
+        .build();
+    runner.run().await.unwrap();
+
+    for (idx, storage) in runner.node_storages().iter().enumerate() {
+        let mut seen = HashSet::new();
+        for (view, action) in storage.action_log().await {
+            assert!(
+                seen.insert((view, action)),
+                "node {idx} recorded {action:?} twice for view {view} — it re-entered a view it \
+                 had already acted in"
+            );
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Late start (with epochs)

--- a/crates/hotshot/new-protocol/src/tests/storage.rs
+++ b/crates/hotshot/new-protocol/src/tests/storage.rs
@@ -1,0 +1,69 @@
+use std::{sync::atomic::Ordering, time::Duration};
+
+use hotshot::types::BLSPubKey;
+use hotshot_example_types::{node_types::TestTypes, storage_types::TestStorage};
+use hotshot_types::{data::ViewNumber, traits::signature_key::SignatureKey};
+use tokio::time::timeout;
+
+use crate::storage::{ActionKind, Storage, StorageOutput};
+
+fn test_storage() -> (
+    Storage<TestTypes, TestStorage<TestTypes>>,
+    TestStorage<TestTypes>,
+) {
+    let (_, private_key) = BLSPubKey::generated_from_seed_indexed([0; 32], 0);
+    let inner = TestStorage::<TestTypes>::default();
+    (Storage::new(inner.clone(), private_key), inner)
+}
+
+/// A successful write surfaces exactly one completion through `next()`.
+#[tokio::test]
+async fn test_record_action_completion() {
+    let (mut storage, inner) = test_storage();
+    let view = ViewNumber::new(7);
+
+    storage.record_action(view, None, ActionKind::Vote);
+
+    let stored = storage.next().await.expect("completion");
+    assert_eq!(stored, StorageOutput::Action(view, ActionKind::Vote));
+    assert_eq!(inner.last_actioned_view().await, view);
+    assert_eq!(inner.restart_view().await, view + 1);
+    assert!(storage.next().await.is_none());
+}
+
+/// A failing write retries until it succeeds and only then completes.
+#[tokio::test]
+async fn test_record_action_retries_until_success() {
+    let (mut storage, inner) = test_storage();
+    let view = ViewNumber::new(3);
+
+    inner.should_return_err.store(true, Ordering::Relaxed);
+    storage.record_action(view, None, ActionKind::Propose);
+    assert!(
+        timeout(Duration::from_millis(100), storage.next())
+            .await
+            .is_err(),
+        "no completion while the write keeps failing"
+    );
+
+    inner.should_return_err.store(false, Ordering::Relaxed);
+    let stored = timeout(Duration::from_secs(5), storage.next())
+        .await
+        .expect("completes once the write succeeds")
+        .expect("completion");
+    assert_eq!(stored, StorageOutput::Action(view, ActionKind::Propose));
+    assert!(storage.next().await.is_none());
+}
+
+/// gc aborts in-flight writes below the given view; no completion fires.
+#[tokio::test]
+async fn test_gc_aborts_pending_writes() {
+    let (mut storage, inner) = test_storage();
+
+    inner.should_return_err.store(true, Ordering::Relaxed);
+    storage.record_action(ViewNumber::new(2), None, ActionKind::Vote);
+    storage.gc(ViewNumber::new(5));
+    inner.should_return_err.store(false, Ordering::Relaxed);
+
+    assert!(storage.next().await.is_none());
+}

--- a/crates/hotshot/types/src/event.rs
+++ b/crates/hotshot/types/src/event.rs
@@ -489,7 +489,7 @@ pub enum LegacyEventType<TYPES: NodeType> {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 /// A list of actions that we track for nodes
 pub enum HotShotAction {
     /// A quorum vote was sent


### PR DESCRIPTION
Gate new-protocol sends on durable storage

Consensus storage is now a prerequisite for sending: a vote requires the view's actioned-record stored; vote1 additionally the proposal; vote2 additionally the node's own VID share; proposals mirror legacy (Propose record + appended proposal). The coordinator is never blocked — storage tasks report completions, which flow back into Consensus as inputs and release stashed messages.

If all nodes crash mid-view: any cert1 implies a quorum durably holds the proposal, any cert2 implies a quorum durably holds VID shares for the payload, and recorded actions plus the new restart-view wiring guarantee no node replays a view it acted in.
Reviewer focus: 
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:

The stash/release logic in consensus.rs (maybe_vote_1/maybe_vote_2_and_update_lock/maybe_propose + handle_stored) — pending messages are stashed rather than re-derived because gc(Local) clears states_verified/voted_*_views on every view change; and skip_to_view raising timeout_view, which is the guard against voting replayed stale proposals after restart.


<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
