### PR TITLE
Optimise serialisation of VID shares.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14273,6 +14273,7 @@ dependencies = [
  "rand 0.8.6",
  "reed-solomon-simd",
  "serde",
+ "serde_bytes",
  "sha2 0.10.9",
  "sha3",
  "tagged-base64",

--- a/vid/Cargo.toml
+++ b/vid/Cargo.toml
@@ -29,6 +29,7 @@ jf-utils = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 reed-solomon-simd = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 tagged-base64 = { workspace = true }

--- a/vid/src/avidm_gf2.rs
+++ b/vid/src/avidm_gf2.rs
@@ -58,9 +58,35 @@ pub struct AvidmGf2Share {
     /// Range of this share in the encoded payload.
     range: Range<usize>,
     /// Actual share content.
+    #[serde(with = "nested_bytes")]
     payload: Vec<Vec<u8>>,
     /// Merkle proof of the content.
     mt_proofs: Vec<MerkleProof>,
+}
+
+/// Optimised serialisation of a sequence of `Vec<u8>`s using `serde_bytes`.
+mod nested_bytes {
+    use serde::{Deserialize, Deserializer, Serializer, ser::SerializeSeq};
+    use serde_bytes::{ByteBuf, Bytes};
+
+    pub fn serialize<S>(v: &[Vec<u8>], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = s.serialize_seq(Some(v.len()))?;
+        for inner in v {
+            seq.serialize_element(Bytes::new(inner))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Vec<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v: Vec<ByteBuf> = Deserialize::deserialize(d)?;
+        Ok(v.into_iter().map(ByteBuf::into_vec).collect())
+    }
 }
 
 impl AvidmGf2Share {


### PR DESCRIPTION
Use `serde_bytes` to avoid serialising individual bytes. The result is compatible with exisiting bincode and JSON artefacts that do not use `serde_bytes`.