### PR TITLE
fix(backport): install claude code CLI instead of using claude code action

### DIFF
--- a/.github/claude/backport-resolve.md
+++ b/.github/claude/backport-resolve.md
@@ -1,0 +1,9 @@
+For each PR: create a local branch tracking origin/<branch>, resolve the markers, run `just fmt`, commit. Do not push
+and do not use the `gh` CLI; the workflow will verify compilation and push.
+
+Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend,
+--author=, --reuse-message=, git rebase, or `git cherry-pick --continue`; those preserve the original PR author's
+identity, which must never happen here.
+
+For each PR, write a concise markdown summary of the conflicts and how you resolved them to
+`claude-summaries/<pr-number>.md` (create the directory first; do not commit these files).

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -96,20 +96,10 @@ jobs:
           set -euo pipefail
           curl -fsSL https://claude.ai/install.sh | bash
           export PATH="$HOME/.local/bin:$PATH"
-          claude -p "Mergiraf left conflict markers in these backport PRs:
-          $NEEDS_CLAUDE
-
-          For each PR: create a local branch tracking origin/<branch>, resolve the markers, run \`just fmt\`,
-          commit. Do not push and do not use the \`gh\` CLI; the workflow will verify compilation and push.
-
-          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use
-          --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the
-          original PR author's identity, which must never happen here.
-
-          For each PR, write a concise markdown summary of the conflicts and how you resolved them to
-          \`claude-summaries/<pr-number>.md\` (create the directory first; do not commit these files)." \
-            --model claude-opus-4-8 \
-            --dangerously-skip-permissions
+          # Prompt body lives in .github/claude/backport-resolve.md.
+          prompt=$(printf 'Mergiraf left conflict markers in these backport PRs:\n%s\n\n%s' \
+            "$NEEDS_CLAUDE" "$(cat .github/claude/backport-resolve.md)")
+          claude -p "$prompt" --model claude-opus-4-8 --dangerously-skip-permissions
 
       - name: Install protoc
         if: steps.resolve.outputs.needs_claude != ''

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -99,11 +99,15 @@ jobs:
           claude -p "Mergiraf left conflict markers in these backport PRs:
           $NEEDS_CLAUDE
 
-          For each PR: create a local branch tracking origin/<branch>, resolve the markers, run \`just fmt\`, commit. Do not push and do not use the \`gh\` CLI; the workflow will verify compilation and push.
+          For each PR: create a local branch tracking origin/<branch>, resolve the markers, run \`just fmt\`,
+          commit. Do not push and do not use the \`gh\` CLI; the workflow will verify compilation and push.
 
-          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the original PR author's identity, which must never happen here.
+          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use
+          --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the
+          original PR author's identity, which must never happen here.
 
-          For each PR, write a concise markdown summary of the conflicts and how you resolved them to \`claude-summaries/<pr-number>.md\` (create the directory first; do not commit these files)." \
+          For each PR, write a concise markdown summary of the conflicts and how you resolved them to
+          \`claude-summaries/<pr-number>.md\` (create the directory first; do not commit these files)." \
             --model claude-opus-4-8 \
             --dangerously-skip-permissions
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -89,21 +89,21 @@ jobs:
       - name: Claude conflict resolution
         if: steps.resolve.outputs.needs_claude != ''
         timeout-minutes: 30
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Bogus token: skips the OIDC->app-token exchange (which 401s on
-          # pull_request_target) while granting Claude no GitHub access. This
-          # step only edits files locally; the workflow pushes afterward.
-          github_token: not-a-real-token
-          prompt: |
-            Mergiraf left conflict markers in these backport PRs:
-            ${{ steps.resolve.outputs.needs_claude }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NEEDS_CLAUDE: ${{ steps.resolve.outputs.needs_claude }}
+        run: |
+          set -euo pipefail
+          curl -fsSL https://claude.ai/install.sh | bash
+          export PATH="$HOME/.local/bin:$PATH"
+          claude -p "Mergiraf left conflict markers in these backport PRs:
+          $NEEDS_CLAUDE
 
-            For each PR: create a local branch tracking origin/<branch>, resolve the markers, run `just fmt`, commit. Do not push and do not use the `gh` CLI; the workflow will verify compilation and push.
+          For each PR: create a local branch tracking origin/<branch>, resolve the markers, run \`just fmt\`, commit. Do not push and do not use the \`gh\` CLI; the workflow will verify compilation and push.
 
-            Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend, --author=, --reuse-message=, git rebase, or `git cherry-pick --continue`; those preserve the original PR author's identity, which must never happen here.
-          claude_args: "--model claude-opus-4-6"
+          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the original PR author's identity, which must never happen here." \
+            --model claude-opus-4-8 \
+            --dangerously-skip-permissions
 
       - uses: Swatinem/rust-cache@v2
         if: steps.resolve.outputs.needs_claude != ''

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -101,9 +101,17 @@ jobs:
 
           For each PR: create a local branch tracking origin/<branch>, resolve the markers, run \`just fmt\`, commit. Do not push and do not use the \`gh\` CLI; the workflow will verify compilation and push.
 
-          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the original PR author's identity, which must never happen here." \
+          Commit attribution: only create new commits authored by the current git identity (the bot). Do not use --amend, --author=, --reuse-message=, git rebase, or \`git cherry-pick --continue\`; those preserve the original PR author's identity, which must never happen here.
+
+          For each PR, write a concise markdown summary of the conflicts and how you resolved them to \`claude-summaries/<pr-number>.md\` (create the directory first; do not commit these files)." \
             --model claude-opus-4-8 \
             --dangerously-skip-permissions
+
+      - name: Install protoc
+        if: steps.resolve.outputs.needs_claude != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - uses: Swatinem/rust-cache@v2
         if: steps.resolve.outputs.needs_claude != ''
@@ -126,4 +134,7 @@ jobs:
             git push origin "$branch"
             gh pr edit "$pr" --add-label claude-resolved
             gh pr ready "$pr"
+            if [ -f "claude-summaries/$pr.md" ]; then
+              gh pr comment "$pr" --body-file "claude-summaries/$pr.md"
+            fi
           done

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 jobs:
   backport:
     name: Backport pull request
@@ -93,6 +92,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Mergiraf left conflict markers in these backport PRs:
             ${{ steps.resolve.outputs.needs_claude }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -92,7 +92,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Bogus token: skips the OIDC->app-token exchange (which 401s on
+          # pull_request_target) while granting Claude no GitHub access. This
+          # step only edits files locally; the workflow pushes afterward.
+          github_token: not-a-real-token
           prompt: |
             Mergiraf left conflict markers in these backport PRs:
             ${{ steps.resolve.outputs.needs_claude }}


### PR DESCRIPTION
- The conflict-resolution step only edits files locally, so the action's
  GitHub context/MCP/OIDC machinery was pure overhead (and the OIDC
  exchange 401s on pull_request_target)
- Install Claude Code CLI and run claude -p with the API key directly;
  no GitHub token or id-token permission needed
- Use --dangerously-skip-permissions for non-interactive CI; model opus 4-8

Testing here: https://github.com/EspressoSystems/espresso-network/actions/runs/27407282554/job/80999461205
