### PR TITLE
[new-protocol] GC VID reconstructor with a small margin

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -55,6 +55,12 @@ use crate::{
     vote::VoteCollector,
 };
 
+/// Views to retain in the VID reconstructor behind the decided view. A decide
+/// can arrive while we are still reconstructing the payload of an earlier
+/// view. Garbage collecting at the decided view would abort that task and drop its
+/// accumulated shares.
+const VID_RECONSTRUCT_GC_MARGIN: u64 = 20;
+
 #[allow(clippy::large_enum_variant)]
 pub enum CoordinatorOutput<T: NodeType> {
     Consensus(ConsensusOutput<T>),
@@ -1518,7 +1524,8 @@ where
                 self.pending_proposal_fetches.gc(view);
                 self.state_manager.gc(view);
                 self.storage.gc(view);
-                self.vid_reconstructor.gc(view);
+                self.vid_reconstructor
+                    .gc(view.saturating_sub(VID_RECONSTRUCT_GC_MARGIN).into());
                 self.da_payloads = self
                     .da_payloads
                     .split_off(&(view, VidCommitment2::default()));

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -55,11 +55,16 @@ use crate::{
     vote::VoteCollector,
 };
 
-/// Views to retain in the VID reconstructor behind the decided view. A decide
-/// can arrive while we are still reconstructing the payload of an earlier
-/// view. Garbage collecting at the decided view would abort that task and drop its
-/// accumulated shares.
-const VID_RECONSTRUCT_GC_MARGIN: u64 = 20;
+/// Views to retain in the VID reconstructor behind the decided view
+///
+/// A decide can land while an earlier view's payload is still being
+/// reconstructed, and GC at the decided view would abort that task.
+/// A decide proves a quorum reconstructed the payload
+/// so it can be fetched later assuming the quorum includes at
+/// least one query node serving catchup.
+/// The margin gives in flight reconstruction tasks time to finish, which is
+/// cheaper than fetching the payload through catchup.
+const VID_RECONSTRUCT_GC_MARGIN: u64 = 5;
 
 #[allow(clippy::large_enum_variant)]
 pub enum CoordinatorOutput<T: NodeType> {


### PR DESCRIPTION

On a decided event, the coordinator GC'd the VID reconstructor for < decided view. `VidReconstructor::gc` drops share accumulators below the given view and aborts in-flight reconstruction tasks

This keeps a 5 viewmargin behind the decided view (`VID_RECONSTRUCT_GC_MARGIN`)