### PR TITLE
[new-protocol] GC storage with a small view margin

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -66,12 +66,8 @@ use crate::{
 /// cheaper than fetching the payload through catchup.
 const VID_RECONSTRUCT_GC_MARGIN: u64 = 5;
 
-/// Views to retain in storage GC behind the decided view
-///
-/// Storage writes are spawned tasks with retry loops; a write for a view
-/// just behind the decided view may still be in flight when the decide
-/// lands. GC at the decided view would abort it and the data would never
-/// be persisted. The margin gives in-flight writes time to complete.
+/// Views to retain in storage GC behind the decided view, so in-flight
+/// storage writes for recent views aren't aborted before they persist.
 const STORAGE_GC_MARGIN: u64 = 5;
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -66,6 +66,14 @@ use crate::{
 /// cheaper than fetching the payload through catchup.
 const VID_RECONSTRUCT_GC_MARGIN: u64 = 5;
 
+/// Views to retain in storage GC behind the decided view
+///
+/// Storage writes are spawned tasks with retry loops; a write for a view
+/// just behind the decided view may still be in flight when the decide
+/// lands. GC at the decided view would abort it and the data would never
+/// be persisted. The margin gives in-flight writes time to complete.
+const STORAGE_GC_MARGIN: u64 = 5;
+
 #[allow(clippy::large_enum_variant)]
 pub enum CoordinatorOutput<T: NodeType> {
     Consensus(ConsensusOutput<T>),
@@ -1542,7 +1550,8 @@ where
                 self.epoch_root_collector.gc(view, epoch);
                 self.pending_proposal_fetches.gc(view);
                 self.state_manager.gc(view);
-                self.storage.gc(view);
+                self.storage
+                    .gc(view.saturating_sub(STORAGE_GC_MARGIN).into());
                 self.vid_reconstructor
                     .gc(view.saturating_sub(VID_RECONSTRUCT_GC_MARGIN).into());
                 let vc = VidCommitment2::default();


### PR DESCRIPTION
## Summary

`storage.gc()` aborts the in-flight persistence tasks (proposal/VID/DA/cert/action writes, each with a retry loop) for views below the cutoff. A write for a view just behind the decided view may still be in flight when the decide lands; GC'ing exactly at the decided view aborts it and the data is never persisted.

Follows the same pattern as #4483: keep a 5-view margin behind the decided view so in-flight writes get time to complete.