### PR TITLE
Rename `NetworkController` to `NetworkSender`.

### DIFF
--- a/crates/cliquenet/benches/bench1.rs
+++ b/crates/cliquenet/benches/bench1.rs
@@ -206,10 +206,10 @@ fn bench_cliquenet(c: &mut Criterion) {
 // -- Bidirectional throughput -------------------------------------------------
 
 struct BiDir {
-    ctrl_a: cliquenet::NetworkController,
+    send_a: cliquenet::NetworkSender,
     recv_a: cliquenet::NetworkReceiver,
     pka: PublicKey,
-    ctrl_b: cliquenet::NetworkController,
+    send_b: cliquenet::NetworkSender,
     recv_b: cliquenet::NetworkReceiver,
     pkb: PublicKey,
 }
@@ -259,10 +259,10 @@ async fn setup_bidir() -> BiDir {
     let (ctrl_b, recv_b) = net_b.split_into();
 
     BiDir {
-        ctrl_a,
+        send_a: ctrl_a,
         recv_a,
         pka,
-        ctrl_b,
+        send_b: ctrl_b,
         recv_b,
         pkb,
     }
@@ -289,7 +289,7 @@ fn bench_bidirectional(c: &mut Criterion) {
                         tokio::join!(
                             async {
                                 for _ in 0..ROUNDS {
-                                    bd.ctrl_a.unicast(Slot::MIN, bd.pkb, data.clone()).unwrap();
+                                    bd.send_a.unicast(Slot::MIN, bd.pkb, data.clone()).unwrap();
                                     let (src, recv) = bd.recv_a.receive().await.unwrap();
                                     assert_eq!(src, bd.pkb);
                                     assert_eq!(recv.len(), n);
@@ -297,7 +297,7 @@ fn bench_bidirectional(c: &mut Criterion) {
                             },
                             async {
                                 for _ in 0..ROUNDS {
-                                    bd.ctrl_b.unicast(Slot::MIN, bd.pka, data.clone()).unwrap();
+                                    bd.send_b.unicast(Slot::MIN, bd.pka, data.clone()).unwrap();
                                     let (src, recv) = bd.recv_b.receive().await.unwrap();
                                     assert_eq!(src, bd.pka);
                                     assert_eq!(recv.len(), n);
@@ -332,7 +332,7 @@ fn bench_bidirectional(c: &mut Criterion) {
                                         .retry(RetryPolicy::NoRetry)
                                         .action(SendAction::Unicast(bd.pkb, data.clone()))
                                         .build();
-                                    bd.ctrl_a.send(cmd).unwrap();
+                                    bd.send_a.send(cmd).unwrap();
                                     let (src, recv) = bd.recv_a.receive().await.unwrap();
                                     assert_eq!(src, bd.pkb);
                                     assert_eq!(recv.len(), n);
@@ -345,7 +345,7 @@ fn bench_bidirectional(c: &mut Criterion) {
                                         .retry(RetryPolicy::NoRetry)
                                         .action(SendAction::Unicast(bd.pka, data.clone()))
                                         .build();
-                                    bd.ctrl_b.send(cmd).unwrap();
+                                    bd.send_b.send(cmd).unwrap();
                                     let (src, recv) = bd.recv_b.receive().await.unwrap();
                                     assert_eq!(src, bd.pka);
                                     assert_eq!(recv.len(), n);

--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -19,7 +19,7 @@ pub use error::NetworkError;
 pub use metrics::Metrics;
 pub use msg::Slot;
 pub use net::{
-    Network, NetworkController, NetworkReceiver, RetryPolicy, SendAction, SendCommand,
+    Network, NetworkReceiver, NetworkSender, RetryPolicy, SendAction, SendCommand,
     SendCommandBuilder,
 };
 

--- a/crates/cliquenet/src/net.rs
+++ b/crates/cliquenet/src/net.rs
@@ -1,12 +1,7 @@
 pub mod peer;
 pub mod server;
 
-use std::{
-    collections::HashMap,
-    fmt,
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use std::{fmt, ops::Deref, sync::Arc};
 
 use bon::Builder;
 use bytes::Bytes;
@@ -17,7 +12,6 @@ use tokio::{
         mpsc::{self, UnboundedReceiver, UnboundedSender},
         oneshot, watch,
     },
-    task::JoinHandle,
 };
 use tracing::{debug, info, warn};
 
@@ -31,7 +25,7 @@ type PeerMessage = (PublicKey, Bytes, Option<OwnedSemaphorePermit>);
 #[derive(Debug)]
 pub struct Network {
     recv: NetworkReceiver,
-    ctrl: NetworkController,
+    send: NetworkSender,
 }
 
 #[derive(Debug)]
@@ -39,22 +33,20 @@ pub struct NetworkReceiver {
     rx: UnboundedReceiver<PeerMessage>,
 }
 
-pub struct NetworkController {
+#[derive(Clone)]
+pub struct NetworkSender {
     conf: Arc<Config>,
     node: PublicKey,
-    parties: HashMap<PublicKey, Role>,
     tx: UnboundedSender<Command>,
     next_slot: watch::Sender<Slot>,
-    lower_bound: Slot,
-    task: JoinHandle<()>,
     metrics: Arc<dyn Metrics>,
 }
 
-impl fmt::Debug for NetworkController {
+impl fmt::Debug for NetworkSender {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NetworkController")
+        f.debug_struct("NetworkSender")
             .field("node", &self.node)
-            .field("lower_bound", &self.lower_bound)
+            .field("lower_bound", &*self.next_slot.borrow())
             .field("conf", &self.conf)
             .finish()
     }
@@ -118,9 +110,8 @@ impl Network {
             .await
             .map_err(|e| NetworkError::Bind(conf.bind.clone(), e))?;
 
-        let _addr = listener.local_addr()?;
+        let addr = listener.local_addr()?;
         let node = conf.keypair.public_key();
-        let parties = HashMap::from_iter(conf.parties.iter().map(|(k, _)| (*k, Role::Active)));
 
         // Command channel from application to network.
         let (otx, orx) = mpsc::unbounded_channel();
@@ -132,7 +123,9 @@ impl Network {
 
         let metr = conf.metrics.clone().unwrap_or_else(|| Arc::new(NoMetrics));
         let conf = Arc::new(conf);
-        let serv = Server::spawn(
+
+        // The server ends when all `NetworkSender`s are dropped.
+        Server::spawn(
             conf.clone(),
             listener,
             Role::Active,
@@ -141,41 +134,35 @@ impl Network {
             erx,
             metr.clone(),
         );
+
         let recv = NetworkReceiver { rx: irx };
-        let ctrl = NetworkController {
+        let send = NetworkSender {
             conf: conf.clone(),
             node,
-            parties,
             tx: otx,
-            task: serv,
             next_slot: etx,
-            lower_bound: Slot::MIN,
             metrics: metr,
         };
 
-        info!(name = %conf.name, %node, addr = %_addr, "listening");
+        info!(name = %conf.name, %node, %addr, "listening");
 
-        Ok(Self { recv, ctrl })
+        Ok(Self { recv, send })
     }
 
-    pub fn controller(&mut self) -> &mut NetworkController {
-        &mut self.ctrl
+    pub fn sender(&self) -> &NetworkSender {
+        &self.send
     }
 
-    pub fn receiver(&mut self) -> &mut NetworkReceiver {
+    pub fn receiver(&self) -> &NetworkReceiver {
+        &self.recv
+    }
+
+    pub fn receiver_mut(&mut self) -> &mut NetworkReceiver {
         &mut self.recv
     }
 
-    pub fn split(&self) -> (&NetworkController, &NetworkReceiver) {
-        (&self.ctrl, &self.recv)
-    }
-
-    pub fn split_mut(&mut self) -> (&mut NetworkController, &mut NetworkReceiver) {
-        (&mut self.ctrl, &mut self.recv)
-    }
-
-    pub fn split_into(self) -> (NetworkController, NetworkReceiver) {
-        (self.ctrl, self.recv)
+    pub fn split_into(self) -> (NetworkSender, NetworkReceiver) {
+        (self.send, self.recv)
     }
 
     pub async fn receive(&mut self) -> Option<(PublicKey, Bytes)> {
@@ -184,16 +171,10 @@ impl Network {
 }
 
 impl Deref for Network {
-    type Target = NetworkController;
+    type Target = NetworkSender;
 
     fn deref(&self) -> &Self::Target {
-        &self.ctrl
-    }
-}
-
-impl DerefMut for Network {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.ctrl
+        &self.send
     }
 }
 
@@ -208,18 +189,13 @@ impl NetworkReceiver {
     }
 }
 
-impl NetworkController {
+impl NetworkSender {
     pub fn config(&self) -> &Config {
         &self.conf
     }
 
-    /// Iterate over all parties.
-    pub fn parties(&self) -> impl Iterator<Item = (&PublicKey, &Role)> {
-        self.parties.iter()
-    }
-
     /// Send a message to a party, identified by the given public key.
-    pub fn unicast(&mut self, s: Slot, to: PublicKey, msg: Vec<u8>) -> Result<(), NetworkError> {
+    pub fn unicast(&self, s: Slot, to: PublicKey, msg: Vec<u8>) -> Result<(), NetworkError> {
         debug!(slot = %s, %to, len = msg.len(), "unicast");
         self.length_check(&msg)?;
         if self.lt_lower_bound(s) {
@@ -235,7 +211,7 @@ impl NetworkController {
     }
 
     /// Send a message to all parties.
-    pub fn broadcast(&mut self, s: Slot, msg: Vec<u8>) -> Result<(), NetworkError> {
+    pub fn broadcast(&self, s: Slot, msg: Vec<u8>) -> Result<(), NetworkError> {
         debug!(slot = %s, len = msg.len(), "broadcast");
         self.length_check(&msg)?;
         if self.lt_lower_bound(s) {
@@ -251,7 +227,7 @@ impl NetworkController {
     }
 
     /// Send a message to several parties, identified by their public keys.
-    pub fn multicast<P>(&mut self, s: Slot, to: P, msg: Vec<u8>) -> Result<(), NetworkError>
+    pub fn multicast<P>(&self, s: Slot, to: P, msg: Vec<u8>) -> Result<(), NetworkError>
     where
         P: IntoIterator<Item = PublicKey>,
     {
@@ -270,7 +246,7 @@ impl NetworkController {
     }
 
     /// General send operation, supporting custom retry policies.
-    pub fn send(&mut self, cmd: SendCommand) -> Result<(), NetworkError> {
+    pub fn send(&self, cmd: SendCommand) -> Result<(), NetworkError> {
         let bytes = msg_bytes(&cmd);
         debug!(slot = %cmd.slot, len = %bytes.len(), "send");
         self.length_check(bytes)?;
@@ -283,27 +259,25 @@ impl NetworkController {
     }
 
     /// Add the given peers to the network.
-    pub fn add_peers<P>(&mut self, r: Role, peers: P) -> Result<(), NetworkError>
+    pub fn add_peers<P>(&self, r: Role, peers: P) -> Result<(), NetworkError>
     where
         P: IntoIterator<Item = (PublicKey, NetAddr)>,
     {
         debug!(role = %r, "add_peers");
         let peers = peers.into_iter().collect::<Vec<_>>();
-        self.parties.extend(peers.iter().map(|(p, ..)| (*p, r)));
         self.tx
             .send(Command::Peer(PeerCommand::Add(r, peers)))
             .map_err(|_| NetworkError::ChannelClosed)
     }
 
     /// Remove the given peers from the network.
-    pub fn remove_peers<P>(&mut self, peers: P) -> Result<(), NetworkError>
+    pub fn remove_peers<P>(&self, peers: P) -> Result<(), NetworkError>
     where
         P: IntoIterator<Item = PublicKey>,
     {
         debug!("remove_peers");
         let peers = peers.into_iter().collect::<Vec<_>>();
         for p in &peers {
-            self.parties.remove(p);
             self.metrics.del(p);
         }
         self.tx
@@ -312,38 +286,38 @@ impl NetworkController {
     }
 
     /// Assign the given role to the given peers.
-    pub fn assign_peers<P>(&mut self, r: Role, peers: P) -> Result<(), NetworkError>
+    pub fn assign_peers<P>(&self, r: Role, peers: P) -> Result<(), NetworkError>
     where
         P: IntoIterator<Item = PublicKey>,
     {
         debug!(role = %r, "assign_peers");
         let peers = peers.into_iter().collect::<Vec<_>>();
-        for p in &peers {
-            if let Some(role) = self.parties.get_mut(p) {
-                *role = r
-            }
-        }
         self.tx
             .send(Command::Peer(PeerCommand::Assign(r, peers)))
             .map_err(|_| NetworkError::ChannelClosed)
     }
 
-    pub fn gc(&mut self, s: Slot) -> Result<(), NetworkError> {
+    /// Trigger garbage collection of messages below the given slot.
+    pub fn gc(&self, s: Slot) -> Result<(), NetworkError> {
         debug!(slot = %s, "gc");
-        if s <= self.lower_bound {
-            return Ok(());
+        if self.next_slot.is_closed() {
+            return Err(NetworkError::ChannelClosed);
         }
-        self.next_slot
-            .send(s)
-            .map_err(|_| NetworkError::ChannelClosed)?;
-        self.lower_bound = s;
+        self.next_slot.send_if_modified(|lower_bound| {
+            if s > *lower_bound {
+                *lower_bound = s;
+                true
+            } else {
+                false
+            }
+        });
         Ok(())
     }
 
     /// Trigger network shutdown.
     ///
     /// The returned future will resolve once the server task finished.
-    pub fn shutdown(&mut self) -> Result<impl Future<Output = ()> + use<>, NetworkError> {
+    pub fn shutdown(&self) -> Result<impl Future<Output = ()> + use<>, NetworkError> {
         debug!("shutdown");
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -371,12 +345,13 @@ impl NetworkController {
 
     /// Check if the given slot is less than our lower bound.
     fn lt_lower_bound(&self, s: Slot) -> bool {
-        if s < self.lower_bound {
+        let lower_bound = *self.next_slot.borrow();
+        if s < lower_bound {
             warn!(
                 name = %self.conf.name,
                 node = %self.node,
                 slot = %s,
-                lower_bound = %self.lower_bound,
+                %lower_bound,
                 "slot below lower bound"
             );
             return true;
@@ -390,11 +365,5 @@ fn msg_bytes(cmd: &SendCommand) -> &[u8] {
         SendAction::Unicast(_, b) => b,
         SendAction::Multicast(_, b) => b,
         SendAction::Broadcast(b) => b,
-    }
-}
-
-impl Drop for NetworkController {
-    fn drop(&mut self) {
-        self.task.abort();
     }
 }

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -431,7 +431,7 @@ impl Server {
                         return
                     }
                     let s = *self.next_slot.borrow_and_update();
-                    debug_assert!(s > self.lower_bound); // ensured by controller
+                    debug_assert!(s > self.lower_bound); // ensured by `NetworkSender::gc`
                     self.lower_bound = s;
                     self.metrics.set(&self.key, LOWER_BOUND, u64::from(s) as usize);
                     for party in self.parties.values() {

--- a/crates/cliquenet/tests/network.rs
+++ b/crates/cliquenet/tests/network.rs
@@ -77,7 +77,7 @@ async fn two_nodes() -> (Network, Network, PublicKey, PublicKey) {
 /// Unicast from A to B.
 #[tokio::test]
 async fn unicast() {
-    let (mut net_a, mut net_b, pka, pkb) = two_nodes().await;
+    let (net_a, mut net_b, pka, pkb) = two_nodes().await;
 
     net_a.unicast(Slot::MIN, pkb, b"hello".to_vec()).unwrap();
 
@@ -93,7 +93,7 @@ async fn unicast() {
 /// Unicast multiple messages, all arrive in order.
 #[tokio::test]
 async fn unicast_multiple() {
-    let (mut net_a, mut net_b, _pka, pkb) = two_nodes().await;
+    let (net_a, mut net_b, _pka, pkb) = two_nodes().await;
 
     let n = 10usize;
     for i in 0..n {
@@ -222,7 +222,7 @@ async fn self_unicast() {
 /// Large message spanning multiple Noise frames.
 #[tokio::test]
 async fn large_message() {
-    let (mut net_a, mut net_b, _pka, pkb) = two_nodes().await;
+    let (net_a, mut net_b, _pka, pkb) = two_nodes().await;
 
     let big: Vec<u8> = (0..200 * 1024).map(|i| (i % 251) as u8).collect();
     net_a.unicast(Slot::MIN, pkb, big.clone()).unwrap();
@@ -237,20 +237,20 @@ async fn large_message() {
 /// Message too large is rejected at the API level.
 #[tokio::test]
 async fn message_too_large() {
-    let (mut net_a, _net_b, _pka, pkb) = two_nodes().await;
+    let (net_a, _net_b, _pka, pkb) = two_nodes().await;
 
     let huge = vec![0u8; 11 * 1024 * 1024]; // > 10 MiB default
     let result = net_a.unicast(Slot::MIN, pkb, huge);
     assert!(matches!(result, Err(NetworkError::MessageTooLarge)));
 }
 
-/// Dropping the controller shuts down the network.
+/// Dropping all senders shuts down the network.
 #[tokio::test]
 async fn shutdown_on_drop() {
     let (net_a, _net_b, _pka, _pkb) = two_nodes().await;
 
-    let (ctrl_a, mut rx_a) = net_a.split_into();
-    drop(ctrl_a);
+    let (send_a, mut rx_a) = net_a.split_into();
+    drop(send_a);
 
     let result = timeout(Duration::from_secs(2), rx_a.receive()).await;
     match result {
@@ -302,7 +302,7 @@ async fn three_node_broadcast() {
 /// Empty payload is delivered correctly.
 #[tokio::test]
 async fn empty_payload() {
-    let (mut net_a, mut net_b, _pka, pkb) = two_nodes().await;
+    let (net_a, mut net_b, _pka, pkb) = two_nodes().await;
 
     net_a.unicast(Slot::MIN, pkb, vec![]).unwrap();
 
@@ -316,7 +316,7 @@ async fn empty_payload() {
 /// GC discards old-slot messages while current-slot messages are delivered.
 #[tokio::test]
 async fn gc() {
-    let (mut net_a, mut net_b, _pka, pkb) = two_nodes().await;
+    let (net_a, mut net_b, _pka, pkb) = two_nodes().await;
 
     // Send messages in slots 1 and 3.
     net_a.unicast(Slot::new(1), pkb, b"old".to_vec()).unwrap();
@@ -350,7 +350,7 @@ async fn add_peer() {
 
     // Start A and B knowing only each other.
     let all_ab = [&a, &b];
-    let mut net_a = Network::create(make_config(&a, &all_ab)).await.unwrap();
+    let net_a = Network::create(make_config(&a, &all_ab)).await.unwrap();
     let _net_b = Network::create(make_config(&b, &all_ab)).await.unwrap();
 
     // Start C knowing A and B.
@@ -539,7 +539,7 @@ async fn reconnect_after_restart() {
     // B knows itself and A.
     let all_b = [&a, &b];
 
-    let mut net_a = Network::create(make_config(&a, &all_a)).await.unwrap();
+    let net_a = Network::create(make_config(&a, &all_a)).await.unwrap();
     let net_b = Network::create(make_config(&b, &all_b)).await.unwrap();
 
     sleep(SETTLE).await;
@@ -597,7 +597,7 @@ async fn unknown_peer_backs_off() {
     // C knows A and connects. Without the backoff, C's 1 s retry would
     // cause it to reconnect immediately after each rejection. With the
     // backoff, C sleeps 60 s after the first hello exchange.
-    let mut net_c = Network::create(
+    let net_c = Network::create(
         Config::builder()
             .name("test")
             .keypair(c.keypair.clone())
@@ -640,7 +640,7 @@ async fn update_party_address() {
 
     // A knows B at its first address.
     let all = [&a, &b1];
-    let mut net_a = Network::create(make_config(&a, &all)).await.unwrap();
+    let net_a = Network::create(make_config(&a, &all)).await.unwrap();
     let mut net_b1 = Network::create(make_config(&b1, &all)).await.unwrap();
 
     sleep(SETTLE).await;


### PR DESCRIPTION
Also make the sender cloneable to allow multiple send endpoints in potentially different tasks.