### PR TITLE
[Fast Finality] Verify VID Commitment on Reconstructed Block

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -536,7 +536,7 @@ where
                     }
                     Err(err) => {
                         finish_measurement(next_input);
-                        return Err(CoordinatorError::regular(err.to_string()).context("vid reconstruction"))
+                        return Err(CoordinatorError::regular(err).context("vid reconstruction"))
                     }
                 },
                 Some(stored) = self.storage.next() => {

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -534,9 +534,9 @@ where
                         }
                         return Ok(ConsensusInput::BlockReconstructed(out.view, out.payload_commitment))
                     }
-                    Err(()) => {
+                    Err(err) => {
                         finish_measurement(next_input);
-                        return Err(CoordinatorError::unspecified().context("vid reconstruction"))
+                        return Err(CoordinatorError::regular(err.to_string()).context("vid reconstruction"))
                     }
                 },
                 Some(stored) = self.storage.next() => {

--- a/crates/hotshot/new-protocol/src/coordinator/error.rs
+++ b/crates/hotshot/new-protocol/src/coordinator/error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::{
     block::BlockError, epoch::EpochManagerError, network::NetworkError, proposal::ValidationError,
+    vid::VidReconstructError,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -86,6 +87,9 @@ pub enum ErrorSource {
 
     #[error("epoch manager error: {0}")]
     EpochManager(#[from] EpochManagerError),
+
+    #[error("vid reconstruction error: {0}")]
+    VidReconstruct(#[from] VidReconstructError),
 }
 
 impl From<NetworkError> for CoordinatorError {

--- a/crates/hotshot/new-protocol/src/tests/vid.rs
+++ b/crates/hotshot/new-protocol/src/tests/vid.rs
@@ -1,6 +1,6 @@
 use hotshot::types::BLSPubKey;
 use hotshot_example_types::node_types::TestTypes;
-use hotshot_types::traits::signature_key::SignatureKey;
+use hotshot_types::{traits::signature_key::SignatureKey, vid::avidm_gf2::AvidmGf2Scheme};
 
 use super::common::utils::TestData;
 use crate::vid::VidReconstructor;
@@ -56,7 +56,7 @@ async fn test_no_duplicate_reconstruction_after_threshold() {
     match second {
         Err(_elapsed) => { /* timed out — no duplicate, good */ },
         Ok(None) => { /* no more tasks — no duplicate, good */ },
-        Ok(Some(Err(()))) => { /* error, not a duplicate success */ },
+        Ok(Some(Err(_))) => { /* error, not a duplicate success */ },
         Ok(Some(Ok(out))) => {
             panic!(
                 "BUG: got a duplicate BlockReconstructed for view {:?} — the reconstructor \
@@ -103,7 +103,7 @@ async fn test_retire_view_skips_reconstruction() {
     match result {
         Err(_elapsed) => { /* no task ever spawned — good */ },
         Ok(None) => { /* no tasks — good */ },
-        Ok(Some(Err(()))) => { /* error, not a duplicate success */ },
+        Ok(Some(Err(_))) => { /* error, not a duplicate success */ },
         Ok(Some(Ok(out))) => {
             panic!(
                 "BUG: retire_view should have suppressed reconstruction, but got a result for \
@@ -169,7 +169,7 @@ async fn test_shares_after_reconstruction_are_ignored() {
     match extra {
         Err(_elapsed) => { /* timed out — good, no extra task */ },
         Ok(None) => { /* no tasks — good */ },
-        Ok(Some(Err(()))) => { /* error, not a duplicate success */ },
+        Ok(Some(Err(_))) => { /* error, not a duplicate success */ },
         Ok(Some(Ok(out))) => {
             panic!(
                 "BUG: got a duplicate BlockReconstructed for view {:?} after reconstruction was \
@@ -178,4 +178,83 @@ async fn test_shares_after_reconstruction_are_ignored() {
             );
         },
     }
+}
+
+/// Reconstruction must fail when the recovered payload does not re-commit to
+/// the commitment the shares claimed, and the failure must not block a later
+/// attempt with the correct commitment.
+#[tokio::test]
+async fn test_reconstruction_rejects_mismatched_commitment() {
+    let test_data = TestData::new(1).await;
+    let view = &test_data.views[0];
+    let mut reconstructor = VidReconstructor::<TestTypes>::new();
+
+    // A valid commitment over different payload bytes.
+    let param = &view.vid_shares[0].common.param;
+    let other_payload = vec![0xa5u8; 64];
+    let (wrong_commitment, _) = AvidmGf2Scheme::commit(
+        param,
+        &other_payload,
+        std::iter::once(0..other_payload.len()),
+    )
+    .unwrap();
+
+    // Feed threshold-plus shares with honest content but a wrong claimed
+    // commitment: decoding succeeds and the recommit check must reject it.
+    let proposal_key = BLSPubKey::generated_from_seed_indexed([0u8; 32], 0).0;
+    let mut proposal_share = view
+        .vid_shares
+        .iter()
+        .find(|s| s.recipient_key == proposal_key)
+        .unwrap()
+        .clone();
+    proposal_share.payload_commitment = wrong_commitment;
+    reconstructor.handle_vid_share(proposal_share, view.proposal.data.block_header.metadata);
+    for i in 1..THRESHOLD {
+        let key = BLSPubKey::generated_from_seed_indexed([0u8; 32], i).0;
+        let mut share = view
+            .vid_shares
+            .iter()
+            .find(|s| s.recipient_key == key)
+            .unwrap()
+            .clone();
+        share.payload_commitment = wrong_commitment;
+        reconstructor.handle_vid_share(share, None);
+    }
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), reconstructor.next())
+        .await
+        .expect("reconstruction attempt should complete in time")
+        .expect("should produce a result");
+    let err = match result {
+        Err(err) => err,
+        Ok(out) => panic!(
+            "BUG: reconstruction for view {:?} accepted a payload that doesn't match the claimed \
+             commitment",
+            out.view
+        ),
+    };
+    assert_eq!(err.view, view.view_number);
+
+    // The failure must not retire the view: one more share claiming the
+    // correct commitment triggers a retry that succeeds.
+    let key = BLSPubKey::generated_from_seed_indexed([0u8; 32], THRESHOLD).0;
+    let share = view
+        .vid_shares
+        .iter()
+        .find(|s| s.recipient_key == key)
+        .unwrap()
+        .clone();
+    reconstructor.handle_vid_share(share, None);
+
+    let retry = tokio::time::timeout(std::time::Duration::from_secs(5), reconstructor.next())
+        .await
+        .expect("retry should complete in time")
+        .expect("should produce a result")
+        .expect("retry with the correct commitment should succeed");
+    assert_eq!(retry.view, view.view_number);
+    assert_eq!(
+        retry.payload_commitment,
+        view.vid_shares[0].payload_commitment
+    );
 }

--- a/crates/hotshot/new-protocol/src/vid.rs
+++ b/crates/hotshot/new-protocol/src/vid.rs
@@ -3,12 +3,16 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use committable::Commitment;
 use hotshot::traits::BlockPayload;
 use hotshot_types::{
-    data::{EpochNumber, VidCommitment2, VidDisperse2, VidDisperseShare2, ViewNumber},
+    data::{
+        EpochNumber, VidCommitment2, VidDisperse2, VidDisperseShare2, ViewNumber,
+        ns_table::parse_ns_table,
+    },
     epoch_membership::EpochMembershipCoordinator,
-    traits::node_implementation::NodeType,
+    traits::{block_contents::EncodeBytes, node_implementation::NodeType},
     vid::avidm_gf2::{AvidmGf2Common, AvidmGf2Scheme, AvidmGf2Share},
 };
 use tokio::task::{AbortHandle, JoinSet};
+use tracing::warn;
 
 pub struct VidDisperseOutput<T: NodeType> {
     pub view: ViewNumber,
@@ -23,6 +27,17 @@ pub struct VidReconstructOutput<T: NodeType> {
     pub payload: T::BlockPayload,
     pub metadata: <T::BlockPayload as BlockPayload<T>>::Metadata,
     pub tx_commitments: Vec<Commitment<T::Transaction>>,
+}
+
+/// A reconstruction attempt failed: either decoding errored or the recovered
+/// payload did not re-commit to the expected payload commitment.
+///
+/// Carries the view so the reconstructor can drop its in-flight marker; the
+/// accumulated shares are kept, so a later share triggers another attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("VID reconstruction failed for view {view}")]
+pub struct VidReconstructError {
+    pub view: ViewNumber,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -127,7 +142,7 @@ impl<T: NodeType> VidShareAccumulator<T> {
 pub struct VidReconstructor<T: NodeType> {
     accumulators: BTreeMap<ViewNumber, VidShareAccumulator<T>>,
     reconstructed: BTreeSet<ViewNumber>,
-    tasks: JoinSet<Result<VidReconstructOutput<T>, ()>>,
+    tasks: JoinSet<Result<VidReconstructOutput<T>, VidReconstructError>>,
     calculations: BTreeMap<ViewNumber, AbortHandle>,
 }
 
@@ -179,7 +194,7 @@ impl<T: NodeType> VidReconstructor<T> {
         }
     }
 
-    pub async fn next(&mut self) -> Option<Result<VidReconstructOutput<T>, ()>> {
+    pub async fn next(&mut self) -> Option<Result<VidReconstructOutput<T>, VidReconstructError>> {
         loop {
             match self.tasks.join_next().await {
                 Some(Ok(Ok(out))) => {
@@ -188,9 +203,11 @@ impl<T: NodeType> VidReconstructor<T> {
                     self.reconstructed.insert(out.view);
                     return Some(Ok(out));
                 },
-                Some(Ok(Err(()))) => {
-                    // TODO: Handle error
-                    return Some(Err(()));
+                Some(Ok(Err(err))) => {
+                    // Drop the in-flight marker but keep the accumulated
+                    // shares: a later share triggers another attempt.
+                    self.calculations.remove(&err.view);
+                    return Some(Err(err));
                 },
                 Some(Err(_)) => continue,
                 None => return None,
@@ -213,11 +230,30 @@ impl<T: NodeType> VidReconstructor<T> {
         };
         let epoch = accumulator.epoch.unwrap_or(EpochNumber::genesis());
         let task = self.tasks.spawn_blocking(move || {
-            let Ok(result) = AvidmGf2Scheme::recover(&common, &shares) else {
-                // TODO: Handle error
-                return Err(());
-            };
-            let payload = T::BlockPayload::from_bytes(&result, &metadata);
+            let bytes = AvidmGf2Scheme::recover(&common, &shares).map_err(|err| {
+                warn!(%view, %err, "VID recovery failed");
+                VidReconstructError { view }
+            })?;
+            // Recovery does not bind the decoded bytes to the commitment: a
+            // Byzantine disperser can commit to a non-codeword, and a bad
+            // share poisons the erasure decoding. Recommit and compare before
+            // trusting the payload.
+            let ns_table = parse_ns_table(bytes.len(), &metadata.encode());
+            let (recomputed, _) =
+                AvidmGf2Scheme::commit(&common.param, &bytes, ns_table).map_err(|err| {
+                    warn!(%view, %err, "failed to recommit reconstructed VID payload");
+                    VidReconstructError { view }
+                })?;
+            if recomputed != payload_commitment {
+                warn!(
+                    %view,
+                    expected = %payload_commitment,
+                    %recomputed,
+                    "reconstructed payload does not match the payload commitment"
+                );
+                return Err(VidReconstructError { view });
+            }
+            let payload = T::BlockPayload::from_bytes(&bytes, &metadata);
             let tx_commitments = payload.transaction_commitments(&metadata);
             Ok(VidReconstructOutput {
                 view,


### PR DESCRIPTION
AVID-M recovery does not bind the decoded bytes to the payload
commitment: shares verify against the disperser's merkle tree, but a
Byzantine disperser can commit to a non-codeword, and a bad share
poisons the erasure decoding into silently producing garbage. The
reconstructor then shipped whatever commitment the shares claimed,
so the coordinator stored and emitted unverified payloads.

After recovery, recompute the VID commitment from the recovered bytes
(mirroring calculate_vid_disperse) and fail reconstruction on mismatch.
Failures now carry the view so the reconstructor drops its in-flight
marker; accumulated shares are kept, letting a later share trigger a
retry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
