### PR TITLE
Add Deserialize to LightClientOptions

### DIFF
--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -52,7 +52,7 @@ pub struct Genesis {
     pub stake_table: Vec<StakeTableEntry<PubKey>>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct LightClientOptions {
     /// Maximum number of stake tables to cache in memory at any given time.


### PR DESCRIPTION
LightClientOptions is included into Espresso Stack's ReaderConfig. It's useful to make it readable from a config file, like toml. 