### PR TITLE
Add Deserialize to LightClientSqliteOptions

### DIFF
--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -20,7 +20,7 @@ use super::{
     v0_3::{EventKey, IndexedStake, StakeTableEvent},
 };
 use crate::{
-    AuthenticatedValidatorMap, EpochCommittees, PubKey, RegisteredValidatorMap,
+    AuthenticatedValidatorMap, PubKey, RegisteredValidatorMap,
     v0::{
         GenesisHeader, L1BlockInfo, L1Client, Timestamp, Upgrade, UpgradeMode,
         impls::{StakeTableHash, fetch_and_calculate_block_reward, reward::EpochRewardsCalculator},
@@ -273,7 +273,7 @@ impl NodeState {
         use hotshot_example_types::storage_types::TestStorage;
         use versions::version;
 
-        use crate::v0_3::Fetcher;
+        use crate::{EpochCommittees, v0_3::Fetcher};
 
         let chain_config = ChainConfig::default();
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
@@ -300,7 +300,7 @@ impl NodeState {
         use hotshot_example_types::storage_types::TestStorage;
         use versions::version;
 
-        use crate::v0_3::Fetcher;
+        use crate::{EpochCommittees, v0_3::Fetcher};
 
         let chain_config = ChainConfig::default();
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
@@ -327,7 +327,7 @@ impl NodeState {
         use hotshot_example_types::storage_types::TestStorage;
         use versions::version;
 
-        use crate::v0_3::Fetcher;
+        use crate::{EpochCommittees, v0_3::Fetcher};
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
             .expect("Failed to create L1 client");
 
@@ -415,7 +415,7 @@ impl Default for NodeState {
         use hotshot_example_types::storage_types::TestStorage;
         use versions::version;
 
-        use crate::v0_3::Fetcher;
+        use crate::{EpochCommittees, v0_3::Fetcher};
 
         let chain_config = ChainConfig::default();
         let l1 = L1Client::new(vec!["http://localhost:3331".parse().unwrap()])

--- a/crates/espresso/types/src/v0/impls/stake_table.rs
+++ b/crates/espresso/types/src/v0/impls/stake_table.rs
@@ -36,7 +36,6 @@ use hotshot_contract_adapter::{
     stake_table::StakeTableSolError,
 };
 use hotshot_types::{
-    PeerConfig,
     addr::NetAddr,
     data::{EpochNumber, vid_disperse::VID_TARGET_TOTAL_STAKE},
     x25519,
@@ -53,7 +52,7 @@ use vbs::version::Version;
 #[cfg(any(test, feature = "testing"))]
 use super::v0_3::DAMembers;
 use super::{
-    Header, L1Client, SeqTypes,
+    Header, L1Client,
     traits::{MembershipPersistence, StateCatchup},
     v0_3::{
         AuthenticatedValidator, ChainConfig, EventKey, Fetcher, MAX_VALIDATORS,
@@ -1752,6 +1751,10 @@ enum GetStakeTablesError {
 impl super::v0_3::StakeTable {
     /// Generate a `StakeTable` with `n` members.
     pub fn mock(n: u64) -> Self {
+        use hotshot_types::PeerConfig;
+
+        use super::SeqTypes;
+
         [..n]
             .iter()
             .map(|_| PeerConfig::test_default())
@@ -1764,6 +1767,10 @@ impl super::v0_3::StakeTable {
 impl DAMembers {
     /// Generate a `DaMembers` (alias committee) with `n` members.
     pub fn mock(n: u64) -> Self {
+        use hotshot_types::PeerConfig;
+
+        use super::SeqTypes;
+
         [..n]
             .iter()
             .map(|_| PeerConfig::test_default())

--- a/hotshot-query-service/src/data_source/extension.rs
+++ b/hotshot-query-service/src/data_source/extension.rs
@@ -19,10 +19,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use hotshot::types::Event;
 use hotshot_events_service::events_source::{EventFilterSet, EventsSource, StartupInfo};
-use hotshot_types::{
-    data::VidShare, event::LegacyEvent, new_protocol::CoordinatorEvent,
-    traits::node_implementation::NodeType,
-};
+use hotshot_types::{data::VidShare, event::LegacyEvent, traits::node_implementation::NodeType};
 use jf_merkle_tree_compat::prelude::MerkleProof;
 use tagged_base64::TaggedBase64;
 
@@ -568,6 +565,7 @@ where
 #[cfg(any(test, feature = "testing"))]
 mod impl_testable_data_source {
     use hotshot::types::Event;
+    use hotshot_types::new_protocol::CoordinatorEvent;
 
     use super::*;
     use crate::{

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -14,7 +14,7 @@ use hotshot_query_service_types::{
     availability::{BlockId, LeafId, LeafQueryData},
 };
 use hotshot_types::{data::EpochNumber, light_client::StateVerKey, x25519};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::{QueryBuilder, SqlitePool, query, query_as, sqlite::SqlitePoolOptions};
 use tempfile::{Builder, TempDir};
@@ -118,7 +118,7 @@ pub trait Storage: Sized + Send + Sync + 'static {
     ) -> impl Send + Future<Output = Result<()>>;
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct LightClientSqliteOptions {
     /// Maximum number of simultaneous DB connections to allow.


### PR DESCRIPTION
LightClientSqliteOptions are useful for configuring Espresso Stack from a config file, like toml. 
Missed this one in #4506 