### PR TITLE
test: add V5 all nodes restart at transition block

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -9145,4 +9145,149 @@ mod test {
 
         Ok(())
     }
+
+    /// Start a network at V5 from genesis, restart ALL nodes just before an epoch transition block
+    /// (`boundary - 3`), and confirm the chain keeps producing blocks afterward.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_v5_restart_before_epoch_boundary() {
+        const NUM_NODES: usize = 3;
+        const EPOCH_HEIGHT: u64 = 10;
+        // Rewards start in epoch 4. Restart 3 blocks before the boundary that closes epoch 4, so
+        // the restarted network produces the boundary block (`4 * EPOCH_HEIGHT`) itself.
+        const RESTART_EPOCH: u64 = 4;
+        const RESTART_BOUNDARY: u64 = RESTART_EPOCH * EPOCH_HEIGHT;
+        const RESTART_HEIGHT: u64 = RESTART_BOUNDARY - 3;
+        // Blocks to produce after the restart before declaring success.
+        const BLOCKS_AFTER_RESTART: u64 = 5;
+
+        const V5: Upgrade = Upgrade::trivial(EPOCH_REWARD_VERSION);
+
+        let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+
+        // Slow empty-block production so we comfortably stop at the exact target height. On an idle
+        // chain the empty-block time is ~`builder_timeout`; raise `next_view_timeout` above it so
+        // the slow (but healthy) views aren't treated as failures.
+        let network_config = TestConfigBuilder::<NUM_NODES>::default()
+            .epoch_height(EPOCH_HEIGHT)
+            .builder_timeout(Duration::from_secs(3))
+            .next_view_timeout(Duration::from_secs(10))
+            .build();
+
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+        let persistence: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(SqlDataSource::options(
+                &storage[0],
+                Options::with_port(port),
+            ))
+            .persistences(persistence.clone())
+            .catchups(std::array::from_fn(|_| {
+                StatePeers::<SequencerApiVersion>::from_urls(
+                    vec![format!("http://localhost:{port}").parse().unwrap()],
+                    Default::default(),
+                    Duration::from_secs(2),
+                    &NoMetrics,
+                )
+            }))
+            .network_config(network_config)
+            .pos_hook(DelegationConfig::MultipleDelegators, Default::default(), V5)
+            .await
+            .unwrap()
+            .build();
+
+        let mut network = TestNetwork::new(config, V5).await;
+
+        // Watch the decide stream and stop as soon as `boundary - 3` is decided. Consuming the
+        // stream (rather than polling `decided_leaf`) makes this independent of block timing: we
+        // see every decided leaf and stop the network the moment the target height appears, so we
+        // can never race past it regardless of how fast blocks are produced.
+        {
+            let mut events = network.server.event_stream();
+            'wait: loop {
+                let event = events
+                    .next()
+                    .await
+                    .expect("event stream ended unexpectedly");
+                let CoordinatorEvent::LegacyEvent(Event {
+                    event: EventType::Decide { leaf_chain, .. },
+                    ..
+                }) = event
+                else {
+                    continue;
+                };
+                // `leaf_chain` is newest-first; once any decided leaf has reached the target
+                // height, the chain is at or past it.
+                for LeafInfo { leaf, .. } in leaf_chain.iter() {
+                    if leaf.block_header().height() >= RESTART_HEIGHT {
+                        break 'wait;
+                    }
+                }
+            }
+        }
+
+        let restart_height = network.server.decided_leaf().await.height();
+        tracing::info!(
+            restart_height,
+            restart_epoch = RESTART_EPOCH,
+            restart_boundary = RESTART_BOUNDARY,
+            "restarting all nodes 3 blocks before an epoch boundary"
+        );
+
+        // Clone the TestConfig before dropping the network so the anvil/L1/contracts stay alive.
+        let saved_cfg = network.cfg.clone();
+
+        network.stop_consensus().await;
+        drop(network);
+
+        // Rebuild reusing the same persistence so nodes resume from stored state.
+        let port2 = reserve_tcp_port().expect("OS should have ephemeral ports available");
+        let config2 = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(SqlDataSource::options(
+                &storage[0],
+                Options::with_port(port2),
+            ))
+            .persistences(persistence)
+            .catchups(std::array::from_fn(|_| {
+                StatePeers::<SequencerApiVersion>::from_urls(
+                    vec![format!("http://localhost:{port2}").parse().unwrap()],
+                    Default::default(),
+                    Duration::from_secs(2),
+                    &NoMetrics,
+                )
+            }))
+            .network_config(saved_cfg)
+            .build();
+        let network2 = TestNetwork::new(config2, V5).await;
+
+        // The restarted network must keep advancing, including across the next epoch boundary.
+        // Require BLOCKS_AFTER_RESTART new decides, using a lack-of-progress watchdog so a
+        // healthy-but-slow chain still passes.
+        let target_height = restart_height + BLOCKS_AFTER_RESTART;
+        let stall_limit = 30; // 30 polls * 2s = 60s without a new decide => stalled
+        let mut last_height = network2.server.decided_leaf().await.height();
+        let mut stalled_polls = 0;
+        while last_height < target_height {
+            sleep(Duration::from_secs(2)).await;
+            let height = network2.server.decided_leaf().await.height();
+            if height > last_height {
+                last_height = height;
+                stalled_polls = 0;
+            } else {
+                stalled_polls += 1;
+                if stalled_polls >= stall_limit {
+                    panic!(
+                        "chain stalled after restart 3 blocks before boundary {RESTART_BOUNDARY}: \
+                         no new decide for 60s at height {last_height}, unable to produce/cross \
+                         the epoch boundary (target height was {target_height})."
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1294,6 +1294,23 @@ pub mod testing {
             self
         }
 
+        /// Override the builder timeout. On an idle chain the test builder returns no block (so it
+        /// doesn't drive empty blocks at full speed); the leader retries until this timeout elapses
+        /// and only then proposes an empty block itself. So for an empty mempool this is effectively
+        /// the empty-block time. Keep it below [`Self::next_view_timeout`] or views time out before
+        /// the leader proposes.
+        pub fn builder_timeout(mut self, timeout: Duration) -> Self {
+            self.config.builder_timeout = timeout;
+            self
+        }
+
+        /// Override the base next-view (failure) timeout. Raise it when using a large
+        /// [`Self::builder_timeout`] so a slow-but-healthy view isn't mistaken for a failed one.
+        pub fn next_view_timeout(mut self, timeout: Duration) -> Self {
+            self.config.next_view_timeout = timeout.as_millis() as u64;
+            self
+        }
+
         /// Override the views during which the upgrade is proposed. Call after `set_upgrades`.
         pub fn upgrade_proposing_views(mut self, start: u64, stop: u64) -> Self {
             for upgrade in self.upgrades.values_mut() {

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -961,7 +961,7 @@ pub mod testing {
     };
     use espresso_types::{
         EpochVersion, Event, FeeAccount, L1Client, NetworkConfig, PubKey, SeqTypes, Transaction,
-        Upgrade, UpgradeMap,
+        Upgrade, UpgradeMap, UpgradeMode,
         eth_signature_key::EthKeyPair,
         v0::traits::{EventConsumer, NullEventConsumer, PersistenceOptions, StateCatchup},
     };
@@ -1291,6 +1291,19 @@ pub mod testing {
 
         pub fn epoch_start_block(mut self, start_block: u64) -> Self {
             self.config.epoch_start_block = start_block;
+            self
+        }
+
+        /// Override the views during which the upgrade is proposed. Call after `set_upgrades`.
+        pub fn upgrade_proposing_views(mut self, start: u64, stop: u64) -> Self {
+            for upgrade in self.upgrades.values_mut() {
+                if let UpgradeMode::View(v) = &mut upgrade.mode {
+                    v.start_proposing_view = start;
+                    v.stop_proposing_view = stop;
+                }
+            }
+            self.config.start_proposing_view = start;
+            self.config.stop_proposing_view = stop;
             self
         }
 

--- a/crates/espresso/node/src/state.rs
+++ b/crates/espresso/node/src/state.rs
@@ -434,6 +434,53 @@ where
     let mut parent_leaf = parent_leaf.await;
     let mut parent_state = ValidatedState::from_header(parent_leaf.header());
 
+    // Seed the parent's reward tree from storage.
+    //
+    // `from_header` starts the reward tree empty, and the epoch boundary only
+    // repopulates it when the previous epoch actually distributed rewards. If the
+    // previous epoch predates rewards (e.g. the first boundary after a V4→V5
+    // upgrade, where the previous epoch is pre-V5), `handle_epoch_rewards` returns
+    // zero and passes the empty tree through unchanged. So after a restart in such
+    // an epoch the tree stays empty until the next boundary, where the save in
+    // `update_state_storage` fails as it serializes the tree as full key-value pairs
+    // and bails because the accounts are missing.
+    //
+    // Load the parent's tree from storage to avoid this. Doing it once is enough
+    // every later iteration carries the tree forward in `parent_state`.
+    if parent_leaf.header().version() > EPOCH_VERSION && parent_leaf.height() > 0 {
+        // The tree is only written at epoch boundaries, so the parent height
+        // usually has no row; fall back to the most recent tree at or below it.
+        let reward_merkle_tree_v2 = match storage
+            .load_reward_merkle_tree_v2(parent_leaf.height())
+            .await
+        {
+            Ok(tree) => tree,
+            Err(_) => storage
+                .load_latest_reward_merkle_tree_v2(parent_leaf.height())
+                .await
+                .context(
+                    "Error starting the state storage update loop: failed to load \
+                     RewardMerkleTreeV2 for the previous height",
+                )?,
+        };
+
+        // The fallback returns the latest tree at or below the parent height,
+        // which is the parent's tree only if their roots match (they do within an
+        // epoch). Verify against the root the parent header commits to.
+        let parent_reward_root = parent_leaf
+            .header()
+            .reward_merkle_tree_root()
+            .right()
+            .context("V5+ parent header must have a v2 reward root")?;
+        ensure!(
+            reward_merkle_tree_v2.tree.commitment() == parent_reward_root,
+            "loaded reward tree root {} does not match parent header {parent_reward_root}",
+            reward_merkle_tree_v2.tree.commitment(),
+        );
+
+        parent_state.reward_merkle_tree_v2 = reward_merkle_tree_v2.tree;
+    }
+
     if last_height == 0 {
         // If the last height is 0, we need to insert the genesis state, since this state is
         // never the result of a state update and thus is not inserted in the loop below.

--- a/crates/espresso/types/src/v0/impls/header.rs
+++ b/crates/espresso/types/src/v0/impls/header.rs
@@ -858,9 +858,10 @@ impl Header {
     ///   validation.
     ///
     /// If the previous epoch's result is missing at the boundary (e.g. after a
-    /// restart or catchup), the function fetches the epoch's leaf, recovers the
-    /// leader counts and stake table, computes rewards synchronously, and applies
-    /// them before proceeding.
+    /// restart), the function spawns the calculation and awaits it before
+    /// applying. The background task fetches the epoch's leaf and recovers the
+    /// leader counts and stake table itself, returning zero rewards for epochs
+    /// whose header version is < V5
     ///
     /// # Returns
     /// `(total_rewards_applied, changed_accounts)` — the total reward amount

--- a/crates/espresso/types/src/v0/impls/header.rs
+++ b/crates/espresso/types/src/v0/impls/header.rs
@@ -12,7 +12,6 @@ use hotshot_query_service_types::{
 use hotshot_types::{
     data::{EpochNumber, VidCommitment, ViewNumber, vid_commitment},
     light_client::LightClientState,
-    stake_table::HSStakeTable,
     traits::{
         BlockPayload, EncodeBytes, ValidatedState as _,
         block_contents::{BlockHeader, BuilderFee, GENESIS_VID_NUM_STORAGE_NODES},
@@ -912,7 +911,7 @@ impl Header {
 
         tracing::info!(%height, %epoch, %prev_epoch, "epoch boundary: applying rewards");
 
-        // Take the result. A failed eager task propagates its
+        // Take the result. A failed task propagates its
         // error here rather than retrying
         let result = reward_calculator.get_result(prev_epoch).await.transpose()?;
 

--- a/crates/espresso/types/src/v0/impls/header.rs
+++ b/crates/espresso/types/src/v0/impls/header.rs
@@ -53,7 +53,7 @@ use crate::{
     },
     v0_4::{self, RewardAccountV2, RewardMerkleCommitmentV2},
     v0_5::{self, LeaderCounts, MAX_VALIDATORS},
-    v0_6::{self, REWARD_MERKLE_TREE_V2_HEIGHT, RewardMerkleTreeV2},
+    v0_6::{self},
 };
 
 impl v0_1::Header {
@@ -912,9 +912,11 @@ impl Header {
 
         tracing::info!(%height, %epoch, %prev_epoch, "epoch boundary: applying rewards");
 
-        let (epoch_rewards_applied, changed_accounts) = if let Some(result) =
-            reward_calculator.get_result(prev_epoch).await
-        {
+        // Take the result. A failed eager task propagates its
+        // error here rather than retrying
+        let result = reward_calculator.get_result(prev_epoch).await.transpose()?;
+
+        let (epoch_rewards_applied, changed_accounts) = if let Some(result) = result {
             tracing::info!(
                 %epoch,
                 prev_epoch = %result.epoch,
@@ -927,95 +929,39 @@ impl Header {
             // Previous epoch is too early to have rewards.
             (RewardAmount::default(), HashSet::new())
         } else {
-            // the background result is missing
-            // Fetch the previous epoch's leaf and compute rewards synchronously.
-            let prev_epoch_last_block = *prev_epoch * epoch_height;
-            if let Err(err) = coordinator.membership_for_epoch(Some(prev_epoch)) {
-                tracing::info!(%prev_epoch, "stake table missing for prev_epoch, triggering catchup: {err:#}");
-                coordinator
-                    .wait_for_catchup(prev_epoch)
-                    .await
-                    .context(format!("failed to catch up for prev_epoch={prev_epoch}"))?;
-            }
+            // The background result is missing so compute
+            tracing::warn!(
+                %epoch,
+                %prev_epoch,
+                "missing epoch rewards at boundary, spawning calculation now"
+            );
 
-            let prev_snapshot = coordinator
-                .membership()
-                .snapshot(prev_epoch)
-                .with_context(|| format!("no committee for prev_epoch={prev_epoch}"))?;
+            reward_calculator.spawn_background_task(
+                prev_epoch,
+                epoch_height,
+                validated_state.reward_merkle_tree_v2.clone(),
+                instance_state.clone(),
+                coordinator.clone(),
+                None,
+            );
 
-            let stake_table = HSStakeTable::from_iter(prev_snapshot.stake_table());
-            let success_threshold = prev_snapshot.success_threshold();
-
-            let prev_epoch_leaf = instance_state
-                .state_catchup
-                .as_ref()
-                .fetch_leaf(prev_epoch_last_block, stake_table, success_threshold)
+            let result = reward_calculator
+                .get_result(prev_epoch)
                 .await
-                .with_context(|| {
-                    format!(
-                        "failed to fetch leaf at height {prev_epoch_last_block} for prev_epoch \
-                         {prev_epoch}"
-                    )
-                })?;
-            let prev_epoch_header = prev_epoch_leaf.block_header();
+                .context(format!("no pending reward task for epoch {prev_epoch}"))?
+                .context(format!(
+                    "failed to calculate missing rewards for epoch {prev_epoch}"
+                ))?;
 
-            if prev_epoch_header.version() >= EPOCH_REWARD_VERSION {
-                tracing::warn!(
-                    %epoch,
-                    %prev_epoch,
-                    "missing epoch rewards at boundary, spawning calculation now"
-                );
+            tracing::info!(
+                %epoch,
+                %prev_epoch,
+                total = %result.total_distributed.0,
+                "applied delayed epoch rewards"
+            );
 
-                if !reward_calculator.is_calculating(prev_epoch) {
-                    // Pick the reward tree to build on
-                    // use the local tree if its
-                    // root matches what the previous epoch's header committed to,
-                    // otherwise start from an empty tree because catchup will fill it
-                    let expected_root = prev_epoch_header.reward_merkle_tree_root().right();
-                    let actual_root = validated_state.reward_merkle_tree_v2.commitment();
-                    let reward_tree = if expected_root == Some(actual_root) {
-                        validated_state.reward_merkle_tree_v2.clone()
-                    } else {
-                        tracing::warn!(
-                            %epoch,
-                            %prev_epoch,
-                            ?expected_root,
-                            ?actual_root,
-                            "reward merkle tree root mismatch, using empty tree for catchup"
-                        );
-                        RewardMerkleTreeV2::new(REWARD_MERKLE_TREE_V2_HEIGHT)
-                    };
-
-                    reward_calculator.spawn_background_task(
-                        prev_epoch,
-                        epoch_height,
-                        reward_tree,
-                        instance_state.clone(),
-                        coordinator.clone(),
-                        prev_epoch_header.leader_counts().copied(),
-                    );
-                }
-
-                let result = reward_calculator
-                    .get_result(prev_epoch)
-                    .await
-                    .context(format!(
-                        "failed to calculate missing rewards for epoch {prev_epoch}"
-                    ))?;
-
-                tracing::info!(
-                    %epoch,
-                    %prev_epoch,
-                    total = %result.total_distributed.0,
-                    "applied delayed epoch rewards"
-                );
-
-                validated_state.reward_merkle_tree_v2 = result.reward_tree.clone();
-                (result.total_distributed, result.changed_accounts)
-            } else {
-                tracing::info!(%epoch, %prev_epoch, "no rewards for pre-V5 epoch");
-                (RewardAmount::default(), HashSet::new())
-            }
+            validated_state.reward_merkle_tree_v2 = result.reward_tree.clone();
+            (result.total_distributed, result.changed_accounts)
         };
 
         // Verify the reward tree root matches the proposed header, if available.

--- a/crates/espresso/types/src/v0/impls/reward.rs
+++ b/crates/espresso/types/src/v0/impls/reward.rs
@@ -1090,11 +1090,13 @@ impl EpochRewardsCalculator {
 
     /// Retrieve the completed reward calculation for `epoch`.
     ///
-    /// If a background task is pending for the requested epoch, this awaits its
-    /// completion and returns the result. If the pending task is for a
-    /// *different* epoch, it is left untouched and `None` is returned. Also
-    /// returns `None` when no pending task exists or the task failed/panicked.
-    pub async fn get_result(&mut self, epoch: EpochNumber) -> Option<EpochRewardsResult> {
+    /// Returns `None` when there is no pending task for the requested epoch
+    /// Otherwise awaits the task and returns `Some(Ok(result))` on success or
+    /// `Some(Err(..))` if it failed or panicked
+    pub async fn get_result(
+        &mut self,
+        epoch: EpochNumber,
+    ) -> Option<anyhow::Result<EpochRewardsResult>> {
         let (pending_epoch, handle) = self.pending.take()?;
         if pending_epoch != epoch {
             // Not the epoch we're looking for — put the task back.
@@ -1102,20 +1104,21 @@ impl EpochRewardsCalculator {
             return None;
         }
 
-        match handle.await {
+        let result = match handle.await {
             Ok(Ok(result)) => {
                 tracing::info!(%epoch, total = %result.total_distributed.0, "epoch rewards calculation completed");
-                Some(result)
+                Ok(result)
             },
             Ok(Err(e)) => {
                 tracing::error!(%epoch, error = %e, "epoch rewards calculation failed");
-                None
+                Err(e)
             },
             Err(e) => {
                 tracing::error!(%epoch, error = %e, "epoch rewards task panicked");
-                None
+                Err(anyhow::Error::new(e).context("epoch rewards task panicked"))
             },
-        }
+        };
+        Some(result)
     }
 
     /// Start a background task that calculates epoch rewards.
@@ -1221,11 +1224,19 @@ impl EpochRewardsCalculator {
                 "fetch_and_calculate: fetched leaf"
             );
 
-            anyhow::ensure!(
-                header.version() >= EPOCH_REWARD_VERSION,
-                "header version {} is pre-V6, cannot calculate rewards",
-                header.version()
-            );
+            if header.version() < EPOCH_REWARD_VERSION {
+                tracing::info!(
+                    %epoch,
+                    header_version = %header.version(),
+                    "no rewards to distribute"
+                );
+                return Ok(EpochRewardsResult {
+                    epoch,
+                    reward_tree,
+                    total_distributed: RewardAmount::default(),
+                    changed_accounts: HashSet::new(),
+                });
+            }
 
             // Validate the reward merkle tree against the header commitment.
             // If they don't match, use an empty tree so the rebuild logic

--- a/slow-tests/tests/epoch_reward_restart.rs
+++ b/slow-tests/tests/epoch_reward_restart.rs
@@ -1,0 +1,271 @@
+use std::time::Duration;
+
+use alloy::primitives::U256;
+use espresso_node::{
+    SequencerApiVersion,
+    api::{
+        Options,
+        data_source::testing::TestableSequencerDataSource,
+        sql::DataSource as SqlDataSource,
+        test_helpers::{TestNetwork, TestNetworkConfigBuilder},
+    },
+    catchup::StatePeers,
+    testing::TestConfigBuilder,
+};
+use espresso_types::ValidatedState;
+use futures::{StreamExt, future::join_all};
+use hotshot_types::{event::EventType, traits::metrics::NoMetrics, utils::epoch_from_block_number};
+use jf_merkle_tree_compat::MerkleTreeScheme;
+use test_utils::reserve_tcp_port;
+use tokio::time::sleep;
+use versions::{DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_REWARD_VERSION, Upgrade};
+
+/// Regression guard: restarting ALL nodes after the reward tree is non-empty causes
+/// ValidatedState::from_header to build a sparse tree. At the next epoch boundary the full
+/// tree is needed to compute the previous epoch's rewards; no peer can serve it, and the chain
+/// stalls.
+///
+/// The V4 base already distributes rewards every block, so the reward tree is non-empty before
+/// the upgrade. The V5 upgrade is configured to take effect in epoch 4 (epoch boundaries at
+/// 200, 400, 600, 800 with EPOCH_HEIGHT = 200), and the restart happens a few blocks later,
+/// mid-epoch-4, before the epoch 4 -> 5 boundary at block 800. Crossing that boundary requires
+/// computing the pre-V5 previous epoch's rewards from the full tree.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn slow_test_epoch_reward_restart() {
+    const NUM_NODES: usize = 3;
+    const EPOCH_HEIGHT: u64 = 200;
+    // Propose the upgrade mid-epoch-4 so it takes effect before the epoch 4 -> 5 boundary.
+    const UPGRADE_START_VIEW: u64 = 650;
+    const UPGRADE_STOP_VIEW: u64 = 1400;
+
+    let upgrade = Upgrade::new(DRB_AND_HEADER_UPGRADE_VERSION, EPOCH_REWARD_VERSION);
+
+    let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+
+    // V4 base already has epochs, so epoch_start_block = 0.
+    let test_config = TestConfigBuilder::default()
+        .epoch_height(EPOCH_HEIGHT)
+        .epoch_start_block(0)
+        .set_upgrades(upgrade.target)
+        .await
+        .upgrade_proposing_views(UPGRADE_START_VIEW, UPGRADE_STOP_VIEW)
+        .build();
+
+    let chain_config_upgrade = test_config.get_upgrade_map().chain_config(upgrade.target);
+
+    let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+    let persistence: [_; NUM_NODES] = storage
+        .iter()
+        .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+
+    // V4 base requires stake_table_contract in chain config from genesis.
+    let genesis_state = ValidatedState {
+        chain_config: chain_config_upgrade.into(),
+        ..Default::default()
+    };
+    let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+        .api_config(SqlDataSource::options(
+            &storage[0],
+            Options::with_port(port),
+        ))
+        .persistences(persistence.clone())
+        .catchups(std::array::from_fn(|_| {
+            StatePeers::<SequencerApiVersion>::from_urls(
+                vec![format!("http://localhost:{port}").parse().unwrap()],
+                Default::default(),
+                Duration::from_secs(2),
+                &NoMetrics,
+            )
+        }))
+        .states(std::array::from_fn(|_| genesis_state.clone()))
+        .network_config(test_config)
+        .build();
+
+    let mut network = TestNetwork::new(config, upgrade).await;
+
+    // Wait for the upgrade proposal and then for the upgrade to take effect.
+    let mut hotshot_events = network
+        .server
+        .consensus_handle()
+        .legacy_consensus()
+        .read()
+        .await
+        .event_stream();
+    let upgrade_cert = loop {
+        let event = hotshot_events.next().await.unwrap();
+        if let EventType::UpgradeProposal { proposal, .. } = event.event {
+            let cert = proposal.data.upgrade_proposal;
+            assert_eq!(cert.new_version, EPOCH_REWARD_VERSION);
+            break cert;
+        }
+    };
+    let wanted_view = upgrade_cert.new_version_first_view;
+    loop {
+        let event = hotshot_events.next().await.unwrap();
+        if event.view_number > wanted_view {
+            break;
+        }
+    }
+    drop(hotshot_events);
+
+    // Wait for the upgrade to appear on the decided chain, then advance a few more blocks so
+    // the restart happens mid-epoch, before the next epoch boundary.
+    let upgrade_height = loop {
+        sleep(Duration::from_secs(1)).await;
+        let leaf = network.server.decided_leaf().await;
+        if leaf.block_header().version() >= EPOCH_REWARD_VERSION {
+            break leaf.height();
+        }
+    };
+    loop {
+        sleep(Duration::from_secs(1)).await;
+        if network.server.decided_leaf().await.height() >= upgrade_height + 5 {
+            break;
+        }
+    }
+
+    let decided_state = network
+        .server
+        .decided_state()
+        .await
+        .expect("decided state must be available");
+    let decided_leaf = network.server.decided_leaf().await;
+    let num_leaves_before_restart = decided_state.reward_merkle_tree_v2.num_leaves();
+    let rewards_before_restart = decided_leaf
+        .block_header()
+        .total_reward_distributed()
+        .expect("V5+ header must carry total_reward_distributed");
+    let restart_height = decided_leaf.height();
+    let restart_epoch = epoch_from_block_number(restart_height, EPOCH_HEIGHT);
+    let upgrade_epoch = epoch_from_block_number(upgrade_height, EPOCH_HEIGHT);
+    tracing::info!(
+        upgrade_height,
+        upgrade_epoch,
+        restart_height,
+        restart_epoch,
+        num_leaves_before_restart,
+        total_reward_distributed = %rewards_before_restart.0,
+        "restarting all nodes with non-empty reward tree"
+    );
+    // Preconditions for the test to exercise the bug:
+    // - The reward tree must be non-empty; otherwise from_header builds a fresh empty tree
+    //   rather than a sparse one and the bug cannot trigger.
+    // - The upgrade must take effect after the first epoch and the restart must stay in the
+    //   same epoch as the upgrade, so the upcoming boundary computes the pre-V5 previous
+    //   epoch's rewards from the recovered tree.
+    assert!(
+        num_leaves_before_restart > 0,
+        "num_leaves={num_leaves_before_restart}: reward tree must be non-empty at restart"
+    );
+    assert!(
+        rewards_before_restart.0 > U256::ZERO,
+        "no rewards distributed before restart (total_reward_distributed=0)"
+    );
+    assert!(
+        upgrade_epoch > 1,
+        "upgrade must not take effect in the first epoch (upgrade_epoch={upgrade_epoch})"
+    );
+    assert_eq!(
+        restart_epoch, upgrade_epoch,
+        "restart must stay in the upgrade epoch, before the next epoch boundary"
+    );
+
+    // Clone the TestConfig before dropping the network so the anvil/L1/contracts stay alive.
+    let saved_cfg = network.cfg.clone();
+
+    network.stop_consensus().await;
+    drop(network);
+
+    // Rebuild reusing the same persistence so nodes resume from stored state.
+    let port2 = reserve_tcp_port().expect("OS should have ephemeral ports available");
+    let config2 = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+        .api_config(SqlDataSource::options(
+            &storage[0],
+            Options::with_port(port2),
+        ))
+        .persistences(persistence)
+        .catchups(std::array::from_fn(|_| {
+            StatePeers::<SequencerApiVersion>::from_urls(
+                vec![format!("http://localhost:{port2}").parse().unwrap()],
+                Default::default(),
+                Duration::from_secs(2),
+                &NoMetrics,
+            )
+        }))
+        .states(std::array::from_fn(|_| genesis_state.clone()))
+        .network_config(saved_cfg)
+        .build();
+    let network2 = TestNetwork::new(config2, upgrade).await;
+
+    // The chain must keep advancing across two epoch boundaries whose reward trees are computed
+    // entirely after the restart. If the sparse tree cannot be recovered, consensus wedges and
+    // the decided height freezes. Use a lack-of-progress watchdog (not a fixed deadline) so a
+    // healthy-but-slow chain still passes while a genuine stall fails.
+    let target_height = (restart_epoch + 2) * EPOCH_HEIGHT;
+    let stall_limit = 30; // 30 polls * 2s = 60s without a new decide => stalled
+    let mut last_height = network2.server.decided_leaf().await.height();
+    let mut stalled_polls = 0;
+    while last_height < target_height {
+        sleep(Duration::from_secs(2)).await;
+        let height = network2.server.decided_leaf().await.height();
+        if height > last_height {
+            last_height = height;
+            stalled_polls = 0;
+        } else {
+            stalled_polls += 1;
+            if stalled_polls >= stall_limit {
+                let stalled_epoch = epoch_from_block_number(last_height, EPOCH_HEIGHT);
+                let next_boundary = (stalled_epoch + 1) * EPOCH_HEIGHT;
+                panic!(
+                    "chain stalled after restart: no new decide for 60s at height {last_height} \
+                     (epoch {stalled_epoch}), unable to cross next epoch boundary at height \
+                     {next_boundary}. The sparse reward tree could not be recovered (target \
+                     height was {target_height})."
+                );
+            }
+        }
+    }
+
+    // Rewards must keep being distributed across the post-restart boundaries, confirming the
+    // reward path is still exercised (not merely that empty blocks advanced).
+    let rewards_after_restart = network2
+        .server
+        .decided_leaf()
+        .await
+        .block_header()
+        .total_reward_distributed()
+        .expect("V5+ header must carry total_reward_distributed");
+    assert!(
+        rewards_after_restart.0 > rewards_before_restart.0,
+        "no rewards distributed after restart: before={}, after={}",
+        rewards_before_restart.0,
+        rewards_after_restart.0
+    );
+
+    // Consistency check: all peers agree on the reward_merkle_tree_root at the decided leaf.
+    let roots: Vec<_> = join_all(network2.peers.iter().map(|peer| async {
+        peer.consensus_handle()
+            .decided_state()
+            .await
+            .unwrap()
+            .reward_merkle_tree_v2
+            .commitment()
+    }))
+    .await;
+    let server_root = network2
+        .server
+        .decided_state()
+        .await
+        .unwrap()
+        .reward_merkle_tree_v2
+        .commitment();
+    for root in &roots {
+        assert_eq!(
+            root, &server_root,
+            "reward_merkle_tree_root mismatch across peers"
+        );
+    }
+}


### PR DESCRIPTION
Adds a test that starts a V5 network, restarts all nodes 3 blocks at the transition block, and asserts the chain keeps producing blocks across the boundary.