### PR TITLE
fix(telemetry): always ship a node id plus pubkey slug

### DIFF
--- a/crates/espresso/telemetry/src/lifecycle.rs
+++ b/crates/espresso/telemetry/src/lifecycle.rs
@@ -38,7 +38,6 @@ use crate::{UnauthenticatedToken, push_task, remote_write::Label};
 const SERVICE_NAME: &str = "espresso-node";
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Matches the telemetry proxy's `node_id_from_token` pubkey slug length.
 const PUBKEY_SLUG_LEN: usize = 24;
 
 fn pubkey_slug(staking_key: &SignKey) -> String {
@@ -49,8 +48,6 @@ fn pubkey_slug(staking_key: &SignKey) -> String {
         .collect()
 }
 
-/// Partition key for logs and metrics: `{node_name|unknown}-{pubkey_slug}`,
-/// lowercased.
 fn instance_id(node_name: Option<&str>, staking_key: &SignKey) -> String {
     format!(
         "{}-{}",

--- a/crates/espresso/telemetry/src/lifecycle.rs
+++ b/crates/espresso/telemetry/src/lifecycle.rs
@@ -47,10 +47,18 @@ fn pubkey_slug(staking_key: &SignKey) -> String {
         .collect()
 }
 
-fn instance_id(node_name: Option<&str>, staking_key: &SignKey) -> String {
+fn segment(value: Option<&str>) -> String {
+    match value.unwrap_or("").trim() {
+        "" => "unk".to_owned(),
+        v => v.replace(' ', "-"),
+    }
+}
+
+fn instance_id(company: Option<&str>, node: Option<&str>, staking_key: &SignKey) -> String {
     format!(
-        "{}-{}",
-        node_name.unwrap_or("unknown"),
+        "{}-{}-{}",
+        segment(company),
+        segment(node),
         pubkey_slug(staking_key)
     )
     .to_lowercase()
@@ -373,7 +381,7 @@ pub fn init(
     let telemetry_log_filter: Arc<String> = Arc::new(opts.log_filter.clone());
     let rate_limit_warned: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
-    let instance = instance_id(node_name, staking_key);
+    let instance = instance_id(company_name, node_name, staking_key);
 
     let logger_provider = if logs_on {
         Some(build_logger_provider(jwt.clone(), &endpoint, &instance)?)
@@ -459,9 +467,13 @@ mod tests {
 
         let slug = slug.to_lowercase();
         assert_eq!(
-            instance_id(Some("Node-42"), &key),
-            format!("node-42-{slug}")
+            instance_id(Some("Acme Corp"), Some("Node 42"), &key),
+            format!("acme-corp-node-42-{slug}")
         );
-        assert_eq!(instance_id(None, &key), format!("unknown-{slug}"));
+        assert_eq!(instance_id(None, None, &key), format!("unk-unk-{slug}"));
+        assert_eq!(
+            instance_id(Some("  "), Some("node-1"), &key),
+            format!("unk-node-1-{slug}")
+        );
     }
 }

--- a/crates/espresso/telemetry/src/lifecycle.rs
+++ b/crates/espresso/telemetry/src/lifecycle.rs
@@ -27,7 +27,6 @@ use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{Compression, LogExporter, Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::{Resource, logs::SdkLoggerProvider};
 use prometheus::Registry;
-use tagged_base64::TaggedBase64;
 use tokio::sync::oneshot;
 use tracing::Subscriber;
 use tracing_subscriber::{EnvFilter, Layer, registry::LookupSpan};
@@ -41,7 +40,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const PUBKEY_SLUG_LEN: usize = 24;
 
 fn pubkey_slug(staking_key: &SignKey) -> String {
-    TaggedBase64::from(&VerKey::from(staking_key))
+    VerKey::from(staking_key)
         .to_string()
         .chars()
         .take(PUBKEY_SLUG_LEN)
@@ -449,15 +448,11 @@ mod tests {
 
     use super::*;
 
-    fn staking_key() -> SignKey {
-        BLSOverBN254CurveSignatureScheme::key_gen(&(), &mut rand::thread_rng())
-            .unwrap()
-            .0
-    }
-
     #[test]
     fn instance_id_appends_pubkey_slug() {
-        let key = staking_key();
+        let key = BLSOverBN254CurveSignatureScheme::key_gen(&(), &mut rand::thread_rng())
+            .unwrap()
+            .0;
         let slug = pubkey_slug(&key);
         assert_eq!(slug.len(), PUBKEY_SLUG_LEN);
         assert!(slug.starts_with("BLS_VER_KEY~"));

--- a/crates/espresso/telemetry/src/lifecycle.rs
+++ b/crates/espresso/telemetry/src/lifecycle.rs
@@ -21,12 +21,13 @@ use std::{
 use anyhow::Context;
 use clap::Parser;
 use derivative::Derivative;
-use jf_signature::bls_over_bn254::SignKey;
+use jf_signature::bls_over_bn254::{SignKey, VerKey};
 use opentelemetry::KeyValue;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{Compression, LogExporter, Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::{Resource, logs::SdkLoggerProvider};
 use prometheus::Registry;
+use tagged_base64::TaggedBase64;
 use tokio::sync::oneshot;
 use tracing::Subscriber;
 use tracing_subscriber::{EnvFilter, Layer, registry::LookupSpan};
@@ -36,6 +37,33 @@ use crate::{UnauthenticatedToken, push_task, remote_write::Label};
 
 const SERVICE_NAME: &str = "espresso-node";
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Length of the BLS key prefix used to disambiguate operators, matching the
+/// telemetry proxy's `node_id_from_token` slug.
+const PUBKEY_SLUG_LEN: usize = 24;
+
+/// First [`PUBKEY_SLUG_LEN`] chars of the verification key's tagged-base64
+/// string, identical to the proxy's pubkey fallback so node-side and
+/// proxy-side ids agree.
+fn pubkey_slug(staking_key: &SignKey) -> String {
+    TaggedBase64::from(&VerKey::from(staking_key))
+        .to_string()
+        .chars()
+        .take(PUBKEY_SLUG_LEN)
+        .collect()
+}
+
+/// Partition key stamped on logs (`service.instance.id`) and metrics
+/// (`instance` label): `{node_name}-{pubkey_slug}`, with `node_name` defaulting
+/// to `unknown`. Anchors the key to the BLS key so the aggregator never falls
+/// back to a bare `unknown`. Set in-process, so spoofable.
+fn instance_id(node_name: Option<&str>, staking_key: &SignKey) -> String {
+    format!(
+        "{}-{}",
+        node_name.unwrap_or("unknown"),
+        pubkey_slug(staking_key)
+    )
+}
 
 /// Join `thread`, detaching it after [`SHUTDOWN_TIMEOUT`] so a wedged exporter
 /// can't hang shutdown on the main thread.
@@ -354,23 +382,25 @@ pub fn init(
     let telemetry_log_filter: Arc<String> = Arc::new(opts.log_filter.clone());
     let rate_limit_warned: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
+    let instance = instance_id(node_name, staking_key);
+
     let logger_provider = if logs_on {
-        Some(build_logger_provider(jwt.clone(), &endpoint, node_name)?)
+        Some(build_logger_provider(jwt.clone(), &endpoint, &instance)?)
     } else {
         None
     };
 
     let metrics_interval = Duration::from_secs(opts.metrics_interval_secs.max(1));
-    let mut metrics_external_labels = vec![Label {
-        name: "service".to_owned(),
-        value: SERVICE_NAME.to_owned(),
-    }];
-    if let Some(name) = node_name {
-        metrics_external_labels.push(Label {
+    let metrics_external_labels = vec![
+        Label {
+            name: "service".to_owned(),
+            value: SERVICE_NAME.to_owned(),
+        },
+        Label {
             name: "instance".to_owned(),
-            value: name.to_owned(),
-        });
-    }
+            value: instance,
+        },
+    ];
     let mut handle = TelemetryHandle {
         logger_provider,
         log_filter: opts.log_filter.clone(),
@@ -394,7 +424,7 @@ pub fn init(
 fn build_logger_provider(
     jwt: String,
     endpoint: &str,
-    node_name: Option<&str>,
+    instance: &str,
 ) -> anyhow::Result<SdkLoggerProvider> {
     let logs_endpoint = format!("{}/v1/logs", endpoint.trim_end_matches('/'));
 
@@ -411,14 +441,40 @@ fn build_logger_provider(
         .build()
         .context("build OTLP log exporter")?;
 
-    let mut resource = Resource::builder().with_service_name(SERVICE_NAME);
-    if let Some(name) = node_name {
-        // service.instance.id distinguishes individual operators in the aggregator.
-        resource = resource.with_attribute(KeyValue::new("service.instance.id", name.to_owned()));
-    }
+    // service.instance.id distinguishes individual operators in the aggregator.
+    let resource = Resource::builder()
+        .with_service_name(SERVICE_NAME)
+        .with_attribute(KeyValue::new("service.instance.id", instance.to_owned()));
 
     Ok(SdkLoggerProvider::builder()
         .with_resource(resource.build())
         .with_batch_exporter(exporter)
         .build())
+}
+
+#[cfg(test)]
+mod tests {
+    use jf_signature::{SignatureScheme, bls_over_bn254::BLSOverBN254CurveSignatureScheme};
+
+    use super::*;
+
+    fn staking_key() -> SignKey {
+        BLSOverBN254CurveSignatureScheme::key_gen(&(), &mut rand::thread_rng())
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn instance_id_appends_pubkey_slug() {
+        let key = staking_key();
+        let slug = pubkey_slug(&key);
+        assert_eq!(slug.len(), PUBKEY_SLUG_LEN);
+        assert!(slug.starts_with("BLS_VER_KEY~"));
+
+        assert_eq!(
+            instance_id(Some("node-42"), &key),
+            format!("node-42-{slug}")
+        );
+        assert_eq!(instance_id(None, &key), format!("unknown-{slug}"));
+    }
 }

--- a/crates/espresso/telemetry/src/lifecycle.rs
+++ b/crates/espresso/telemetry/src/lifecycle.rs
@@ -38,13 +38,9 @@ use crate::{UnauthenticatedToken, push_task, remote_write::Label};
 const SERVICE_NAME: &str = "espresso-node";
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Length of the BLS key prefix used to disambiguate operators, matching the
-/// telemetry proxy's `node_id_from_token` slug.
+/// Matches the telemetry proxy's `node_id_from_token` pubkey slug length.
 const PUBKEY_SLUG_LEN: usize = 24;
 
-/// First [`PUBKEY_SLUG_LEN`] chars of the verification key's tagged-base64
-/// string, identical to the proxy's pubkey fallback so node-side and
-/// proxy-side ids agree.
 fn pubkey_slug(staking_key: &SignKey) -> String {
     TaggedBase64::from(&VerKey::from(staking_key))
         .to_string()
@@ -53,16 +49,15 @@ fn pubkey_slug(staking_key: &SignKey) -> String {
         .collect()
 }
 
-/// Partition key stamped on logs (`service.instance.id`) and metrics
-/// (`instance` label): `{node_name}-{pubkey_slug}`, with `node_name` defaulting
-/// to `unknown`. Anchors the key to the BLS key so the aggregator never falls
-/// back to a bare `unknown`. Set in-process, so spoofable.
+/// Partition key for logs and metrics: `{node_name|unknown}-{pubkey_slug}`,
+/// lowercased.
 fn instance_id(node_name: Option<&str>, staking_key: &SignKey) -> String {
     format!(
         "{}-{}",
         node_name.unwrap_or("unknown"),
         pubkey_slug(staking_key)
     )
+    .to_lowercase()
 }
 
 /// Join `thread`, detaching it after [`SHUTDOWN_TIMEOUT`] so a wedged exporter
@@ -441,7 +436,6 @@ fn build_logger_provider(
         .build()
         .context("build OTLP log exporter")?;
 
-    // service.instance.id distinguishes individual operators in the aggregator.
     let resource = Resource::builder()
         .with_service_name(SERVICE_NAME)
         .with_attribute(KeyValue::new("service.instance.id", instance.to_owned()));
@@ -471,8 +465,9 @@ mod tests {
         assert_eq!(slug.len(), PUBKEY_SLUG_LEN);
         assert!(slug.starts_with("BLS_VER_KEY~"));
 
+        let slug = slug.to_lowercase();
         assert_eq!(
-            instance_id(Some("node-42"), &key),
+            instance_id(Some("Node-42"), &key),
             format!("node-42-{slug}")
         );
         assert_eq!(instance_id(None, &key), format!("unknown-{slug}"));


### PR DESCRIPTION
Better human readable instance ID for telemetry logs.
