### PR TITLE
fix(libp2p): await swarm task on shutdown to release listen socket

### DIFF
--- a/crates/hotshot/libp2p-networking/src/network/mod.rs
+++ b/crates/hotshot/libp2p-networking/src/network/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
     node::{
         DEFAULT_REPLICATION_FACTOR, GossipConfig, NetworkNode, NetworkNodeConfig,
         NetworkNodeConfigBuilder, NetworkNodeConfigBuilderError, NetworkNodeHandle,
-        NetworkNodeReceiver, RequestResponseConfig, spawn_network_node,
+        NetworkNodeReceiver, RequestResponseConfig, SwarmTaskHandle, spawn_network_node,
     },
 };
 

--- a/crates/hotshot/libp2p-networking/src/network/node.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node.rs
@@ -49,6 +49,7 @@ use rand::{prelude::SliceRandom, thread_rng};
 use tokio::{
     select, spawn,
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    task::JoinHandle,
 };
 use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
 
@@ -79,6 +80,9 @@ use crate::network::{
     },
     log_summary::LogEvent,
 };
+
+/// Join handle for the spawned swarm event-loop task.
+pub type SwarmTaskHandle = JoinHandle<Result<(), NetworkError>>;
 
 /// Maximum size of a message
 pub const MAX_GOSSIP_MSG_SIZE: usize = 2_000_000_000;
@@ -863,6 +867,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
         (
             UnboundedSender<ClientRequest>,
             UnboundedReceiver<NetworkEvent>,
+            SwarmTaskHandle,
         ),
         NetworkError,
     > {
@@ -873,7 +878,9 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
         self.dht_handler.set_bootstrap_sender(bootstrap_tx.clone());
 
         DHTBootstrapTask::run(bootstrap_rx, s_input.clone());
-        spawn(
+        // Keep the task's `JoinHandle` so callers can await the swarm loop
+        // ending on shutdown, ensuring the listening socket is released.
+        let task = spawn(
             async move {
                 loop {
                     select! {
@@ -894,11 +901,12 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
                         }
                     }
                 }
+                drop(self.swarm);
                 Ok::<(), NetworkError>(())
             }
             .instrument(info_span!("Libp2p NetworkBehaviour Handler")),
         );
-        Ok((s_input, r_output))
+        Ok((s_input, r_output, task))
     }
 
     /// Get a reference to the network node's peer id.

--- a/crates/hotshot/libp2p-networking/src/network/node/handle.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node/handle.rs
@@ -20,7 +20,7 @@ use tokio::{
 use tracing::{debug, info, instrument};
 
 use crate::network::{
-    ClientRequest, NetworkEvent, NetworkNode, NetworkNodeConfig,
+    ClientRequest, NetworkEvent, NetworkNode, NetworkNodeConfig, SwarmTaskHandle,
     behaviours::dht::{
         record::{Namespace, RecordKey, RecordValue},
         store::persistent::DhtPersistentStorage,
@@ -50,6 +50,9 @@ pub struct NetworkNodeHandle<T: NodeType> {
 
     /// human readable id
     id: usize,
+
+    /// Handle to the spawned swarm event-loop task.
+    swarm_task: Arc<Mutex<Option<SwarmTaskHandle>>>,
 }
 
 /// internal network node receiver
@@ -112,7 +115,7 @@ pub async fn spawn_network_node<T: NodeType, D: DhtPersistentStorage>(
     })?;
     // pin here to force the future onto the heap since it can be large
     // in the case of flume
-    let (send_chan, recv_chan) = network.spawn_listeners().map_err(|err| {
+    let (send_chan, recv_chan, swarm_task) = network.spawn_listeners().map_err(|err| {
         NetworkError::ListenError(format!("failed to spawn listeners for Libp2p: {err}"))
     })?;
     log_summary::spawn_summary_task();
@@ -128,6 +131,7 @@ pub async fn spawn_network_node<T: NodeType, D: DhtPersistentStorage>(
         listen_addr,
         peer_id,
         id,
+        swarm_task: Arc::new(Mutex::new(Some(swarm_task))),
     };
     Ok((receiver, handle))
 }
@@ -139,6 +143,19 @@ impl<T: NodeType> NetworkNodeHandle<T> {
     #[instrument]
     pub async fn shutdown(&self) -> Result<(), NetworkError> {
         self.send_request(ClientRequest::Shutdown)?;
+
+        // Wait for the swarm event-loop task to actually finish, so its
+        // listening socket is released before we return.
+        let task = self.swarm_task.lock().take();
+        if let Some(task) = task {
+            match timeout(Duration::from_secs(5), task).await {
+                Ok(Ok(_)) => {},
+                Ok(Err(e)) => debug!("swarm task ended with error during shutdown: {e}"),
+                Err(_) => {
+                    debug!("timed out waiting for swarm task to finish during shutdown");
+                },
+            }
+        }
         Ok(())
     }
     /// Notify the network to begin the bootstrap process


### PR DESCRIPTION
`spawn_listeners` now returns the swarm event-loop's `JoinHandle`, which `NetworkNodeHandle::shutdown` awaits (5s timeout) before returning.

This ensures the swarm's listening socket is dropped before shutdown completes, so a restart can re-bind the same port instead of failing with "failed to listen for Libp2p".

Split out of #4463.