### PR TITLE
feat(libp2p): add network discriminator to identify protocol

### DIFF
--- a/crates/hotshot/libp2p-networking/src/network/log_summary.rs
+++ b/crates/hotshot/libp2p-networking/src/network/log_summary.rs
@@ -88,9 +88,7 @@ pub fn spawn_summary_task() {
 mod tests {
     use std::sync::{Mutex, MutexGuard, OnceLock, atomic::Ordering};
 
-    use tracing_test::traced_test;
-
-    use super::{COUNTERS, LogEvent, drain_and_format, emit_summary};
+    use super::{COUNTERS, LogEvent, drain_and_format};
 
     fn test_lock() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -106,12 +104,10 @@ mod tests {
     }
 
     #[test]
-    #[traced_test]
     fn emits_only_nonzero_and_skips_when_idle() {
         let _g = test_lock();
         reset();
-        emit_summary();
-        assert!(!logs_contain("libp2p"));
+        assert!(drain_and_format().is_none());
 
         for _ in 0..3 {
             LogEvent::DialFailure.record();
@@ -119,11 +115,10 @@ mod tests {
         for _ in 0..5 {
             LogEvent::AuthFailure.record();
         }
-        emit_summary();
-        assert!(logs_contain("libp2p 60s summary:"));
-        assert!(logs_contain("auth_failures=5"));
-        assert!(logs_contain("dial_failures=3"));
-        assert!(!logs_contain("verify_failures"));
+        let summary = drain_and_format().expect("expected a summary");
+        assert!(summary.contains("auth_failures=5"));
+        assert!(summary.contains("dial_failures=3"));
+        assert!(!summary.contains("verify_failures"));
         assert!(drain_and_format().is_none());
     }
 

--- a/crates/hotshot/libp2p-networking/src/network/node.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node.rs
@@ -110,6 +110,9 @@ pub(crate) fn mainnet_kad_protocol() -> StreamProtocol {
 pub(crate) fn mainnet_direct_message_protocol() -> StreamProtocol {
     StreamProtocol::new("/HotShot/direct_message/1.0")
 }
+pub(crate) fn mainnet_identify_protocol() -> &'static str {
+    "HotShot/identify/1.0"
+}
 
 /// Resolve the gossipsub `protocol_id_prefix` for the given network discriminator.
 /// `None` returns the mainnet value (the libp2p default).
@@ -126,6 +129,14 @@ pub(crate) fn kad_protocol(discriminator: Option<U256>) -> Result<StreamProtocol
         None => Ok(mainnet_kad_protocol()),
         Some(d) => StreamProtocol::try_from_owned(format!("/ipfs/kad/1.0.0/{d:#x}"))
             .map_err(|err| NetworkError::ConfigError(format!("invalid kademlia protocol: {err}"))),
+    }
+}
+
+/// Resolve the identify protocol string for the given network discriminator.
+pub(crate) fn identify_protocol(discriminator: Option<U256>) -> String {
+    match discriminator {
+        None => mainnet_identify_protocol().to_string(),
+        Some(d) => format!("HotShot/identify/1.0/{d:#x}"),
     }
 }
 
@@ -320,8 +331,10 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
             //   node connection information
             //   E.g. this will answer the question: how are other nodes
             //   seeing the peer from behind a NAT
-            let identify_cfg =
-                IdentifyConfig::new("HotShot/identify/1.0".to_string(), keypair.public());
+            let identify_cfg = IdentifyConfig::new(
+                identify_protocol(config.network_discriminator),
+                keypair.public(),
+            );
             let identify = IdentifyBehaviour::new(identify_cfg);
 
             // - Build DHT needed for peer discovery
@@ -917,14 +930,15 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
 
 #[cfg(test)]
 mod tests {
-    use super::{U256, direct_message_protocol, gossipsub_prefix, kad_protocol};
+    use super::{U256, direct_message_protocol, gossipsub_prefix, identify_protocol, kad_protocol};
 
     fn snapshot_for(discriminator: Option<U256>) -> String {
         format!(
-            "gossipsub_prefix: {:?}\nkad: {}\ndirect_message: {}",
+            "gossipsub_prefix: {:?}\nkad: {}\ndirect_message: {}\nidentify: {}",
             gossipsub_prefix(discriminator),
             kad_protocol(discriminator).unwrap(),
             direct_message_protocol(discriminator).unwrap(),
+            identify_protocol(discriminator),
         )
     }
 

--- a/crates/hotshot/libp2p-networking/src/network/snapshots/hotshot_libp2p_networking__network__node__tests__decaf_libp2p_protocol_identifiers.snap
+++ b/crates/hotshot/libp2p-networking/src/network/snapshots/hotshot_libp2p_networking__network__node__tests__decaf_libp2p_protocol_identifiers.snap
@@ -5,3 +5,4 @@ expression: "snapshot_for(Some(U256::from(0xdecafu64)))"
 gossipsub_prefix: Some("/HotShot/gossipsub/1.0/0xdecaf")
 kad: /ipfs/kad/1.0.0/0xdecaf
 direct_message: /HotShot/direct_message/1.0/0xdecaf
+identify: HotShot/identify/1.0/0xdecaf

--- a/crates/hotshot/libp2p-networking/src/network/snapshots/hotshot_libp2p_networking__network__node__tests__mainnet_libp2p_protocol_identifiers.snap
+++ b/crates/hotshot/libp2p-networking/src/network/snapshots/hotshot_libp2p_networking__network__node__tests__mainnet_libp2p_protocol_identifiers.snap
@@ -5,3 +5,4 @@ expression: snapshot_for(None)
 gossipsub_prefix: None
 kad: /ipfs/kad/1.0.0
 direct_message: /HotShot/direct_message/1.0
+identify: HotShot/identify/1.0


### PR DESCRIPTION
- Add identify_protocol() resolver following the same pattern as kad_protocol, gossipsub_prefix, and direct_message_protocol
- Prevents TCP connections forming between nodes on different networks
- Update snapshot tests to include identify protocol strings
- Fix broken (cargo test, works only with nextest) log_summary test: drop #[traced_test] which panics when the global tracing subscriber is already set by another test in the same process; assert on drain_and_format() directly instead
