### PR TITLE
feat(shutdown): graceful shutdown for long-running binaries

### DIFF
--- a/crates/builder/src/bin/permissionless-builder.rs
+++ b/crates/builder/src/bin/permissionless-builder.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use espresso_node::{Genesis, L1Params};
 use espresso_types::{eth_signature_key::EthKeyPair, parse_duration};
 use espresso_utils::logging;
-use futures::future::pending;
 use hotshot::traits::ValidatedState;
 use hotshot_types::data::ViewNumber;
 use url::Url;
@@ -153,8 +152,7 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) -> anyhow::Result<()> {
     )
     .await?;
 
-    // Sleep forever
-    pending::<()>().await;
+    espresso_utils::shutdown::wait_for_shutdown_signal().await;
 
     Ok(())
 }

--- a/crates/espresso/dev-node/src/main.rs
+++ b/crates/espresso/dev-node/src/main.rs
@@ -746,10 +746,12 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) -> anyhow::Result<()> {
     ));
     handles.push(dev_node_handle);
 
-    // if any of the async task is complete then dev node binary exits
-    if let Some(item) = handles.next().await {
-        tracing::error!("exiting dev node: {item:?}");
-        drop(network);
+    tokio::select! {
+        Some(item) = handles.next() => {
+            tracing::error!("exiting dev node: {item:?}");
+            drop(network);
+        },
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => drop(network),
     }
 
     Ok(())

--- a/crates/espresso/node/src/bin/cdn-broker.rs
+++ b/crates/espresso/node/src/bin/cdn-broker.rs
@@ -149,8 +149,10 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
     // Uses TCP from broker connections and Quic for user connections.
     let broker = Broker::new(broker_config).await?;
 
-    // Start the main loop, consuming it
-    broker.start().await?;
+    tokio::select! {
+        res = broker.start() => res?,
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+    }
 
     Ok(())
 }

--- a/crates/espresso/node/src/bin/cdn-marshal.rs
+++ b/crates/espresso/node/src/bin/cdn-marshal.rs
@@ -98,8 +98,10 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
     // Create new `Marshal` from the config
     let marshal = Marshal::<ProductionDef<SeqTypes>>::new(config).await?;
 
-    // Start the main loop, consuming it
-    marshal.start().await?;
+    tokio::select! {
+        res = marshal.start() => res?,
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+    }
 
     Ok(())
 }

--- a/crates/espresso/node/src/bin/dev-cdn.rs
+++ b/crates/espresso/node/src/bin/dev-cdn.rs
@@ -102,9 +102,11 @@ async fn main() -> Result<()> {
     let broker_jh = spawn(broker.start());
     let marshal_jh = spawn(marshal.start());
 
-    // Await on both
-    let _ = broker_jh.await;
-    let _ = marshal_jh.await;
+    tokio::select! {
+        _ = broker_jh => {},
+        _ = marshal_jh => {},
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+    }
 
     Ok(())
 }

--- a/crates/espresso/node/src/bin/nasty-client.rs
+++ b/crates/espresso/node/src/bin/nasty-client.rs
@@ -1400,9 +1400,12 @@ async fn serve(port: u16, metrics: PrometheusMetrics) {
 
 fn main() {
     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-    tokio::runtime::Runtime::new()
-        .unwrap()
-        .block_on(async_main(migrated_envs))
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        tokio::select! {
+            _ = async_main(migrated_envs) => {},
+            _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+        }
+    })
 }
 
 async fn async_main(migrated_envs: Vec<(&str, &str)>) {

--- a/crates/espresso/node/src/bin/orchestrator.rs
+++ b/crates/espresso/node/src/bin/orchestrator.rs
@@ -147,10 +147,11 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) {
     config.config.da_staked_committee_size = args.num_nodes.get();
     config.config.builder_urls = Vec1::try_from_vec(args.builder_urls).unwrap();
     config.config.builder_timeout = args.builder_timeout;
-    run_orchestrator(
-        config,
-        format!("http://0.0.0.0:{}", args.port).parse().unwrap(),
-    )
-    .await
-    .unwrap();
+    tokio::select! {
+        res = run_orchestrator(
+            config,
+            format!("http://0.0.0.0:{}", args.port).parse().unwrap(),
+        ) => res.unwrap(),
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+    }
 }

--- a/crates/espresso/node/src/bin/state-relay-server.rs
+++ b/crates/espresso/node/src/bin/state-relay-server.rs
@@ -47,12 +47,13 @@ async fn async_main(migrated_envs: Vec<(&str, &str)>) {
 
     tracing::info!(port = args.port, "starting state relay server");
 
-    run_relay_server(
-        None,
-        args.sequencer_url,
-        format!("http://0.0.0.0:{}", args.port).parse().unwrap(),
-        SequencerApiVersion::instance(),
-    )
-    .await
-    .unwrap();
+    tokio::select! {
+        res = run_relay_server(
+            None,
+            args.sequencer_url,
+            format!("http://0.0.0.0:{}", args.port).parse().unwrap(),
+            SequencerApiVersion::instance(),
+        ) => res.unwrap(),
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+    }
 }

--- a/crates/espresso/node/src/bin/submit-transactions.rs
+++ b/crates/espresso/node/src/bin/submit-transactions.rs
@@ -178,9 +178,12 @@ impl Options {
 
 fn main() {
     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-    tokio::runtime::Runtime::new()
-        .unwrap()
-        .block_on(async_main(migrated_envs))
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        tokio::select! {
+            _ = async_main(migrated_envs) => {},
+            _ = espresso_utils::shutdown::wait_for_shutdown_signal() => {},
+        }
+    })
 }
 
 async fn async_main(migrated_envs: Vec<(&str, &str)>) {

--- a/crates/espresso/node/src/run.rs
+++ b/crates/espresso/node/src/run.rs
@@ -4,7 +4,6 @@ use espresso_telemetry as telemetry;
 use espresso_types::traits::{NullEventConsumer, SequencerPersistence};
 use futures::future::FutureExt;
 use hotshot_types::traits::metrics::NoMetrics;
-use tokio::signal::unix::{SignalKind, signal};
 use url::Url;
 
 use super::{
@@ -141,28 +140,12 @@ where
     // Start doing consensus.
     ctx.start_consensus().await;
 
-    // Run until consensus stops on its own or we receive a shutdown signal. On a signal, shut down
-    // gracefully
     tokio::select! {
         () = ctx.join() => tracing::warn!("consensus stopped; exiting"),
-        signal = wait_for_shutdown_signal() => {
-            tracing::warn!(signal, "received shutdown signal; shutting down gracefully");
-            ctx.shut_down().await;
-        },
+        _ = espresso_utils::shutdown::wait_for_shutdown_signal() => ctx.shut_down().await,
     }
 
     Ok(())
-}
-
-/// Wait for a shutdown signal
-async fn wait_for_shutdown_signal() -> &'static str {
-    let mut interrupt = signal(SignalKind::interrupt()).expect("install SIGINT handler");
-    let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
-
-    tokio::select! {
-        _ = interrupt.recv() => "SIGINT",
-        _ = terminate.recv() => "SIGTERM",
-    }
 }
 
 pub async fn init_with_storage<S>(

--- a/crates/espresso/utils/src/lib.rs
+++ b/crates/espresso/utils/src/lib.rs
@@ -18,6 +18,7 @@ pub mod build_info;
 pub mod env_compat;
 pub mod logging;
 pub mod ser;
+pub mod shutdown;
 pub mod test_utils;
 
 pub async fn wait_for_http(

--- a/crates/espresso/utils/src/shutdown.rs
+++ b/crates/espresso/utils/src/shutdown.rs
@@ -1,0 +1,19 @@
+//! Graceful shutdown on OS termination signals.
+
+use tokio::signal::unix::{SignalKind, signal};
+
+/// Block until the process receives `SIGINT` or `SIGTERM`, log the signal at
+/// `WARN`, and return its name.
+///
+/// Intended for use in a `tokio::select!` alongside a daemon's main future so
+/// the process exits cleanly instead of being hard-killed.
+pub async fn wait_for_shutdown_signal() -> &'static str {
+    let mut interrupt = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let signal = tokio::select! {
+        _ = interrupt.recv() => "SIGINT",
+        _ = terminate.recv() => "SIGTERM",
+    };
+    tracing::warn!(signal, "received shutdown signal; shutting down gracefully");
+    signal
+}


### PR DESCRIPTION
- add espresso_utils::shutdown::wait_for_shutdown_signal: waits for SIGINT/SIGTERM, logs the signal at WARN, returns its name
- extract the node's private signal handler into the shared util
- wire builder, orchestrator, state-relay-server, cdn-marshal, cdn-broker, dev-cdn, dev-node, submit-transactions, nasty-client to exit cleanly on signal via tokio::select!
