### PR TITLE
fix(aggregator): timeout-and-rebuild stream to recover from missed notifications

### DIFF
--- a/hotshot-query-service/src/data_source/fetching.rs
+++ b/hotshot-query-service/src/data_source/fetching.rs
@@ -82,7 +82,11 @@ use hotshot_types::{
 };
 use jf_merkle_tree_compat::{MerkleTreeScheme, prelude::MerkleProof};
 use tagged_base64::TaggedBase64;
-use tokio::{spawn, sync::Mutex, time::sleep};
+use tokio::{
+    spawn,
+    sync::Mutex,
+    time::{sleep, timeout},
+};
 use tracing::Instrument;
 
 use super::{
@@ -1681,6 +1685,15 @@ where
     }
 }
 
+/// How long the aggregator waits for the next block before rebuilding the stream.
+///
+/// The aggregator drives an in-order stream of passive fetches. A single missed availability
+/// notification would otherwise park the stream until the 8h proactive scan. On this interval
+/// the aggregator breaks the inner loop and rebuilds the stream from the committed aggregate
+/// height, which re-evaluates `might_exist` against current storage and loads now-present
+/// heights as `Ready`.
+pub(crate) const AGGREGATOR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
 impl<Types, S, P> Fetcher<Types, S, P>
 where
     Types: NodeType,
@@ -1721,7 +1734,7 @@ where
                 None => (0, Aggregate::default()),
             };
 
-            tracing::info!(start, "starting aggregator");
+            tracing::debug!(start, "starting aggregator");
             metrics.height.set(start);
 
             let mut blocks = self
@@ -1730,46 +1743,56 @@ where
                 .then(Fetch::resolve)
                 .ready_chunks(chunk_size)
                 .boxed();
-            while let Some(chunk) = blocks.next().await {
-                let Some(last) = chunk.last() else {
-                    // This is not supposed to happen, but if the chunk is empty, just skip it.
-                    tracing::warn!("ready_chunks returned an empty chunk");
-                    continue;
-                };
-                let height = last.height();
-                let num_blocks = chunk.len();
-                tracing::debug!(
-                    num_blocks,
-                    height,
-                    "updating aggregate statistics for chunk"
-                );
-                loop {
-                    let res = async {
-                        let mut tx = self.write().await.context("opening transaction")?;
-                        let aggregate =
-                            tx.update_aggregates(prev_aggregate.clone(), &chunk).await?;
-                        tx.commit().await.context("committing transaction")?;
-                        prev_aggregate = aggregate;
-                        anyhow::Result::<_>::Ok(())
-                    }
-                    .await;
-                    match res {
-                        Ok(()) => {
-                            break;
-                        },
-                        Err(err) => {
-                            tracing::warn!(
-                                num_blocks,
-                                height,
-                                "failed to update aggregates for chunk: {err:#}"
-                            );
-                            sleep(Duration::from_secs(1)).await;
-                        },
-                    }
+            loop {
+                match timeout(AGGREGATOR_RETRY_INTERVAL, blocks.next()).await {
+                    Ok(Some(chunk)) => {
+                        let Some(last) = chunk.last() else {
+                            // This is not supposed to happen, but if the chunk is empty, skip it.
+                            tracing::warn!("ready_chunks returned an empty chunk");
+                            continue;
+                        };
+                        let height = last.height();
+                        let num_blocks = chunk.len();
+                        tracing::debug!(
+                            num_blocks,
+                            height,
+                            "updating aggregate statistics for chunk"
+                        );
+                        loop {
+                            let res = async {
+                                let mut tx = self.write().await.context("opening transaction")?;
+                                let aggregate =
+                                    tx.update_aggregates(prev_aggregate.clone(), &chunk).await?;
+                                tx.commit().await.context("committing transaction")?;
+                                prev_aggregate = aggregate;
+                                anyhow::Result::<_>::Ok(())
+                            }
+                            .await;
+                            match res {
+                                Ok(()) => {
+                                    break;
+                                },
+                                Err(err) => {
+                                    tracing::warn!(
+                                        num_blocks,
+                                        height,
+                                        "failed to update aggregates for chunk: {err:#}"
+                                    );
+                                    sleep(Duration::from_secs(1)).await;
+                                },
+                            }
+                        }
+                        metrics.height.set(height as usize);
+                    },
+                    Ok(None) => break, // stream ended (unbounded range: should not happen)
+                    // A legitimately slow in-progress fetch is intentionally abandoned here:
+                    // we cannot distinguish "slow fetch" from "missed-notification stall", so
+                    // we rebuild the stream, which re-loads now-present heights as Ready and
+                    // re-issues any genuinely-missing fetch from the committed aggregate height.
+                    Err(_elapsed) => break,
                 }
-                metrics.height.set(height as usize);
             }
-            tracing::warn!("aggregator block stream ended unexpectedly; will restart");
+            tracing::debug!("aggregator stream restarting");
         }
     }
 }
@@ -2633,7 +2656,15 @@ async fn select_some<T>(
 
 #[cfg(test)]
 mod test {
-    use hotshot_example_types::node_types::TEST_VERSIONS;
+    use hotshot::traits::BlockPayload;
+    use hotshot_example_types::{
+        block_types::{TestBlockHeader, TestMetadata},
+        node_types::TEST_VERSIONS,
+        state_types::{TestInstanceState, TestValidatedState},
+    };
+    use hotshot_types::{
+        data::vid_commitment, traits::block_contents::EncodeBytes, utils::BuilderCommitment,
+    };
 
     use super::*;
     use crate::{
@@ -2642,7 +2673,10 @@ mod test {
             storage::{SqlStorage, StorageConnectionType},
         },
         fetching::provider::NoFetching,
-        testing::{consensus::MockSqlDataSource, mocks::MockTypes},
+        testing::{
+            consensus::MockSqlDataSource,
+            mocks::{MockPayload, MockTypes, mock_transaction},
+        },
     };
 
     #[test]
@@ -2916,5 +2950,140 @@ mod test {
             .unwrap_err();
         tracing::info!("loading partial VID common range failed as expected: {err:#}");
         assert!(matches!(err, QueryError::Missing));
+    }
+
+    /// Repeatedly poll `f` until it returns `Some`, up to `max_wait`. Panics on timeout.
+    async fn poll_until<T, F, Fut>(max_wait: Duration, interval: Duration, f: F) -> T
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Option<T>>,
+    {
+        let deadline = std::time::Instant::now() + max_wait;
+        loop {
+            if let Some(v) = f().await {
+                return v;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for condition"
+            );
+            sleep(interval).await;
+        }
+    }
+
+    /// Aggregator recovers after blocks land in storage without a notification, and produces the
+    /// exact expected cumulative transaction count.
+    ///
+    /// This exercises the stall scenario: the aggregator's `get_range` stream subscribes to
+    /// notifications before checking storage. If blocks are written to the underlying storage
+    /// after the subscription+check cycle (bypassing `store_and_notify`), the notification is
+    /// missed and the stream parks. The `AGGREGATOR_RETRY_INTERVAL` timeout fires, the aggregator
+    /// breaks and rebuilds the stream from the committed aggregate height, finding the now-present
+    /// blocks as `Ready`.
+    ///
+    /// Each block at height `i` carries `i + 1` transactions, so the expected total is
+    /// `n * (n + 1) / 2`. A double-count or skip would fail the final assertion.
+    ///
+    /// This test is slow because it must wait for `AGGREGATOR_RETRY_INTERVAL` (30 s) to elapse.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg(not(target_os = "windows"))]
+    async fn test_aggregator_recovery_after_missed_notification() {
+        let storage = TmpDb::init().await;
+        let db = SqlStorage::connect(storage.config(), StorageConnectionType::Query)
+            .await
+            .unwrap();
+
+        let ds = MockSqlDataSource::builder(db, NoFetching)
+            .build()
+            .await
+            .unwrap();
+
+        // Build N blocks: block at height i has i+1 transactions.
+        // Each block gets a distinct payload (and thus a distinct payload_commitment),
+        // so the payload table rows are not collapsed by the (hash, ns_table) dedup.
+        // Expected cumulative total = 1 + 2 + ... + n = n*(n+1)/2.
+        let n = 5usize;
+        let expected_total = n * (n + 1) / 2;
+
+        let genesis_leaf = LeafQueryData::<MockTypes>::genesis(
+            &Default::default(),
+            &Default::default(),
+            TEST_VERSIONS.test,
+        )
+        .await;
+
+        let mut leaves = vec![genesis_leaf];
+        let mut blocks: Vec<BlockQueryData<MockTypes>> = Vec::new();
+
+        for i in 0..n {
+            // Height i carries i+1 distinct transactions.
+            let txs = (0..=i).map(|j| mock_transaction(vec![j as u8]));
+            let (payload, metadata) = <MockPayload as BlockPayload<MockTypes>>::from_transactions(
+                txs,
+                &TestValidatedState::default(),
+                &TestInstanceState::default(),
+            )
+            .await
+            .unwrap();
+            let encoded = payload.encode();
+            let payload_commitment =
+                vid_commitment(&encoded, &metadata.encode(), 1, TEST_VERSIONS.test.base);
+            let header = TestBlockHeader {
+                block_number: i as u64,
+                payload_commitment,
+                builder_commitment: BuilderCommitment::from_bytes([]),
+                metadata: TestMetadata {
+                    num_transactions: metadata.num_transactions,
+                },
+                timestamp: i as u64,
+                timestamp_millis: i as u64 * 1_000,
+                random: 1,
+                version: TEST_VERSIONS.test.base,
+            };
+            if i > 0 {
+                let mut leaf = leaves[i - 1].clone();
+                *leaf.leaf.block_header_mut() = header.clone();
+                leaves.push(leaf);
+            } else {
+                *leaves[0].leaf.block_header_mut() = header.clone();
+            }
+            blocks.push(BlockQueryData::new(header, payload));
+        }
+
+        // Insert leaves and blocks directly into the underlying storage, bypassing
+        // `store_and_notify`. The aggregator task has already started and is waiting on a
+        // notification for height 0 that will never arrive via this path.
+        {
+            let inner = ds.inner();
+            let mut tx = inner.write().await.unwrap();
+            for leaf in &leaves {
+                tx.insert_leaf(leaf).await.unwrap();
+            }
+            for block in &blocks {
+                tx.insert_block(block).await.unwrap();
+            }
+            tx.commit().await.unwrap();
+        }
+
+        // The aggregator rebuilds after AGGREGATOR_RETRY_INTERVAL elapses. Allow 4× for the
+        // rebuild and processing.
+        poll_until(
+            AGGREGATOR_RETRY_INTERVAL * 4,
+            Duration::from_millis(500),
+            || async {
+                ds.count_transactions_in_range(..=n - 1, None)
+                    .await
+                    .ok()
+                    .map(|_| ())
+            },
+        )
+        .await;
+
+        // Exact sum verifies no double-count and no skip.
+        let total = ds
+            .count_transactions_in_range(.., None)
+            .await
+            .expect("aggregate should be available after recovery");
+        assert_eq!(total, expected_total);
     }
 }

--- a/light-client/migrations/02_add_leaf_last_used.sql
+++ b/light-client/migrations/02_add_leaf_last_used.sql
@@ -1,0 +1,2 @@
+ALTER TABLE leaf ADD COLUMN last_used BIGINT NOT NULL DEFAULT 0;
+CREATE INDEX leaf_last_used ON leaf (last_used);

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -1,6 +1,16 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::PathBuf,
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
+    time::Duration,
+};
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
-use std::{future::Future, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 use alloy::primitives::Address;
 use anyhow::{Context, Result};
@@ -45,6 +55,65 @@ const WRITE_BACKOFF: BackoffParams = BackoffParams::new(
         denominator: 10,
     },
 );
+
+/// In-memory LRU recency tracker shared across all clones of a [`SqliteStorage`].
+///
+/// `touch` is called on the read path (pure, no DB write). `drain` is called inside
+/// `insert_leaf` to flush pending recency updates as part of the existing write transaction.
+/// Held in an `Arc`, so its `Drop` runs exactly once, when the last `SqliteStorage` clone is
+/// dropped, flushing any touches that no `insert_leaf` persisted (graceful shutdown).
+#[derive(Debug)]
+struct Recency {
+    /// Monotonically increasing tick counter. Persisted maximum is seeded at `connect` time so
+    /// ticks always exceed any value already stored in the DB after a restart.
+    next_tick: AtomicI64,
+    /// height -> latest tick; flushed to DB by the next `insert_leaf` or by `Drop`.
+    dirty: std::sync::Mutex<HashMap<i64, i64>>,
+    /// Pool handle kept alive for the on-drop flush.
+    pool: SqlitePool,
+}
+
+impl Recency {
+    fn touch(&self, height: i64) {
+        let t = self.next_tick.fetch_add(1, Ordering::Relaxed);
+        self.dirty.lock().unwrap().insert(height, t);
+    }
+
+    fn drain(&self) -> Vec<(i64, i64)> {
+        self.dirty.lock().unwrap().drain().collect()
+    }
+}
+
+impl Drop for Recency {
+    /// Flush pending read-path touches to the DB on graceful shutdown.
+    ///
+    /// Touches are otherwise only persisted by the next `insert_leaf`; without this, GC after a
+    /// restart would rank recently-read leaves by a stale `last_used` and could evict them.
+    /// Best-effort: a failure only degrades GC ranking, it never corrupts data. The flush is a
+    /// short, file-local write driven on the current thread; the SQLite work runs on sqlx's own
+    /// worker thread, so it does not deadlock a runtime worker.
+    fn drop(&mut self) {
+        let pending: Vec<(i64, i64)> = self.dirty.get_mut().unwrap().drain().collect();
+        if pending.is_empty() {
+            return;
+        }
+        let pool = self.pool.clone();
+        let flush = async move {
+            let mut tx = pool.begin().await?;
+            for (h, tick) in &pending {
+                query("UPDATE leaf SET last_used = $1 WHERE height = $2")
+                    .bind(tick)
+                    .bind(h)
+                    .execute(tx.as_mut())
+                    .await?;
+            }
+            tx.commit().await
+        };
+        if let Err(err) = futures::executor::block_on(flush) {
+            tracing::warn!(%err, "failed to flush LRU recency on drop");
+        }
+    }
+}
 
 /// Client-side database for a [`LightClient`].
 pub trait Storage: Sized + Send + Sync + 'static {
@@ -209,10 +278,21 @@ impl LightClientSqliteOptions {
             .await?;
         sqlx::migrate!("./migrations").run(&pool).await?;
 
+        // Seed the tick counter so new ticks always exceed any value persisted in the DB.
+        let (max_used,): (i64,) = sqlx::query_as("SELECT COALESCE(MAX(last_used), 0) FROM leaf")
+            .fetch_one(&pool)
+            .await?;
+        let recency = Arc::new(Recency {
+            next_tick: AtomicI64::new(max_used + 1),
+            dirty: Default::default(),
+            pool: pool.clone(),
+        });
+
         Ok(SqliteStorage {
             pool,
             num_leaves: self.num_leaves,
             num_stake_tables: self.num_stake_tables,
+            recency,
             _tmp,
         })
     }
@@ -224,6 +304,8 @@ pub struct SqliteStorage {
     pool: SqlitePool,
     num_leaves: u32,
     num_stake_tables: u32,
+    /// Shared across all clones; all map operations are sync and never held across `.await`.
+    recency: Arc<Recency>,
     _tmp: Option<Arc<TempDir>>,
 }
 
@@ -244,9 +326,7 @@ impl Storage for SqliteStorage {
         &self,
         id: impl Into<LeafRequest> + Send,
     ) -> Result<Option<LeafQueryData<SeqTypes>>> {
-        let mut tx = self.pool.begin().await?;
-
-        let mut q = QueryBuilder::new("SELECT height, data FROM leaf WHERE ");
+        let mut q = QueryBuilder::new("SELECT data FROM leaf WHERE ");
         match id.into() {
             LeafRequest::Leaf(LeafId::Number(n)) | LeafRequest::Header(BlockId::Number(n)) => {
                 q.push("height >= ")
@@ -267,26 +347,16 @@ impl Storage for SqliteStorage {
         }
         q.push(" LIMIT 1");
 
-        let Some((height, data)) = q
-            .build_query_as::<(i64, _)>()
-            .fetch_optional(tx.as_mut())
+        let Some((data,)) = q
+            .build_query_as::<(serde_json::Value,)>()
+            .fetch_optional(&self.pool)
             .await?
         else {
             return Ok(None);
         };
-        let leaf = serde_json::from_value(data)?;
 
-        // Mark this leaf as recently used.
-        let (id,): (i32,) = query_as("SELECT max(id) + 1 FROM leaf")
-            .fetch_one(tx.as_mut())
-            .await?;
-        query("UPDATE leaf SET id = $1 WHERE height = $2")
-            .bind(id)
-            .bind(height)
-            .execute(tx.as_mut())
-            .await?;
-        tx.commit().await?;
-
+        let leaf: LeafQueryData<SeqTypes> = serde_json::from_value(data)?;
+        self.recency.touch(leaf.height() as i64);
         Ok(Some(leaf))
     }
 
@@ -295,22 +365,21 @@ impl Storage for SqliteStorage {
         start_height: u32,
         end_height: u32,
     ) -> Result<Vec<LeafQueryData<SeqTypes>>> {
-        let mut tx = self.pool.begin().await?;
-
-        let leaves = query_as::<_, (i64, serde_json::Value)>(
+        query_as::<_, (i64, serde_json::Value)>(
             "SELECT height, data FROM leaf WHERE height >= $1 AND height < $2 ORDER BY height",
         )
         .bind(start_height as i64)
         .bind(end_height as i64)
-        .fetch_all(tx.as_mut())
+        .fetch_all(&self.pool)
         .await?
         .into_iter()
-        .map(|(_height, data)| serde_json::from_value(data))
-        .collect::<Result<Vec<_>, _>>()?;
-
-        tx.commit().await?;
-
-        Ok(leaves)
+        .map(|(height, data)| {
+            let leaf = serde_json::from_value(data)?;
+            self.recency.touch(height);
+            Ok(leaf)
+        })
+        .collect::<Result<Vec<_>, serde_json::Error>>()
+        .map_err(anyhow::Error::new)
     }
 
     async fn insert_leaf(&self, leaf: LeafQueryData<SeqTypes>) -> Result<()> {
@@ -320,7 +389,11 @@ impl Storage for SqliteStorage {
         let payload_hash = leaf.payload_hash().to_string();
         let data = serde_json::to_value(&leaf)?;
 
-        WRITE_BACKOFF
+        // Compute both values before the retry loop so retries reuse them (idempotent).
+        let pending = self.recency.drain();
+        let insert_tick = self.recency.next_tick.fetch_add(1, Ordering::Relaxed);
+
+        let result = WRITE_BACKOFF
             .retry_if(
                 WRITE_RETRY_MAX,
                 |_| true,
@@ -328,42 +401,48 @@ impl Storage for SqliteStorage {
                     let mut tx = self.pool.begin().await?;
 
                     tracing::debug!(height, hash, "inserting leaf");
-                    let (id,): (i32,) = query_as(
-                        "INSERT INTO leaf (height, hash, block_hash, payload_hash, data) VALUES \
-                         ($1, $2, $3, $4, $5)
-                    ON CONFLICT (height) DO UPDATE SET id = excluded.id
-                    RETURNING id",
+                    query(
+                        "INSERT INTO leaf (height, hash, block_hash, payload_hash, data, \
+                         last_used) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (height) DO \
+                         UPDATE SET data = excluded.data, last_used = excluded.last_used",
                     )
                     .bind(height)
                     .bind(&hash)
                     .bind(&block_hash)
                     .bind(&payload_hash)
                     .bind(&data)
-                    .fetch_one(tx.as_mut())
+                    .bind(insert_tick)
+                    .execute(tx.as_mut())
                     .await
                     .context("inserting new leaf")?;
-                    tracing::debug!(height, hash, id, "inserted leaf");
+                    tracing::debug!(height, hash, "inserted leaf");
 
-                    // Delete the oldest leaves as necessary until the number of leaves stored does
-                    // not exceed `num_leaves`.
+                    // Flush pending recency touches accumulated since the last insert.
+                    for (h, tick) in &pending {
+                        query("UPDATE leaf SET last_used = $1 WHERE height = $2")
+                            .bind(tick)
+                            .bind(h)
+                            .execute(tx.as_mut())
+                            .await
+                            .context("flushing recency touch")?;
+                    }
+
+                    // GC: evict least-recently-used leaves until count <= num_leaves.
                     let (num_leaves,): (u32,) = query_as("SELECT count(*) FROM leaf")
                         .fetch_one(tx.as_mut())
                         .await
                         .context("counting leaves")?;
                     let to_delete = num_leaves.saturating_sub(self.num_leaves);
                     if to_delete > 0 {
-                        let (id_to_delete,): (i64,) =
-                            query_as("SELECT id FROM leaf ORDER BY id LIMIT 1 OFFSET $1")
-                                .bind(to_delete - 1)
-                                .fetch_one(tx.as_mut())
-                                .await
-                                .context("finding timestamp for GC")?;
-                        tracing::info!(id_to_delete, "garbage collecting {to_delete} leaves");
-                        let res = query("DELETE FROM leaf WHERE id <= $1")
-                            .bind(id_to_delete)
-                            .execute(tx.as_mut())
-                            .await
-                            .context("deleting old leaves")?;
+                        tracing::info!("garbage collecting {to_delete} leaves");
+                        let res = query(
+                            "DELETE FROM leaf WHERE height IN (SELECT height FROM leaf ORDER BY \
+                             last_used ASC, height ASC LIMIT $1)",
+                        )
+                        .bind(to_delete)
+                        .execute(tx.as_mut())
+                        .await
+                        .context("deleting old leaves")?;
                         tracing::info!("deleted {} leaves", res.rows_affected());
                     }
 
@@ -371,7 +450,18 @@ impl Storage for SqliteStorage {
                     Ok(())
                 },
             )
-            .await
+            .await;
+
+        if result.is_err() {
+            // Restore drained touches so a recently-read leaf is not wrongly evicted later.
+            // Use `or_insert` so any newer touch already recorded for that height wins.
+            let mut dirty = self.recency.dirty.lock().unwrap();
+            for (h, tick) in pending {
+                dirty.entry(h).or_insert(tick);
+            }
+        }
+
+        result
     }
 
     async fn stake_table_lower_bound(
@@ -700,6 +790,43 @@ mod test {
         drop(db);
     }
 
+    // Regression: `leaf_upper_bound` previously did a SELECT then an UPDATE
+    // (LRU recency bump) inside one write transaction, so every read took the
+    // WAL write lock and contended with concurrent inserts under a full-history
+    // backfill, producing SQLITE_BUSY. The read path is now a pure SELECT.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_reads_do_not_lock() {
+        let db = Arc::new(SqliteStorage::default().await.unwrap());
+        let leaves = leaf_chain(0..40, EPOCH_VERSION).await;
+
+        let mut tasks = Vec::new();
+        for leaf in leaves {
+            let db = db.clone();
+            tasks.push(tokio::spawn(async move {
+                db.insert_leaf(leaf).await.map(|_| ())
+            }));
+        }
+        for h in 0..40usize {
+            let read_db = db.clone();
+            tasks.push(tokio::spawn(async move {
+                read_db
+                    .leaf_upper_bound(LeafId::Number(h))
+                    .await
+                    .map(|_| ())
+            }));
+            let height_db = db.clone();
+            tasks.push(tokio::spawn(async move {
+                height_db.block_height().await.map(|_| ())
+            }));
+        }
+
+        for task in tasks {
+            task.await
+                .unwrap()
+                .expect("concurrent op must not fail with a database lock error");
+        }
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     #[test_log::test]
@@ -876,9 +1003,10 @@ mod test {
         assert_eq!(db.leaf_upper_bound(LeafId::Number(1)).await.unwrap(), None);
     }
 
+    // LRU GC: leaf touched by a read is kept; untouched leaf is evicted.
     #[tokio::test]
     #[test_log::test]
-    async fn test_gc_last_selected() {
+    async fn test_gc_evicts_least_recently_used() {
         let db = LightClientSqliteOptions {
             num_leaves: 2,
             ..Default::default()
@@ -891,39 +1019,155 @@ mod test {
         db.insert_leaf(leaves[0].clone()).await.unwrap();
         db.insert_leaf(leaves[1].clone()).await.unwrap();
 
-        // Select leaf 0, making it more recently used than leaf 1.
-        assert_eq!(
-            db.leaf_upper_bound(LeafId::Number(0))
-                .await
-                .unwrap()
-                .unwrap(),
-            leaves[0]
-        );
+        // Touch leaf 0 via a read, making leaf 1 the least-recently-used.
+        db.leaf_upper_bound(LeafId::Number(0)).await.unwrap();
 
-        // Insert a third leaf, causing the least recently used (leaf 1) to be garbage collected.
+        // Insert leaf 2; GC evicts 1 (LRU) to bring count back to 2.
         db.insert_leaf(leaves[2].clone()).await.unwrap();
 
+        // Check exact presence/absence via hash lookups (the Number variant is an
+        // upper bound, so it would return a higher leaf instead of None).
         assert_eq!(
-            db.leaf_upper_bound(LeafId::Number(0))
+            db.leaf_upper_bound(LeafId::Hash(leaves[0].hash()))
                 .await
-                .unwrap()
                 .unwrap(),
-            leaves[0]
+            Some(leaves[0].clone()),
+            "leaf 0 was recently read and must be kept"
         );
         assert_eq!(
-            db.leaf_upper_bound(LeafId::Number(1))
+            db.leaf_upper_bound(LeafId::Hash(leaves[1].hash()))
                 .await
-                .unwrap()
                 .unwrap(),
-            leaves[2]
+            None,
+            "leaf 1 was least-recently-used and must be evicted"
         );
         assert_eq!(
-            db.leaf_upper_bound(LeafId::Number(2))
+            db.leaf_upper_bound(LeafId::Hash(leaves[2].hash()))
                 .await
-                .unwrap()
                 .unwrap(),
-            leaves[2]
+            Some(leaves[2].clone()),
+            "leaf 2 was just inserted and must be kept"
         );
+    }
+
+    // Recency (last_used) must survive a process restart so GC after reopen
+    // still honours access history. Specifically: `next_tick` must be seeded
+    // above the persisted MAX(last_used) so that a touch recorded after reopen
+    // outranks all pre-restart last_used values.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_recency_survives_restart() {
+        let dir = tempdir().unwrap();
+        let lc_path = dir.path().join("lc.db");
+
+        let opts = || LightClientSqliteOptions {
+            lc_path: Some(lc_path.clone()),
+            num_leaves: 2,
+            ..Default::default()
+        };
+
+        let leaves = leaf_chain(0..=3, EPOCH_VERSION).await;
+
+        {
+            let db = opts().connect().await.unwrap();
+            db.insert_leaf(leaves[0].clone()).await.unwrap();
+            db.insert_leaf(leaves[1].clone()).await.unwrap();
+
+            // Touch leaf 0 so it has a higher last_used than leaf 1.
+            db.leaf_upper_bound(LeafId::Number(0)).await.unwrap();
+
+            // Insert leaf 2; GC evicts leaf 1 (LRU); flushes the touch for leaf 0.
+            // After GC: {leaf 0, leaf 2} remain.
+            db.insert_leaf(leaves[2].clone()).await.unwrap();
+        }
+
+        // Reopen. next_tick seeds from MAX(last_used) + 1, so any post-reopen
+        // tick is strictly greater than all persisted last_used values.
+        {
+            let db = opts().connect().await.unwrap();
+
+            // Touch leaf 2 after reopen; its tick now exceeds all pre-restart last_used.
+            db.leaf_upper_bound(LeafId::Hash(leaves[2].hash()))
+                .await
+                .unwrap();
+
+            // Insert leaf 3; GC evicts the leaf with the lowest last_used (leaf 0,
+            // whose pre-restart tick is lower than leaf 2's post-reopen tick).
+            // After GC: {leaf 2, leaf 3} remain.
+            db.insert_leaf(leaves[3].clone()).await.unwrap();
+
+            assert_eq!(
+                db.leaf_upper_bound(LeafId::Hash(leaves[0].hash()))
+                    .await
+                    .unwrap(),
+                None,
+                "leaf 0 had the lowest persisted last_used and must be evicted"
+            );
+            assert_eq!(
+                db.leaf_upper_bound(LeafId::Hash(leaves[2].hash()))
+                    .await
+                    .unwrap(),
+                Some(leaves[2].clone()),
+                "leaf 2 was touched after reopen and must survive"
+            );
+            assert_eq!(
+                db.leaf_upper_bound(LeafId::Hash(leaves[3].hash()))
+                    .await
+                    .unwrap(),
+                Some(leaves[3].clone()),
+                "leaf 3 was just inserted and must survive"
+            );
+        }
+    }
+
+    // Dropping the last clone (graceful shutdown) must persist read-path touches
+    // when no insert follows the final reads, so GC after restart honours them.
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_recency_flushed_on_drop_without_insert() {
+        let dir = tempdir().unwrap();
+        let lc_path = dir.path().join("lc.db");
+
+        let opts = || LightClientSqliteOptions {
+            lc_path: Some(lc_path.clone()),
+            num_leaves: 2,
+            ..Default::default()
+        };
+
+        let leaves = leaf_chain(0..=2, EPOCH_VERSION).await;
+
+        {
+            let db = opts().connect().await.unwrap();
+            db.insert_leaf(leaves[0].clone()).await.unwrap();
+            db.insert_leaf(leaves[1].clone()).await.unwrap();
+
+            // Touch leaf 0 via a read; recorded only in memory.
+            db.leaf_upper_bound(LeafId::Number(0)).await.unwrap();
+
+            // No insert follows. Dropping db at the end of this scope must flush the touch.
+        }
+
+        // Reopen and insert leaf 2; GC evicts the lowest last_used. With the touch
+        // flushed, leaf 0 outranks leaf 1, so leaf 1 is evicted.
+        {
+            let db = opts().connect().await.unwrap();
+            db.insert_leaf(leaves[2].clone()).await.unwrap();
+
+            assert_eq!(
+                db.leaf_upper_bound(LeafId::Hash(leaves[0].hash()))
+                    .await
+                    .unwrap(),
+                Some(leaves[0].clone()),
+                "leaf 0 was touched before the shutdown flush and must survive"
+            );
+            assert_eq!(
+                db.leaf_upper_bound(LeafId::Hash(leaves[1].hash()))
+                    .await
+                    .unwrap(),
+                None,
+                "leaf 1 was least-recently-used and must be evicted"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Add `AGGREGATOR_RETRY_INTERVAL` (30 s); wrap `blocks.next()` in `timeout()`
- On timeout, break inner loop and rebuild stream from committed aggregate height, which re-evaluates `might_exist` and loads now-present heights as `Ready`
- Add `test_aggregator_recovery_after_missed_notification` unit test covering the stall scenario (blocks written directly to storage, bypassing notify)
- Downgrade restart log lines from info/warn to debug

(cherry picked from commit f8b2aa9a97db2c24dd820b7f176f5f02531f424e)
