### PR TITLE
feat(libp2p): add configurable DHT put quorum override

### DIFF
--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -228,6 +228,8 @@ pub struct NetworkParams {
 
     /// Minimum number of Libp2p peers to emit gossip to during a heartbeat
     pub libp2p_gossip_lazy: usize,
+
+    pub libp2p_dht_put_quorum: Option<std::num::NonZeroUsize>,
 }
 
 pub struct L1Params {
@@ -793,6 +795,7 @@ where
             &validator_config.private_key,
             hotshot::traits::implementations::Libp2pMetricsValue::new(&*metrics),
             network_discriminator,
+            network_params.libp2p_dht_put_quorum,
         )
         .await
         .with_context(|| {

--- a/crates/espresso/node/src/options.rs
+++ b/crates/espresso/node/src/options.rs
@@ -209,6 +209,10 @@ pub struct Options {
     )]
     pub libp2p_max_direct_transmit_size: u64,
 
+    /// Only for the decaf network unmerge migration. Do not set unless specifically requested.
+    #[clap(long, env = "ESPRESSO_NODE_LIBP2P_DHT_PUT_QUORUM")]
+    pub libp2p_dht_put_quorum: Option<std::num::NonZeroUsize>,
+
     /// The URL we advertise to other nodes as being for our public API.
     /// Should be supplied in `http://host:port` form.
     #[clap(long, env = "ESPRESSO_NODE_PUBLIC_API_URL")]

--- a/crates/espresso/node/src/run.rs
+++ b/crates/espresso/node/src/run.rs
@@ -209,6 +209,7 @@ where
         libp2p_heartbeat_initial_delay: opt.libp2p_heartbeat_initial_delay,
         libp2p_gossip_factor: opt.libp2p_gossip_factor,
         libp2p_gossip_lazy: opt.libp2p_gossip_lazy,
+        libp2p_dht_put_quorum: opt.libp2p_dht_put_quorum,
     };
 
     let proposal_fetcher_config = opt.proposal_fetcher_config;

--- a/crates/hotshot/examples/src/infra.rs
+++ b/crates/hotshot/examples/src/infra.rs
@@ -767,6 +767,7 @@ where
             private_key,
             Libp2pMetricsValue::default(),
             None,
+            None,
         )
         .await
         .expect("failed to create libp2p network");

--- a/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
@@ -409,6 +409,7 @@ impl<T: NodeType> Libp2pNetwork<T> {
         priv_key: &<T::SignatureKey as SignatureKey>::PrivateKey,
         metrics: Libp2pMetricsValue,
         network_discriminator: Option<U256>,
+        dht_put_quorum: Option<NonZeroUsize>,
     ) -> anyhow::Result<Self> {
         // Try to take our Libp2p config from our broader network config
         let libp2p_config = config
@@ -460,6 +461,7 @@ impl<T: NodeType> Libp2pNetwork<T> {
             .bind_address(Some(bind_address.clone()))
             .announce_addresses(announce_addresses)
             .network_discriminator(network_discriminator);
+        config_builder.dht_put_quorum(dht_put_quorum);
 
         // Connect to the provided bootstrap nodes
         config_builder.to_connect_addrs(HashSet::from_iter(libp2p_config.bootstrap_nodes.clone()));

--- a/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
+++ b/crates/hotshot/hotshot/src/traits/networking/libp2p_network.rs
@@ -460,8 +460,8 @@ impl<T: NodeType> Libp2pNetwork<T> {
             .replication_factor(replication_factor)
             .bind_address(Some(bind_address.clone()))
             .announce_addresses(announce_addresses)
-            .network_discriminator(network_discriminator);
-        config_builder.dht_put_quorum(dht_put_quorum);
+            .network_discriminator(network_discriminator)
+            .dht_put_quorum(dht_put_quorum);
 
         // Connect to the provided bootstrap nodes
         config_builder.to_connect_addrs(HashSet::from_iter(libp2p_config.bootstrap_nodes.clone()));

--- a/crates/hotshot/libp2p-networking/src/network/node.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node.rs
@@ -153,6 +153,16 @@ pub(crate) fn direct_message_protocol(
     }
 }
 
+fn resolve_put_quorum(
+    quorum_override: Option<NonZeroUsize>,
+    replication_factor: NonZeroUsize,
+) -> NonZeroUsize {
+    quorum_override.unwrap_or_else(|| {
+        NonZeroUsize::new(replication_factor.get() / 2)
+            .expect("replication factor should be bigger than 0")
+    })
+}
+
 /// Network definition
 #[derive(derive_more::Debug)]
 pub struct NetworkNode<T: NodeType, D: DhtPersistentStorage> {
@@ -176,6 +186,7 @@ pub struct NetworkNode<T: NodeType, D: DhtPersistentStorage> {
     /// Whether we've already emitted the loud "not publicly reachable" error for the
     /// current Private episode. Reset whenever AutoNAT leaves Private status.
     autonat_private_logged: bool,
+    dht_put_quorum: Option<NonZeroUsize>,
 }
 
 impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
@@ -439,6 +450,7 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
             ),
             resend_tx: None,
             autonat_private_logged: false,
+            dht_put_quorum: config.dht_put_quorum,
         })
     }
 
@@ -453,13 +465,13 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
         // Set the record's expiration time to the proper time
         record.expires = Some(Instant::now() + self.kademlia_record_ttl);
 
-        match self.swarm.behaviour_mut().dht.put_record(
-            record,
-            libp2p::kad::Quorum::N(
-                NonZeroUsize::try_from(self.dht_handler.replication_factor().get() / 2)
-                    .expect("replication factor should be bigger than 0"),
-            ),
-        ) {
+        let quorum = resolve_put_quorum(self.dht_put_quorum, self.dht_handler.replication_factor());
+        match self
+            .swarm
+            .behaviour_mut()
+            .dht
+            .put_record(record, libp2p::kad::Quorum::N(quorum))
+        {
             Err(e) => {
                 // failed try again later
                 query.progress = DHTProgress::NotStarted;
@@ -930,7 +942,12 @@ impl<T: NodeType, D: DhtPersistentStorage> NetworkNode<T, D> {
 
 #[cfg(test)]
 mod tests {
-    use super::{U256, direct_message_protocol, gossipsub_prefix, identify_protocol, kad_protocol};
+    use std::num::NonZeroUsize;
+
+    use super::{
+        U256, direct_message_protocol, gossipsub_prefix, identify_protocol, kad_protocol,
+        resolve_put_quorum,
+    };
 
     fn snapshot_for(discriminator: Option<U256>) -> String {
         format!(
@@ -953,5 +970,21 @@ mod tests {
             "decaf_libp2p_protocol_identifiers",
             snapshot_for(Some(U256::from(0xdecafu64)))
         );
+    }
+
+    #[test]
+    fn put_quorum_override() {
+        let nz = |n| NonZeroUsize::new(n).unwrap();
+
+        // default path: quorum = replication_factor / 2
+        assert_eq!(resolve_put_quorum(None, nz(20)), nz(10));
+        assert_eq!(resolve_put_quorum(None, nz(2)), nz(1));
+
+        // override below default
+        assert_eq!(resolve_put_quorum(Some(nz(1)), nz(20)), nz(1));
+        // override independent of replication factor
+        assert_eq!(resolve_put_quorum(Some(nz(7)), nz(20)), nz(7));
+        // resolver does not clamp; kad caps separately at min(n, rf)
+        assert_eq!(resolve_put_quorum(Some(nz(50)), nz(20)), nz(50));
     }
 }

--- a/crates/hotshot/libp2p-networking/src/network/node/config.rs
+++ b/crates/hotshot/libp2p-networking/src/network/node/config.rs
@@ -75,6 +75,9 @@ pub struct NetworkNodeConfig {
     /// `None` is the legacy value, used for mainnet.
     #[builder(default)]
     pub network_discriminator: Option<U256>,
+
+    #[builder(default)]
+    pub dht_put_quorum: Option<NonZeroUsize>,
 }
 
 impl Clone for NetworkNodeConfig {
@@ -93,6 +96,7 @@ impl Clone for NetworkNodeConfig {
             auth_message: self.auth_message.clone(),
             dht_timeout: self.dht_timeout,
             network_discriminator: self.network_discriminator,
+            dht_put_quorum: self.dht_put_quorum,
         }
     }
 }


### PR DESCRIPTION
- add ESPRESSO_NODE_LIBP2P_DHT_PUT_QUORUM clap/env option
- quorum defaults to replication_factor / 2 when unset, mainnet unchanged
- extract resolve_put_quorum pure fn with unit tests
- intended only for the one-time decaf network unmerge migration
