### PR TITLE
fix(node): only run startup epoch-window catchup on new protocol

### DIFF
--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -46,6 +46,7 @@ use tokio::{
 };
 use tracing::{Instrument, Level};
 use url::Url;
+use versions::NEW_PROTOCOL_VERSION;
 
 use crate::{
     Node, SeqTypes, SequencerApiVersion,
@@ -118,7 +119,7 @@ where
         state_catchup: ParallelStateCatchup,
         persistence: Arc<P>,
         network: Arc<N>,
-        coordinator_network: Cliquenet<SeqTypes>,
+        mut coordinator_network: Cliquenet<SeqTypes>,
         state_relay_server: Option<Url>,
         metrics: &dyn Metrics,
         stake_table_capacity: usize,
@@ -183,21 +184,27 @@ where
         // `first_epoch` is now seeded on the shared membership. Walk the
         // catchup chain forward to populate the stake-table window for the
         // current epoch.
-        let current_epoch = bootstrap_epoch_window(
-            &membership_coordinator,
-            epoch_height,
-            bootstrap_epoch_catchup_timeout,
-        )
-        .await
-        .context("startup stake-table catchup failed")?;
-        tracing::info!(%current_epoch, "Startup catchup complete");
+        //
+        // Only the new protocol (cliquenet) needs this
+        let max_configured_version = std::cmp::max(upgrade.base, upgrade.target);
+        if max_configured_version >= NEW_PROTOCOL_VERSION {
+            let current_epoch = bootstrap_epoch_window(
+                &membership_coordinator,
+                epoch_height,
+                bootstrap_epoch_catchup_timeout,
+            )
+            .await
+            .context("startup stake-table catchup failed")?;
+            tracing::info!(%current_epoch, "Startup catchup complete");
 
-        // Push the resolved peer window into the coordinator network. For
-        // cliquenet this dials the N-1/N/N+1 sliding window for the current
-        // epoch before consensus starts.
-        let mut coordinator_network = coordinator_network;
-        if let Err(err) = coordinator_network.apply_epoch(current_epoch, &membership_coordinator) {
-            tracing::warn!(%current_epoch, %err, "coordinator network apply_epoch failed at startup");
+            // Push the resolved peer window into the coordinator network. For
+            // cliquenet this dials the N-1/N/N+1 sliding window for the current
+            // epoch before consensus starts.
+            if let Err(err) =
+                coordinator_network.apply_epoch(current_epoch, &membership_coordinator)
+            {
+                tracing::warn!(%current_epoch, %err, "coordinator network apply_epoch failed at startup");
+            }
         }
 
         // Restore the persisted lock so the new protocol resumes with the lock


### PR DESCRIPTION
Skip the startup stake-table window catchup unless the genesis max version is at or above the new protocol, since only cliquenet requires it.