### PR TITLE
fix(new-protocol): compute epoch-root DRB from the decided leaf

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -594,11 +594,6 @@ where
                         self.timeout_one_honest_collector.retry_pending_votes();
                         return Ok(ConsensusInput::DrbResult(epoch, drb_result))
                     }
-                    Ok(EpochRootResult::EpochRootAdded(epoch)) => {
-                        finish_measurement(next_input);
-                        debug!(%epoch, "epoch root added to membership");
-                        continue;
-                    }
                     Err(failure) => {
                         finish_measurement(next_input);
                         // Catchup/compute failed. The epoch manager clears

--- a/crates/hotshot/new-protocol/src/epoch.rs
+++ b/crates/hotshot/new-protocol/src/epoch.rs
@@ -104,23 +104,35 @@ impl<T: NodeType> EpochManager<T> {
                 return;
             };
 
-            // Push the epoch root into membership directly from the decided
-            // header
             let target_epoch = epoch + 2;
+            if self.completed_drb_requests.contains(&target_epoch)
+                || self.pending_drb_requests.contains(&target_epoch)
+            {
+                return;
+            }
+            self.pending_drb_requests.insert(target_epoch);
+
             let membership_coordinator = self.membership_coordinator.clone();
-            let header = leaf.block_header().clone();
+            let root_leaf = leaf.clone();
             let handles = self.handles.entry(target_epoch).or_default();
             handles.push(self.tasks.spawn(async move {
-                let result = membership_coordinator
-                    .membership()
-                    .add_epoch_root(header)
-                    .await
-                    .map(|()| EpochRootResult::EpochRootAdded(target_epoch))
-                    .map_err(|e| EpochManagerError::EpochRoot(anyhow::anyhow!("{e}")));
+                let result = async {
+                    membership_coordinator
+                        .membership()
+                        .add_epoch_root(root_leaf.block_header().clone())
+                        .await
+                        .map_err(|e| EpochManagerError::EpochRoot(anyhow::anyhow!("{e}")))?;
+
+                    // Compute the DRB from the decided root leaf.
+                    let drb = membership_coordinator
+                        .compute_drb_result(target_epoch, root_leaf)
+                        .await
+                        .map_err(EpochManagerError::DrbCompute)?;
+                    Ok(EpochRootResult::DrbResult(target_epoch, drb))
+                }
+                .await;
                 (target_epoch, result)
             }));
-
-            self.request_drb_result(target_epoch);
         }
 
         // If this is the transition block of an epoch feed the DRB result to the coordinator.

--- a/crates/hotshot/new-protocol/src/epoch.rs
+++ b/crates/hotshot/new-protocol/src/epoch.rs
@@ -16,7 +16,6 @@ use tracing::error;
 
 pub enum EpochRootResult {
     DrbResult(EpochNumber, DrbResult),
-    EpochRootAdded(EpochNumber),
 }
 
 /// Epoch + error for the Err path so retries can re-kick the task.
@@ -71,9 +70,6 @@ impl<T: NodeType> EpochManager<T> {
                         Ok(root @ EpochRootResult::DrbResult(..)) => {
                             self.pending_drb_requests.remove(&epoch);
                             self.completed_drb_requests.insert(epoch);
-                            return Some(Ok(root));
-                        },
-                        Ok(root @ EpochRootResult::EpochRootAdded(_)) => {
                             return Some(Ok(root));
                         },
                         Err(error) => {


### PR DESCRIPTION
Compute the epoch-root DRB locally from the decided root leaf instead of fetching the leaf


At an epoch root, new protocol obtained the next epoch's DRB via request_drb_result → get_epoch_drb(), which  fetched the previous epoch's transition block (e.g. block 597 for epoch 3).The DRB is needed to produce the transition block and the transition block requires the DRB so there is a circular dependency. 
in this PR at the epoch root, DRB is computed from the decided root leaf.  This mirrors what the legacy protocol does