### PR TITLE
Adopt an embedded QC from timeout votes.

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -89,6 +89,11 @@ pub enum ConsensusInput<T: NodeType> {
     BlockReconstructed(ViewNumber, VidCommitment2),
     Certificate1(Certificate1<T>),
     Certificate2(Certificate2<T>),
+    /// A quorum certificate that locks a newer view than ours.
+    ///
+    /// Adopting it advances the lock and the view, which is used to help
+    /// divergent nodes re-converge on restart.
+    AdoptHighQc(Certificate1<T>),
     /// Atomic pair emitted by the `EpochRootVoteCollector` for epoch-root views:
     /// a `Certificate1` and its matching `LightClientStateUpdateCertificateV2`.
     /// Consensus never sees an epoch-root Cert1 without the matching state_cert.
@@ -611,6 +616,14 @@ impl<T: NodeType> Consensus<T> {
                 );
                 self.handle_certificate2(certificate, outbox)
             },
+            ConsensusInput::AdoptHighQc(certificate) => {
+                debug!(
+                    view  = %certificate.view_number(),
+                    epoch = ?certificate.epoch().map(|e| *e),
+                    "apply: adopt high qc"
+                );
+                self.handle_adopt_high_qc(certificate, outbox)
+            },
             ConsensusInput::EpochRootCertificates { cert1, state_cert } => {
                 info!(
                     epoch = %state_cert.epoch,
@@ -1110,6 +1123,59 @@ impl<T: NodeType> Consensus<T> {
             },
         }
         self.certs2.insert(view, certificate);
+        Protocol::Continue
+    }
+
+    /// Adopt a quorum certificate that locks a newer view than our current lock.
+    ///
+    /// Adopting the highest QC any peer advertises pulls the lock and the view
+    /// forward to a common point, also resetting the timer (via `ViewChanged`)
+    /// so the node re-times-out there and `TimeoutOneHonest` fire.
+    #[instrument(level = "debug", skip_all)]
+    fn handle_adopt_high_qc(
+        &mut self,
+        cert1: Certificate1<T>,
+        outbox: &mut Outbox<ConsensusOutput<T>>,
+    ) -> Protocol {
+        let view = cert1.view_number();
+
+        if self
+            .locked_cert
+            .as_ref()
+            .is_some_and(|locked| locked.view_number() >= view)
+        {
+            return Protocol::Continue;
+        }
+
+        let Some(epoch) = cert1.epoch() else {
+            warn!(%view, "cert1 has no epoch number");
+            return Protocol::Abort;
+        };
+
+        match self.try_verify_cert(&cert1, epoch) {
+            CertVerification::Valid => {},
+            CertVerification::Invalid => {
+                warn!(%view, "cert1 is invalid");
+                return Protocol::Abort;
+            },
+            CertVerification::EpochUnavailable => {
+                debug!(%view, %epoch, "missing epoch to verify cert1");
+                outbox.push_back(ConsensusOutput::RequestDrbResult(epoch));
+                return Protocol::Continue;
+            },
+        }
+
+        self.certs.entry(view).or_insert_with(|| cert1.clone());
+        self.locked_cert = Some(cert1.clone());
+        let next_view = view + 1;
+
+        if next_view > self.current_view {
+            self.current_view = next_view;
+            self.current_epoch = Some(epoch);
+            outbox.push_back(ConsensusOutput::ViewChanged(next_view, epoch));
+        }
+
+        outbox.push_back(ConsensusOutput::PersistHighQc(cert1));
         Protocol::Continue
     }
 
@@ -2365,6 +2431,9 @@ impl<T: NodeType> ConsensusInput<T> {
             ConsensusInput::BlockReconstructed(view, _) => *view,
             ConsensusInput::Certificate1(cert) => cert.view_number(),
             ConsensusInput::Certificate2(cert) => cert.view_number(),
+            // Adopting a QC for view v moves us into view v + 1, so the
+            // post-apply retries run for the view we land in.
+            ConsensusInput::AdoptHighQc(cert) => cert.view_number() + 1,
             ConsensusInput::EpochRootCertificates { cert1, .. } => cert1.view_number(),
             ConsensusInput::HeaderCreated(view, ..) => *view,
             ConsensusInput::ProposalWithVidShare(_, prop, _) => prop.view_number(),

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -1053,6 +1053,20 @@ where
                         .accumulate_vote(timeout_msg.vote.clone());
                     self.timeout_one_honest_collector
                         .accumulate_vote(timeout_msg.vote);
+
+                    // If a peer times out in a view at or ahead of us we adopt an
+                    // embedded cert1, so divergent nodes re-converge on the highest
+                    // justified view on restart.
+                    //
+                    // TODO: Above we reject timeout votes too far ahead. A valid cert1
+                    // has precendence over that check so we need to move this up, but
+                    // first we need to verify the cert1 itself.
+                    if let Some(lock) = timeout_msg.lock
+                        && lock.view_number() >= current_view
+                    {
+                        return Some(ConsensusInput::AdoptHighQc(lock));
+                    }
+
                     None
                 },
                 ConsensusMessage::TimeoutCertificate(tc) => {

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -1059,7 +1059,7 @@ where
                     // justified view on restart.
                     //
                     // TODO: Above we reject timeout votes too far ahead. A valid cert1
-                    // has precendence over that check so we need to move this up, but
+                    // has precedence over that check so we need to move this up, but
                     // first we need to verify the cert1 itself.
                     if let Some(lock) = timeout_msg.lock
                         && lock.view_number() >= current_view

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -597,3 +597,48 @@ async fn test_f_plus_1_timeout_votes_trigger_timeout_one_honest() {
         "f+1 timeout votes should trigger TimeoutOneHonest"
     );
 }
+
+/// A peer's timeout vote carries its locked QC. A node that is behind adopts
+/// that QC and advances its view to one past it — the restart-convergence
+/// catch-up. A lock that would not advance us (lower than our view) is ignored,
+/// so a lagging peer can never pull a node backward.
+#[tokio::test]
+async fn test_timeout_vote_lock_advances_view() {
+    use crate::consensus::ConsensusOutput;
+
+    let view_changed_to = |outputs, v| {
+        count_matching(
+            outputs,
+            |o| matches!(o, ConsensusOutput::ViewChanged(view, _) if **view == v),
+        )
+    };
+
+    let test_data = TestData::new(3).await;
+    let mut harness = TestHarness::new(0).await;
+
+    // The node starts at genesis. A peer times out view 2 while carrying a
+    // locked QC for view 1 (`views[0].cert1`). Adopting that QC moves us into
+    // view 2.
+    let high_qc = test_data.views[0].cert1.clone();
+    harness
+        .message(test_data.views[1].timeout_vote_input(1, Some(high_qc.clone())))
+        .await;
+
+    assert_eq!(
+        view_changed_to(harness.outputs(), 2),
+        1,
+        "adopting the locked QC from a timeout vote should advance us to view 2"
+    );
+
+    // A later timeout vote for view 3 carrying the same (now stale) view-1 lock
+    // would not advance us, so no further view change is emitted.
+    let view_changes_before = count_matching(harness.outputs(), is_view_changed);
+    harness
+        .message(test_data.views[2].timeout_vote_input(2, Some(high_qc)))
+        .await;
+    assert_eq!(
+        count_matching(harness.outputs(), is_view_changed),
+        view_changes_before,
+        "a lock below our current view must not advance us"
+    );
+}


### PR DESCRIPTION
If larger than a node's current view this is used to help divergent nodes to get back to a common view.