### PR TITLE
fix(shutdown): cooperatively cancel blocking drb computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6771,6 +6771,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tide-disco",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "vbs",

--- a/crates/espresso/node-sqlite/src/main.rs
+++ b/crates/espresso/node-sqlite/src/main.rs
@@ -1,4 +1,8 @@
 pub fn main() -> anyhow::Result<()> {
     let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-    tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
+    let rt = tokio::runtime::Runtime::new()?;
+    let result = rt.block_on(espresso_node::main(migrated_envs));
+    // Bound teardown so a stuck blocking-pool task cannot hang exit indefinitely.
+    rt.shutdown_timeout(std::time::Duration::from_secs(5));
+    result
 }

--- a/crates/espresso/node/src/main.rs
+++ b/crates/espresso/node/src/main.rs
@@ -46,6 +46,9 @@ pub fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "embedded-db"))]
     {
         let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
-        tokio::runtime::Runtime::new()?.block_on(espresso_node::main(migrated_envs))
+        let rt = tokio::runtime::Runtime::new()?;
+        let result = rt.block_on(espresso_node::main(migrated_envs));
+        rt.shutdown_timeout(std::time::Duration::from_secs(5));
+        result
     }
 }

--- a/crates/espresso/node/src/main.rs
+++ b/crates/espresso/node/src/main.rs
@@ -48,6 +48,7 @@ pub fn main() -> anyhow::Result<()> {
         let migrated_envs = espresso_utils::env_compat::migrate_legacy_env_vars();
         let rt = tokio::runtime::Runtime::new()?;
         let result = rt.block_on(espresso_node::main(migrated_envs));
+        // Bound teardown so a stuck blocking-pool task cannot hang exit indefinitely.
         rt.shutdown_timeout(std::time::Duration::from_secs(5));
         result
     }

--- a/crates/hotshot/hotshot/src/types/handle.rs
+++ b/crates/hotshot/hotshot/src/types/handle.rs
@@ -272,6 +272,8 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES> + 'static> SystemContextHandl
 
     /// Shut down the inner hotshot and wait until all background threads are closed.
     pub async fn shut_down(&mut self) {
+        self.membership_coordinator.cancel_all_drb();
+
         // this is required because `SystemContextHandle` holds an inactive receiver and
         // `broadcast_direct` below can wait indefinitely
         self.internal_event_stream.0.set_await_active(false);

--- a/crates/hotshot/testing/Cargo.toml
+++ b/crates/hotshot/testing/Cargo.toml
@@ -53,6 +53,7 @@ versions = { workspace = true }
 
 [dev-dependencies]
 test-log = { workspace = true }
+tokio-util = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/hotshot/testing/tests/tests_1/unit.rs
+++ b/crates/hotshot/testing/tests/tests_1/unit.rs
@@ -3,6 +3,7 @@ use hotshot_types::{
     traits::storage::{null_load_drb_progress_fn, null_store_drb_progress_fn},
 };
 use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(test)]
 #[tokio::test(flavor = "multi_thread")]
@@ -29,8 +30,10 @@ async fn test_compute_drb_result() {
         drb_input,
         null_store_drb_progress_fn(),
         null_load_drb_progress_fn(),
+        CancellationToken::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     assert_eq!(expected_result, actual_result);
 }
@@ -59,8 +62,10 @@ async fn test_compute_drb_result_2() {
         drb_input,
         null_store_drb_progress_fn(),
         null_load_drb_progress_fn(),
+        CancellationToken::new(),
     )
-    .await;
+    .await
+    .unwrap();
 
     assert_eq!(expected_result, actual_result);
 }

--- a/crates/hotshot/types/src/drb.rs
+++ b/crates/hotshot/types/src/drb.rs
@@ -9,6 +9,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Instant};
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use vbs::version::Version;
 use versions::DRB_AND_HEADER_UPGRADE_VERSION;
@@ -69,6 +70,10 @@ pub const DIFFICULTY_LEVEL: u64 = 10;
 /// Interval at which to store the results
 pub const DRB_CHECKPOINT_INTERVAL: u64 = 1_000_000_000;
 
+/// Hashes between cancellation checks. Bounds how long hashing continues after `cancel`
+/// fires; independent of the `DRB_CHECKPOINT_INTERVAL` persistence cadence.
+const DRB_CANCEL_BATCH: u64 = 1_000_000;
+
 /// DRB seed input for epoch 1 and 2.
 pub const INITIAL_DRB_SEED_INPUT: [u8; 32] = [0; 32];
 /// DRB result for epoch 1 and 2.
@@ -94,18 +99,39 @@ pub fn difficulty_level() -> u64 {
     unimplemented!("Use an arbitrary `DIFFICULTY_LEVEL` for now before we bench the hash time.");
 }
 
+/// Hash `hash` repeatedly `count` times, checking `cancel` between batches.
+///
+/// Returns `None` if cancelled, `Some(hash)` otherwise.
+fn hash_batches(mut hash: [u8; 32], count: u64, cancel: CancellationToken) -> Option<[u8; 32]> {
+    let mut done = 0u64;
+    while done < count {
+        if cancel.is_cancelled() {
+            return None;
+        }
+        let n = DRB_CANCEL_BATCH.min(count - done);
+        for _ in 0..n {
+            hash = Sha256::digest(hash).into();
+        }
+        done += n;
+    }
+    Some(hash)
+}
+
 /// Compute the DRB result for the leader rotation.
 ///
 /// This is to be started two epochs in advance and spawned in a non-blocking thread.
+/// Returns `None` if the computation was cancelled via `cancel`.
 ///
 /// # Arguments
 /// * `drb_seed_input` - Serialized QC signature.
+/// * `cancel` - Token that stops the hash loop when fired.
 #[must_use]
 pub async fn compute_drb_result(
     drb_input: DrbInput,
     store_drb_progress: StoreDrbProgressFn,
     load_drb_progress: LoadDrbProgressFn,
-) -> DrbResult {
+    cancel: CancellationToken,
+) -> Option<DrbResult> {
     info!(target: "announce::drb", ?drb_input, "beginning drb calculation");
     let mut drb_input = drb_input;
 
@@ -123,7 +149,7 @@ pub async fn compute_drb_result(
         }
     }
 
-    let mut hash = drb_input.value.to_vec();
+    let mut hash: [u8; 32] = drb_input.value;
     let mut iteration = drb_input.iteration;
     let remaining_iterations = drb_input
         .difficulty_level
@@ -143,28 +169,17 @@ pub async fn compute_drb_result(
 
     // loop up to, but not including, the `final_checkpoint`
     for _ in 0..final_checkpoint {
-        hash = tokio::task::spawn_blocking(move || {
-            let mut hash_tmp = hash.clone();
-            for _ in 0..DRB_CHECKPOINT_INTERVAL {
-                // TODO: This may be optimized to avoid memcopies after we bench the hash time.
-                // <https://github.com/EspressoSystems/HotShot/issues/3880>
-                hash_tmp = Sha256::digest(&hash_tmp).to_vec();
-            }
-
-            hash_tmp
-        })
-        .await
-        .expect("DRB calculation failed: this should never happen");
-
-        let mut partial_drb_result = [0u8; 32];
-        partial_drb_result.copy_from_slice(&hash);
+        let c = cancel.clone();
+        hash = tokio::task::spawn_blocking(move || hash_batches(hash, DRB_CHECKPOINT_INTERVAL, c))
+            .await
+            .expect("completes")?;
 
         iteration += DRB_CHECKPOINT_INTERVAL;
 
         let updated_drb_input = DrbInput {
             epoch: drb_input.epoch,
             iteration,
-            value: partial_drb_result,
+            value: hash,
             difficulty_level: drb_input.difficulty_level,
         };
 
@@ -189,24 +204,18 @@ pub async fn compute_drb_result(
     }
 
     let final_checkpoint_iteration = iteration;
+    // Holds by construction: `iteration` only ever reaches multiples of the checkpoint
+    // interval not exceeding `difficulty_level`.
+    let remainder = drb_input
+        .difficulty_level
+        .checked_sub(final_checkpoint_iteration)
+        .expect("sufficient iterations");
 
     // perform the remaining iterations
-    hash = tokio::task::spawn_blocking(move || {
-        let mut hash_tmp = hash.clone();
-        for _ in final_checkpoint_iteration..drb_input.difficulty_level {
-            // TODO: This may be optimized to avoid memcopies after we bench the hash time.
-            // <https://github.com/EspressoSystems/HotShot/issues/3880>
-            hash_tmp = Sha256::digest(&hash_tmp).to_vec();
-        }
-
-        hash_tmp
-    })
-    .await
-    .expect("DRB calculation failed: this should never happen");
-
-    // Convert the hash to the DRB result.
-    let mut drb_result = [0u8; 32];
-    drb_result.copy_from_slice(&hash);
+    let c = cancel.clone();
+    let drb_result = tokio::task::spawn_blocking(move || hash_batches(hash, remainder, c))
+        .await
+        .expect("DRB spawn_blocking panicked")?;
 
     let final_drb_input = DrbInput {
         epoch: drb_input.epoch,
@@ -224,7 +233,7 @@ pub async fn compute_drb_result(
         }
     });
 
-    drb_result
+    Some(drb_result)
 }
 
 /// Seeds for DRB computation and computed results.
@@ -402,13 +411,85 @@ mod tests {
     use alloy::primitives::U256;
     use rand::RngCore;
     use sha2::{Digest, Sha256};
+    use tokio_util::sync::CancellationToken;
 
-    use super::election::{generate_stake_cdf, select_randomized_leader};
+    use super::{
+        DRB_CANCEL_BATCH, DRB_CHECKPOINT_INTERVAL, DrbInput, compute_drb_result,
+        election::{generate_stake_cdf, select_randomized_leader},
+        hash_batches,
+    };
     use crate::{
         signature_key::BLSPubKey,
         stake_table::StakeTableEntry,
-        traits::signature_key::{BuilderSignatureKey, StakeTableEntryType},
+        traits::{
+            signature_key::{BuilderSignatureKey, StakeTableEntryType},
+            storage::{null_load_drb_progress_fn, null_store_drb_progress_fn},
+        },
     };
+
+    #[test]
+    fn test_hash_batches_pre_cancelled() {
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        assert_eq!(hash_batches([0u8; 32], 10, cancel), None);
+    }
+
+    #[test]
+    fn test_hash_batches_count_zero() {
+        let input = [42u8; 32];
+        let result = hash_batches(input, 0, CancellationToken::new());
+        assert_eq!(result, Some(input));
+    }
+
+    #[test]
+    fn test_hash_batches_small_count() {
+        let input = [1u8; 32];
+        let count = 5u64;
+        // count < DRB_CANCEL_BATCH, so a single batch completes
+        let mut expected = input;
+        for _ in 0..count {
+            expected = Sha256::digest(expected).into();
+        }
+        let result = hash_batches(input, count, CancellationToken::new());
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn test_hash_batches_cancel_after_first_batch() {
+        // count spans 2 batches; cancel after first batch boundary
+        let count = DRB_CANCEL_BATCH + 1;
+        let cancel = CancellationToken::new();
+
+        // Compute one full batch, then cancel, then try to hash the remainder
+        let intermediate = hash_batches([0u8; 32], DRB_CANCEL_BATCH, CancellationToken::new())
+            .expect("first batch must complete");
+        cancel.cancel();
+        // The remaining 1 iteration sees cancelled token on first check
+        let result = hash_batches(intermediate, count - DRB_CANCEL_BATCH, cancel);
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_compute_drb_result_cancelled() {
+        // A pre-cancelled token must abandon a multi-checkpoint computation
+        // immediately rather than running it to completion.
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let drb_input = DrbInput {
+            epoch: 1,
+            iteration: 0,
+            value: [0u8; 32],
+            difficulty_level: DRB_CHECKPOINT_INTERVAL * 5,
+        };
+        let result = compute_drb_result(
+            drb_input,
+            null_store_drb_progress_fn(),
+            null_load_drb_progress_fn(),
+            cancel,
+        )
+        .await;
+        assert_eq!(result, None);
+    }
 
     #[test]
     fn test_randomized_leader() {

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -645,23 +645,21 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
         let store_drb_progress_fn = self.store_drb_progress_fn.clone();
         let load_drb_progress_fn = self.load_drb_progress_fn.clone();
 
-        // Race the local computation against the cancellation token. If the
-        // token fires, an external source has already added the DRB to
-        // membership, so read it back rather than waiting for the local hash
-        // loop to finish.
-        let drb = tokio::select! {
-            drb = compute_drb_result(drb_input, store_drb_progress_fn, load_drb_progress_fn) => {
-                drb
-            },
-            () = cancel_token.cancelled() => {
-                tracing::info!(
-                    "DRB calculation for epoch {epoch} cancelled by external supplier"
-                );
+        let drb = match compute_drb_result(
+            drb_input,
+            store_drb_progress_fn,
+            load_drb_progress_fn,
+            cancel_token,
+        )
+        .await
+        {
+            Some(drb) => drb,
+            None => {
                 self.clear_drb_state(epoch);
                 return self.membership.get_epoch_drb(epoch).await.map_err(|e| {
                     anytrace::error!(
-                        "DRB calculation for epoch {epoch} was cancelled but the externally \
-                         supplied result is no longer available: {e}"
+                        "DRB calculation for epoch {epoch} was cancelled but no externally \
+                         supplied result is available: {e}"
                     )
                 });
             },
@@ -716,6 +714,14 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
     fn clear_drb_state(&self, epoch: EpochNumber) {
         self.drb_calculation_map.lock().remove(&epoch);
         self.drb_cancel_map.lock().remove(&epoch);
+    }
+
+    /// Cancel all in-flight DRB calculations (e.g. on shutdown).
+    pub fn cancel_all_drb(&self) {
+        let tokens: Vec<_> = self.drb_cancel_map.lock().drain().map(|(_, t)| t).collect();
+        for token in tokens {
+            token.cancel();
+        }
     }
 }
 


### PR DESCRIPTION
I believe this fixes the issue where shutdown is incomplete that I previously encountered when syncing a decaf node.