### PR TITLE
[new-protocol] fix restart vote2 handling: re-cast without re-recording

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -193,7 +193,7 @@ pub struct Consensus<T: NodeType> {
     stored_vids: BTreeSet<ViewNumber>,
     stored_actions: BTreeSet<(ViewNumber, ActionKind)>,
     requested_actions: BTreeSet<(ViewNumber, ActionKind)>,
-    /// Highest locked-QC view confirmed durable; gates release of phase-2 votes.
+    /// Highest locked-QC view confirmed persisted; gates release of phase-2 votes.
     stored_high_qc: Option<ViewNumber>,
 
     /// Messages constructed and accounted for in `voted_*_views` /
@@ -215,6 +215,10 @@ pub struct Consensus<T: NodeType> {
     pending_timeout_certs: BTreeMap<ViewNumber, TimeoutCertificate2<T>>,
 
     timeout_view: ViewNumber,
+    /// Highest view this node may have acted in before a restart (from the
+    /// persisted action log). Bars re-*recording* a view's Vote action, not
+    /// re-casting the phase-2 vote itself (see [`Self::vote2_persisted`]).
+    restart_barred_view: ViewNumber,
     current_view: ViewNumber,
     current_epoch: Option<EpochNumber>,
 
@@ -312,6 +316,7 @@ impl<T: NodeType> Consensus<T> {
             node_id: KeyPrefix::from(&public_key),
             public_key,
             timeout_view: ViewNumber::genesis(),
+            restart_barred_view: ViewNumber::genesis(),
             current_view: ViewNumber::genesis(),
             current_epoch: None,
             stake_table_coordinator: membership_coordinator,
@@ -359,7 +364,7 @@ impl<T: NodeType> Consensus<T> {
         reconstructed: impl IntoIterator<Item = (ViewNumber, VidCommitment2)>,
     ) {
         self.current_epoch = Some(proposal.epoch);
-        // The seed cert comes from durable storage, so its lock is already persisted.
+        // The seed cert comes from persistent storage, so its lock is already persisted.
         self.bump_stored_high_qc(cert1.view_number());
         self.certs.insert(cert1.view_number(), cert1.clone());
         self.locked_cert = Some(cert1);
@@ -384,8 +389,8 @@ impl<T: NodeType> Consensus<T> {
     /// Restore the locked QC persisted on a prior run. Called after
     /// `seed_parent`: the persisted lock can be newer than the decided-anchor
     /// QC, and restoring it keeps the node from voting against a block it had
-    /// already locked. The loaded value is durable, so it also advances the
-    /// durability watermark.
+    /// already locked. The loaded value is persisted, so it also advances the
+    /// persistence watermark.
     pub fn seed_locked_cert(&mut self, cert1: Certificate1<T>) {
         let view = cert1.view_number();
         self.bump_stored_high_qc(view);
@@ -399,15 +404,15 @@ impl<T: NodeType> Consensus<T> {
         }
     }
 
-    /// Advance the locked-QC durability watermark to `view` if it is newer.
+    /// Advance the locked-QC persistence watermark to `view` if it is newer.
     fn bump_stored_high_qc(&mut self, view: ViewNumber) {
         if self.stored_high_qc.is_none_or(|cur| cur < view) {
             self.stored_high_qc = Some(view);
         }
     }
 
-    /// Whether the locked QC at `required` view is durably persisted.
-    fn high_qc_durable(&self, required: ViewNumber) -> bool {
+    /// Whether the locked QC at `required` view is persisted.
+    fn high_qc_persisted(&self, required: ViewNumber) -> bool {
         self.stored_high_qc.is_some_and(|stored| stored >= required)
     }
 
@@ -798,8 +803,9 @@ impl<T: NodeType> Consensus<T> {
     }
 
     /// On restart, bar voting and proposing in every view this node may have
-    /// acted in by raising `timeout_view`, and place the view cursor just past
-    /// the high QC. Forward-only: never regresses either view.
+    /// acted in by raising `timeout_view` (vote1, propose) and
+    /// `restart_barred_view` (vote-action re-recording), and place the view
+    /// cursor just past the high QC. Forward-only: never regresses any view.
     pub fn resume_from_restart(
         &mut self,
         anchor_view: ViewNumber,
@@ -810,6 +816,9 @@ impl<T: NodeType> Consensus<T> {
         let last_barred = first_allowed - 1;
         if last_barred > self.timeout_view {
             self.timeout_view = last_barred;
+        }
+        if last_barred > self.restart_barred_view {
+            self.restart_barred_view = last_barred;
         }
         // `Coordinator::start` enters `current_view + 1`, so parking the cursor
         // at the high QC makes the node re-enter at `high_qc + 1`.
@@ -1776,7 +1785,7 @@ impl<T: NodeType> Consensus<T> {
             },
             StorageOutput::HighQc(view) => {
                 self.bump_stored_high_qc(view);
-                // A higher durable lock can unblock vote2 across many views; re-check all.
+                // A newly persisted lock can unblock vote2 across many views; re-check all.
                 let pending: Vec<ViewNumber> = self.pending_vote2.keys().copied().collect();
                 for view in pending {
                     self.release_vote2(view, outbox);
@@ -1810,15 +1819,25 @@ impl<T: NodeType> Consensus<T> {
         let Some((_, required)) = self.pending_vote2.get(&view) else {
             return;
         };
+        if self.certs2.contains_key(&view) {
+            self.pending_vote2.remove(&view);
+            return;
+        }
         let required = *required;
-        if !self.stored_actions.contains(&(view, ActionKind::Vote))
-            || !self.stored_vids.contains(&view)
-            || !self.high_qc_durable(required)
-        {
+        if !self.vote2_persisted(view) || !self.high_qc_persisted(required) {
             return;
         }
         let (vote2, _) = self.pending_vote2.remove(&view).expect("checked above");
         outbox.push_back(ConsensusOutput::SendVote2(vote2));
+    }
+
+    /// Whether the view's Vote action and VID share are persisted, gating the
+    /// phase-2 vote. A restart-barred view persisted both before the crash:
+    /// its vote is re-cast, but its Vote action is never re-recorded.
+    fn vote2_persisted(&self, view: ViewNumber) -> bool {
+        view <= self.restart_barred_view
+            || (self.stored_actions.contains(&(view, ActionKind::Vote))
+                && self.stored_vids.contains(&view))
     }
 
     fn release_proposal(&mut self, view: ViewNumber, outbox: &mut Outbox<ConsensusOutput<T>>) {
@@ -2089,6 +2108,10 @@ impl<T: NodeType> Consensus<T> {
             outbox.push_back(ConsensusOutput::PersistHighQc(cert1.clone()));
         }
 
+        if self.certs2.contains_key(&view) {
+            return;
+        }
+
         if !self.staked_in_epoch(proposal_epoch) {
             return;
         }
@@ -2111,17 +2134,16 @@ impl<T: NodeType> Consensus<T> {
             },
         };
         self.voted_2_views.insert(view);
-        // Lock is set above and >= view; the vote waits until it is durable.
+        // Lock is set above and >= view; the vote waits until it is persisted.
         let required = self
             .locked_view()
             .expect("locked_cert is set before voting in phase 2");
-        if self.stored_actions.contains(&(view, ActionKind::Vote))
-            && self.stored_vids.contains(&view)
-            && self.high_qc_durable(required)
-        {
+        if self.vote2_persisted(view) && self.high_qc_persisted(required) {
             outbox.push_back(ConsensusOutput::SendVote2(vote));
         } else {
-            self.request_action(view, Some(proposal_epoch), ActionKind::Vote, outbox);
+            if view > self.restart_barred_view {
+                self.request_action(view, Some(proposal_epoch), ActionKind::Vote, outbox);
+            }
             self.pending_vote2.insert(view, (vote, required));
         }
     }

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1645,10 +1645,15 @@ impl<T: NodeType> Consensus<T> {
             );
             return;
         }
+        // A Cert2 can arrive before its Cert1; require both before mutating any
+        // decided state.
+        let Some(cert1) = self.certs.get(&view).cloned() else {
+            debug!(%view, "cert1 missing");
+            return;
+        };
         // Handle Epoch Change by broadcasting the epoch change message if we have
         // all the data we need.
         if is_last_block(proposal.block_header.block_number(), *self.epoch_height)
-            && let Some(cert1) = self.certs.get(&view)
             && cert1.data.leaf_commit == proposal_commit
         {
             let epoch_change = EpochChangeMessage {
@@ -1693,10 +1698,6 @@ impl<T: NodeType> Consensus<T> {
         }
         self.last_decided_view = new_decided_view;
         self.last_decided_leaf = last_decided_leaf;
-        let Some(cert1) = self.certs.get(&view).cloned() else {
-            debug!(%view, "cert1 missing");
-            return;
-        };
         outbox.push_back(ConsensusOutput::LeafDecided {
             leaves: decided,
             cert1,

--- a/crates/hotshot/new-protocol/src/tests/common/assertions.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/assertions.rs
@@ -16,6 +16,15 @@ pub(crate) fn is_leaf_decided(output: &ConsensusOutput<TestTypes>) -> bool {
     matches!(output, ConsensusOutput::LeafDecided { .. })
 }
 
+/// True if `output` is a `LeafDecided` whose decided leaves include `view`.
+pub(crate) fn decides_view(output: &ConsensusOutput<TestTypes>, view: u64) -> bool {
+    matches!(
+        output,
+        ConsensusOutput::LeafDecided { leaves, .. }
+            if leaves.iter().any(|l| *l.view_number() == view)
+    )
+}
+
 pub(crate) fn is_request_state(output: &ConsensusOutput<TestTypes>) -> bool {
     matches!(output, ConsensusOutput::RequestState(_))
 }

--- a/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/coordinator_builder.rs
@@ -9,16 +9,16 @@ use hotshot_example_types::{
 };
 use hotshot_types::{
     data::{
-        EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, VidCommitment,
-        ViewChangeEvidence2, ViewNumber,
+        EpochNumber, Leaf2, QuorumProposal2, QuorumProposalWrapper, ViewChangeEvidence2, ViewNumber,
     },
     epoch_membership::EpochMembershipCoordinator,
     light_client::StateKeyPair,
     message::Proposal as SignedProposal,
     simple_vote::QuorumData2,
-    traits::{block_contents::BlockHeader, signature_key::SignatureKey, storage::Storage as _},
+    traits::{signature_key::SignatureKey, storage::Storage as _},
 };
 
+use super::utils::reconstructed_blocks;
 use crate::{
     block::{BlockBuilder, BlockBuilderConfig},
     client::CoordinatorClient,
@@ -158,22 +158,15 @@ pub async fn build_test_coordinator(
             TestTypes,
         >>::from_header(anchor_leaf.block_header());
         state_manager.seed_state(anchor_view, Arc::new(anchor_state), anchor_leaf.clone());
-        let reconstructed: Vec<_> =
-            std::iter::once((anchor_view, anchor_leaf.block_header().clone()))
-                .chain(
-                    storage
-                        .proposals_cloned()
-                        .await
-                        .into_iter()
-                        .map(|(view, p)| (view, p.data.block_header().clone())),
-                )
-                .filter_map(|(view, header)| {
-                    match BlockHeader::<TestTypes>::payload_commitment(&header) {
-                        VidCommitment::V2(commitment) => Some((view, commitment)),
-                        _ => None,
-                    }
-                })
-                .collect();
+        let reconstructed = reconstructed_blocks(
+            std::iter::once((anchor_view, anchor_leaf.block_header().clone())).chain(
+                storage
+                    .proposals_cloned()
+                    .await
+                    .into_iter()
+                    .map(|(view, p)| (view, p.data.block_header().clone())),
+            ),
+        );
         // Seed persisted proposals before `seed_parent` so its authoritative
         // anchor wins (mirrors `Coordinator::maker`).
         consensus.seed_proposals(

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -25,8 +25,8 @@ use hotshot_testing::{
 };
 use hotshot_types::{
     data::{
-        EpochNumber, Leaf2, VidCommitment, VidDisperse, VidDisperse2, VidDisperseShare2,
-        ViewNumber, vid_commitment,
+        EpochNumber, Leaf2, VidCommitment, VidCommitment2, VidDisperse, VidDisperse2,
+        VidDisperseShare2, ViewNumber, vid_commitment,
     },
     epoch_membership::EpochMembershipCoordinator,
     light_client::{StakeTableState, StateKeyPair},
@@ -845,6 +845,22 @@ fn extract_vid_disperse(
     (vid_disperse, vid_shares)
 }
 
+/// The `(view, VID commitment)` pairs a restarted node seeds as
+/// already-reconstructed blocks, mirroring `Coordinator::maker`.
+pub fn reconstructed_blocks(
+    headers: impl IntoIterator<Item = (ViewNumber, TestBlockHeader)>,
+) -> Vec<(ViewNumber, VidCommitment2)> {
+    headers
+        .into_iter()
+        .filter_map(
+            |(view, header)| match BlockHeader::<TestTypes>::payload_commitment(&header) {
+                VidCommitment::V2(commitment) => Some((view, commitment)),
+                _ => None,
+            },
+        )
+        .collect()
+}
+
 /// Lightweight consensus-only test harness. Wraps a single [`Consensus`]
 /// instance and auto-responds to outputs that consensus expects feedback for
 /// (`RequestState`, `RequestBlockAndHeader`, `RequestVidDisperse`,
@@ -893,8 +909,9 @@ impl ConsensusHarness {
 
     /// Build a harness whose consensus has been restarted from a persisted
     /// decided anchor, mirroring `Coordinator::maker`: `Consensus::new` is
-    /// given the anchor leaf, the undecided proposals above it are re-seeded,
-    /// and the anchor is installed as the parent via `seed_parent`.
+    /// given the anchor leaf, the undecided proposals above it are re-seeded
+    /// and marked reconstructed, and the anchor is installed as the parent via
+    /// `seed_parent`.
     pub async fn restarted_from(
         node_index: u64,
         anchor_proposal: Proposal<TestTypes>,
@@ -922,8 +939,14 @@ impl ConsensusHarness {
             epoch_height,
         );
 
+        let undecided_proposals: Vec<_> = undecided_proposals.into_iter().collect();
+        let reconstructed = reconstructed_blocks(
+            std::iter::once(&anchor_proposal)
+                .chain(&undecided_proposals)
+                .map(|p| (p.view_number, p.block_header.clone())),
+        );
         consensus.seed_proposals(undecided_proposals);
-        consensus.seed_parent(anchor_cert1, anchor_proposal, std::iter::empty());
+        consensus.seed_parent(anchor_cert1, anchor_proposal, reconstructed);
         consensus.resume_from_restart(anchor_view, anchor_view + 1, anchor_view);
 
         Self {

--- a/crates/hotshot/new-protocol/src/tests/consensus.rs
+++ b/crates/hotshot/new-protocol/src/tests/consensus.rs
@@ -21,7 +21,7 @@ use crate::{
     storage::{ActionKind, StorageOutput},
     tests::common::{
         assertions::{
-            any, count_matching, is_leaf_decided, is_persist_proposal, is_proposal,
+            any, count_matching, decides_view, is_leaf_decided, is_persist_proposal, is_proposal,
             is_record_action, is_request_block_and_header, is_request_state, is_send_timeout_cert,
             is_send_timeout_vote, is_view_changed, is_vote1, is_vote2, node_index_for_key,
         },
@@ -956,6 +956,86 @@ async fn test_restart_does_not_redecide_anchor() {
     assert!(
         decided_views.iter().all(|view| *view > anchor_view),
         "the decide re-included the anchor view {anchor_view:?}; decided {decided_views:?}"
+    );
+}
+
+/// Certificates re-delivered after a restart for views this node already
+/// acted in must not re-record the view's Vote action or re-cast its phase-2
+/// vote once the Cert2 is known; a late Cert2 must still *decide* the view.
+#[tokio::test]
+async fn test_no_revote2_for_restart_barred_views() {
+    let test_data = TestData::new(4).await;
+    // Decided up to view 2 (the anchor) and voted in view 3 before going down.
+    let anchor = &test_data.views[1];
+    let voted = &test_data.views[2];
+    let anchor_view = anchor.view_number;
+
+    let mut harness = ConsensusHarness::restarted_from(
+        0,
+        anchor.proposal.data.clone(),
+        anchor.cert1.clone(),
+        [voted.proposal.data.clone()],
+    )
+    .await;
+    // Raise the action bar to the voted view, as `Coordinator::maker` does.
+    harness
+        .consensus
+        .resume_from_restart(anchor_view, anchor_view + 1, voted.view_number);
+
+    // A peer relays the missed Cert2s before re-broadcasting the Cert1s.
+    harness.apply(anchor.cert2_input()).await;
+    harness.apply(anchor.cert1_input()).await;
+    harness.apply(voted.cert2_input()).await;
+    harness.apply(voted.cert1_input()).await;
+
+    assert!(
+        any(harness.outputs(), |o| decides_view(o, *voted.view_number)),
+        "a late cert2 must still decide the undecided barred view"
+    );
+    assert!(
+        !any(harness.outputs(), is_vote2),
+        "must not re-cast a phase-2 vote in a view acted in before the restart"
+    );
+    assert_eq!(
+        count_matching(harness.outputs(), is_record_action),
+        0,
+        "no action may be re-recorded for views acted in before the restart"
+    );
+}
+
+/// If Cert1 formed before a crash but no Cert2 did, the restarted node must
+/// re-cast its (identical) phase-2 vote — without the barred quorum's re-votes
+/// the Cert2 can never form — while not re-recording the Vote action.
+#[tokio::test]
+async fn test_revote2_after_restart_without_cert2() {
+    let test_data = TestData::new(4).await;
+    let anchor = &test_data.views[1];
+    let voted = &test_data.views[2];
+    let anchor_view = anchor.view_number;
+
+    let mut harness = ConsensusHarness::restarted_from(
+        0,
+        anchor.proposal.data.clone(),
+        anchor.cert1.clone(),
+        [voted.proposal.data.clone()],
+    )
+    .await;
+    harness
+        .consensus
+        .resume_from_restart(anchor_view, anchor_view + 1, voted.view_number);
+
+    // A peer re-broadcasts Cert1 for the voted view; no Cert2 exists anywhere.
+    harness.apply(voted.cert1_input()).await;
+
+    assert_eq!(
+        count_matching(harness.outputs(), is_vote2),
+        1,
+        "the phase-2 vote must be re-cast after restart when no cert2 exists"
+    );
+    assert_eq!(
+        count_matching(harness.outputs(), is_record_action),
+        0,
+        "re-casting the vote must not re-record the view's Vote action"
     );
 }
 

--- a/crates/hotshot/new-protocol/src/tests/restarts.rs
+++ b/crates/hotshot/new-protocol/src/tests/restarts.rs
@@ -125,6 +125,54 @@ async fn restart_all_nodes_with_storage() {
     }
 }
 
+/// All nodes crash at the epoch boundary and restart with storage: the quorum
+/// must re-cast its phase-2 votes (without re-recording any action) or the
+/// epoch transition never completes.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_all_nodes_at_epoch_boundary() {
+    let num_nodes = 5;
+    let crash_view = 10;
+    let mut runner = TestRunner::builder()
+        .num_nodes(num_nodes)
+        .target_decisions(35)
+        .epoch_height(10)
+        .persistent_storage(true)
+        .tolerated_failed_views(views(1..=30))
+        .node_changes(vec![(
+            crash_view,
+            (0..num_nodes)
+                .map(|idx| NodeChange {
+                    idx,
+                    action: NodeAction::Restart,
+                })
+                .collect(),
+        )])
+        .build();
+    runner.run().await.unwrap();
+
+    for (idx, storage) in runner.node_storages().iter().enumerate() {
+        let mut seen = HashSet::new();
+        for (view, action) in storage.action_log().await {
+            assert!(
+                seen.insert((view, action)),
+                "node {idx} recorded {action:?} twice for view {view} — it re-entered a view it \
+                 had already acted in"
+            );
+        }
+
+        let (anchor, _) = storage
+            .anchor_leaf()
+            .await
+            .unwrap_or_else(|| panic!("node {idx} has no persisted anchor"));
+        assert!(
+            *anchor.view_number() > crash_view,
+            "node {idx} anchor stuck at view {} — it did not keep deciding past the epoch \
+             boundary after the restart",
+            anchor.view_number()
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Late start (with epochs)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Stack: **PR 1/3** ← this · [cert2 broadcast] · [gap-fill decides]

## What

Two restart-correctness fixes for the new protocol:

1. **Require Cert1 before mutating decided state.** `maybe_decide` advanced `last_decided_view` before discovering the view's Cert1 was missing, then bailed without emitting the decide. A Cert2 arriving before its Cert1 (vote2s can complete first) corrupted the watermark and made the view permanently undecidable.

2. **Re-cast vote2 after a restart instead of suppressing it.** A restart must never re-record a view's Vote action (the one-recorded-action-kind-per-view invariant that `restart_all_nodes_with_storage` asserts), but suppressing the phase-2 vote itself is fatal: if Cert1 formed for an epoch's last block and the network went down before any Cert2 existed, at most f unbarred stake remains — Cert2 can never reach quorum, the next epoch's first proposal hard-requires it, and timeout re-proposals must still extend the locked leaf. Permanent halt at the boundary.

   The new `restart_barred_view` bars *re-recording*, not re-voting: the vote is identical to any pre-crash one (Cert1 per view is unique), the persisted action log already durably bars re-entering the view, and reaching a vote2 requires the reconstructed-block seed, which proves the payload was persisted (`append_da`) before the crash (`vote2_durable`). The lock-durability gate is kept — required for two-phase safety on first-ever vote2s.

   Additionally, a phase-2 vote is skipped entirely once the view's Cert2 is known, both at vote creation and at pending-vote release.

## Reviewer focus

- `vote2_durable` (consensus.rs): the argument that the pre-crash run's durability stands in for `stored_actions`/`stored_vids` on the barred path.
- The hoisted Cert1 check in `maybe_decide`: bails now happen before any decided-state mutation.

## Tests

- `test_no_revote2_for_restart_barred_views` — re-delivered certs (Cert2 relayed first) neither re-vote nor re-record, and still decide the barred view.
- `test_revote2_after_restart_without_cert2` — the deadlock regression: vote2 is re-cast exactly once with zero re-recorded actions.
- `restart_all_nodes_at_epoch_boundary` — 5-node runner crash/restart in the epoch-boundary window; asserts no double-recorded actions and decides continue past the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
