### PR TITLE
Fix stale config node response snapshot on release-mainnet-1.2.0-rc

### DIFF
--- a/crates/espresso/node/src/snapshots/espresso_node__options__tests__config_node_response_postgres.snap
+++ b/crates/espresso/node/src/snapshots/espresso_node__options__tests__config_node_response_postgres.snap
@@ -102,7 +102,6 @@ local_catchup_timeout:
 bootstrap_epoch_catchup_timeout:
   secs: 30
   nanos: 0
-new_protocol_consensus_gc_interval: 100
 catchup_backoff:
   factor: 4
   base:


### PR DESCRIPTION
## Problem

`Test / test-postgres (6)` has failed on every `release-mainnet-1.2.0-rc` CI run since 2026-06-22: `espresso-node options::tests::config_node_response_snapshot` fails deterministically because the stored insta snapshot expects

```yaml
new_protocol_consensus_gc_interval: 100
```

but `PublicNodeConfig` on this branch has no such field, so the serialized YAML never contains it.

## Root cause

#4359 (backport of #4268, merge commit b89479f301f) also brought in 87f9e01de6c ("test: update config snapshot for new_protocol_consensus_gc_interval", #4351) — but the change that adds that field to `PublicNodeConfig` was never backported to this branch. The snapshot and the code have been out of sync ever since: the field appears in zero `.rs` files on this branch, only in the `.snap`.

First failing run (the #4359 merge itself): https://github.com/EspressoSystems/espresso-network/actions/runs/27985128308/job/82826316708
Latest (base branch, no open PRs involved): https://github.com/EspressoSystems/espresso-network/actions/runs/28788618981/job/85363222133

## Fix

Remove the stale line from the snapshot so it matches what the code actually serializes. If the `new_protocol_consensus_gc_interval` feature is intended for this release line, its code change should be backported separately, regenerating this snapshot.
