### PR TITLE
fix(clippy): resolve lints and bump rust-overlay

### DIFF
--- a/contracts/rust/adapter/src/bin/eval_domain.rs
+++ b/contracts/rust/adapter/src/bin/eval_domain.rs
@@ -32,5 +32,5 @@ fn main() {
         let new_element_str = format!("0x{:X} ", element_bigint.clone()).to_lowercase();
         domain_elements_str = domain_elements_str.to_owned() + &new_element_str;
     }
-    println!("domain elements: {}", &domain_elements_str);
+    println!("domain elements: {}", domain_elements_str);
 }

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -396,7 +396,7 @@ where
         .with_context(|| {
             format!(
                 "Failed to derive Libp2p bind address of {}",
-                &network_params.libp2p_bind_address
+                network_params.libp2p_bind_address
             )
         })?;
     let advertise_multiaddr = network_params

--- a/crates/hotshot/task-impls/src/stats.rs
+++ b/crates/hotshot/task-impls/src/stats.rs
@@ -148,7 +148,7 @@ impl<TYPES: NodeType> StatsTaskState<TYPES> {
 
     fn dump_stats(&self) -> Result<()> {
         let mut writer = csv::Writer::from_writer(vec![]);
-        for (_, leader_stats) in self.leader_stats.iter() {
+        for leader_stats in self.leader_stats.values() {
             writer
                 .serialize(leader_stats)
                 .map_err(|e| warn!("Failed to serialize leader stats: {}", e))?;
@@ -162,7 +162,7 @@ impl<TYPES: NodeType> StatsTaskState<TYPES> {
                 .map_err(|e| warn!("Failed to convert leader stats to string: {}", e))?
         );
         let mut writer = csv::Writer::from_writer(vec![]);
-        for (_, replica_stats) in self.replica_stats.iter() {
+        for replica_stats in self.replica_stats.values() {
             writer
                 .serialize(replica_stats)
                 .map_err(|e| warn!("Failed to serialize replica stats: {}", e))?;

--- a/crates/hotshot/task/src/dependency.rs
+++ b/crates/hotshot/task/src/dependency.rs
@@ -89,12 +89,9 @@ impl<T: Clone + Send + Sync> Dependency<T> for OrDependency<T> {
     async fn completed(self) -> Option<T> {
         let mut futures = FuturesUnordered::from_iter(self.deps);
         loop {
-            if let Some(maybe) = futures.next().await {
-                if maybe.is_some() {
-                    return maybe;
-                }
-            } else {
-                return None;
+            let maybe = futures.next().await?;
+            if maybe.is_some() {
+                return maybe;
             }
         }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -397,11 +397,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783404876,
-        "narHash": "sha256-DAh1CfiRVwr8Szkj5PiHmsqh10NHPb8SKPx7w/B+l9E=",
+        "lastModified": 1783663825,
+        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c161f20193bd91a73913b417e5b06d41860336d",
+        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
         "type": "github"
       },
       "original": {

--- a/hotshot-query-service/src/data_source/update.rs
+++ b/hotshot-query-service/src/data_source/update.rs
@@ -137,7 +137,6 @@ where
                     LeafInfo {
                         leaf: leaf2,
                         vid_share,
-                        state_cert: _,
                         ..
                     },
                 ) in qcs.zip(leaf_chain.iter().rev())


### PR DESCRIPTION
- drop redundant references in format args
- iterate map values instead of (_, v) pairs
- use ? for stream exhaustion in OrDependency
- match trailing LeafInfo field with ..
- update rust-overlay for latest rust toolchain
