### PR TITLE
fix: demote spammy warn log to debug

### DIFF
--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -706,7 +706,7 @@ where
                 // hash of the expected stake table, and so we can not verify that we computed the
                 // correct stake table. Since this applies only to Decaf, which is a testnet, it is
                 // acceptable to trust that the server supplied the correct events in this case.
-                tracing::warn!(
+                tracing::debug!(
                     ?epoch,
                     root_height,
                     computed_hash = %stake_table.commit(),


### PR DESCRIPTION
- Being on decaf is no inferred via chain ID instead of env var so can't be misconfigured by operators.
- The log is not actionable.
