### PR TITLE
[new-protocol] verify leaf chain cert2 against the cert2 epoch

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -9871,12 +9871,7 @@ mod test {
             Client::new(format!("http://localhost:{port}").parse().unwrap());
         wait_until_block_height(&height_client, "node/block-height", TARGET_HEIGHT + 5).await;
 
-        // Get the stake table and threshold for the epoch containing TARGET_HEIGHT
         let coordinator = network.server.node_state().coordinator;
-        let epoch = EpochNumber::new(epoch_from_block_number(TARGET_HEIGHT, EPOCH_HEIGHT));
-        let snapshot = coordinator.membership().snapshot(epoch).expect("snapshot");
-        let stake_table = HSStakeTable::from_iter(snapshot.stake_table());
-        let success_threshold = snapshot.success_threshold();
 
         // Use StatePeers to fetch the leaf at the exact target height
         let catchup = StatePeers::<StaticVersion<0, 1>>::from_urls(
@@ -9886,9 +9881,7 @@ mod test {
             &NoMetrics,
         );
 
-        let leaf = catchup
-            .fetch_leaf(TARGET_HEIGHT, stake_table, success_threshold)
-            .await?;
+        let leaf = catchup.fetch_leaf(coordinator, TARGET_HEIGHT).await?;
 
         assert_eq!(
             leaf.height(),

--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -29,7 +29,7 @@ use futures::{
     future::{Future, FutureExt, TryFuture, TryFutureExt},
     stream::FuturesUnordered,
 };
-use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
+use hotshot_new_protocol::utils::verify_new_protocol_leaf_chain;
 use hotshot_types::{
     ValidatorConfig,
     data::{EpochNumber, ViewNumber},
@@ -431,7 +431,7 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await
                 .with_context(|| format!("failed to fetch cert2 for height {cert2_height}"))?;
 
-            verify_leaf_chain_with_cert2(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
+            verify_new_protocol_leaf_chain(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
                 .await
                 .with_context(|| {
                     format!("failed to verify leaf chain with cert2 at height {height}")

--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use alloy::primitives::U256;
 use anyhow::{Context, anyhow, bail, ensure};
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -33,16 +32,16 @@ use futures::{
 use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
 use hotshot_types::{
     ValidatorConfig,
-    data::ViewNumber,
+    data::{EpochNumber, ViewNumber},
+    epoch_membership::EpochMembershipCoordinator,
     message::UpgradeLock,
     network::NetworkConfig,
     simple_certificate::LightClientStateUpdateCertificateV2,
-    stake_table::HSStakeTable,
     traits::{
         ValidatedState as ValidatedStateTrait,
         metrics::{Counter, CounterFamily, Metrics},
     },
-    utils::verify_leaf_chain,
+    utils::{epoch_from_block_number, verify_leaf_chain},
 };
 use itertools::Itertools;
 use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme, prelude::MerkleNode};
@@ -367,9 +366,8 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
     async fn try_fetch_leaf(
         &self,
         retry: usize,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         // Fetch the leaf chain. For new protocol heights this is a leaf range
         // `[height..=cert2_height]`
@@ -410,23 +408,24 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                 .await
                 .with_context(|| format!("failed to fetch cert2 for height {cert2_height}"))?;
 
-            verify_leaf_chain_with_cert2(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-                cert2,
-            )
-            .await
-            .with_context(|| format!("failed to verify leaf chain with cert2 at height {height}"))
+            verify_leaf_chain_with_cert2(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
+                .await
+                .with_context(|| {
+                    format!("failed to verify leaf chain with cert2 at height {height}")
+                })
         } else {
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
+            let epoch =
+                EpochNumber::new(epoch_from_block_number(height, *coordinator.epoch_height()));
+            let membership = coordinator
+                .stake_table_for_epoch(Some(epoch))
+                .map_err(|err| anyhow!("no stake table available for epoch {epoch}: {err:?}"))?;
+            let stake_table: Vec<_> = membership.stake_table().cloned().collect();
             verify_leaf_chain(
                 leaf_chain,
                 &stake_table,
-                success_threshold,
+                membership.success_threshold(),
                 height,
                 &upgrade_lock,
             )
@@ -759,9 +758,8 @@ where
     async fn try_fetch_leaf(
         &self,
         _retry: usize,
+        _coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        _stake_table: HSStakeTable<SeqTypes>,
-        _success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         // Leaves in our local DB were verified before they were stored, so we can return the leaf
         // at `height` directly without re-verifying.
@@ -954,9 +952,8 @@ impl StateCatchup for NullStateCatchup {
     async fn try_fetch_leaf(
         &self,
         _retry: usize,
+        _coordinator: EpochMembershipCoordinator<SeqTypes>,
         _height: u64,
-        _stake_table: HSStakeTable<SeqTypes>,
-        _success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         bail!("state catchup is disabled")
     }
@@ -1174,16 +1171,15 @@ impl StateCatchup for ParallelStateCatchup {
     async fn try_fetch_leaf(
         &self,
         retry: usize,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         // Try fetching the leaf on the local providers first
         let local_result = self
-            .on_local_providers(clone! {(stake_table) move |provider| {
-                clone!{(stake_table) async move {
+            .on_local_providers(clone! {(coordinator) move |provider| {
+                clone!{(coordinator) async move {
                     provider
-                        .try_fetch_leaf(retry, height, stake_table, success_threshold)
+                        .try_fetch_leaf(retry, coordinator, height)
                         .await
                 }}
             }})
@@ -1196,10 +1192,10 @@ impl StateCatchup for ParallelStateCatchup {
         }
 
         // If that fails, try the remote ones
-        self.on_remote_providers(clone! {(stake_table) move |provider| {
-            clone!{(stake_table) async move {
+        self.on_remote_providers(clone! {(coordinator) move |provider| {
+            clone!{(coordinator) async move {
                 provider
-                    .try_fetch_leaf(retry, height, stake_table, success_threshold)
+                    .try_fetch_leaf(retry, coordinator, height)
                     .await
             }}
         }})
@@ -1537,16 +1533,15 @@ impl StateCatchup for ParallelStateCatchup {
 
     async fn fetch_leaf(
         &self,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         // Try fetching the leaf on the local providers first
         let local_result = self
-            .on_local_providers(clone! {(stake_table) move |provider| {
-                clone!{(stake_table) async move {
+            .on_local_providers(clone! {(coordinator) move |provider| {
+                clone!{(coordinator) async move {
                     provider
-                        .try_fetch_leaf(0, height, stake_table, success_threshold)
+                        .try_fetch_leaf(0, coordinator, height)
                         .await
                 }}
             }})
@@ -1559,10 +1554,10 @@ impl StateCatchup for ParallelStateCatchup {
         }
 
         // If that fails, try the remote ones (with retry)
-        self.on_remote_providers(clone! {(stake_table) move |provider| {
-        clone!{(stake_table) async move {
+        self.on_remote_providers(clone! {(coordinator) move |provider| {
+        clone!{(coordinator) async move {
             provider
-                .fetch_leaf(height, stake_table, success_threshold)
+                .fetch_leaf(coordinator, height)
                 .await
         }}
         }})

--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -278,6 +278,29 @@ impl<ApiVer: StaticVersionType> StatePeers<ApiVer> {
     }
 }
 
+/// Verify a legacy (pre-V6) leaf chain
+pub(crate) async fn verify_legacy_leaf_chain(
+    leaf_chain: Vec<Leaf2>,
+    coordinator: &EpochMembershipCoordinator<SeqTypes>,
+    height: u64,
+) -> anyhow::Result<Leaf2> {
+    let upgrade_lock = UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
+    let epoch = EpochNumber::new(epoch_from_block_number(height, *coordinator.epoch_height()));
+    let membership = coordinator
+        .stake_table_for_epoch(Some(epoch))
+        .map_err(|err| anyhow!("no stake table available for epoch {epoch}: {err:?}"))?;
+    let stake_table: Vec<_> = membership.stake_table().cloned().collect();
+    verify_leaf_chain(
+        leaf_chain,
+        &stake_table,
+        membership.success_threshold(),
+        height,
+        &upgrade_lock,
+    )
+    .await
+    .with_context(|| format!("failed to verify leaf chain at height {height}"))
+}
+
 #[async_trait]
 impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
     #[tracing::instrument(skip(self, _instance))]
@@ -414,23 +437,7 @@ impl<ApiVer: StaticVersionType> StateCatchup for StatePeers<ApiVer> {
                     format!("failed to verify leaf chain with cert2 at height {height}")
                 })
         } else {
-            let upgrade_lock =
-                UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
-            let epoch =
-                EpochNumber::new(epoch_from_block_number(height, *coordinator.epoch_height()));
-            let membership = coordinator
-                .stake_table_for_epoch(Some(epoch))
-                .map_err(|err| anyhow!("no stake table available for epoch {epoch}: {err:?}"))?;
-            let stake_table: Vec<_> = membership.stake_table().cloned().collect();
-            verify_leaf_chain(
-                leaf_chain,
-                &stake_table,
-                membership.success_threshold(),
-                height,
-                &upgrade_lock,
-            )
-            .await
-            .with_context(|| format!("failed to verify leaf chain at height {height}"))
+            verify_legacy_leaf_chain(leaf_chain, &coordinator, height).await
         }
     }
 

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -14,7 +14,7 @@ use espresso_types::{
     },
 };
 use hotshot::traits::NodeImplementation;
-use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
+use hotshot_new_protocol::utils::verify_new_protocol_leaf_chain;
 use hotshot_types::{
     data::ViewNumber, epoch_membership::EpochMembershipCoordinator, message::UpgradeLock,
     simple_certificate::LightClientStateUpdateCertificateV2, traits::network::ConnectedNetwork,
@@ -292,7 +292,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
                 .await
                 .with_context(|| format!("failed to request cert2 at height {cert2_height}"))?;
 
-            verify_leaf_chain_with_cert2(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
+            verify_new_protocol_leaf_chain(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
                 .await
                 .with_context(|| "leaf chain verification with cert2 failed")?
         } else {

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -16,20 +16,17 @@ use espresso_types::{
 use hotshot::traits::NodeImplementation;
 use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
 use hotshot_types::{
-    data::{EpochNumber, ViewNumber},
-    epoch_membership::EpochMembershipCoordinator,
-    message::UpgradeLock,
-    simple_certificate::LightClientStateUpdateCertificateV2,
-    traits::network::ConnectedNetwork,
-    utils::{epoch_from_block_number, verify_leaf_chain},
+    data::ViewNumber, epoch_membership::EpochMembershipCoordinator, message::UpgradeLock,
+    simple_certificate::LightClientStateUpdateCertificateV2, traits::network::ConnectedNetwork,
 };
 use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
 use request_response::RequestType;
 use tokio::time::timeout;
-use versions::{EPOCH_VERSION, NEW_PROTOCOL_VERSION};
+use versions::NEW_PROTOCOL_VERSION;
 
 use crate::{
     api::RewardMerkleTreeV2Data,
+    catchup::verify_legacy_leaf_chain,
     request_response::{
         RequestResponseProtocol,
         request::{Request, Response},
@@ -299,25 +296,7 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
                 .await
                 .with_context(|| "leaf chain verification with cert2 failed")?
         } else {
-            let upgrade_lock =
-                UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
-            let epoch =
-                EpochNumber::new(epoch_from_block_number(height, *coordinator.epoch_height()));
-            let membership = coordinator
-                .stake_table_for_epoch(Some(epoch))
-                .map_err(|err| {
-                    anyhow::anyhow!("no stake table available for epoch {epoch}: {err:?}")
-                })?;
-            let stake_table: Vec<_> = membership.stake_table().cloned().collect();
-            verify_leaf_chain(
-                leaf_chain,
-                &stake_table,
-                membership.success_threshold(),
-                height,
-                &upgrade_lock,
-            )
-            .await
-            .with_context(|| "leaf chain verification failed")?
+            verify_legacy_leaf_chain(leaf_chain, &coordinator, height).await?
         };
 
         tracing::info!("Fetched leaf for height: {height}");

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use alloy::primitives::U256;
 use anyhow::Context;
 use async_trait::async_trait;
 use committable::{Commitment, Committable};
@@ -17,9 +16,12 @@ use espresso_types::{
 use hotshot::traits::NodeImplementation;
 use hotshot_new_protocol::utils::verify_leaf_chain_with_cert2;
 use hotshot_types::{
-    data::ViewNumber, message::UpgradeLock,
-    simple_certificate::LightClientStateUpdateCertificateV2, stake_table::HSStakeTable,
-    traits::network::ConnectedNetwork, utils::verify_leaf_chain,
+    data::{EpochNumber, ViewNumber},
+    epoch_membership::EpochMembershipCoordinator,
+    message::UpgradeLock,
+    simple_certificate::LightClientStateUpdateCertificateV2,
+    traits::network::ConnectedNetwork,
+    utils::{epoch_from_block_number, verify_leaf_chain},
 };
 use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
 use request_response::RequestType;
@@ -41,20 +43,16 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
     async fn try_fetch_leaf(
         &self,
         _retry: usize,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         // Timeout after a few batches
         let timeout_duration = self.config.request_batch_interval * 3;
 
         // Fetch the leaf
-        timeout(
-            timeout_duration,
-            self.fetch_leaf(height, stake_table, success_threshold),
-        )
-        .await
-        .with_context(|| "timed out while fetching leaf")?
+        timeout(timeout_duration, self.fetch_leaf(coordinator, height))
+            .await
+            .with_context(|| "timed out while fetching leaf")?
     }
 
     async fn try_fetch_accounts(
@@ -241,9 +239,8 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
 
     async fn fetch_leaf(
         &self,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         tracing::info!("Fetching leaf for height: {height}");
 
@@ -298,23 +295,24 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
                 .await
                 .with_context(|| format!("failed to request cert2 at height {cert2_height}"))?;
 
-            verify_leaf_chain_with_cert2(
-                leaf_chain,
-                &stake_table,
-                success_threshold,
-                height,
-                &upgrade_lock,
-                cert2,
-            )
-            .await
-            .with_context(|| "leaf chain verification with cert2 failed")?
+            verify_leaf_chain_with_cert2(leaf_chain, &coordinator, height, &upgrade_lock, cert2)
+                .await
+                .with_context(|| "leaf chain verification with cert2 failed")?
         } else {
             let upgrade_lock =
                 UpgradeLock::<SeqTypes>::new(versions::Upgrade::trivial(EPOCH_VERSION));
+            let epoch =
+                EpochNumber::new(epoch_from_block_number(height, *coordinator.epoch_height()));
+            let membership = coordinator
+                .stake_table_for_epoch(Some(epoch))
+                .map_err(|err| {
+                    anyhow::anyhow!("no stake table available for epoch {epoch}: {err:?}")
+                })?;
+            let stake_table: Vec<_> = membership.stake_table().cloned().collect();
             verify_leaf_chain(
                 leaf_chain,
                 &stake_table,
-                success_threshold,
+                membership.success_threshold(),
                 height,
                 &upgrade_lock,
             )

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -17,7 +17,7 @@ use hotshot_types::{
         election::{RandomizedCommittee, generate_stake_cdf, select_randomized_leader},
     },
     epoch_membership::EpochMembershipCoordinator,
-    stake_table::{HSStakeTable, StakeTableEntry},
+    stake_table::StakeTableEntry,
     traits::{
         block_contents::BlockHeader,
         election::{Membership, MembershipSnapshot, NonEpochMembershipSnapshot},
@@ -251,6 +251,7 @@ impl EpochCommittees {
         epoch: EpochNumber,
         header: &Header,
         validators: &AuthenticatedValidatorMap,
+        coordinator: &EpochMembershipCoordinator<SeqTypes>,
     ) -> anyhow::Result<Option<RewardAmount>> {
         let epoch_height = self.epoch_height;
         let current_epoch = epoch_from_block_number(header.height(), *epoch_height);
@@ -313,16 +314,9 @@ impl EpochCommittees {
                          root height",
                     )?;
 
-                    let prev_snapshot = self
-                        .snapshot(EpochNumber::new(previous_epoch))
-                        .context("Stake table not found")?;
-                    let prev_stake_table =
-                        HSStakeTable(prev_snapshot.stake_table().cloned().collect());
-                    let success_threshold = prev_snapshot.success_threshold();
-
                     self.fetcher
                         .peers
-                        .fetch_leaf(root_height, prev_stake_table, success_threshold)
+                        .fetch_leaf(coordinator.clone(), root_height)
                         .await
                         .context("Epoch root leaf not found")?
                         .block_header()
@@ -628,7 +622,6 @@ pub async fn fetch_and_calculate_block_reward(
             info!(?root_epoch, "catchup epoch root header");
 
             let leaf = coordinator
-                .membership()
                 .get_epoch_root(EpochNumber::new(root_epoch))
                 .await
                 .with_context(|| format!("Failed to get epoch root for root_epoch={root_epoch}"))?;
@@ -663,7 +656,7 @@ pub async fn fetch_and_calculate_block_reward(
 
     coordinator
         .membership()
-        .calculate_dynamic_block_reward(current_epoch, &header, &committee.validators)
+        .calculate_dynamic_block_reward(current_epoch, &header, &committee.validators, &coordinator)
         .await
         .with_context(|| {
             format!("dynamic block reward calculation failed for epoch={current_epoch}")
@@ -687,7 +680,11 @@ impl Membership<SeqTypes> for EpochCommittees {
     /// Adds the epoch committee and block reward for a given epoch,
     /// either by fetching from L1 or using local state if available.
     /// It also calculates and stores the block reward based on header version.
-    async fn add_epoch_root(&self, block_header: Header) -> Result<(), Self::Error> {
+    async fn add_epoch_root(
+        &self,
+        block_header: Header,
+        coordinator: &EpochMembershipCoordinator<SeqTypes>,
+    ) -> Result<(), Self::Error> {
         let block_number = block_header.block_number();
 
         let epoch_height = *self.epoch_height;
@@ -793,7 +790,12 @@ impl Membership<SeqTypes> for EpochCommittees {
         if block_reward.is_none() && version >= DRB_AND_HEADER_UPGRADE_VERSION {
             info!(?epoch, "calculating dynamic block reward");
             let reward = self
-                .calculate_dynamic_block_reward(epoch, &block_header, &active_validators)
+                .calculate_dynamic_block_reward(
+                    epoch,
+                    &block_header,
+                    &active_validators,
+                    coordinator,
+                )
                 .await
                 .map_err(Self::Error::Reward)?;
 
@@ -873,21 +875,20 @@ impl Membership<SeqTypes> for EpochCommittees {
         Ok(())
     }
 
-    async fn get_epoch_root(&self, epoch: EpochNumber) -> Result<Leaf2, Self::Error> {
+    async fn get_epoch_root(
+        &self,
+        epoch: EpochNumber,
+        coordinator: &EpochMembershipCoordinator<SeqTypes>,
+    ) -> Result<Leaf2, Self::Error> {
         let block_height = root_block_in_epoch(*epoch, *self.epoch_height());
         let peers = self.fetcher.peers.clone();
-        let snapshot = self
-            .snapshot(epoch)
-            .ok_or_else(|| Self::Error::Message(format!("no committee for epoch={epoch}")))?;
-        let stake_table = HSStakeTable(snapshot.stake_table().cloned().collect());
-        let success_threshold = snapshot.success_threshold();
 
         // the root block may not exist anywhere yet
         // Each attempt tries all peers once
         // `retry` only scales the per peer timeout
         for retry in 0..3 {
             match peers
-                .try_fetch_leaf(retry, block_height, stake_table.clone(), success_threshold)
+                .try_fetch_leaf(retry, coordinator.clone(), block_height)
                 .await
             {
                 Ok(leaf) => return Ok(leaf),
@@ -901,7 +902,11 @@ impl Membership<SeqTypes> for EpochCommittees {
         )))
     }
 
-    async fn get_epoch_drb(&self, epoch: EpochNumber) -> Result<DrbResult, Self::Error> {
+    async fn get_epoch_drb(
+        &self,
+        epoch: EpochNumber,
+        coordinator: &EpochMembershipCoordinator<SeqTypes>,
+    ) -> Result<DrbResult, Self::Error> {
         let peers = self.fetcher.peers.clone();
 
         // Try to retrieve the DRB result from an existing snapshot's randomized committee.
@@ -926,12 +931,6 @@ impl Membership<SeqTypes> for EpochCommittees {
             },
         };
 
-        let prev_snapshot = self.snapshot(previous_epoch).ok_or_else(|| {
-            Self::Error::Message(format!("no committee for previous_epoch={previous_epoch}"))
-        })?;
-        let stake_table = HSStakeTable(prev_snapshot.stake_table().cloned().collect());
-        let success_threshold = prev_snapshot.success_threshold();
-
         let block_height = transition_block_for_epoch(*previous_epoch, *self.epoch_height());
 
         debug!(
@@ -939,7 +938,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             epoch, block_height
         );
         let drb_leaf = peers
-            .try_fetch_leaf(1, block_height, stake_table, success_threshold)
+            .try_fetch_leaf(1, coordinator.clone(), block_height)
             .await
             .map_err(Self::Error::Catchup)?;
 
@@ -1852,7 +1851,12 @@ mod tests {
             // Brief warmup so the reader is in its loop before the
             // mutation lands.
             tokio::time::sleep(Duration::from_millis(2)).await;
-            committees
+            let coordinator = EpochMembershipCoordinator::<SeqTypes>::new(
+                committees.clone(),
+                *committees.epoch_height(),
+                &hotshot_example_types::storage_types::TestStorage::default(),
+            );
+            coordinator
                 .add_epoch_root(header.clone())
                 .await
                 .expect("add_epoch_root should succeed for the prefilled state");

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -491,13 +491,11 @@ impl Upgrade {
 pub mod mock {
     use std::collections::HashMap;
 
-    use alloy::primitives::U256;
     use anyhow::Context;
     use async_trait::async_trait;
     use committable::Commitment;
     use hotshot_types::{
         data::ViewNumber, simple_certificate::LightClientStateUpdateCertificateV2,
-        stake_table::HSStakeTable,
     };
     use jf_merkle_tree_compat::{ForgetableMerkleTreeScheme, MerkleTreeScheme};
 
@@ -548,9 +546,8 @@ pub mod mock {
         async fn try_fetch_leaf(
             &self,
             _retry: usize,
+            _coordinator: EpochMembershipCoordinator<SeqTypes>,
             _height: u64,
-            _stake_table: HSStakeTable<SeqTypes>,
-            _success_threshold: U256,
         ) -> anyhow::Result<Leaf2> {
             Err(anyhow::anyhow!("todo"))
         }

--- a/crates/espresso/types/src/v0/impls/reward.rs
+++ b/crates/espresso/types/src/v0/impls/reward.rs
@@ -16,7 +16,6 @@ use hotshot_contract_adapter::reward::RewardProofSiblings;
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
     epoch_membership::EpochMembershipCoordinator,
-    stake_table::HSStakeTable,
     traits::election::{Membership, MembershipSnapshot},
     utils::epoch_from_block_number,
 };
@@ -1196,17 +1195,10 @@ impl EpochRewardsCalculator {
         } else {
             // Fetch the leaf at the last block of the epoch so we can verify
             // the header via QC against the stake table
-            let snapshot = coordinator
-                .membership()
-                .snapshot(epoch)
-                .context(format!("no committee for epoch={epoch}"))?;
-            let stake_table = HSStakeTable::from_iter(snapshot.stake_table());
-            let success_threshold = snapshot.success_threshold();
-
             let leaf = instance_state
                 .state_catchup
                 .as_ref()
-                .fetch_leaf(epoch_last_block_height, stake_table, success_threshold)
+                .fetch_leaf(coordinator.clone(), epoch_last_block_height)
                 .await
                 .with_context(|| {
                     format!(

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -2,7 +2,7 @@
 //! It also includes some trait implementations that cannot be implemented in an external crate.
 use std::{cmp::max, collections::BTreeMap, fmt::Debug, ops::Range, sync::Arc};
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::Address;
 use anyhow::{Context, bail, ensure};
 use async_trait::async_trait;
 use committable::Commitment;
@@ -19,6 +19,7 @@ use hotshot_types::{
         QuorumProposalWrapper, VidCommitment, VidDisperseShare, ViewNumber,
     },
     drb::{DrbInput, DrbResult},
+    epoch_membership::EpochMembershipCoordinator,
     event::{HotShotAction, LeafInfo},
     message::{Proposal, convert_proposal},
     new_protocol::CoordinatorEvent,
@@ -26,7 +27,6 @@ use hotshot_types::{
         CertificatePair, LightClientStateUpdateCertificateV2, NextEpochQuorumCertificate2,
         QuorumCertificate, QuorumCertificate2, UpgradeCertificate,
     },
-    stake_table::HSStakeTable,
     traits::{
         ValidatedState as HotShotState, metrics::Metrics, node_implementation::NodeType,
         storage::Storage,
@@ -57,30 +57,27 @@ use crate::{
 #[async_trait]
 pub trait StateCatchup: Send + Sync {
     /// Fetch the leaf at the given height without retrying on transient errors.
+    ///
+    /// `coordinator` resolves the stake tables used to verify the fetched leaf
+    /// chain, triggering catchup for epochs whose stake table is not yet
+    /// available.
     async fn try_fetch_leaf(
         &self,
         retry: usize,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2>;
 
     /// Fetch the leaf at the given height, retrying on transient errors.
     async fn fetch_leaf(
         &self,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
         self.backoff()
             .retry(self, |provider, retry| {
-                let stake_table_clone = stake_table.clone();
-                async move {
-                    provider
-                        .try_fetch_leaf(retry, height, stake_table_clone, success_threshold)
-                        .await
-                }
-                .boxed()
+                let coordinator = coordinator.clone();
+                async move { provider.try_fetch_leaf(retry, coordinator, height).await }.boxed()
             })
             .await
     }
@@ -301,24 +298,18 @@ impl<T: StateCatchup + ?Sized> StateCatchup for Arc<T> {
     async fn try_fetch_leaf(
         &self,
         retry: usize,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
-        (**self)
-            .try_fetch_leaf(retry, height, stake_table, success_threshold)
-            .await
+        (**self).try_fetch_leaf(retry, coordinator, height).await
     }
 
     async fn fetch_leaf(
         &self,
+        coordinator: EpochMembershipCoordinator<SeqTypes>,
         height: u64,
-        stake_table: HSStakeTable<SeqTypes>,
-        success_threshold: U256,
     ) -> anyhow::Result<Leaf2> {
-        (**self)
-            .fetch_leaf(height, stake_table, success_threshold)
-            .await
+        (**self).fetch_leaf(coordinator, height).await
     }
 
     async fn try_fetch_accounts(

--- a/crates/hotshot/example-types/src/membership/strict_membership.rs
+++ b/crates/hotshot/example-types/src/membership/strict_membership.rs
@@ -12,6 +12,7 @@ use hotshot_types::{
     PeerConfig,
     data::{BlockNumber, EpochNumber, Leaf2, ViewNumber},
     drb::DrbResult,
+    epoch_membership::EpochMembershipCoordinator,
     event::Event,
     traits::{
         block_contents::BlockHeader,
@@ -161,7 +162,11 @@ where
         inner.table.set_first_epoch(*e, initial_drb_result);
     }
 
-    async fn add_epoch_root(&self, hdr: T::BlockHeader) -> Result<(), Self::Error> {
+    async fn add_epoch_root(
+        &self,
+        hdr: T::BlockHeader,
+        _coordinator: &EpochMembershipCoordinator<T>,
+    ) -> Result<(), Self::Error> {
         let epoch = epoch_from_block_number(hdr.block_number(), *self.epoch_height) + 2;
 
         let mut inner = self.inner.write();
@@ -171,7 +176,11 @@ where
         Ok(())
     }
 
-    async fn get_epoch_root(&self, e: EpochNumber) -> Result<Leaf2<T>, Self::Error> {
+    async fn get_epoch_root(
+        &self,
+        e: EpochNumber,
+        _coordinator: &EpochMembershipCoordinator<T>,
+    ) -> Result<Leaf2<T>, Self::Error> {
         let block_height = root_block_in_epoch(*e, *self.epoch_height);
 
         let (stake_table, fetcher) = {
@@ -198,7 +207,11 @@ where
         Err(anyhow!("Failed to fetch epoch root from any peer").into())
     }
 
-    async fn get_epoch_drb(&self, e: EpochNumber) -> Result<DrbResult, Self::Error> {
+    async fn get_epoch_drb(
+        &self,
+        e: EpochNumber,
+        _coordinator: &EpochMembershipCoordinator<T>,
+    ) -> Result<DrbResult, Self::Error> {
         let epoch_height = self.epoch_height;
 
         let (epoch_drb, fetcher) = {

--- a/crates/hotshot/hotshot/src/lib.rs
+++ b/crates/hotshot/hotshot/src/lib.rs
@@ -321,7 +321,7 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> SystemContext<TYPES, I> {
         let validated_state = initializer.anchor_state;
 
         load_start_epoch_info(
-            membership_coordinator.membership(),
+            &membership_coordinator,
             &initializer.start_epoch_info,
             config.epoch_height,
             config.epoch_start_block,
@@ -1288,11 +1288,12 @@ impl<TYPES: NodeType> HotShotInitializer<TYPES> {
 }
 
 async fn load_start_epoch_info<TYPES: NodeType>(
-    membership: &TYPES::Membership,
+    coordinator: &EpochMembershipCoordinator<TYPES>,
     start_epoch_info: &Vec<InitializerEpochInfo<TYPES>>,
     epoch_height: u64,
     epoch_start_block: u64,
 ) {
+    let membership = coordinator.membership();
     let first_epoch_number =
         EpochNumber::new(epoch_from_block_number(epoch_start_block, epoch_height));
 
@@ -1305,7 +1306,7 @@ async fn load_start_epoch_info<TYPES: NodeType>(
         if let Some(block_header) = &epoch_info.block_header {
             tracing::warn!("Calling add_epoch_root for epoch {}", epoch_info.epoch);
 
-            membership
+            coordinator
                 .add_epoch_root(block_header.clone())
                 .await
                 .unwrap_or_else(|err| {

--- a/crates/hotshot/new-protocol/src/epoch.rs
+++ b/crates/hotshot/new-protocol/src/epoch.rs
@@ -7,7 +7,7 @@ use hotshot_types::{
     data::{BlockNumber, EpochNumber, Leaf2},
     drb::DrbResult,
     epoch_membership::EpochMembershipCoordinator,
-    traits::{block_contents::BlockHeader, election::Membership, node_implementation::NodeType},
+    traits::{block_contents::BlockHeader, node_implementation::NodeType},
     utils::{is_epoch_root, is_transition_block},
 };
 use hotshot_utils::anytrace;
@@ -114,7 +114,6 @@ impl<T: NodeType> EpochManager<T> {
             handles.push(self.tasks.spawn(async move {
                 let result = async {
                     membership_coordinator
-                        .membership()
                         .add_epoch_root(root_leaf.block_header().clone())
                         .await
                         .map_err(|e| EpochManagerError::EpochRoot(anyhow::anyhow!("{e}")))?;

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -647,7 +647,7 @@ pub fn mock_membership_with_leaf_fetcher_network(
     membership.set_first_epoch(EpochNumber::genesis(), [0u8; 32]);
 
     let coordinator =
-        EpochMembershipCoordinator::new(membership, num_nodes as u64, &TestStorage::default());
+        EpochMembershipCoordinator::new(membership, epoch_height, &TestStorage::default());
     // Set the DRB difficulty selector so compute_drb_result can run.
     // Difficulty 0 makes the computation instant for tests.
     coordinator

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -444,7 +444,6 @@ impl TestData {
                 let target_epoch =
                     EpochNumber::new(epoch_from_block_number(block_number, epoch_height) + 2);
                 let _ = membership
-                    .membership()
                     .add_epoch_root(proposal.block_header.clone())
                     .await;
                 if let Ok(drb) = membership
@@ -1107,7 +1106,6 @@ impl ConsensusHarness {
                     }
                     let header = leaf.block_header().clone();
                     self.membership_coordinator
-                        .membership()
                         .add_epoch_root(header)
                         .await
                         .expect("add_epoch_root should succeed in test harness");

--- a/crates/hotshot/new-protocol/src/utils.rs
+++ b/crates/hotshot/new-protocol/src/utils.rs
@@ -1,9 +1,8 @@
-use alloy::primitives::U256;
 use anyhow::{anyhow, ensure};
 use committable::Committable;
 use hotshot_types::{
-    PeerConfig,
     data::Leaf2,
+    epoch_membership::EpochMembershipCoordinator,
     message::UpgradeLock,
     stake_table::StakeTableEntries,
     traits::node_implementation::NodeType,
@@ -25,8 +24,7 @@ use crate::message::Certificate2;
 /// commitment, and block height.
 pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
     mut leaf_chain: Vec<Leaf2<T>>,
-    stake_table: &[PeerConfig<T>],
-    success_threshold: U256,
+    coordinator: &EpochMembershipCoordinator<T>,
     expected_height: u64,
     upgrade_lock: &UpgradeLock<T>,
     cert2: Certificate2<T>,
@@ -35,29 +33,37 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
     leaf_chain.reverse();
 
     ensure!(!leaf_chain.is_empty(), "empty leaf chain");
+    let newest = &leaf_chain[0];
 
-    let stake_table_entries = StakeTableEntries::<T>::from(stake_table.to_vec()).0;
-
-    cert2.is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
+    let membership = coordinator
+        .stake_table_for_epoch(Some(cert2.data.epoch))
+        .map_err(|err| {
+            anyhow!(
+                "no stake table available for epoch {}: {err:?}",
+                cert2.data.epoch
+            )
+        })?;
+    let entries = StakeTableEntries::<T>::from_iter(membership.stake_table()).0;
+    cert2.is_valid_cert(&entries, membership.success_threshold(), upgrade_lock)?;
 
     ensure!(
-        cert2.data.leaf_commit == leaf_chain[0].commit(),
+        cert2.data.leaf_commit == newest.commit(),
         "cert2 does not match the newest leaf in the chain"
     );
     ensure!(
-        cert2.data.block_number == leaf_chain[0].height(),
+        cert2.data.block_number == newest.height(),
         "cert2 block number does not match the newest leaf"
     );
     ensure!(
-        cert2.view_number() == leaf_chain[0].view_number(),
+        cert2.view_number() == newest.view_number(),
         "cert2 view does not match the newest leaf"
     );
 
-    if leaf_chain[0].height() == expected_height {
-        return Ok(leaf_chain[0].clone());
+    if newest.height() == expected_height {
+        return Ok(newest.clone());
     }
 
-    let mut current = &leaf_chain[0];
+    let mut current = newest;
     for leaf in leaf_chain[1..].iter() {
         let justify_qc = current.justify_qc();
         if justify_qc.view_number() != leaf.view_number()
@@ -78,7 +84,15 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
             leaf.height().checked_add(1) == Some(current.height()),
             "leaf heights do not chain"
         );
-        justify_qc.is_valid_cert(&stake_table_entries, success_threshold, upgrade_lock)?;
+        let qc_epoch = justify_qc
+            .data()
+            .epoch
+            .ok_or_else(|| anyhow!("justify QC at height {} is missing an epoch", leaf.height()))?;
+        let membership = coordinator
+            .stake_table_for_epoch(Some(qc_epoch))
+            .map_err(|err| anyhow!("no stake table available for epoch {qc_epoch}: {err:?}"))?;
+        let entries = StakeTableEntries::<T>::from_iter(membership.stake_table()).0;
+        justify_qc.is_valid_cert(&entries, membership.success_threshold(), upgrade_lock)?;
         if leaf.height() == expected_height {
             return Ok(leaf.clone());
         }

--- a/crates/hotshot/new-protocol/src/utils.rs
+++ b/crates/hotshot/new-protocol/src/utils.rs
@@ -1,11 +1,12 @@
 use anyhow::{anyhow, ensure};
 use committable::Committable;
 use hotshot_types::{
-    data::Leaf2,
+    data::{EpochNumber, Leaf2, ViewNumber},
     epoch_membership::EpochMembershipCoordinator,
     message::UpgradeLock,
     stake_table::StakeTableEntries,
     traits::node_implementation::NodeType,
+    utils::epoch_from_block_number,
     vote::{Certificate, HasViewNumber},
 };
 
@@ -22,7 +23,7 @@ use crate::message::Certificate2;
 /// leaves that are not on the certified ancestry path. Those leaves are ignored;
 /// every accepted step must match the current leaf's justify QC, parent
 /// commitment, and block height.
-pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
+pub async fn verify_new_protocol_leaf_chain<T: NodeType>(
     mut leaf_chain: Vec<Leaf2<T>>,
     coordinator: &EpochMembershipCoordinator<T>,
     expected_height: u64,
@@ -35,14 +36,24 @@ pub async fn verify_leaf_chain_with_cert2<T: NodeType>(
     ensure!(!leaf_chain.is_empty(), "empty leaf chain");
     let newest = &leaf_chain[0];
 
+    ensure!(
+        cert2.view_number() > ViewNumber::genesis(),
+        "cert2 must not be the genesis view"
+    );
+    let epoch = EpochNumber::new(epoch_from_block_number(
+        cert2.data.block_number,
+        *coordinator.epoch_height(),
+    ));
+    ensure!(
+        cert2.data.epoch == epoch,
+        "cert2 epoch {} does not match epoch {epoch} derived from its block number {}",
+        cert2.data.epoch,
+        cert2.data.block_number
+    );
+
     let membership = coordinator
-        .stake_table_for_epoch(Some(cert2.data.epoch))
-        .map_err(|err| {
-            anyhow!(
-                "no stake table available for epoch {}: {err:?}",
-                cert2.data.epoch
-            )
-        })?;
+        .stake_table_for_epoch(Some(epoch))
+        .map_err(|err| anyhow!("no stake table available for epoch {epoch}: {err:?}"))?;
     let entries = StakeTableEntries::<T>::from_iter(membership.stake_table()).0;
     cert2.is_valid_cert(&entries, membership.success_threshold(), upgrade_lock)?;
 

--- a/crates/hotshot/task-impls/src/helpers.rs
+++ b/crates/hotshot/task-impls/src/helpers.rs
@@ -269,11 +269,7 @@ async fn decide_epoch_root<TYPES: NodeType, I: NodeImplementation<TYPES>>(
             // First add the epoch root to `membership`
             {
                 let start = Instant::now();
-                if let Err(e) = membership_clone
-                    .membership()
-                    .add_epoch_root(decided_block_header)
-                    .await
-                {
+                if let Err(e) = membership_clone.add_epoch_root(decided_block_header).await {
                     tracing::error!("Failed to add epoch root for epoch {next_epoch_number}: {e}");
                 }
                 tracing::info!("Time taken to add epoch root: {:?}", start.elapsed());

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -106,6 +106,31 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
         &self.membership
     }
 
+    /// Handles notifications that a new epoch root has been created.
+    pub async fn add_epoch_root(
+        &self,
+        header: TYPES::BlockHeader,
+    ) -> std::result::Result<(), <TYPES::Membership as Membership<TYPES>>::Error> {
+        self.membership.add_epoch_root(header, self).await
+    }
+
+    /// Gets the validated block header and epoch number of the epoch root
+    /// at the given block height.
+    pub async fn get_epoch_root(
+        &self,
+        epoch: EpochNumber,
+    ) -> std::result::Result<Leaf2<TYPES>, <TYPES::Membership as Membership<TYPES>>::Error> {
+        self.membership.get_epoch_root(epoch, self).await
+    }
+
+    /// Gets the DRB result for the given epoch.
+    pub async fn get_epoch_drb(
+        &self,
+        epoch: EpochNumber,
+    ) -> std::result::Result<DrbResult, <TYPES::Membership as Membership<TYPES>>::Error> {
+        self.membership.get_epoch_drb(epoch, self).await
+    }
+
     /// Set the DRB difficulty selector
     pub fn set_drb_difficulty_selector(&self, f: DrbDifficultySelectorFn) {
         let mut drb_difficulty_selector_writer = self.drb_difficulty_selector.write();
@@ -412,7 +437,7 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
             },
         };
 
-        match self.membership.get_epoch_drb(epoch).await {
+        match self.get_epoch_drb(epoch).await {
             Ok(drb_result) => {
                 tracing::warn!(
                     ?drb_result,
@@ -578,8 +603,7 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
             ));
         };
 
-        self.membership
-            .add_epoch_root(root_leaf.block_header().clone())
+        self.add_epoch_root(root_leaf.block_header().clone())
             .await
             .map_err(|e| {
                 anytrace::error!("Failed to add epoch root for epoch {epoch:?} to membership: {e}")
@@ -656,7 +680,7 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
             Some(drb) => drb,
             None => {
                 self.clear_drb_state(epoch);
-                return self.membership.get_epoch_drb(epoch).await.map_err(|e| {
+                return self.get_epoch_drb(epoch).await.map_err(|e| {
                     anytrace::error!(
                         "DRB calculation for epoch {epoch} was cancelled but no externally \
                          supplied result is available: {e}"
@@ -805,7 +829,7 @@ impl<TYPES: NodeType> EpochMembership<TYPES> {
         let Some(epoch) = self.epoch() else {
             anyhow::bail!("Cannot get root for None epoch");
         };
-        let leaf = self.coordinator.membership.get_epoch_root(epoch).await?;
+        let leaf = self.coordinator.get_epoch_root(epoch).await?;
         Ok(leaf)
     }
 
@@ -813,11 +837,7 @@ impl<TYPES: NodeType> EpochMembership<TYPES> {
         let Some(epoch) = self.epoch() else {
             return Err(anytrace::warn!("Cannot get drb for None epoch"));
         };
-        self.coordinator
-            .membership
-            .get_epoch_drb(epoch)
-            .await
-            .wrap()
+        self.coordinator.get_epoch_drb(epoch).await.wrap()
     }
 
     /// Borrow the per-epoch snapshot, or `None` for the pre-epoch case.

--- a/crates/hotshot/types/src/traits/election.rs
+++ b/crates/hotshot/types/src/traits/election.rs
@@ -24,6 +24,7 @@ use crate::{
     PeerConfig,
     data::{EpochNumber, Leaf2, ViewNumber},
     drb::DrbResult,
+    epoch_membership::EpochMembershipCoordinator,
     stake_table::supermajority_threshold,
     traits::signature_key::StakeTableEntryType,
 };
@@ -293,18 +294,21 @@ pub trait Membership<T: NodeType>: Debug + Send + Sync {
     fn get_epoch_root(
         &self,
         e: EpochNumber,
+        coordinator: &EpochMembershipCoordinator<T>,
     ) -> impl Future<Output = Result<Leaf2<T>, Self::Error>> + Send;
 
     /// Gets the DRB result for the given epoch.
     fn get_epoch_drb(
         &self,
         e: EpochNumber,
+        coordinator: &EpochMembershipCoordinator<T>,
     ) -> impl Future<Output = Result<DrbResult, Self::Error>> + Send;
 
     /// Handles notifications that a new epoch root has been created.
     fn add_epoch_root(
         &self,
         h: T::BlockHeader,
+        coordinator: &EpochMembershipCoordinator<T>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Called to notify the Membership when a new DRB result has been calculated.


### PR DESCRIPTION
leafchain catchup terminates at the first available cert2 at or after the requested height, which can belong to a later epoch than the requested block. Certificates carry their epoch, so `verify_leaf_chain_with_cert2` now takes the EpochMembershipCoordinator and validates certificate against the stake table of the epoch it belong to