### PR TITLE
[new-protocol]: Bound block builder dedup state.

### DIFF
--- a/crates/hotshot/new-protocol/src/block.rs
+++ b/crates/hotshot/new-protocol/src/block.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -39,8 +39,10 @@ use crate::{
 pub enum BlockError {
     #[error("payload construction failed: {0}")]
     PayloadConstruction(String),
+
     #[error("stake table unavailable")]
     StakeTableUnavailable,
+
     #[error("builder signature failed")]
     BuilderSignature,
 }
@@ -94,8 +96,7 @@ pub struct BlockBuilder<T: NodeType> {
     retry_total_bytes: u64,
     leader_buffer: HashMap<Commitment<T::Transaction>, T::Transaction>,
     leader_total_bytes: u64,
-    dedup_set: HashSet<Commitment<T::Transaction>>,
-    dedup_views: VecDeque<(ViewNumber, Vec<Commitment<T::Transaction>>)>,
+    dedups: BTreeMap<ViewNumber, HashSet<Commitment<T::Transaction>>>,
     config: BlockBuilderConfig,
     upgrade_lock: UpgradeLock<T>,
     current_view: ViewNumber,
@@ -123,8 +124,7 @@ impl<T: NodeType> BlockBuilder<T> {
             retry_total_bytes: 0,
             leader_buffer: HashMap::new(),
             leader_total_bytes: 0,
-            dedup_set: HashSet::new(),
-            dedup_views: VecDeque::new(),
+            dedups: BTreeMap::new(),
             current_view: ViewNumber::genesis(),
             calculations: BTreeMap::new(),
             tasks: JoinSet::new(),
@@ -275,7 +275,7 @@ impl<T: NodeType> BlockBuilder<T> {
         for tx in msg.transactions {
             let hash = tx.commit();
 
-            if self.dedup_set.contains(&hash) {
+            if self.dedups.values().any(|hs| hs.contains(&hash)) {
                 continue;
             }
 
@@ -302,28 +302,19 @@ impl<T: NodeType> BlockBuilder<T> {
             }
         }
 
-        self.dedup_set.extend(hashes.iter().copied());
-        self.dedup_views.push_back((view, hashes));
+        let lower_bound: ViewNumber = self
+            .current_view
+            .saturating_sub(self.config.dedup_window_size)
+            .into();
 
-        let current = self.current_view.u64();
-        let window = self.config.dedup_window_size;
-
-        while let Some((view, hashes)) = self.dedup_views.pop_front() {
-            if current.saturating_sub(view.u64()) <= window {
-                self.dedup_views.push_front((view, hashes));
-                break;
-            }
-            for hash in &hashes {
-                self.dedup_set.remove(hash);
-            }
+        if view >= lower_bound {
+            self.dedups.entry(view).or_default().extend(hashes);
         }
+
+        self.dedups = self.dedups.split_off(&lower_bound);
     }
 
-    pub fn on_view_changed(
-        &mut self,
-        view: ViewNumber,
-        _epoch: EpochNumber,
-    ) -> Vec<T::Transaction> {
+    pub fn on_view_changed(&mut self, view: ViewNumber) -> Vec<T::Transaction> {
         self.current_view = view;
 
         let mut expired_bytes = 0u64;
@@ -351,7 +342,8 @@ impl<T: NodeType> BlockBuilder<T> {
         }
     }
 
-    pub fn drain(
+    #[cfg(test)]
+    pub(crate) fn drain(
         &mut self,
         view: ViewNumber,
         epoch: EpochNumber,

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -899,7 +899,7 @@ where
                 info!(%node, %view, %epoch, "view changed");
                 self.timer.reset_with_epoch(view, epoch);
                 self.gc(epoch, GcScope::Local(view))?;
-                let txns = self.block_builder.on_view_changed(view, epoch);
+                let txns = self.block_builder.on_view_changed(view);
                 self.participation.on_view_changed(epoch);
                 self.on_view_changed_metrics(view, epoch);
                 if !txns.is_empty() {
@@ -1190,7 +1190,8 @@ where
                             hashes = manifest.hashes.len(),
                             "recv dedup manifest"
                         );
-                        if let Some(view_leader) = self.leader(manifest.view, manifest.epoch)
+                        if !self.is_too_far_ahead(manifest.view)
+                            && let Some(view_leader) = self.leader(manifest.view, manifest.epoch)
                             && view_leader == message.sender
                         {
                             self.block_builder.on_dedup_manifest(manifest)

--- a/crates/hotshot/new-protocol/src/tests/block.rs
+++ b/crates/hotshot/new-protocol/src/tests/block.rs
@@ -61,7 +61,7 @@ async fn test_retry_buffer() {
     // t1 reconstructed and should be removed from retry
     b.on_block_reconstructed(vec![t1.commit()]);
 
-    let forwarded = b.on_view_changed(view(1), epoch());
+    let forwarded = b.on_view_changed(view(1));
     assert_eq!(
         forwarded,
         vec![t2],
@@ -69,7 +69,7 @@ async fn test_retry_buffer() {
     );
 
     // past ttl
-    let forwarded = b.on_view_changed(view(6), epoch());
+    let forwarded = b.on_view_changed(view(6));
     assert!(forwarded.is_empty(), "tx past ttl should expire");
 }
 
@@ -193,7 +193,7 @@ async fn test_dedup_window() {
     );
 
     // Advance past the threshold: current_view - view(1) > window_size(2)
-    b.on_view_changed(view(4), epoch());
+    b.on_view_changed(view(4));
     b.on_dedup_manifest(DedupManifest {
         view: view(4),
         epoch: epoch(),


### PR DESCRIPTION
The dedup bookkeeping kept transaction hashes in a `HashSet` used for lookups, and in an arrival-ordered `VecDeque` of `(view, hashes)` used for eviction. Eviction stopped at the first in-window deque entry, so a manifest claiming a far-future view parked at the front and blocked eviction of everything behind it, growing both structures without bound.

Here we replace both structures with a single ordered map. A hash is deduplicated while any in-window view lists it, regardless of arrival order. Deduplication complexity changes from O(1) to O(n) with n being the length of the window plus any future views that arrived, i.e. n <= 41 by default.

The `Coordinator` now also ignores dedup manifests more than 30 views ahead, as it already does for votes, bounding the map from above.