### PR TITLE
[Fast Finality] Help restarted nodes reach highest view

### DIFF
--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -126,7 +126,11 @@ pub enum ConsensusOutput<T: NodeType> {
     RecordAction(ViewNumber, Option<EpochNumber>, ActionKind),
     PersistProposal(SignedProposal<T, Proposal<T>>),
     SendProposal(SignedProposal<T, Proposal<T>>),
-    SendTimeoutVote(TimeoutVote2<T>, Option<Certificate1<T>>),
+    SendTimeoutVote(
+        TimeoutVote2<T>,
+        Option<Certificate1<T>>,
+        Option<TimeoutCertificate2<T>>,
+    ),
     SendVote1(Vote1<T>),
     SendVote2(Vote2<T>),
     /// Persist the locked QC before the matching phase-2 vote is released.
@@ -576,6 +580,14 @@ impl<T: NodeType> Consensus<T> {
     /// Return the Certificate1 (QC) stored at the given view, if any.
     pub fn cert1_at(&self, view: ViewNumber) -> Option<&Certificate1<T>> {
         self.certs.get(&view)
+    }
+
+    pub fn latest_timeout_cert(&self) -> Option<&TimeoutCertificate2<T>> {
+        self.timeout_certs.last_key_value().map(|(_, tc)| tc)
+    }
+
+    pub fn locked_cert(&self) -> Option<&Certificate1<T>> {
+        self.locked_cert.as_ref()
     }
 
     fn signed_vid_share(
@@ -1421,6 +1433,7 @@ impl<T: NodeType> Consensus<T> {
         outbox.push_back(ConsensusOutput::SendTimeoutVote(
             vote,
             self.locked_cert.clone(),
+            self.latest_timeout_cert().cloned(),
         ));
         Protocol::Abort
     }

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -44,8 +44,8 @@ use crate::{
     helpers::proposal_commitment,
     logging::KeyPrefix,
     message::{
-        Certificate1, Certificate2, EpochChangeMessage, Proposal, ProposalFetchRequest,
-        ProposalMessage, Validated, Vote1, Vote2,
+        CatchupEvidence, Certificate1, Certificate2, EpochChangeMessage, Proposal,
+        ProposalFetchRequest, ProposalMessage, Validated, Vote1, Vote2,
     },
     outbox::Outbox,
     state::{StateRequest, StateResponse},
@@ -126,11 +126,7 @@ pub enum ConsensusOutput<T: NodeType> {
     RecordAction(ViewNumber, Option<EpochNumber>, ActionKind),
     PersistProposal(SignedProposal<T, Proposal<T>>),
     SendProposal(SignedProposal<T, Proposal<T>>),
-    SendTimeoutVote(
-        TimeoutVote2<T>,
-        Option<Certificate1<T>>,
-        Option<TimeoutCertificate2<T>>,
-    ),
+    SendTimeoutVote(TimeoutVote2<T>, Option<CatchupEvidence<T>>),
     SendVote1(Vote1<T>),
     SendVote2(Vote2<T>),
     /// Persist the locked QC before the matching phase-2 vote is released.
@@ -582,12 +578,19 @@ impl<T: NodeType> Consensus<T> {
         self.certs.get(&view)
     }
 
-    pub fn latest_timeout_cert(&self) -> Option<&TimeoutCertificate2<T>> {
-        self.timeout_certs.last_key_value().map(|(_, tc)| tc)
-    }
-
-    pub fn locked_cert(&self) -> Option<&Certificate1<T>> {
-        self.locked_cert.as_ref()
+    /// The highest certificate we hold: the locked QC or the latest timeout
+    /// certificate, whichever has the higher view (ties go to the timeout
+    /// certificate).
+    pub fn catchup_evidence(&self) -> Option<CatchupEvidence<T>> {
+        let tc = self.timeout_certs.last_key_value().map(|(_, tc)| tc);
+        match (tc, self.locked_cert.as_ref()) {
+            (Some(tc), Some(qc)) if qc.view_number() > tc.view_number() => {
+                Some(CatchupEvidence::Qc(qc.clone()))
+            },
+            (Some(tc), _) => Some(CatchupEvidence::Tc(tc.clone())),
+            (None, Some(qc)) => Some(CatchupEvidence::Qc(qc.clone())),
+            (None, None) => None,
+        }
     }
 
     fn signed_vid_share(
@@ -1432,8 +1435,7 @@ impl<T: NodeType> Consensus<T> {
         };
         outbox.push_back(ConsensusOutput::SendTimeoutVote(
             vote,
-            self.locked_cert.clone(),
-            self.latest_timeout_cert().cloned(),
+            self.catchup_evidence(),
         ));
         Protocol::Abort
     }

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -784,11 +784,16 @@ where
                     }
                 }
             },
-            ConsensusOutput::SendTimeoutVote(vote, lock) => {
+            ConsensusOutput::SendTimeoutVote(vote, lock, tc) => {
                 let view = vote.view_number();
-                debug!(%node, %view, has_lock = lock.is_some(), "send timeout vote");
+                debug!(
+                    %node, %view,
+                    has_lock = lock.is_some(),
+                    has_tc = tc.is_some(),
+                    "send timeout vote"
+                );
                 self.broadcast(
-                    ConsensusMessage::TimeoutVote(message::TimeoutVoteMessage { vote, lock }),
+                    ConsensusMessage::TimeoutVote(message::TimeoutVoteMessage { vote, lock, tc }),
                     "broadcast timeout vote",
                 )?
             },
@@ -1123,13 +1128,15 @@ where
                     if view < current_view {
                         debug!(
                             %node, %sender, %view, %current_view,
-                            "ignoring timeout vote for stale view"
+                            "timeout vote for stale view; replying with catchup evidence"
                         );
+                        self.send_catchup_evidence(&message.sender, view);
                         return None;
                     }
                     debug!(
                         %node, %sender, %view,
                         has_lock = timeout_msg.lock.is_some(),
+                        has_tc = timeout_msg.tc.is_some(),
                         "recv timeout vote"
                     );
                     self.timeout_collector
@@ -1137,13 +1144,19 @@ where
                     self.timeout_one_honest_collector
                         .accumulate_vote(timeout_msg.vote);
 
-                    // If a peer times out in a view at or ahead of us we adopt the
-                    // view of an embedded cert1, so divergent nodes re-converge on
-                    // the highest justified view on restart.
+                    // If a peer times out in a view at or ahead of us we adopt its
+                    // highest certificate.
                     //
-                    // TODO: Above we reject timeout votes too far ahead. A valid cert1
-                    // has precedence over that check so we need to move this up, but
-                    // first we need to verify the cert1 itself.
+                    // TODO: Above we reject timeout votes too far ahead. Valid
+                    // evidence has precedence over that check so we need to move
+                    // this up, but first we need to verify the certs themselves.
+                    let lock_view = timeout_msg.lock.as_ref().map(|c| c.view_number());
+                    if let Some(tc) = timeout_msg.tc
+                        && tc.view_number() >= current_view
+                        && lock_view.is_none_or(|lv| tc.view_number() >= lv)
+                    {
+                        return Some(ConsensusInput::TimeoutCertificate(tc));
+                    }
                     if let Some(cert) = timeout_msg.lock
                         && cert.view_number() >= current_view
                     {
@@ -1160,6 +1173,15 @@ where
                         "recv timeout certificate"
                     );
                     Some(ConsensusInput::TimeoutCertificate(tc))
+                },
+                ConsensusMessage::HighQc(qc) => {
+                    debug!(
+                        %node, %sender,
+                        view = %qc.view_number(),
+                        epoch = ?qc.epoch().map(|e| *e),
+                        "recv high qc"
+                    );
+                    Some(ConsensusInput::AdvanceView(qc))
                 },
                 ConsensusMessage::EpochChange(epoch_change) => {
                     debug!(
@@ -1488,7 +1510,11 @@ where
                 let message = Message {
                     sender: self.public_key.clone(),
                     message_type: MessageType::Consensus(ConsensusMessage::TimeoutVote(
-                        message::TimeoutVoteMessage { vote, lock: None },
+                        message::TimeoutVoteMessage {
+                            vote,
+                            lock: None,
+                            tc: None,
+                        },
                     )),
                 };
                 if let Err(err) = self
@@ -1827,6 +1853,39 @@ where
     /// We ignore votes more that 30 views ahead of our current view.
     fn is_too_far_ahead(&self, v: ViewNumber) -> bool {
         v > self.consensus.current_view() + 30
+    }
+
+    pub(crate) fn catchup_evidence(&self) -> Option<ConsensusMessage<T, Validated>> {
+        let tc = self.consensus.latest_timeout_cert();
+        let qc = self.consensus.locked_cert();
+        match (tc, qc) {
+            (Some(tc), Some(qc)) if qc.view_number() > tc.view_number() => {
+                Some(ConsensusMessage::HighQc(qc.clone()))
+            },
+            (Some(tc), _) => Some(ConsensusMessage::TimeoutCertificate(tc.clone())),
+            (None, Some(qc)) => Some(ConsensusMessage::HighQc(qc.clone())),
+            (None, None) => None,
+        }
+    }
+
+    fn send_catchup_evidence(&mut self, peer: &T::SignatureKey, stale_view: ViewNumber) {
+        let Some(evidence) = self.catchup_evidence() else {
+            return;
+        };
+        if evidence.view_number() < stale_view {
+            return;
+        }
+        let message = Message {
+            sender: self.public_key.clone(),
+            message_type: MessageType::Consensus(evidence),
+        };
+        if let Err(err) =
+            self.network
+                .sender()
+                .unicast(self.consensus.current_view(), peer, &message)
+        {
+            warn!(%stale_view, %err, "failed to send catchup evidence");
+        }
     }
 }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -45,9 +45,9 @@ use crate::{
     helpers::proposal_commitment,
     logging::KeyPrefix,
     message::{
-        self, BlockMessage, Certificate1, Certificate2, ConsensusMessage, Message, MessageType,
-        OpaqueMessage, Proposal, ProposalFetchMessage, ProposalMessage, TimeoutOneHonest,
-        TransactionMessage, Unchecked, Validated, Vote2,
+        self, BlockMessage, CatchupEvidence, Certificate1, Certificate2, ConsensusMessage, Message,
+        MessageType, OpaqueMessage, Proposal, ProposalFetchMessage, ProposalMessage,
+        TimeoutOneHonest, TransactionMessage, Unchecked, Validated, Vote2,
     },
     network::Cliquenet,
     outbox::Outbox,
@@ -784,16 +784,15 @@ where
                     }
                 }
             },
-            ConsensusOutput::SendTimeoutVote(vote, lock, tc) => {
+            ConsensusOutput::SendTimeoutVote(vote, evidence) => {
                 let view = vote.view_number();
                 debug!(
                     %node, %view,
-                    has_lock = lock.is_some(),
-                    has_tc = tc.is_some(),
+                    has_evidence = evidence.is_some(),
                     "send timeout vote"
                 );
                 self.broadcast(
-                    ConsensusMessage::TimeoutVote(message::TimeoutVoteMessage { vote, lock, tc }),
+                    ConsensusMessage::TimeoutVote(message::TimeoutVoteMessage { vote, evidence }),
                     "broadcast timeout vote",
                 )?
             },
@@ -1116,54 +1115,47 @@ where
                 },
                 ConsensusMessage::TimeoutVote(timeout_msg) => {
                     let view = timeout_msg.vote.view_number();
-                    if self.is_too_far_ahead(view) {
-                        warn!(%node, %sender, %view, "timeout vote is too far ahead");
-                        return None;
-                    }
                     if timeout_msg.vote.signing_key() != message.sender {
                         warn!(%node, %sender, %view, "timeout vote signing key != sender");
                         return None;
                     }
                     let current_view = self.consensus.current_view();
+                    let has_evidence = timeout_msg.evidence.is_some();
+
+                    // If a peer times out in a view at or ahead of us we adopt its
+                    // highest certificate. Evidence takes precedence over
+                    // the vote being too far ahead, and a valid certificate proves
+                    // the network reached that view, and consensus verifies it
+                    // before acting on it.
+                    //
+                    // TODO: Make verification asynchronous
+                    let evidence = timeout_msg
+                        .evidence
+                        .filter(|e| e.view_number() >= current_view)
+                        .map(|e| match e {
+                            CatchupEvidence::Qc(qc) => ConsensusInput::AdvanceView(qc),
+                            CatchupEvidence::Tc(tc) => ConsensusInput::TimeoutCertificate(tc),
+                        });
+
+                    if self.is_too_far_ahead(view) {
+                        warn!(%node, %sender, %view, "timeout vote is too far ahead");
+                        return evidence;
+                    }
                     if view < current_view {
                         debug!(
                             %node, %sender, %view, %current_view,
                             "timeout vote for stale view; replying with catchup evidence"
                         );
                         self.send_catchup_evidence(&message.sender, view);
-                        return None;
+                        return evidence;
                     }
-                    debug!(
-                        %node, %sender, %view,
-                        has_lock = timeout_msg.lock.is_some(),
-                        has_tc = timeout_msg.tc.is_some(),
-                        "recv timeout vote"
-                    );
+                    debug!(%node, %sender, %view, has_evidence, "recv timeout vote");
                     self.timeout_collector
                         .accumulate_vote(timeout_msg.vote.clone());
                     self.timeout_one_honest_collector
                         .accumulate_vote(timeout_msg.vote);
 
-                    // If a peer times out in a view at or ahead of us we adopt its
-                    // highest certificate.
-                    //
-                    // TODO: Above we reject timeout votes too far ahead. Valid
-                    // evidence has precedence over that check so we need to move
-                    // this up, but first we need to verify the certs themselves.
-                    let lock_view = timeout_msg.lock.as_ref().map(|c| c.view_number());
-                    if let Some(tc) = timeout_msg.tc
-                        && tc.view_number() >= current_view
-                        && lock_view.is_none_or(|lv| tc.view_number() >= lv)
-                    {
-                        return Some(ConsensusInput::TimeoutCertificate(tc));
-                    }
-                    if let Some(cert) = timeout_msg.lock
-                        && cert.view_number() >= current_view
-                    {
-                        return Some(ConsensusInput::AdvanceView(cert));
-                    }
-
-                    None
+                    evidence
                 },
                 ConsensusMessage::TimeoutCertificate(tc) => {
                     debug!(
@@ -1512,8 +1504,7 @@ where
                     message_type: MessageType::Consensus(ConsensusMessage::TimeoutVote(
                         message::TimeoutVoteMessage {
                             vote,
-                            lock: None,
-                            tc: None,
+                            evidence: None,
                         },
                     )),
                 };
@@ -1856,16 +1847,10 @@ where
     }
 
     pub(crate) fn catchup_evidence(&self) -> Option<ConsensusMessage<T, Validated>> {
-        let tc = self.consensus.latest_timeout_cert();
-        let qc = self.consensus.locked_cert();
-        match (tc, qc) {
-            (Some(tc), Some(qc)) if qc.view_number() > tc.view_number() => {
-                Some(ConsensusMessage::HighQc(qc.clone()))
-            },
-            (Some(tc), _) => Some(ConsensusMessage::TimeoutCertificate(tc.clone())),
-            (None, Some(qc)) => Some(ConsensusMessage::HighQc(qc.clone())),
-            (None, None) => None,
-        }
+        Some(match self.consensus.catchup_evidence()? {
+            CatchupEvidence::Qc(qc) => ConsensusMessage::HighQc(qc),
+            CatchupEvidence::Tc(tc) => ConsensusMessage::TimeoutCertificate(tc),
+        })
     }
 
     fn send_catchup_evidence(&mut self, peer: &T::SignatureKey, stale_view: ViewNumber) {

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -103,6 +103,7 @@ impl<T: NodeType> HasViewNumber for Vote1<T> {
 pub struct TimeoutVoteMessage<T: NodeType> {
     pub vote: TimeoutVote2<T>,
     pub lock: Option<Certificate1<T>>,
+    pub tc: Option<TimeoutCertificate2<T>>,
 }
 
 impl<T: NodeType> HasViewNumber for TimeoutVoteMessage<T> {
@@ -178,6 +179,7 @@ pub enum ConsensusMessage<T: NodeType, S> {
     VidShareFragment(VidShareFragmentMessage<T>),
     /// A node's own VID share, broadcast independently of Vote1.
     VidShareBroadcast(VidDisperseShare2<T>),
+    HighQc(Certificate1<T>),
 }
 
 impl<T: NodeType, S> ConsensusMessage<T, S> {
@@ -194,6 +196,7 @@ impl<T: NodeType, S> ConsensusMessage<T, S> {
             Self::EpochChange(c) => ConsensusMessage::EpochChange(c),
             Self::VidShareFragment(v) => ConsensusMessage::VidShareFragment(v),
             Self::VidShareBroadcast(v) => ConsensusMessage::VidShareBroadcast(v),
+            Self::HighQc(c) => ConsensusMessage::HighQc(c),
         }
     }
 }
@@ -211,6 +214,7 @@ impl<T: NodeType, S> HasViewNumber for ConsensusMessage<T, S> {
             Self::EpochChange(epoch_change) => epoch_change.cert1.view_number(),
             Self::VidShareFragment(fragment) => fragment.data.view_number(),
             Self::VidShareBroadcast(vid_share) => vid_share.view_number(),
+            Self::HighQc(certificate) => certificate.view_number(),
         }
     }
 }

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -102,13 +102,32 @@ impl<T: NodeType> HasViewNumber for Vote1<T> {
 #[serde(bound(deserialize = ""))]
 pub struct TimeoutVoteMessage<T: NodeType> {
     pub vote: TimeoutVote2<T>,
-    pub lock: Option<Certificate1<T>>,
-    pub tc: Option<TimeoutCertificate2<T>>,
+    pub evidence: Option<CatchupEvidence<T>>,
 }
 
 impl<T: NodeType> HasViewNumber for TimeoutVoteMessage<T> {
     fn view_number(&self) -> ViewNumber {
         self.vote.view_number()
+    }
+}
+
+/// The highest certificate a node holds: its locked QC or its latest timeout
+/// certificate, whichever has the higher view. Attached to timeout votes and
+/// sent to peers stuck on stale views, so divergent nodes re-converge on the
+/// highest justified view.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Eq)]
+#[serde(bound(deserialize = ""))]
+pub enum CatchupEvidence<T: NodeType> {
+    Qc(Certificate1<T>),
+    Tc(TimeoutCertificate2<T>),
+}
+
+impl<T: NodeType> HasViewNumber for CatchupEvidence<T> {
+    fn view_number(&self) -> ViewNumber {
+        match self {
+            Self::Qc(qc) => qc.view_number(),
+            Self::Tc(tc) => tc.view_number(),
+        }
     }
 }
 

--- a/crates/hotshot/new-protocol/src/tests/common/harness.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/harness.rs
@@ -233,4 +233,12 @@ impl TestHarness {
     pub fn outputs(&self) -> &Outbox<ConsensusOutput<TestTypes>> {
         &self.outputs
     }
+
+    pub fn current_view(&self) -> hotshot_types::data::ViewNumber {
+        self.coordinator.current_view()
+    }
+
+    pub fn coordinator(&self) -> &MockCoordinator {
+        &self.coordinator
+    }
 }

--- a/crates/hotshot/new-protocol/src/tests/common/runner.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/runner.rs
@@ -16,6 +16,7 @@ use hotshot_types::{
     data::ViewNumber,
     epoch_membership::EpochMembershipCoordinator,
     message::UpgradeLock,
+    simple_certificate::TimeoutCertificate2,
     traits::{metrics::NoMetrics, signature_key::SignatureKey},
     vote::HasViewNumber,
     x25519::Keypair,
@@ -33,7 +34,7 @@ use tracing::{debug, info};
 
 use crate::{
     client::CoordinatorClient,
-    consensus::{ConsensusOutput, PreCutoverSeed},
+    consensus::{ConsensusInput, ConsensusOutput, PreCutoverSeed},
     coordinator::{Coordinator, error::Severity},
     helpers::test_upgrade_lock,
     network::Cliquenet,
@@ -138,6 +139,13 @@ pub struct TestRunner {
     /// the specified view.
     #[builder(default)]
     node_changes: Vec<(u64, Vec<NodeChange>)>,
+
+    /// Timeout certificates applied to specific nodes' coordinators before
+    /// they start, advancing their view past the rest of the network.
+    /// Simulates certificates that formed while other nodes were down (the
+    /// certs are not forwarded, so only the seeded nodes know them).
+    #[builder(default)]
+    initial_timeout_certs: BTreeMap<usize, Vec<TimeoutCertificate2<TestTypes>>>,
 
     pre_cutover_seed: Option<PreCutoverSeed<TestTypes>>,
 
@@ -343,7 +351,7 @@ impl TestRunner {
             let (membership, storage, client, external_events_tx) =
                 self.make_membership(*public_key, self.node_storages[i].clone(), &connect_infos);
 
-            let coord = build_test_coordinator(
+            let mut coord = build_test_coordinator(
                 i as u64,
                 network,
                 membership,
@@ -354,6 +362,20 @@ impl TestRunner {
                 self.pre_cutover_seed.clone(),
             )
             .await;
+
+            if let Some(certs) = self.initial_timeout_certs.get(&i) {
+                for tc in certs {
+                    coord.apply_consensus(ConsensusInput::TimeoutCertificate(tc.clone()));
+                    for output in coord.outbox_mut().take() {
+                        // Keep the seeded certs local to this node; the
+                        // real network never delivered them to the others.
+                        if matches!(output, ConsensusOutput::SendTimeoutCertificate(..)) {
+                            continue;
+                        }
+                        let _ = coord.process_consensus_output(output);
+                    }
+                }
+            }
 
             let tx = event_tx.clone();
             let generation = generations[i];
@@ -732,7 +754,7 @@ async fn run_node(
                     }
                 }
                 send(NodeEvent::Decided(commits.clone()));
-            } else if let ConsensusOutput::SendTimeoutVote(vote, _) = &output {
+            } else if let ConsensusOutput::SendTimeoutVote(vote, ..) = &output {
                 let view = vote.view_number();
                 debug!(node = %coord.node_id(), %view, "timeout vote");
                 send(NodeEvent::TimedOut(view));

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -255,6 +255,16 @@ impl TestView {
         node_index: u64,
         lock: Option<Certificate1<TestTypes>>,
     ) -> Message<TestTypes, Validated> {
+        self.timeout_vote_input_with_tc(node_index, lock, None)
+    }
+
+    /// Build a TimeoutVote Event carrying the sender's latest timeout cert.
+    pub fn timeout_vote_input_with_tc(
+        &self,
+        node_index: u64,
+        lock: Option<Certificate1<TestTypes>>,
+        tc: Option<TimeoutCertificate2<TestTypes>>,
+    ) -> Message<TestTypes, Validated> {
         let (pub_key, priv_key) = BLSPubKey::generated_from_seed_indexed([0u8; 32], node_index);
         let data = TimeoutData2 {
             view: self.view_number,
@@ -271,7 +281,7 @@ impl TestView {
         Message {
             sender: pub_key,
             message_type: MessageType::Consensus(ConsensusMessage::TimeoutVote(
-                TimeoutVoteMessage { vote, lock },
+                TimeoutVoteMessage { vote, lock, tc },
             )),
         }
     }
@@ -1262,7 +1272,7 @@ pub(crate) fn build_cert2(
     )
 }
 
-fn build_timeout_cert(
+pub(crate) fn build_timeout_cert(
     view_number: ViewNumber,
     epoch: EpochNumber,
     epoch_membership: &hotshot_types::epoch_membership::EpochMembership<TestTypes>,

--- a/crates/hotshot/new-protocol/src/tests/common/utils.rs
+++ b/crates/hotshot/new-protocol/src/tests/common/utils.rs
@@ -57,8 +57,8 @@ use crate::{
     consensus::{Consensus, ConsensusInput, ConsensusOutput},
     helpers::{proposal_commitment, test_upgrade_lock},
     message::{
-        Certificate1, Certificate2, ConsensusMessage, Message, MessageType, Proposal,
-        ProposalMessage, TimeoutVoteMessage, Validated, Vote1, Vote2,
+        CatchupEvidence, Certificate1, Certificate2, ConsensusMessage, Message, MessageType,
+        Proposal, ProposalMessage, TimeoutVoteMessage, Validated, Vote1, Vote2,
     },
     outbox::Outbox,
     state::StateResponse,
@@ -249,21 +249,12 @@ impl TestView {
         }
     }
 
-    /// Build a TimeoutVote Event from a specific validator.
+    /// Build a TimeoutVote Event from a specific validator, optionally
+    /// carrying the sender's catchup evidence.
     pub fn timeout_vote_input(
         &self,
         node_index: u64,
-        lock: Option<Certificate1<TestTypes>>,
-    ) -> Message<TestTypes, Validated> {
-        self.timeout_vote_input_with_tc(node_index, lock, None)
-    }
-
-    /// Build a TimeoutVote Event carrying the sender's latest timeout cert.
-    pub fn timeout_vote_input_with_tc(
-        &self,
-        node_index: u64,
-        lock: Option<Certificate1<TestTypes>>,
-        tc: Option<TimeoutCertificate2<TestTypes>>,
+        evidence: Option<CatchupEvidence<TestTypes>>,
     ) -> Message<TestTypes, Validated> {
         let (pub_key, priv_key) = BLSPubKey::generated_from_seed_indexed([0u8; 32], node_index);
         let data = TimeoutData2 {
@@ -281,7 +272,7 @@ impl TestView {
         Message {
             sender: pub_key,
             message_type: MessageType::Consensus(ConsensusMessage::TimeoutVote(
-                TimeoutVoteMessage { vote, lock, tc },
+                TimeoutVoteMessage { vote, evidence },
             )),
         }
     }

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -7,7 +7,7 @@ use hotshot_types::{traits::signature_key::SignatureKey, vote::HasViewNumber};
 use super::common::{harness::TestHarness, utils::TestData};
 use crate::{
     consensus::ConsensusInput,
-    message::{Certificate1, ConsensusMessage, EpochChangeMessage, Proposal},
+    message::{CatchupEvidence, ConsensusMessage, EpochChangeMessage, Proposal},
     tests::common::assertions::{
         any, count_matching, is_block_built, is_block_reconstructed, is_cert1, is_cert2,
         is_drb_result, is_header_created, is_header_created_for_view, is_leaf_decided, is_proposal,
@@ -77,11 +77,11 @@ async fn send_timeout_votes(
     harness: &mut TestHarness,
     test_data: &TestData,
     view_idx: usize,
-    lock: Option<Certificate1<TestTypes>>,
+    evidence: Option<CatchupEvidence<TestTypes>>,
 ) {
     let test_view = &test_data.views[view_idx];
     for i in 0..THRESHOLD {
-        harness.message(test_view.timeout_vote_input(i, lock.clone()));
+        harness.message(test_view.timeout_vote_input(i, evidence.clone()));
     }
     harness
         .process_until(|inputs| {
@@ -259,7 +259,7 @@ async fn test_timeout_votes_form_tc() {
     // Process view 1 to establish locked_qc (needed for TC handling)
     send_proposal_and_vote1s(&mut harness, &test_data, 0, &node_key).await;
     // Send timeout votes for view 2 and form a TimeoutCertificate.
-    let lock = Some(test_data.views[0].cert1.clone());
+    let lock = Some(CatchupEvidence::Qc(test_data.views[0].cert1.clone()));
     send_timeout_votes(&mut harness, &test_data, 1, lock).await;
 
     assert!(
@@ -298,7 +298,7 @@ async fn test_leader_proposes_after_timeout() {
     // The TC input view is 3 (cert.view+1), which passes the stale filter
     // (3 > timeout_view=2). After ViewChanged(3) resets the timer, the leader
     // must complete VID disperse before the timer fires for view 3.
-    let lock = Some(test_data.views[0].cert1.clone());
+    let lock = Some(CatchupEvidence::Qc(test_data.views[0].cert1.clone()));
     send_timeout_votes(&mut harness, &test_data, 1, lock).await;
 
     harness
@@ -572,7 +572,7 @@ async fn test_f_plus_1_timeout_votes_trigger_timeout_one_honest() {
 
     // Send exactly f+1 timeout votes for view 2 (below the 2f+1 TC threshold).
     let test_view = &test_data.views[1];
-    let lock = Some(test_data.views[0].cert1.clone());
+    let lock = Some(CatchupEvidence::Qc(test_data.views[0].cert1.clone()));
     for i in 0..ONE_HONEST_THRESHOLD {
         harness.message(test_view.timeout_vote_input(i, lock.clone()));
     }
@@ -610,7 +610,7 @@ async fn test_timeout_vote_lock_advances_view() {
     // The node starts at genesis. A peer times out view 2 while carrying a
     // locked QC for view 1 (`views[0].cert1`). Adopting that QC moves us into
     // view 2.
-    let high_qc = test_data.views[0].cert1.clone();
+    let high_qc = CatchupEvidence::Qc(test_data.views[0].cert1.clone());
     harness.message(test_data.views[1].timeout_vote_input(1, Some(high_qc.clone())));
 
     assert_eq!(
@@ -642,8 +642,8 @@ async fn test_timeout_vote_tc_advances_view() {
 
     // The node starts at genesis. A peer times out view 3, attaching the
     // timeout certificate for view 2 that formed without us.
-    let tc = test_data.views[1].timeout_cert.clone();
-    harness.message(test_data.views[2].timeout_vote_input_with_tc(1, None, Some(tc)));
+    let tc = CatchupEvidence::Tc(test_data.views[1].timeout_cert.clone());
+    harness.message(test_data.views[2].timeout_vote_input(1, Some(tc)));
 
     assert_eq!(
         *harness.current_view(),
@@ -658,6 +658,27 @@ async fn test_timeout_vote_tc_advances_view() {
                 .any(|i| matches!(i, ConsensusInput::Timeout(view, _) if **view == 3))
         })
         .await;
+}
+
+/// Catchup evidence takes precedence over the "too far ahead" distance
+/// check: the vote itself is dropped, but the attached certificate still
+/// advances a node that fell far behind.
+#[tokio::test]
+async fn test_timeout_vote_evidence_overrides_distance_check() {
+    let test_data = TestData::new(32).await;
+    let mut harness = TestHarness::new(0).await;
+
+    // The node starts at genesis (view 1). A peer times out view 32 — more
+    // than 30 views ahead, so the vote is dropped — attaching the timeout
+    // certificate for view 31.
+    let tc = CatchupEvidence::Tc(test_data.views[30].timeout_cert.clone());
+    harness.message(test_data.views[31].timeout_vote_input(1, Some(tc)));
+
+    assert_eq!(
+        *harness.current_view(),
+        32,
+        "the attached timeout certificate should advance us to view 32"
+    );
 }
 
 /// A stale timeout vote is answered with the responder's newest certificate,

--- a/crates/hotshot/new-protocol/src/tests/integration.rs
+++ b/crates/hotshot/new-protocol/src/tests/integration.rs
@@ -1,11 +1,13 @@
+use std::time::Duration;
+
 use hotshot::types::BLSPubKey;
 use hotshot_example_types::node_types::TestTypes;
-use hotshot_types::traits::signature_key::SignatureKey;
+use hotshot_types::{traits::signature_key::SignatureKey, vote::HasViewNumber};
 
 use super::common::{harness::TestHarness, utils::TestData};
 use crate::{
     consensus::ConsensusInput,
-    message::{Certificate1, EpochChangeMessage, Proposal},
+    message::{Certificate1, ConsensusMessage, EpochChangeMessage, Proposal},
     tests::common::assertions::{
         any, count_matching, is_block_built, is_block_reconstructed, is_cert1, is_cert2,
         is_drb_result, is_header_created, is_header_created_for_view, is_leaf_decided, is_proposal,
@@ -626,4 +628,64 @@ async fn test_timeout_vote_lock_advances_view() {
         view_changes_before,
         "a lock below our current view must not advance us"
     );
+}
+
+/// A peer's timeout vote carries its latest timeout certificate.
+///
+/// A node that fell behind on views that only advanced via timeouts (so no
+/// newer QC exists anywhere) adopts the certificate and re-arms its timer,
+/// so its next local timeout is for the adopted view.
+#[tokio::test]
+async fn test_timeout_vote_tc_advances_view() {
+    let test_data = TestData::new(3).await;
+    let mut harness = TestHarness::new_with_timer(0, Duration::from_millis(250)).await;
+
+    // The node starts at genesis. A peer times out view 3, attaching the
+    // timeout certificate for view 2 that formed without us.
+    let tc = test_data.views[1].timeout_cert.clone();
+    harness.message(test_data.views[2].timeout_vote_input_with_tc(1, None, Some(tc)));
+
+    assert_eq!(
+        *harness.current_view(),
+        3,
+        "the attached timeout certificate should advance us to view 3"
+    );
+
+    harness
+        .process_until(|inputs| {
+            inputs
+                .iter()
+                .any(|i| matches!(i, ConsensusInput::Timeout(view, _) if **view == 3))
+        })
+        .await;
+}
+
+/// A stale timeout vote is answered with the responder's newest certificate,
+/// so a node stuck behind receives the evidence it needs to advance.
+#[tokio::test]
+async fn test_stale_timeout_vote_answered_with_catchup_evidence() {
+    let test_data = TestData::new(3).await;
+    let mut harness = TestHarness::new(0).await;
+
+    // Advance to view 3 via the network's timeout certificates.
+    harness.apply_and_process(test_data.views[0].timeout_cert_input());
+    harness.apply_and_process(test_data.views[1].timeout_cert_input());
+    assert_eq!(*harness.current_view(), 3);
+
+    let evidence = harness
+        .coordinator()
+        .catchup_evidence()
+        .expect("a node past genesis has catchup evidence");
+    assert!(
+        matches!(
+            &evidence,
+            ConsensusMessage::TimeoutCertificate(tc) if *tc.view_number() == 2
+        ),
+        "expected the view-2 timeout certificate, got {evidence:?}"
+    );
+
+    // The stale vote itself is only answered (unicast to its sender), never
+    // tallied: it must not regress or otherwise disturb consensus state.
+    harness.message(test_data.views[0].timeout_vote_input(1, None));
+    assert_eq!(*harness.current_view(), 3);
 }

--- a/crates/hotshot/new-protocol/src/tests/restarts.rs
+++ b/crates/hotshot/new-protocol/src/tests/restarts.rs
@@ -1,7 +1,17 @@
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::{BTreeMap, HashSet},
+    time::Duration,
+};
+
+use hotshot::types::BLSPubKey;
+use hotshot_types::{
+    data::{EpochNumber, ViewNumber},
+    traits::signature_key::SignatureKey,
+};
 
 use crate::tests::common::{
     runner::{NodeAction, NodeChange, TestRunner},
+    utils::{build_timeout_cert, mock_membership_with_num_nodes},
     views,
 };
 
@@ -171,6 +181,58 @@ async fn restart_all_nodes_at_epoch_boundary() {
             anchor.view_number()
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// View divergence between cohorts
+// ---------------------------------------------------------------------------
+
+/// Reproduces a devnet stall after a mass restart. 4 of 6 nodes (2/3 of
+/// stake — one short of the 2f+1 = 5 timeout-cert threshold) sit on view 1,
+/// while nodes 4 and 5 (1/3 of stake — one short of the f+1 = 3 one-honest
+/// threshold) advanced to view 3 via timeout certificates the majority never
+/// received, e.g. formed while it was down.
+///
+/// Without catchup this deadlocks permanently: the majority's view-1 timeout
+/// votes are stale to the minority (dropped on receipt), so it only ever
+/// re-forms a one-honest cert for view 1, while the minority cannot reach
+/// any threshold at view 3 — no certificate forms on any single view. The
+/// stale-vote catchup reply and the TC attached to timeout votes let the
+/// majority adopt view 3; the pooled timeout votes then form a full timeout
+/// certificate and views progress normally.
+#[tokio::test(flavor = "multi_thread")]
+async fn view_divergence_between_cohorts_recovers() {
+    let num_nodes = 6;
+    let epoch_height = 100;
+    let (public_key, private_key) = BLSPubKey::generated_from_seed_indexed([0u8; 32], 0);
+    let (membership, _storage, _client) =
+        mock_membership_with_num_nodes(num_nodes, epoch_height, public_key);
+    let epoch_membership = membership
+        .membership_for_epoch(Some(EpochNumber::genesis()))
+        .unwrap();
+    let ahead: Vec<_> = [1, 2]
+        .map(|view| {
+            build_timeout_cert(
+                ViewNumber::new(view),
+                EpochNumber::genesis(),
+                &epoch_membership,
+                &public_key,
+                &private_key,
+            )
+        })
+        .into_iter()
+        .collect();
+
+    TestRunner::builder()
+        .num_nodes(num_nodes)
+        .target_decisions(10)
+        .epoch_height(epoch_height)
+        .initial_timeout_certs(BTreeMap::from([(4, ahead.clone()), (5, ahead)]))
+        .tolerated_failed_views(views(1..=3))
+        .build()
+        .run()
+        .await
+        .unwrap();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### This PR:

- Adds a message type for sending `TimeoutCertificates` to other nodes
- Adds `TimeoutCertificate` to timeout votes
- Nodes Send  highest know `TimeoutCertificate` or locked QC to nodes who timeout in a view lower than it's own.  I.e. when we receive a timeout vote for a lower view, we respond with view change evidence to pull that node up to our view
- Nodes attatch their higest TC to timeout votes
- Nodes view change higher views if they receive a valid cert for that view.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
