### PR TITLE
[new-protocol] use consensus last decided view to skip proposal requests in proposal fetcher

### DIFF
--- a/crates/espresso/node/src/consensus_handle.rs
+++ b/crates/espresso/node/src/consensus_handle.rs
@@ -406,7 +406,7 @@ where
                     .request_proposal(view, leaf_commitment)
                     .await
                     .map(convert_proposal)
-                    .map_err(|err| anyhow::anyhow!("{err}"))
+                    .map_err(anyhow::Error::new)
             }
             .boxed());
         }

--- a/crates/espresso/node/src/proposal_fetcher.rs
+++ b/crates/espresso/node/src/proposal_fetcher.rs
@@ -174,13 +174,18 @@ where
     async fn fetch_request(&self, (view, leaf): Request) {
         let span = tracing::warn_span!("fetch proposal", ?view, %leaf);
         let res: anyhow::Result<()> = async {
-            let anchor_view = self
-                .persistence
-                .load_anchor_view()
-                .await
-                .context("loading anchor view")?;
-            if view <= anchor_view {
-                tracing::debug!(?anchor_view, "skipping already-decided proposal");
+            let mut decided_view = self.consensus_handle.decided_leaf().await.view_number();
+            if decided_view == ViewNumber::genesis() {
+                // A freshly restarted node may not have decided anything
+                // yet sofall back to the persisted anchor view
+                decided_view = self
+                    .persistence
+                    .load_anchor_view()
+                    .await
+                    .context("loading anchor view")?;
+            }
+            if view <= decided_view {
+                tracing::debug!(?decided_view, "skipping already-decided proposal");
                 return Ok(());
             }
 
@@ -228,7 +233,7 @@ where
         .instrument(span)
         .await;
         if let Err(err) = res {
-            tracing::warn!("failed to fetch proposal: {err:#}");
+            tracing::warn!(?view, err = %format!("{err:#}"), "failed to fetch proposal");
             self.metrics.failed.add(1);
 
             // Avoid busy loop when operations are failing.


### PR DESCRIPTION
The proposal fetcher gates requests on the persisted anchor view, which can be very far behind if the decide processor lags and has not persisted the last decided view. Consensus cannot serve these requests because it has already garbage collected the proposals, so these requests are dropped. The proposal fetcher should use consensus's last decided view in order to skip fetch requests when it is processing old proposals from the event stream. For a restarted node, it is possible that consensus's last decided view is genesis so in that case we just use the anchor view  from persistence until the node sees a decide.