### PR TITLE
fix(new-protocol): don't stall legacy-event forwarders pre-cutover

### DIFF
--- a/crates/espresso/node/src/consensus_handle.rs
+++ b/crates/espresso/node/src/consensus_handle.rs
@@ -106,6 +106,7 @@ where
                 rx.clone(),
                 client_api.clone(),
                 epoch_height.into(),
+                upgrade_lock.clone(),
             ))),
         ];
 

--- a/crates/espresso/node/src/consensus_handle.rs
+++ b/crates/espresso/node/src/consensus_handle.rs
@@ -97,10 +97,12 @@ where
             AbortOnDropHandle::new(spawn(forward_legacy_timeout_votes(
                 rx.clone(),
                 client_api.clone(),
+                upgrade_lock.clone(),
             ))),
             AbortOnDropHandle::new(spawn(forward_legacy_high_qc(
                 rx.clone(),
                 client_api.clone(),
+                upgrade_lock.clone(),
             ))),
             AbortOnDropHandle::new(spawn(forward_legacy_epoch_changes(
                 rx.clone(),

--- a/crates/espresso/node/src/consensus_handle.rs
+++ b/crates/espresso/node/src/consensus_handle.rs
@@ -16,10 +16,7 @@ use hotshot_new_protocol::{
         Coordinator,
         error::{CoordinatorError, Severity},
     },
-    cutover::{
-        extract_pre_cutover_seed, forward_legacy_epoch_changes, forward_legacy_high_qc,
-        forward_legacy_timeout_votes,
-    },
+    cutover::{extract_pre_cutover_seed, forward_legacy_high_qc, forward_legacy_timeout_votes},
     state::UpdateLeaf,
     storage::NewProtocolStorage,
 };
@@ -102,12 +99,6 @@ where
             AbortOnDropHandle::new(spawn(forward_legacy_high_qc(
                 rx.clone(),
                 client_api.clone(),
-                upgrade_lock.clone(),
-            ))),
-            AbortOnDropHandle::new(spawn(forward_legacy_epoch_changes(
-                rx.clone(),
-                client_api.clone(),
-                epoch_height.into(),
                 upgrade_lock.clone(),
             ))),
         ];

--- a/crates/hotshot/new-protocol/src/client.rs
+++ b/crates/hotshot/new-protocol/src/client.rs
@@ -13,7 +13,7 @@ use hotshot_types::{
     },
     utils::StateAndDelta,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, mpsc::error::TrySendError, oneshot};
 
 use crate::{coordinator::error::CoordinatorError, message::Proposal, state::UpdateLeaf};
 
@@ -136,26 +136,35 @@ impl<T: NodeType> ClientApi<T> {
             .await
     }
 
-    /// Forward a legacy `TimeoutVote2` into the new-protocol timeout collectors.
-    pub async fn submit_timeout_vote(&self, vote: TimeoutVote2<T>) -> Result<(), QueryError> {
-        let (respond, rx) = oneshot::channel();
-        self.call(ClientRequest::SubmitTimeoutVote { vote, respond }, rx)
-            .await
+    /// Fire-and-forget a legacy `TimeoutVote2` into the new-protocol timeout
+    /// collectors.
+    pub fn submit_timeout_vote(&self, vote: TimeoutVote2<T>) -> Result<(), QueryError> {
+        self.try_send(ClientRequest::SubmitTimeoutVote { vote })
     }
 
-    /// Forward the last legacy view's QC so the first new-protocol leader can
-    /// propose on it even if the cutover seed was snapshotted before it formed.
-    pub async fn submit_legacy_high_qc(&self, qc: QuorumCertificate2<T>) -> Result<(), QueryError> {
-        let (respond, rx) = oneshot::channel();
-        self.call(ClientRequest::SubmitLegacyHighQc { qc, respond }, rx)
-            .await
+    /// Fire-and-forget the last legacy view's QC so the first new-protocol
+    /// leader can propose on it even if the cutover seed was snapshotted
+    /// before it formed.
+    pub fn submit_legacy_high_qc(&self, qc: QuorumCertificate2<T>) -> Result<(), QueryError> {
+        self.try_send(ClientRequest::SubmitLegacyHighQc { qc })
     }
 
-    /// Refresh the coordinator network's peer set for `epoch`.
-    pub async fn bump_network_epoch(&self, epoch: EpochNumber) -> Result<(), QueryError> {
-        let (respond, rx) = oneshot::channel();
-        self.call(ClientRequest::BumpNetworkEpoch { epoch, respond }, rx)
-            .await
+    /// Fire-and-forget a refresh of the coordinator network's peer set for
+    /// `epoch`.
+    pub fn bump_network_epoch(&self, epoch: EpochNumber) -> Result<(), QueryError> {
+        self.try_send(ClientRequest::BumpNetworkEpoch { epoch })
+    }
+
+    /// Send `request` without waiting for a response. The fire-and-forget
+    /// bridge methods above use this because they must never block on a
+    /// coordinator that hasn't started processing requests yet: requests
+    /// queue in the bounded request channel until the coordinator starts and
+    /// are dropped with an error when the queue is full.
+    fn try_send(&self, request: ClientRequest<T>) -> Result<(), QueryError> {
+        self.tx.try_send(request).map_err(|err| match err {
+            TrySendError::Closed(_) => QueryError::ChannelClosed,
+            TrySendError::Full(_) => QueryError::ChannelFull,
+        })
     }
 
     async fn call<A>(
@@ -248,15 +257,12 @@ pub(crate) enum ClientRequest<T: NodeType> {
     },
     SubmitTimeoutVote {
         vote: TimeoutVote2<T>,
-        respond: oneshot::Sender<()>,
     },
     SubmitLegacyHighQc {
         qc: QuorumCertificate2<T>,
-        respond: oneshot::Sender<()>,
     },
     BumpNetworkEpoch {
         epoch: EpochNumber,
-        respond: oneshot::Sender<()>,
     },
 }
 
@@ -268,6 +274,9 @@ pub enum QueryError {
 
     #[error("coordinator dropped the response")]
     ResponseDropped,
+
+    #[error("request dropped: coordinator request queue is full")]
+    ChannelFull,
 
     #[error("coordinator error: {0}")]
     Coordinator(#[from] CoordinatorError),

--- a/crates/hotshot/new-protocol/src/client.rs
+++ b/crates/hotshot/new-protocol/src/client.rs
@@ -137,13 +137,13 @@ impl<T: NodeType> ClientApi<T> {
     }
 
     /// Forward a legacy `TimeoutVote2` into the new-protocol timeout collectors.
-    pub fn submit_timeout_vote(&self, vote: TimeoutVote2<T>) -> Result<(), QueryError> {
+    pub fn try_submit_legacy_timeout_vote(&self, vote: TimeoutVote2<T>) -> Result<(), QueryError> {
         self.try_send(ClientRequest::SubmitTimeoutVote { vote })
     }
 
     /// Forward the last legacy view's QC so the first new-protocol leader can
     /// propose on it even if the cutover seed was snapshotted before it formed.
-    pub fn submit_legacy_high_qc(&self, qc: QuorumCertificate2<T>) -> Result<(), QueryError> {
+    pub fn try_submit_legacy_high_qc(&self, qc: QuorumCertificate2<T>) -> Result<(), QueryError> {
         self.try_send(ClientRequest::SubmitLegacyHighQc { qc })
     }
 

--- a/crates/hotshot/new-protocol/src/client.rs
+++ b/crates/hotshot/new-protocol/src/client.rs
@@ -136,30 +136,24 @@ impl<T: NodeType> ClientApi<T> {
             .await
     }
 
-    /// Fire-and-forget a legacy `TimeoutVote2` into the new-protocol timeout
-    /// collectors.
+    /// Forward a legacy `TimeoutVote2` into the new-protocol timeout collectors.
     pub fn submit_timeout_vote(&self, vote: TimeoutVote2<T>) -> Result<(), QueryError> {
         self.try_send(ClientRequest::SubmitTimeoutVote { vote })
     }
 
-    /// Fire-and-forget the last legacy view's QC so the first new-protocol
-    /// leader can propose on it even if the cutover seed was snapshotted
-    /// before it formed.
+    /// Forward the last legacy view's QC so the first new-protocol leader can
+    /// propose on it even if the cutover seed was snapshotted before it formed.
     pub fn submit_legacy_high_qc(&self, qc: QuorumCertificate2<T>) -> Result<(), QueryError> {
         self.try_send(ClientRequest::SubmitLegacyHighQc { qc })
     }
 
-    /// Fire-and-forget a refresh of the coordinator network's peer set for
-    /// `epoch`.
+    /// Refresh the coordinator network's peer set for `epoch`.
     pub fn bump_network_epoch(&self, epoch: EpochNumber) -> Result<(), QueryError> {
         self.try_send(ClientRequest::BumpNetworkEpoch { epoch })
     }
 
-    /// Send `request` without waiting for a response. The fire-and-forget
-    /// bridge methods above use this because they must never block on a
-    /// coordinator that hasn't started processing requests yet: requests
-    /// queue in the bounded request channel until the coordinator starts and
-    /// are dropped with an error when the queue is full.
+    /// Bridge sends must never block on a coordinator that hasn't started:
+    /// requests queue in the bounded channel and are dropped when it is full.
     fn try_send(&self, request: ClientRequest<T>) -> Result<(), QueryError> {
         self.tx.try_send(request).map_err(|err| match err {
             TrySendError::Closed(_) => QueryError::ChannelClosed,

--- a/crates/hotshot/new-protocol/src/client.rs
+++ b/crates/hotshot/new-protocol/src/client.rs
@@ -147,11 +147,6 @@ impl<T: NodeType> ClientApi<T> {
         self.try_send(ClientRequest::SubmitLegacyHighQc { qc })
     }
 
-    /// Refresh the coordinator network's peer set for `epoch`.
-    pub fn bump_network_epoch(&self, epoch: EpochNumber) -> Result<(), QueryError> {
-        self.try_send(ClientRequest::BumpNetworkEpoch { epoch })
-    }
-
     /// Bridge sends must never block on a coordinator that hasn't started:
     /// requests queue in the bounded channel and are dropped when it is full.
     fn try_send(&self, request: ClientRequest<T>) -> Result<(), QueryError> {
@@ -254,9 +249,6 @@ pub(crate) enum ClientRequest<T: NodeType> {
     },
     SubmitLegacyHighQc {
         qc: QuorumCertificate2<T>,
-    },
-    BumpNetworkEpoch {
-        epoch: EpochNumber,
     },
 }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -1485,7 +1485,7 @@ where
                     });
                 let _ = respond.send(result);
             },
-            ClientRequest::SubmitTimeoutVote { vote, respond } => {
+            ClientRequest::SubmitTimeoutVote { vote } => {
                 let view = vote.view_number();
                 let current_view = self.consensus.current_view();
                 if view < current_view {
@@ -1493,7 +1493,6 @@ where
                         %view, %current_view,
                         "ignoring bridged timeout vote for stale view"
                     );
-                    let _ = respond.send(());
                     return Ok(());
                 }
                 self.timeout_collector.accumulate_vote(vote.clone());
@@ -1516,9 +1515,8 @@ where
                 {
                     warn!(%err, "failed to rebroadcast bridged timeout vote");
                 }
-                let _ = respond.send(());
             },
-            ClientRequest::SubmitLegacyHighQc { qc, respond } => {
+            ClientRequest::SubmitLegacyHighQc { qc } => {
                 // QC certifies the last legacy view; cutover view is the next.
                 // Register idempotently so the smooth-start precondition holds
                 // regardless of arrival order vs. the cutover seed.
@@ -1551,16 +1549,14 @@ where
                         }
                     }
                 }
-                let _ = respond.send(());
             },
-            ClientRequest::BumpNetworkEpoch { epoch, respond } => {
+            ClientRequest::BumpNetworkEpoch { epoch } => {
                 if let Err(err) = self
                     .network
                     .apply_epoch(epoch, &self.membership_coordinator)
                 {
                     warn!(%epoch, %err, "network on_epoch_change failed");
                 }
-                let _ = respond.send(());
             },
         }
 

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -1550,14 +1550,6 @@ where
                     }
                 }
             },
-            ClientRequest::BumpNetworkEpoch { epoch } => {
-                if let Err(err) = self
-                    .network
-                    .apply_epoch(epoch, &self.membership_coordinator)
-                {
-                    warn!(%epoch, %err, "network on_epoch_change failed");
-                }
-            },
         }
 
         Ok(())

--- a/crates/hotshot/new-protocol/src/cutover.rs
+++ b/crates/hotshot/new-protocol/src/cutover.rs
@@ -3,10 +3,10 @@
 //! Two concerns live here:
 //! - [`extract_pre_cutover_seed`] walks a live legacy [`SystemContextHandle`]
 //!   and produces a [`PreCutoverSeed`].
-//! - [`forward_legacy_timeout_votes`] and [`forward_legacy_epoch_changes`]
-//!   tail the legacy event stream and bridge those events into the
-//!   coordinator's client API so the new protocol can form TC2s and
-//!   refresh its peer set at epoch boundaries.
+//! - [`forward_legacy_timeout_votes`] and [`forward_legacy_high_qc`] tail the
+//!   legacy event stream and bridge those events into the coordinator's
+//!   client API so the new protocol can form TC2s and propose at the
+//!   boundary.
 
 use std::collections::BTreeMap;
 
@@ -14,11 +14,10 @@ use async_broadcast::InactiveReceiver;
 use futures::StreamExt;
 use hotshot::{traits::NodeImplementation, types::SystemContextHandle};
 use hotshot_types::{
-    data::{EpochNumber, Leaf2},
+    data::Leaf2,
     event::{Event, EventType},
     message::UpgradeLock,
-    traits::{block_contents::BlockHeader, node_implementation::NodeType},
-    utils::epoch_from_block_number,
+    traits::node_implementation::NodeType,
 };
 use versions::NEW_PROTOCOL_VERSION;
 
@@ -126,41 +125,5 @@ pub async fn forward_legacy_high_qc<T: NodeType>(
         {
             tracing::warn!(%err, "failed to forward legacy high QC to new-protocol coordinator");
         }
-    }
-}
-
-/// Forward legacy epoch transitions into `bump_network_epoch`.
-/// `epoch_height == 0` disables forwarding.
-pub async fn forward_legacy_epoch_changes<T: NodeType>(
-    legacy_event_rx: InactiveReceiver<Event<T>>,
-    client_api: ClientApi<T>,
-    epoch_height: u64,
-    upgrade_lock: UpgradeLock<T>,
-) {
-    if epoch_height == 0 {
-        return;
-    }
-    let mut rx = legacy_event_rx.activate_cloned();
-    let mut last_forwarded: Option<EpochNumber> = None;
-    while let Some(event) = rx.next().await {
-        let EventType::Decide { leaf_chain, .. } = &event.event else {
-            continue;
-        };
-        let Some(newest) = leaf_chain.first() else {
-            continue;
-        };
-        if !cutover_decided(&upgrade_lock) {
-            continue;
-        }
-        let block_number = newest.leaf.block_header().block_number();
-        let epoch = EpochNumber::new(epoch_from_block_number(block_number, epoch_height));
-        if last_forwarded.is_some_and(|prev| epoch <= prev) {
-            continue;
-        }
-        if let Err(err) = client_api.bump_network_epoch(epoch) {
-            tracing::warn!(%epoch, %err, "failed to forward legacy epoch change to new-protocol coordinator");
-            continue;
-        }
-        last_forwarded = Some(epoch);
     }
 }

--- a/crates/hotshot/new-protocol/src/cutover.rs
+++ b/crates/hotshot/new-protocol/src/cutover.rs
@@ -83,15 +83,28 @@ where
     })
 }
 
+/// Whether the upgrade to `NEW_PROTOCOL_VERSION` is decided. The forwarders
+/// only bridge events once this holds: bridged requests only matter at the
+/// V0_6 cutover, and forwarding earlier would queue requests the parked
+/// coordinator can't drain and, on networks that never upgrade, would fill
+/// the bounded request queue.
+fn cutover_decided<T: NodeType>(upgrade_lock: &UpgradeLock<T>) -> bool {
+    upgrade_lock
+        .decided_upgrade_cert()
+        .is_some_and(|cert| cert.data.new_version >= NEW_PROTOCOL_VERSION)
+}
+
 /// Forward legacy `TimeoutVote2` events into the new-protocol timeout
 /// collectors so the first new leader can form TC2 at the boundary.
 pub async fn forward_legacy_timeout_votes<T: NodeType>(
     legacy_event_rx: InactiveReceiver<Event<T>>,
     client_api: ClientApi<T>,
+    upgrade_lock: UpgradeLock<T>,
 ) {
     let mut rx = legacy_event_rx.activate_cloned();
     while let Some(event) = rx.next().await {
         if let EventType::LegacyTimeoutVoteEmitted { vote } = event.event
+            && cutover_decided(&upgrade_lock)
             && let Err(err) = client_api.submit_timeout_vote(vote)
         {
             tracing::warn!(%err, "failed to forward legacy TimeoutVote2 to new-protocol coordinator");
@@ -105,10 +118,12 @@ pub async fn forward_legacy_timeout_votes<T: NodeType>(
 pub async fn forward_legacy_high_qc<T: NodeType>(
     legacy_event_rx: InactiveReceiver<Event<T>>,
     client_api: ClientApi<T>,
+    upgrade_lock: UpgradeLock<T>,
 ) {
     let mut rx = legacy_event_rx.activate_cloned();
     while let Some(event) = rx.next().await {
         if let EventType::LegacyHighQcFormed { qc } = event.event
+            && cutover_decided(&upgrade_lock)
             && let Err(err) = client_api.submit_legacy_high_qc(qc)
         {
             tracing::warn!(%err, "failed to forward legacy high QC to new-protocol coordinator");
@@ -136,14 +151,7 @@ pub async fn forward_legacy_epoch_changes<T: NodeType>(
         let Some(newest) = leaf_chain.first() else {
             continue;
         };
-        // Epoch bumps only matter for dialing the peer window ahead of the
-        // V0_6 cutover. Forwarding earlier would queue requests the parked
-        // coordinator can't drain and, on networks that never upgrade, would
-        // fill the bounded request queue.
-        let cutover_decided = upgrade_lock
-            .decided_upgrade_cert()
-            .is_some_and(|cert| cert.data.new_version >= NEW_PROTOCOL_VERSION);
-        if !cutover_decided {
+        if !cutover_decided(&upgrade_lock) {
             continue;
         }
         let block_number = newest.leaf.block_header().block_number();

--- a/crates/hotshot/new-protocol/src/cutover.rs
+++ b/crates/hotshot/new-protocol/src/cutover.rs
@@ -16,9 +16,11 @@ use hotshot::{traits::NodeImplementation, types::SystemContextHandle};
 use hotshot_types::{
     data::{EpochNumber, Leaf2},
     event::{Event, EventType},
+    message::UpgradeLock,
     traits::{block_contents::BlockHeader, node_implementation::NodeType},
     utils::epoch_from_block_number,
 };
+use versions::NEW_PROTOCOL_VERSION;
 
 use crate::{client::ClientApi, consensus::PreCutoverSeed};
 
@@ -90,7 +92,7 @@ pub async fn forward_legacy_timeout_votes<T: NodeType>(
     let mut rx = legacy_event_rx.activate_cloned();
     while let Some(event) = rx.next().await {
         if let EventType::LegacyTimeoutVoteEmitted { vote } = event.event
-            && let Err(err) = client_api.submit_timeout_vote(vote).await
+            && let Err(err) = client_api.submit_timeout_vote(vote)
         {
             tracing::warn!(%err, "failed to forward legacy TimeoutVote2 to new-protocol coordinator");
         }
@@ -107,7 +109,7 @@ pub async fn forward_legacy_high_qc<T: NodeType>(
     let mut rx = legacy_event_rx.activate_cloned();
     while let Some(event) = rx.next().await {
         if let EventType::LegacyHighQcFormed { qc } = event.event
-            && let Err(err) = client_api.submit_legacy_high_qc(qc).await
+            && let Err(err) = client_api.submit_legacy_high_qc(qc)
         {
             tracing::warn!(%err, "failed to forward legacy high QC to new-protocol coordinator");
         }
@@ -120,6 +122,7 @@ pub async fn forward_legacy_epoch_changes<T: NodeType>(
     legacy_event_rx: InactiveReceiver<Event<T>>,
     client_api: ClientApi<T>,
     epoch_height: u64,
+    upgrade_lock: UpgradeLock<T>,
 ) {
     if epoch_height == 0 {
         return;
@@ -133,12 +136,22 @@ pub async fn forward_legacy_epoch_changes<T: NodeType>(
         let Some(newest) = leaf_chain.first() else {
             continue;
         };
+        // Epoch bumps only matter for dialing the peer window ahead of the
+        // V0_6 cutover. Forwarding earlier would queue requests the parked
+        // coordinator can't drain and, on networks that never upgrade, would
+        // fill the bounded request queue.
+        let cutover_decided = upgrade_lock
+            .decided_upgrade_cert()
+            .is_some_and(|cert| cert.data.new_version >= NEW_PROTOCOL_VERSION);
+        if !cutover_decided {
+            continue;
+        }
         let block_number = newest.leaf.block_header().block_number();
         let epoch = EpochNumber::new(epoch_from_block_number(block_number, epoch_height));
         if last_forwarded.is_some_and(|prev| epoch <= prev) {
             continue;
         }
-        if let Err(err) = client_api.bump_network_epoch(epoch).await {
+        if let Err(err) = client_api.bump_network_epoch(epoch) {
             tracing::warn!(%epoch, %err, "failed to forward legacy epoch change to new-protocol coordinator");
             continue;
         }

--- a/crates/hotshot/new-protocol/src/cutover.rs
+++ b/crates/hotshot/new-protocol/src/cutover.rs
@@ -102,7 +102,7 @@ pub async fn forward_legacy_timeout_votes<T: NodeType>(
     while let Some(event) = rx.next().await {
         if let EventType::LegacyTimeoutVoteEmitted { vote } = event.event
             && cutover_decided(&upgrade_lock)
-            && let Err(err) = client_api.submit_timeout_vote(vote)
+            && let Err(err) = client_api.try_submit_legacy_timeout_vote(vote)
         {
             tracing::warn!(%err, "failed to forward legacy TimeoutVote2 to new-protocol coordinator");
         }
@@ -121,7 +121,7 @@ pub async fn forward_legacy_high_qc<T: NodeType>(
     while let Some(event) = rx.next().await {
         if let EventType::LegacyHighQcFormed { qc } = event.event
             && cutover_decided(&upgrade_lock)
-            && let Err(err) = client_api.submit_legacy_high_qc(qc)
+            && let Err(err) = client_api.try_submit_legacy_high_qc(qc)
         {
             tracing::warn!(%err, "failed to forward legacy high QC to new-protocol coordinator");
         }

--- a/crates/hotshot/new-protocol/src/cutover.rs
+++ b/crates/hotshot/new-protocol/src/cutover.rs
@@ -83,11 +83,9 @@ where
     })
 }
 
-/// Whether the upgrade to `NEW_PROTOCOL_VERSION` is decided. The forwarders
-/// only bridge events once this holds: bridged requests only matter at the
-/// V0_6 cutover, and forwarding earlier would queue requests the parked
-/// coordinator can't drain and, on networks that never upgrade, would fill
-/// the bounded request queue.
+/// Bridged requests only matter at the `NEW_PROTOCOL_VERSION` cutover;
+/// forwarding earlier fills the bounded request queue the parked coordinator
+/// can't drain.
 fn cutover_decided<T: NodeType>(upgrade_lock: &UpgradeLock<T>) -> bool {
     upgrade_lock
         .decided_upgrade_cert()

--- a/crates/hotshot/new-protocol/src/tests/cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/cutover.rs
@@ -305,7 +305,7 @@ async fn forward_legacy_high_qc_never_blocks_on_parked_coordinator() {
         .await
         .expect(
             "forward_legacy_high_qc stalled: broadcast channel did not drain (parked coordinator \
-             blocked submit_legacy_high_qc)",
+             blocked try_submit_legacy_high_qc)",
         )
         .expect("forwarder task should not panic");
 

--- a/crates/hotshot/new-protocol/src/tests/cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/cutover.rs
@@ -1,21 +1,29 @@
 //! Unit tests for the cutover bridging API.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
 
+use committable::Committable;
 use hotshot::types::{BLSPubKey, SignatureKey};
 use hotshot_example_types::{node_types::TestTypes, state_types::TestValidatedState};
 use hotshot_types::{
     data::{EpochNumber, Leaf2, ViewNumber},
+    event::{Event, EventType, LeafInfo},
+    message::UpgradeLock,
+    simple_certificate::{CertificatePair, UpgradeCertificate},
     simple_vote::UpgradeProposalData,
     stake_table::StakeTableEntries,
+    traits::block_contents::BlockHeader,
+    utils::epoch_from_block_number,
     vote::{Certificate, HasViewNumber},
 };
 use versions::{NEW_PROTOCOL_VERSION, version};
 
 use crate::{
+    client::{ClientApi, ClientRequest, CoordinatorClient},
     consensus::PreCutoverSeed,
+    cutover::forward_legacy_epoch_changes,
     helpers::test_upgrade_lock,
-    tests::common::utils::{ConsensusHarness, TestData},
+    tests::common::utils::{ConsensusHarness, TestData, TestView},
 };
 
 /// Build a `PreCutoverSeed` from leaves, using `TestValidatedState::default()`
@@ -236,4 +244,171 @@ async fn upgrade_certificate_cutover() {
         .run()
         .await
         .expect("new protocol should decide past the upgrade boundary");
+}
+
+/// Build a `Decide` event carrying a single leaf, for feeding `forward_legacy_epoch_changes`.
+fn decide_event(view: &TestView) -> Event<TestTypes> {
+    let state = Arc::new(TestValidatedState::default());
+    let leaf_info = LeafInfo::new(view.leaf.clone(), state, None, None, None);
+    Event {
+        view_number: view.view_number,
+        event: EventType::Decide {
+            leaf_chain: Arc::new(vec![leaf_info]),
+            committing_qc: Arc::new(CertificatePair::non_epoch_change(view.cert1.clone())),
+            deciding_qc: None,
+            block_size: None,
+        },
+    }
+}
+
+/// Certificate that decides the upgrade to `NEW_PROTOCOL_VERSION`, opening
+/// the `forward_legacy_epoch_changes` gate.
+fn new_protocol_upgrade_cert() -> UpgradeCertificate<TestTypes> {
+    let upgrade_data = UpgradeProposalData {
+        old_version: version(0, 1),
+        new_version: NEW_PROTOCOL_VERSION,
+        decide_by: ViewNumber::genesis(),
+        new_version_hash: Default::default(),
+        old_version_last_view: ViewNumber::genesis(),
+        new_version_first_view: ViewNumber::genesis(),
+    };
+    UpgradeCertificate::new(
+        upgrade_data.clone(),
+        upgrade_data.commit(),
+        ViewNumber::genesis(),
+        Default::default(),
+        Default::default(),
+    )
+}
+
+/// Regression test for the memory leak fixed by making `bump_network_epoch`
+/// fire-and-forget: with the coordinator parked (never polling
+/// `next_request`), the forwarder must keep draining the legacy event
+/// broadcast channel instead of blocking forever awaiting a response that
+/// will never come.
+#[tokio::test]
+async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
+    let test_data = TestData::new(6).await;
+
+    // Small capacity: the coordinator is parked, so nothing ever drains this.
+    let client = CoordinatorClient::<TestTypes>::new(NonZeroUsize::new(4).unwrap());
+    let client_api = client.handle().clone();
+
+    let (legacy_tx, legacy_rx) = async_broadcast::broadcast::<Event<TestTypes>>(8);
+
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    upgrade_lock.set_decided_upgrade_cert(Some(new_protocol_upgrade_cert()));
+
+    let epoch_height = 1; // every Decide crosses an epoch boundary
+    let forwarder = tokio::spawn(forward_legacy_epoch_changes(
+        legacy_rx.deactivate(),
+        client_api,
+        epoch_height,
+        upgrade_lock,
+    ));
+
+    for view in &test_data.views {
+        legacy_tx
+            .broadcast_direct(decide_event(view))
+            .await
+            .expect("legacy event channel should accept the send");
+    }
+    drop(legacy_tx);
+
+    // With the sender dropped, the forwarder exits once it has drained the
+    // channel. Pre-fix it blocked awaiting the parked coordinator's response
+    // and never finished.
+    tokio::time::timeout(Duration::from_secs(5), forwarder)
+        .await
+        .expect(
+            "forward_legacy_epoch_changes stalled: broadcast channel did not drain (parked \
+             coordinator blocked bump_network_epoch)",
+        )
+        .expect("forwarder task should not panic");
+
+    drop(client);
+}
+
+/// Feed `views` as epoch-boundary `Decide`s through a fresh forwarder run
+/// and wait (bounded) for it to drain and exit.
+async fn run_epoch_forwarder(
+    api: ClientApi<TestTypes>,
+    views: &[TestView],
+    lock: UpgradeLock<TestTypes>,
+    epoch_height: u64,
+) {
+    let (legacy_tx, legacy_rx) = async_broadcast::broadcast::<Event<TestTypes>>(8);
+    let forwarder = tokio::spawn(forward_legacy_epoch_changes(
+        legacy_rx.deactivate(),
+        api,
+        epoch_height,
+        lock,
+    ));
+    for view in views {
+        legacy_tx
+            .broadcast_direct(decide_event(view))
+            .await
+            .expect("legacy event channel should accept the send");
+    }
+    drop(legacy_tx);
+    tokio::time::timeout(Duration::from_secs(5), forwarder)
+        .await
+        .expect("forwarder should drain and exit")
+        .expect("forwarder task should not panic");
+}
+
+/// The forwarder must not queue `BumpNetworkEpoch` requests before the
+/// upgrade to `NEW_PROTOCOL_VERSION` is decided, and must forward exactly
+/// one request per epoch once it is.
+#[tokio::test]
+async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
+    let test_data = TestData::new(3).await;
+    let mut client = CoordinatorClient::<TestTypes>::new(NonZeroUsize::new(8).unwrap());
+    let upgrade_lock = test_upgrade_lock::<TestTypes>();
+    let epoch_height = 1; // every Decide crosses an epoch boundary
+
+    // Gate closed: no decided upgrade certificate.
+    run_epoch_forwarder(
+        client.handle().clone(),
+        &test_data.views[..2],
+        upgrade_lock.clone(),
+        epoch_height,
+    )
+    .await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.next_request())
+            .await
+            .is_err(),
+        "no request should be forwarded while the upgrade is undecided",
+    );
+
+    // Gate open: decided certificate targeting NEW_PROTOCOL_VERSION.
+    upgrade_lock.set_decided_upgrade_cert(Some(new_protocol_upgrade_cert()));
+    let boundary_view = &test_data.views[2];
+    run_epoch_forwarder(
+        client.handle().clone(),
+        std::slice::from_ref(boundary_view),
+        upgrade_lock,
+        epoch_height,
+    )
+    .await;
+
+    let request = tokio::time::timeout(Duration::from_millis(50), client.next_request())
+        .await
+        .expect("a request should be forwarded once the upgrade is decided")
+        .expect("request channel should be open");
+    let expected_epoch = EpochNumber::new(epoch_from_block_number(
+        BlockHeader::<TestTypes>::block_number(boundary_view.leaf.block_header()),
+        epoch_height,
+    ));
+    assert!(
+        matches!(request, ClientRequest::BumpNetworkEpoch { epoch } if epoch == expected_epoch),
+        "expected BumpNetworkEpoch for epoch {expected_epoch}",
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.next_request())
+            .await
+            .is_err(),
+        "exactly one request should be forwarded per epoch boundary",
+    );
 }

--- a/crates/hotshot/new-protocol/src/tests/cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/cutover.rs
@@ -7,13 +7,11 @@ use hotshot::types::{BLSPubKey, SignatureKey};
 use hotshot_example_types::{node_types::TestTypes, state_types::TestValidatedState};
 use hotshot_types::{
     data::{EpochNumber, Leaf2, ViewNumber},
-    event::{Event, EventType, LeafInfo},
+    event::{Event, EventType},
     message::UpgradeLock,
-    simple_certificate::{CertificatePair, UpgradeCertificate},
+    simple_certificate::UpgradeCertificate,
     simple_vote::UpgradeProposalData,
     stake_table::StakeTableEntries,
-    traits::block_contents::BlockHeader,
-    utils::epoch_from_block_number,
     vote::{Certificate, HasViewNumber},
 };
 use versions::{NEW_PROTOCOL_VERSION, version};
@@ -21,7 +19,7 @@ use versions::{NEW_PROTOCOL_VERSION, version};
 use crate::{
     client::{ClientApi, ClientRequest, CoordinatorClient},
     consensus::PreCutoverSeed,
-    cutover::forward_legacy_epoch_changes,
+    cutover::forward_legacy_high_qc,
     helpers::test_upgrade_lock,
     tests::common::utils::{ConsensusHarness, TestData, TestView},
 };
@@ -246,16 +244,11 @@ async fn upgrade_certificate_cutover() {
         .expect("new protocol should decide past the upgrade boundary");
 }
 
-fn decide_event(view: &TestView) -> Event<TestTypes> {
-    let state = Arc::new(TestValidatedState::default());
-    let leaf_info = LeafInfo::new(view.leaf.clone(), state, None, None, None);
+fn high_qc_event(view: &TestView) -> Event<TestTypes> {
     Event {
         view_number: view.view_number,
-        event: EventType::Decide {
-            leaf_chain: Arc::new(vec![leaf_info]),
-            committing_qc: Arc::new(CertificatePair::non_epoch_change(view.cert1.clone())),
-            deciding_qc: None,
-            block_size: None,
+        event: EventType::LegacyHighQcFormed {
+            qc: view.cert1.clone(),
         },
     }
 }
@@ -282,7 +275,7 @@ fn new_protocol_upgrade_cert() -> UpgradeCertificate<TestTypes> {
 /// With the coordinator parked (never polling `next_request`), the forwarder
 /// must keep draining the legacy event stream instead of blocking on a reply.
 #[tokio::test]
-async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
+async fn forward_legacy_high_qc_never_blocks_on_parked_coordinator() {
     let test_data = TestData::new(6).await;
 
     let client = CoordinatorClient::<TestTypes>::new(NonZeroUsize::new(4).unwrap());
@@ -293,17 +286,15 @@ async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
     let upgrade_lock = test_upgrade_lock::<TestTypes>();
     upgrade_lock.set_decided_upgrade_cert(Some(new_protocol_upgrade_cert()));
 
-    let epoch_height = 1; // every Decide crosses an epoch boundary
-    let forwarder = tokio::spawn(forward_legacy_epoch_changes(
+    let forwarder = tokio::spawn(forward_legacy_high_qc(
         legacy_rx.deactivate(),
         client_api,
-        epoch_height,
         upgrade_lock,
     ));
 
     for view in &test_data.views {
         legacy_tx
-            .broadcast_direct(decide_event(view))
+            .broadcast_direct(high_qc_event(view))
             .await
             .expect("legacy event channel should accept the send");
     }
@@ -313,31 +304,25 @@ async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
     tokio::time::timeout(Duration::from_secs(5), forwarder)
         .await
         .expect(
-            "forward_legacy_epoch_changes stalled: broadcast channel did not drain (parked \
-             coordinator blocked bump_network_epoch)",
+            "forward_legacy_high_qc stalled: broadcast channel did not drain (parked coordinator \
+             blocked submit_legacy_high_qc)",
         )
         .expect("forwarder task should not panic");
 
     drop(client);
 }
 
-/// Feed `views` as epoch-boundary `Decide`s and wait for the forwarder to exit.
-async fn run_epoch_forwarder(
+/// Feed `views` as `LegacyHighQcFormed` events and wait for the forwarder to exit.
+async fn run_high_qc_forwarder(
     api: ClientApi<TestTypes>,
     views: &[TestView],
     lock: UpgradeLock<TestTypes>,
-    epoch_height: u64,
 ) {
     let (legacy_tx, legacy_rx) = async_broadcast::broadcast::<Event<TestTypes>>(8);
-    let forwarder = tokio::spawn(forward_legacy_epoch_changes(
-        legacy_rx.deactivate(),
-        api,
-        epoch_height,
-        lock,
-    ));
+    let forwarder = tokio::spawn(forward_legacy_high_qc(legacy_rx.deactivate(), api, lock));
     for view in views {
         legacy_tx
-            .broadcast_direct(decide_event(view))
+            .broadcast_direct(high_qc_event(view))
             .await
             .expect("legacy event channel should accept the send");
     }
@@ -348,19 +333,17 @@ async fn run_epoch_forwarder(
         .expect("forwarder task should not panic");
 }
 
-/// No request queues before the V0_6 upgrade is decided; one per epoch after.
+/// No request queues before the V0_6 upgrade is decided; one per event after.
 #[tokio::test]
-async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
+async fn forward_legacy_high_qc_gates_on_decided_upgrade() {
     let test_data = TestData::new(3).await;
     let mut client = CoordinatorClient::<TestTypes>::new(NonZeroUsize::new(8).unwrap());
     let upgrade_lock = test_upgrade_lock::<TestTypes>();
-    let epoch_height = 1; // every Decide crosses an epoch boundary
 
-    run_epoch_forwarder(
+    run_high_qc_forwarder(
         client.handle().clone(),
         &test_data.views[..2],
         upgrade_lock.clone(),
-        epoch_height,
     )
     .await;
     assert!(
@@ -372,11 +355,10 @@ async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
 
     upgrade_lock.set_decided_upgrade_cert(Some(new_protocol_upgrade_cert()));
     let boundary_view = &test_data.views[2];
-    run_epoch_forwarder(
+    run_high_qc_forwarder(
         client.handle().clone(),
         std::slice::from_ref(boundary_view),
         upgrade_lock,
-        epoch_height,
     )
     .await;
 
@@ -384,18 +366,18 @@ async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
         .await
         .expect("a request should be forwarded once the upgrade is decided")
         .expect("request channel should be open");
-    let expected_epoch = EpochNumber::new(epoch_from_block_number(
-        BlockHeader::<TestTypes>::block_number(boundary_view.leaf.block_header()),
-        epoch_height,
-    ));
     assert!(
-        matches!(request, ClientRequest::BumpNetworkEpoch { epoch } if epoch == expected_epoch),
-        "expected BumpNetworkEpoch for epoch {expected_epoch}",
+        matches!(
+            &request,
+            ClientRequest::SubmitLegacyHighQc { qc } if qc.view_number() == boundary_view.view_number
+        ),
+        "expected SubmitLegacyHighQc for view {}",
+        boundary_view.view_number,
     );
     assert!(
         tokio::time::timeout(Duration::from_millis(50), client.next_request())
             .await
             .is_err(),
-        "exactly one request should be forwarded per epoch boundary",
+        "exactly one request should be forwarded per event",
     );
 }

--- a/crates/hotshot/new-protocol/src/tests/cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/cutover.rs
@@ -246,7 +246,6 @@ async fn upgrade_certificate_cutover() {
         .expect("new protocol should decide past the upgrade boundary");
 }
 
-/// Build a `Decide` event carrying a single leaf, for feeding `forward_legacy_epoch_changes`.
 fn decide_event(view: &TestView) -> Event<TestTypes> {
     let state = Arc::new(TestValidatedState::default());
     let leaf_info = LeafInfo::new(view.leaf.clone(), state, None, None, None);
@@ -261,8 +260,7 @@ fn decide_event(view: &TestView) -> Event<TestTypes> {
     }
 }
 
-/// Certificate that decides the upgrade to `NEW_PROTOCOL_VERSION`, opening
-/// the `forward_legacy_epoch_changes` gate.
+/// Certificate deciding the upgrade to `NEW_PROTOCOL_VERSION`.
 fn new_protocol_upgrade_cert() -> UpgradeCertificate<TestTypes> {
     let upgrade_data = UpgradeProposalData {
         old_version: version(0, 1),
@@ -281,16 +279,12 @@ fn new_protocol_upgrade_cert() -> UpgradeCertificate<TestTypes> {
     )
 }
 
-/// Regression test for the memory leak fixed by making `bump_network_epoch`
-/// fire-and-forget: with the coordinator parked (never polling
-/// `next_request`), the forwarder must keep draining the legacy event
-/// broadcast channel instead of blocking forever awaiting a response that
-/// will never come.
+/// With the coordinator parked (never polling `next_request`), the forwarder
+/// must keep draining the legacy event stream instead of blocking on a reply.
 #[tokio::test]
 async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
     let test_data = TestData::new(6).await;
 
-    // Small capacity: the coordinator is parked, so nothing ever drains this.
     let client = CoordinatorClient::<TestTypes>::new(NonZeroUsize::new(4).unwrap());
     let client_api = client.handle().clone();
 
@@ -315,9 +309,7 @@ async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
     }
     drop(legacy_tx);
 
-    // With the sender dropped, the forwarder exits once it has drained the
-    // channel. Pre-fix it blocked awaiting the parked coordinator's response
-    // and never finished.
+    // Pre-fix: blocked awaiting the parked coordinator's reply, never exited.
     tokio::time::timeout(Duration::from_secs(5), forwarder)
         .await
         .expect(
@@ -329,8 +321,7 @@ async fn forward_legacy_epoch_changes_never_blocks_on_parked_coordinator() {
     drop(client);
 }
 
-/// Feed `views` as epoch-boundary `Decide`s through a fresh forwarder run
-/// and wait (bounded) for it to drain and exit.
+/// Feed `views` as epoch-boundary `Decide`s and wait for the forwarder to exit.
 async fn run_epoch_forwarder(
     api: ClientApi<TestTypes>,
     views: &[TestView],
@@ -357,9 +348,7 @@ async fn run_epoch_forwarder(
         .expect("forwarder task should not panic");
 }
 
-/// The forwarder must not queue `BumpNetworkEpoch` requests before the
-/// upgrade to `NEW_PROTOCOL_VERSION` is decided, and must forward exactly
-/// one request per epoch once it is.
+/// No request queues before the V0_6 upgrade is decided; one per epoch after.
 #[tokio::test]
 async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
     let test_data = TestData::new(3).await;
@@ -367,7 +356,6 @@ async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
     let upgrade_lock = test_upgrade_lock::<TestTypes>();
     let epoch_height = 1; // every Decide crosses an epoch boundary
 
-    // Gate closed: no decided upgrade certificate.
     run_epoch_forwarder(
         client.handle().clone(),
         &test_data.views[..2],
@@ -382,7 +370,6 @@ async fn forward_legacy_epoch_changes_gates_on_decided_upgrade() {
         "no request should be forwarded while the upgrade is undecided",
     );
 
-    // Gate open: decided certificate targeting NEW_PROTOCOL_VERSION.
     upgrade_lock.set_decided_upgrade_cert(Some(new_protocol_upgrade_cert()));
     let boundary_view = &test_data.views[2];
     run_epoch_forwarder(

--- a/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
+++ b/crates/hotshot/new-protocol/src/tests/legacy_cutover.rs
@@ -418,16 +418,25 @@ async fn spawn_node(
 
     let client_api = coord.client_api().clone();
 
+    // Same lock production wires in: the legacy handle's, which receives the
+    // decided upgrade certificate and opens the forwarders' cutover gate.
+    let legacy_upgrade_lock = legacy.read().await.hotshot.upgrade_lock.clone();
     let legacy_event_rx = legacy.read().await.event_stream_known_impl().deactivate();
     bg_handles.push(
         tokio::spawn(forward_legacy_timeout_votes(
             legacy_event_rx.clone(),
             client_api.clone(),
+            legacy_upgrade_lock.clone(),
         ))
         .abort_handle(),
     );
     bg_handles.push(
-        tokio::spawn(forward_legacy_high_qc(legacy_event_rx, client_api.clone())).abort_handle(),
+        tokio::spawn(forward_legacy_high_qc(
+            legacy_event_rx,
+            client_api.clone(),
+            legacy_upgrade_lock,
+        ))
+        .abort_handle(),
     );
 
     let (decision_tx, decision_rx) = mpsc::unbounded_channel::<DecisionEvent>();


### PR DESCRIPTION
Closes the memory-soak regression introduced by #4670 (1.8 GB -> 7.8 GB total on epoch-reward, drb-header runner OOM).

## Root cause

- #4670 parks the coordinator until the V0_6 upgrade view; while parked, nothing services its `ClientRequest` queue.
- The legacy-event forwarders (`cutover.rs`) spawn at node construction. `forward_legacy_epoch_changes` called `bump_network_epoch`, which sent a request and awaited a oneshot reply. Parked coordinator: no reply, forwarder blocks forever at the first epoch boundary.
- The blocked forwarder holds an active receiver on HotShot's external broadcast stream (capacity 10,000). Broadcast retains events until all receivers consume them, so the stalled receiver pins the newest 10,000 `Decide` events, each carrying Arc'd validated state (fee/reward merkle trees, VID shares). About 1.2 GB per node on any network below V0_6.

## Changes

- `client.rs`: `submit_timeout_vote`, `submit_legacy_high_qc`, `bump_network_epoch` are now synchronous fire-and-forget (`try_send`, `respond` fields removed). Requests queue in the bounded channel until the coordinator starts; `ChannelFull` drops with an error.
- `cutover.rs`: all three forwarders share a `cutover_decided` gate (decided cert with `new_version >= NEW_PROTOCOL_VERSION`). Prevents non-V0_6 upgrade windows (exercised by the `*-upgrade` demo suites) from filling the 256-slot queue with requests the parked coordinator can't drain.
- `coordinator.rs`: dead `respond` plumbing removed from the three handler arms.

## Tests

- `forward_legacy_epoch_changes_never_blocks_on_parked_coordinator` (`tests/cutover.rs`): reproduces the stall on pre-fix code (forwarder never drains, 5s timeout), passes now.
- `forward_legacy_epoch_changes_gates_on_decided_upgrade`: nothing queues before the cert is decided, exactly one `BumpNetworkEpoch` per epoch after.
- `tests::cutover::` 7/7, `tests::legacy_cutover::` 32/32, clippy clean.

## Review focus

- Cutover behavior without the old send-then-await lockstep: handlers are order-insensitive and idempotent (stale votes dropped by view, high-QC registration idempotent, `apply_epoch` monotone); a `Full`-dropped final epoch bump is covered by the seed-time `apply_epoch`.
- Gate lifecycle across restarts: cert is persisted at decide and restored before event processing.

## Verification pending

- CI memory soak on this branch (`workflow_dispatch` runs `memory-soak-non-pr`): expect epoch-reward `Total (sum)` back at ~1.8 GB.
