### PR TITLE
fix(ci): upgrade Claude review model to fable

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,4 +98,4 @@ jobs:
           #   gh api */pulls/*/comments  - reply to review thread comments
           #   gh api graphql mutation resolveReviewThread - resolve own review threads
           claude_args: |
-            --model claude-opus-4-8 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"
+            --model claude-fable-5 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,4 +98,4 @@ jobs:
           #   gh api */pulls/*/comments  - reply to review thread comments
           #   gh api graphql mutation resolveReviewThread - resolve own review threads
           claude_args: |
-            --model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"
+            --model claude-opus-4-8 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,4 +98,4 @@ jobs:
           #   gh api */pulls/*/comments  - reply to review thread comments
           #   gh api graphql mutation resolveReviewThread - resolve own review threads
           claude_args: |
-            --model claude-fable-5 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"
+            --model fable --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api */pulls/*/comments*),Bash(gh api graphql -f query='mutation { resolveReviewThread*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-opus-4-8 --max-turns 15"
+          claude_args: "--model claude-fable-5 --max-turns 15"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-opus-4-6 --max-turns 15"
+          claude_args: "--model claude-opus-4-8 --max-turns 15"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-fable-5 --max-turns 15"
+          claude_args: "--model fable --max-turns 15"


### PR DESCRIPTION
claude-opus-4-6 is retired; the API rejects it immediately (is_error, $0 cost, no turns), failing the review action.
