### PR TITLE
Restore epoch change notification before activation.

### DIFF
--- a/crates/espresso/node/src/catchup.rs
+++ b/crates/espresso/node/src/catchup.rs
@@ -29,7 +29,7 @@ use futures::{
     future::{Future, FutureExt, TryFuture, TryFutureExt},
     stream::FuturesUnordered,
 };
-use hotshot_new_protocol::utils::verify_new_protocol_leaf_chain;
+use hotshot_new_protocol::{storage::NewProtocolStorage, utils::verify_new_protocol_leaf_chain};
 use hotshot_types::{
     ValidatorConfig,
     data::{EpochNumber, ViewNumber},
@@ -1745,7 +1745,10 @@ pub async fn add_fee_accounts_to_state<I: hotshot::traits::NodeImplementation<Se
     accounts: &[FeeAccount],
     tree: &FeeMerkleTree,
     leaf: Leaf2,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     let (existing_state, delta) = consensus_handle.state_and_delta(*view).await;
     let (state, delta) = match existing_state {
         Some(existing) => {
@@ -1792,7 +1795,10 @@ pub async fn add_v2_reward_accounts_to_state<I: hotshot::traits::NodeImplementat
     accounts: &[RewardAccountV2],
     tree: &RewardMerkleTreeV2,
     leaf: Leaf2,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     let (existing_state, delta) = consensus_handle.state_and_delta(*view).await;
     let (state, delta) = match existing_state {
         Some(existing) => {
@@ -1839,7 +1845,10 @@ pub async fn add_v1_reward_accounts_to_state<I: hotshot::traits::NodeImplementat
     accounts: &[RewardAccountV1],
     tree: &RewardMerkleTreeV1,
     leaf: Leaf2,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     let (existing_state, delta) = consensus_handle.state_and_delta(*view).await;
     let (state, delta) = match existing_state {
         Some(existing) => {

--- a/crates/espresso/node/src/consensus_handle.rs
+++ b/crates/espresso/node/src/consensus_handle.rs
@@ -23,20 +23,19 @@ use hotshot_new_protocol::{
 use hotshot_types::{
     data::{BlockNumber, EpochNumber, Leaf2, QuorumProposalWrapper, VidDisperseShare, ViewNumber},
     epoch_membership::EpochMembershipCoordinator,
-    event::{Event, LeafInfo},
+    event::{Event, EventType, LeafInfo},
     message::{Proposal as SignedProposal, UpgradeLock, convert_proposal},
     new_protocol::CoordinatorEvent,
-    traits::{ValidatedState, node_implementation::NodeType, signature_key::SignatureKey},
-    utils::StateAndDelta,
+    traits::{
+        ValidatedState, block_contents::BlockHeader, node_implementation::NodeType,
+        signature_key::SignatureKey,
+    },
+    utils::{StateAndDelta, epoch_from_block_number},
 };
 use parking_lot::RwLock;
 use tokio::{select, spawn};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{error, warn};
-
-type StartFn<T> = Box<
-    dyn FnOnce(Option<PreCutoverSeed<T>>, CancellationToken) -> AbortOnDropHandle<()> + Send + Sync,
->;
 
 pub struct ConsensusHandle<T: NodeType, I: NodeImplementation<T>> {
     legacy_handle: Arc<AsyncRwLock<SystemContextHandle<T, I>>>,
@@ -44,15 +43,16 @@ pub struct ConsensusHandle<T: NodeType, I: NodeImplementation<T>> {
     legacy_event_rx: InactiveReceiver<Event<T>>,
     event_rx: InactiveReceiver<CoordinatorEvent<T>>,
     upgrade_lock: UpgradeLock<T>,
-    new_proto: RwLock<NewProtocol<T>>,
+    new_proto: Arc<RwLock<NewProtocol<T, I::Storage>>>,
     tasks: Vec<AbortOnDropHandle<()>>,
 }
 
-enum NewProtocol<T: NodeType> {
+#[allow(clippy::large_enum_variant)]
+enum NewProtocol<T: NodeType, S> {
     Empty,
     Init {
-        client_api: ClientApi<T>,
-        start: StartFn<T>,
+        coordinator: Coordinator<T, S>,
+        event_tx: Sender<CoordinatorEvent<T>>,
     },
     Running {
         coordinator: AbortOnDropHandle<()>,
@@ -61,7 +61,7 @@ enum NewProtocol<T: NodeType> {
     },
 }
 
-impl<T: NodeType> NewProtocol<T> {
+impl<T: NodeType, S> NewProtocol<T, S> {
     fn take(&mut self) -> Self {
         mem::replace(self, Self::Empty)
     }
@@ -71,6 +71,7 @@ impl<T, I> ConsensusHandle<T, I>
 where
     T: NodeType,
     I: NodeImplementation<T>,
+    I::Storage: NewProtocolStorage<T>,
 {
     pub async fn new(
         ctx: Arc<AsyncRwLock<SystemContextHandle<T, I>>>,
@@ -78,17 +79,19 @@ where
         epoch_height: BlockNumber,
         rx: InactiveReceiver<Event<T>>,
         event_channel_capacity: usize,
-    ) -> Self
-    where
-        I::Storage: NewProtocolStorage<T>,
-    {
+    ) -> Self {
         let (mut event_tx, mut event_rx) = broadcast(event_channel_capacity);
         event_tx.set_await_active(false);
         event_rx.set_overflow(true);
 
         let upgrade_lock = ctx.read().await.hotshot.upgrade_lock.clone();
 
-        let client_api = coordinator.client_api();
+        let client_api = coordinator.client_api().clone();
+
+        let new_proto = Arc::new(RwLock::new(NewProtocol::Init {
+            coordinator,
+            event_tx,
+        }));
 
         let tasks = vec![
             AbortOnDropHandle::new(spawn(forward_legacy_timeout_votes(
@@ -98,8 +101,13 @@ where
             ))),
             AbortOnDropHandle::new(spawn(forward_legacy_high_qc(
                 rx.clone(),
-                client_api.clone(),
+                client_api,
                 upgrade_lock.clone(),
+            ))),
+            AbortOnDropHandle::new(spawn(forward_legacy_epoch_changes(
+                rx.clone(),
+                new_proto.clone(),
+                epoch_height.into(),
             ))),
         ];
 
@@ -109,17 +117,7 @@ where
             epoch_height,
             legacy_event_rx: rx,
             event_rx: event_rx.deactivate(),
-            new_proto: RwLock::new(NewProtocol::Init {
-                client_api: coordinator.client_api().clone(),
-                start: Box::new(move |seed, shutdown| {
-                    AbortOnDropHandle::new(spawn(run_coordinator(
-                        coordinator,
-                        event_tx,
-                        seed,
-                        shutdown,
-                    )))
-                }),
-            }),
+            new_proto,
             tasks,
         }
     }
@@ -147,10 +145,19 @@ where
         let mut new_proto = self.new_proto.write();
 
         match new_proto.take() {
-            NewProtocol::Init { client_api, start } => {
+            NewProtocol::Init {
+                coordinator,
+                event_tx,
+            } => {
+                let client_api = coordinator.client_api().clone();
                 let shutdown = CancellationToken::new();
                 *new_proto = NewProtocol::Running {
-                    coordinator: start(seed, shutdown.clone()),
+                    coordinator: AbortOnDropHandle::new(spawn(run_coordinator(
+                        coordinator,
+                        event_tx,
+                        seed,
+                        shutdown.clone(),
+                    ))),
                     client_api,
                     shutdown,
                 };
@@ -652,5 +659,45 @@ where
         Err(err) => {
             warn!(%err, "failed to broadcast consensus event");
         },
+    }
+}
+
+/// Forward legacy epoch transitions into the coordinator so cliquenet keeps
+/// dialing the current validator set before cutover.
+///
+/// The parked coordinator's event loop is not running yet, so its network is
+/// bumped directly under the state lock. Once the coordinator runs, it
+/// refreshes peers itself whenever a proposal validates, so this task ends.
+/// `epoch_height == 0` disables forwarding.
+async fn forward_legacy_epoch_changes<T, S>(
+    legacy_event_rx: InactiveReceiver<Event<T>>,
+    new_proto: Arc<RwLock<NewProtocol<T, S>>>,
+    epoch_height: u64,
+) where
+    T: NodeType,
+    S: NewProtocolStorage<T>,
+{
+    if epoch_height == 0 {
+        return;
+    }
+    let mut rx = legacy_event_rx.activate_cloned();
+    let mut last_forwarded: Option<EpochNumber> = None;
+    while let Some(event) = rx.next().await {
+        let EventType::Decide { leaf_chain, .. } = &event.event else {
+            continue;
+        };
+        let Some(newest) = leaf_chain.first() else {
+            continue;
+        };
+        let block_number = newest.leaf.block_header().block_number();
+        let epoch = EpochNumber::new(epoch_from_block_number(block_number, epoch_height));
+        if last_forwarded.is_some_and(|prev| epoch <= prev) {
+            continue;
+        }
+        match &mut *new_proto.write() {
+            NewProtocol::Init { coordinator, .. } => coordinator.bump_network_epoch(epoch),
+            _ => return,
+        }
+        last_forwarded = Some(epoch);
     }
 }

--- a/crates/espresso/node/src/request_response/catchup/state.rs
+++ b/crates/espresso/node/src/request_response/catchup/state.rs
@@ -14,7 +14,7 @@ use espresso_types::{
     },
 };
 use hotshot::traits::NodeImplementation;
-use hotshot_new_protocol::utils::verify_new_protocol_leaf_chain;
+use hotshot_new_protocol::{storage::NewProtocolStorage, utils::verify_new_protocol_leaf_chain};
 use hotshot_types::{
     data::ViewNumber, epoch_membership::EpochMembershipCoordinator, message::UpgradeLock,
     simple_certificate::LightClientStateUpdateCertificateV2, traits::network::ConnectedNetwork,
@@ -36,6 +36,8 @@ use crate::{
 #[async_trait]
 impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerPersistence>
     StateCatchup for RequestResponseProtocol<I, N, P>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
 {
     async fn try_fetch_leaf(
         &self,

--- a/crates/espresso/node/src/request_response/data_source.rs
+++ b/crates/espresso/node/src/request_response/data_source.rs
@@ -13,6 +13,7 @@ use espresso_types::{
     v0_4::{RewardAccountV2, RewardMerkleTreeV2},
 };
 use hotshot::traits::NodeImplementation;
+use hotshot_new_protocol::storage::NewProtocolStorage;
 use hotshot_query_service::{
     data_source::{
         VersionedDataSource,
@@ -67,6 +68,8 @@ pub struct DataSource<
 #[async_trait]
 impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerPersistence>
     DataSourceTrait<Request> for DataSource<I, N, P>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
 {
     async fn derive_response_for(&self, request: &Request) -> Result<Response> {
         match request {
@@ -367,7 +370,10 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
 async fn legacy_leaf_chain_from_memory<I: NodeImplementation<SeqTypes>>(
     consensus_handle: &ConsensusHandle<SeqTypes, I>,
     height: u64,
-) -> anyhow::Result<Vec<espresso_types::Leaf2>> {
+) -> anyhow::Result<Vec<espresso_types::Leaf2>>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     let mut leaves = consensus_handle.undecided_leaves().await;
     leaves.sort_by_key(|l| l.view_number());
 

--- a/crates/espresso/node/src/request_response/mod.rs
+++ b/crates/espresso/node/src/request_response/mod.rs
@@ -4,6 +4,7 @@ use data_source::DataSource;
 use derive_more::derive::Deref;
 use espresso_types::{PubKey, SeqTypes, traits::SequencerPersistence};
 use hotshot::{traits::NodeImplementation, types::BLSPrivKey};
+use hotshot_new_protocol::storage::NewProtocolStorage;
 use hotshot_types::traits::network::ConnectedNetwork;
 use network::Sender;
 use recipient_source::RecipientSource;
@@ -26,7 +27,9 @@ pub struct RequestResponseProtocol<
     I: NodeImplementation<SeqTypes>,
     N: ConnectedNetwork<PubKey>,
     P: SequencerPersistence,
-> {
+> where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     #[deref]
     #[allow(clippy::type_complexity)]
     /// The actual inner request response protocol
@@ -51,6 +54,8 @@ pub struct RequestResponseProtocol<
 
 impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerPersistence>
     RequestResponseProtocol<I, N, P>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
 {
     /// Create a new RequestResponseProtocol from the inner
     pub fn new(
@@ -88,6 +93,8 @@ impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerP
 
 impl<I: NodeImplementation<SeqTypes>, N: ConnectedNetwork<PubKey>, P: SequencerPersistence>
     RequestResponseProtocol<I, N, P>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
 {
     pub async fn request_indefinitely<F, Fut, O>(
         &self,

--- a/crates/espresso/node/src/request_response/recipient_source.rs
+++ b/crates/espresso/node/src/request_response/recipient_source.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use espresso_types::{PubKey, SeqTypes};
 use hotshot::traits::NodeImplementation;
+use hotshot_new_protocol::storage::NewProtocolStorage;
 use hotshot_types::{data::EpochNumber, epoch_membership::EpochMembershipCoordinator};
 use request_response::recipient_source::RecipientSource as RecipientSourceTrait;
 use tracing::warn;
@@ -24,7 +25,10 @@ pub struct RecipientSource<I: NodeImplementation<SeqTypes>> {
 /// Implement the RecipientSourceTrait, which allows the request-response protocol to derive the
 /// intended recipients for a given request
 #[async_trait]
-impl<I: NodeImplementation<SeqTypes>> RecipientSourceTrait<Request, PubKey> for RecipientSource<I> {
+impl<I: NodeImplementation<SeqTypes>> RecipientSourceTrait<Request, PubKey> for RecipientSource<I>
+where
+    I::Storage: NewProtocolStorage<SeqTypes>,
+{
     async fn get_expected_responders(&self, _request: &Request) -> Result<Vec<PubKey>> {
         // Get the current epoch number
         let epoch_number = self

--- a/crates/espresso/node/src/state_signature.rs
+++ b/crates/espresso/node/src/state_signature.rs
@@ -97,6 +97,7 @@ impl<ApiVer: StaticVersionType> StateSigner<ApiVer> {
         consensus_handle: &ConsensusHandle<SeqTypes, I>,
     ) where
         I: hotshot::traits::NodeImplementation<SeqTypes>,
+        I::Storage: hotshot_new_protocol::storage::NewProtocolStorage<SeqTypes>,
     {
         let leaf: &Leaf2<SeqTypes> = match event {
             CoordinatorEvent::LegacyEvent(Event {

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -495,12 +495,7 @@ where
                     Ok(validated) => {
                         // Refresh the network's peer set when a proposal is validated.
                         let epoch = validated.message.proposal.data.epoch;
-                        if let Err(err) = self
-                            .network
-                            .apply_epoch(epoch, &self.membership_coordinator)
-                        {
-                            error!(%epoch, %err, "network apply_epoch failed");
-                        }
+                        self.bump_network_epoch(epoch);
 
                         let view = validated.message.proposal.data.view_number();
                         let VidCommitment::V2(commit) =
@@ -969,6 +964,20 @@ where
 
     pub fn client_api(&self) -> &ClientApi<T> {
         self.client.handle()
+    }
+
+    /// Refresh the network's peer window for `epoch`.
+    ///
+    /// The coordinator does this itself whenever a proposal validates, but
+    /// before its event loop is started callers can trigger this explicitly
+    /// to keep the network up to date.
+    pub fn bump_network_epoch(&mut self, epoch: EpochNumber) {
+        if let Err(err) = self
+            .network
+            .apply_epoch(epoch, &self.membership_coordinator)
+        {
+            error!(%epoch, %err, "network apply_epoch failed");
+        }
     }
 
     pub(crate) fn on_network_message(


### PR DESCRIPTION
Keep Cliquenet peer configuration up to date before the coordinator is started.