### PR TITLE
refactor(demo): run native demo without Docker

### DIFF
--- a/.github/actions/install-native-demo-deps/action.yml
+++ b/.github/actions/install-native-demo-deps/action.yml
@@ -1,0 +1,18 @@
+name: Install native demo deps
+description: Install anvil (foundry), redis-server, and the postgres server for the native demo
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/install-foundry
+    - shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y redis-server postgresql
+        # apt starts these on install; stop them so process-compose can bind the
+        # demo's own redis (6379) and postgres (5432/5433) ports.
+        sudo systemctl stop redis-server postgresql || true
+        # Debian keeps the postgres server binaries (initdb, postgres) off PATH;
+        # only the client wrappers (psql, pg_isready, createdb) are symlinked.
+        echo "$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)" >> "$GITHUB_PATH"

--- a/.github/actions/install-native-demo-deps/action.yml
+++ b/.github/actions/install-native-demo-deps/action.yml
@@ -1,5 +1,5 @@
 name: Install native demo deps
-description: Install anvil (foundry), redis-server, and the postgres server for the native demo
+description: Install anvil (foundry), KeyDB, and the postgres server for the native demo
 
 runs:
   using: composite
@@ -9,10 +9,22 @@ runs:
       run: |
         set -euo pipefail
         sudo apt-get update
-        sudo apt-get install -y redis-server postgresql
-        # apt starts these on install; stop them so process-compose can bind the
-        # demo's own redis (6379) and postgres (5432/5433) ports.
-        sudo systemctl stop redis-server postgresql || true
+        sudo apt-get install -y postgresql
+        # apt starts postgres on install; stop it so process-compose can bind the
+        # demo's own postgres ports (5432/5433).
+        sudo systemctl stop postgresql || true
         # Debian keeps the postgres server binaries (initdb, postgres) off PATH;
         # only the client wrappers (psql, pg_isready, createdb) are symlinked.
         echo "$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)" >> "$GITHUB_PATH"
+
+        # KeyDB: the CDN's broker heartbeat uses KeyDB's EXPIREMEMBER command, which
+        # plain redis/valkey do not implement. There is no KeyDB apt repo for the
+        # runner's ubuntu, so extract the prebuilt keydb-server and supply its runtime
+        # libs (t64 packages provide the same SONAMEs on newer ubuntu; fall back to the
+        # pre-t64 names for older runners).
+        sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4t64 libssl3t64 \
+          || sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4 libssl3
+        curl -fsSL "https://download.keydb.dev/pkg/open_source/deb/ubuntu22.04_jammy/amd64/keydb-latest/keydb-tools_6.3.4-1~jammy1_amd64.deb" -o /tmp/keydb-tools.deb
+        dpkg-deb -x /tmp/keydb-tools.deb /tmp/keydb
+        echo "/tmp/keydb/usr/bin" >> "$GITHUB_PATH"
+        /tmp/keydb/usr/bin/keydb-server --version

--- a/.github/actions/install-native-demo-deps/action.yml
+++ b/.github/actions/install-native-demo-deps/action.yml
@@ -19,11 +19,9 @@ runs:
 
         # KeyDB: the CDN's broker heartbeat uses KeyDB's EXPIREMEMBER command, which
         # plain redis/valkey do not implement. There is no KeyDB apt repo for the
-        # runner's ubuntu, so extract the prebuilt keydb-server and supply its runtime
-        # libs (t64 packages provide the same SONAMEs on newer ubuntu; fall back to the
-        # pre-t64 names for older runners).
-        sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4t64 libssl3t64 \
-          || sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4 libssl3
+        # runner's ubuntu (24.04), so extract the prebuilt keydb-server and supply its
+        # runtime libs (the t64 packages provide the SONAMEs the jammy binary needs).
+        sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4t64 libssl3t64
         curl -fsSL "https://download.keydb.dev/pkg/open_source/deb/ubuntu22.04_jammy/amd64/keydb-latest/keydb-tools_6.3.4-1~jammy1_amd64.deb" -o /tmp/keydb-tools.deb
         dpkg-deb -x /tmp/keydb-tools.deb /tmp/keydb
         echo "/tmp/keydb/usr/bin" >> "$GITHUB_PATH"

--- a/.github/actions/install-native-demo-deps/action.yml
+++ b/.github/actions/install-native-demo-deps/action.yml
@@ -10,17 +10,12 @@ runs:
         set -euo pipefail
         sudo apt-get update
         sudo apt-get install -y postgresql
-        # apt starts postgres on install; stop it so process-compose can bind the
-        # demo's own postgres ports (5432/5433).
+        # stop the auto-started cluster so the demo can bind 5432/5433
         sudo systemctl stop postgresql || true
-        # Debian keeps the postgres server binaries (initdb, postgres) off PATH;
-        # only the client wrappers (psql, pg_isready, createdb) are symlinked.
+        # postgres server binaries (initdb, postgres) are not on PATH on Debian
         echo "$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)" >> "$GITHUB_PATH"
 
-        # KeyDB: the CDN's broker heartbeat uses KeyDB's EXPIREMEMBER command, which
-        # plain redis/valkey do not implement. There is no KeyDB apt repo for the
-        # runner's ubuntu (24.04), so extract the prebuilt keydb-server and supply its
-        # runtime libs (the t64 packages provide the SONAMEs the jammy binary needs).
+        # keydb: extract the prebuilt server (no apt repo for 24.04) + its runtime libs
         sudo apt-get install -y libsnappy1v5 libzstd1 libuuid1 libcurl4t64 libssl3t64
         curl -fsSL "https://download.keydb.dev/pkg/open_source/deb/ubuntu22.04_jammy/amd64/keydb-latest/keydb-tools_6.3.4-1~jammy1_amd64.deb" -o /tmp/keydb-tools.deb
         dpkg-deb -x /tmp/keydb-tools.deb /tmp/keydb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,6 +373,7 @@ jobs:
       - uses: ./.github/actions/install-process-compose
         with:
           version: v1.75.2
+      - uses: ./.github/actions/install-native-demo-deps
 
       - name: Download archive
         uses: actions/download-artifact@v8
@@ -433,6 +434,7 @@ jobs:
       - uses: ./.github/actions/install-process-compose
         with:
           version: v1.75.2
+      - uses: ./.github/actions/install-native-demo-deps
       - uses: ./.github/actions/free-disk-space
 
         # TODO: this downloads all (available) artifacts, which is a bit wasteful but artifact

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
         })
       ];
       pkgs = import nixpkgs { inherit system overlays; };
+      keydb = pkgs.callPackage ./nix/keydb.nix { };
       myShell = pkgs.mkShellNoCC.override (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
         # The mold linker is around 50% faster on Linux than the default linker.
         stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv;
@@ -199,6 +200,8 @@
           };
         };
       };
+      packages.keydb = keydb;
+
       devShells.default =
         let
           stableToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
@@ -237,7 +240,7 @@
             pup
             process-compose
             lazydocker # a docker compose TUI
-            redis # keydb
+            keydb # CDN discovery store for the native demo (prebuilt; see nix/keydb.nix)
             postgresql_18
 
             # Figures

--- a/flake.nix
+++ b/flake.nix
@@ -240,7 +240,7 @@
             pup
             process-compose
             lazydocker # a docker compose TUI
-            keydb # CDN discovery store for the native demo (prebuilt; see nix/keydb.nix)
+            keydb
             postgresql_18
 
             # Figures

--- a/flake.nix
+++ b/flake.nix
@@ -237,9 +237,8 @@
             pup
             process-compose
             lazydocker # a docker compose TUI
-            # `postgresql` defaults to an older version (15), so we select the latest version (16)
-            # explicitly.
-            postgresql_16
+            redis # keydb
+            postgresql_18
 
             # Figures
             graphviz

--- a/nix/keydb.nix
+++ b/nix/keydb.nix
@@ -1,0 +1,104 @@
+# KeyDB is not packaged in nixpkgs and has no clean macOS build, so the native
+# demo needs it provided out-of-band. The CDN (marshal/broker) uses KeyDB's
+# EXPIREMEMBER command for broker heartbeats; plain redis/valkey do not implement
+# it, so a real KeyDB is required.
+#
+# Rather than build from source (KeyDB vendors jemalloc/lua and its macOS build
+# is fragile) this repackages prebuilt binaries:
+#   - Linux: the official keydb-tools .deb, relocated onto nixpkgs libs via
+#     autoPatchelfHook (the binary is a dynamically-linked PIE).
+#   - macOS (aarch64): the Homebrew bottle, whose keydb-server only links
+#     openssl@3 outside the system libs; repoint it at nixpkgs openssl and
+#     re-sign (install_name_tool invalidates the ad-hoc signature).
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, openssl
+, snappy
+, zstd
+, curl
+, util-linux
+, darwin
+}:
+
+let
+  version = "6.3.4";
+  debBase = "https://download.keydb.dev/pkg/open_source/deb/ubuntu22.04_jammy";
+
+  # Linux: official keydb-tools debs (contain keydb-server).
+  linuxSrcs = {
+    x86_64-linux = fetchurl {
+      url = "${debBase}/amd64/keydb-latest/keydb-tools_${version}-1~jammy1_amd64.deb";
+      sha256 = "8653a2631858d6e58106e8607de61d4031b2d0c7bba0a8040859df65ea98724b";
+    };
+    aarch64-linux = fetchurl {
+      url = "${debBase}/arm64/keydb-latest/keydb-tools_${version}-1~jammy1_arm64.deb";
+      sha256 = "5496d9d116cf2449b7be1b12da866f6d882ccb531ace45c8a3d679fcd0ae98af";
+    };
+  };
+
+  # macOS aarch64: Homebrew bottle (oldest arm64 build for broad OS compat).
+  # The sha256 is the ghcr blob digest, which is also the file content hash.
+  darwinBottleSha = "eefed6df2c14cfbab28ac8ce65f888d011bed8a1edec7095b891ba2b418ea733";
+  darwinSrc = fetchurl {
+    url = "https://ghcr.io/v2/homebrew/core/keydb/blobs/sha256:${darwinBottleSha}";
+    sha256 = darwinBottleSha;
+    curlOptsList = [ "-H" "Authorization: Bearer QQ==" ];
+    name = "keydb-bottle-${version}.tar.gz";
+  };
+
+  src =
+    if stdenv.isDarwin then darwinSrc
+    else linuxSrcs.${stdenv.hostPlatform.system}
+      or (throw "keydb.nix: unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "keydb";
+  inherit version src;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.isLinux [ autoPatchelfHook dpkg ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+
+  buildInputs =
+    lib.optionals stdenv.isLinux [
+      (lib.getLib stdenv.cc.cc)
+      openssl
+      snappy
+      zstd
+      curl
+      (lib.getLib util-linux)
+    ]
+    ++ lib.optionals stdenv.isDarwin [ openssl ];
+
+  unpackPhase =
+    if stdenv.isLinux
+    then "dpkg-deb -x $src ."
+    else "tar xzf $src";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+  '' + (if stdenv.isLinux then ''
+    cp usr/bin/keydb-server $out/bin/
+  '' else ''
+    cp keydb/${version}/bin/keydb-server $out/bin/
+    install_name_tool \
+      -change @@HOMEBREW_PREFIX@@/opt/openssl@3/lib/libcrypto.3.dylib ${lib.getLib openssl}/lib/libcrypto.3.dylib \
+      -change @@HOMEBREW_PREFIX@@/opt/openssl@3/lib/libssl.3.dylib ${lib.getLib openssl}/lib/libssl.3.dylib \
+      $out/bin/keydb-server
+  '') + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "KeyDB (Redis fork) server, prebuilt, for the native demo CDN discovery store";
+    homepage = "https://keydb.dev";
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    mainProgram = "keydb-server";
+  };
+}

--- a/nix/keydb.nix
+++ b/nix/keydb.nix
@@ -18,6 +18,10 @@
 , openssl
 , snappy
 , zstd
+, bzip2
+, lz4
+, zlib
+, systemd
 , curl
 , util-linux
 , darwin
@@ -63,14 +67,22 @@ stdenv.mkDerivation {
     ++ lib.optionals stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
   buildInputs =
+    # keydb-server DT_NEEDED on Linux: libcrypto/libssl (openssl), libbz2 (bzip2),
+    # libzstd, liblz4, libsnappy, libz (zlib), libuuid (util-linux), libcurl,
+    # libsystemd, libstdc++/libgcc_s (cc), libm/libc (glibc, provided by stdenv).
     lib.optionals stdenv.isLinux [
       (lib.getLib stdenv.cc.cc)
       openssl
       snappy
       zstd
+      bzip2
+      lz4
+      zlib
+      (lib.getLib systemd)
       curl
       (lib.getLib util-linux)
     ]
+    # macOS bottle only links openssl@3 outside system libs (libz is /usr/lib).
     ++ lib.optionals stdenv.isDarwin [ openssl ];
 
   unpackPhase =

--- a/nix/keydb.nix
+++ b/nix/keydb.nix
@@ -1,15 +1,4 @@
-# KeyDB is not packaged in nixpkgs and has no clean macOS build, so the native
-# demo needs it provided out-of-band. The CDN (marshal/broker) uses KeyDB's
-# EXPIREMEMBER command for broker heartbeats; plain redis/valkey do not implement
-# it, so a real KeyDB is required.
-#
-# Rather than build from source (KeyDB vendors jemalloc/lua and its macOS build
-# is fragile) this repackages prebuilt binaries:
-#   - Linux: the official keydb-tools .deb, relocated onto nixpkgs libs via
-#     autoPatchelfHook (the binary is a dynamically-linked PIE).
-#   - macOS (aarch64): the Homebrew bottle, whose keydb-server only links
-#     openssl@3 outside the system libs; repoint it at nixpkgs openssl and
-#     re-sign (install_name_tool invalidates the ad-hoc signature).
+# Prebuilt KeyDB (not in nixpkgs): Linux keydb-tools .deb, macOS Homebrew bottle.
 { lib
 , stdenv
 , fetchurl
@@ -31,7 +20,6 @@ let
   version = "6.3.4";
   debBase = "https://download.keydb.dev/pkg/open_source/deb/ubuntu22.04_jammy";
 
-  # Linux: official keydb-tools debs (contain keydb-server).
   linuxSrcs = {
     x86_64-linux = fetchurl {
       url = "${debBase}/amd64/keydb-latest/keydb-tools_${version}-1~jammy1_amd64.deb";
@@ -43,8 +31,7 @@ let
     };
   };
 
-  # macOS aarch64: Homebrew bottle (oldest arm64 build for broad OS compat).
-  # The sha256 is the ghcr blob digest, which is also the file content hash.
+  # sha256 == ghcr blob digest.
   darwinBottleSha = "eefed6df2c14cfbab28ac8ce65f888d011bed8a1edec7095b891ba2b418ea733";
   darwinSrc = fetchurl {
     url = "https://ghcr.io/v2/homebrew/core/keydb/blobs/sha256:${darwinBottleSha}";
@@ -67,9 +54,6 @@ stdenv.mkDerivation {
     ++ lib.optionals stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
   buildInputs =
-    # keydb-server DT_NEEDED on Linux: libcrypto/libssl (openssl), libbz2 (bzip2),
-    # libzstd, liblz4, libsnappy, libz (zlib), libuuid (util-linux), libcurl,
-    # libsystemd, libstdc++/libgcc_s (cc), libm/libc (glibc, provided by stdenv).
     lib.optionals stdenv.isLinux [
       (lib.getLib stdenv.cc.cc)
       openssl
@@ -82,7 +66,6 @@ stdenv.mkDerivation {
       curl
       (lib.getLib util-linux)
     ]
-    # macOS bottle only links openssl@3 outside system libs (libz is /usr/lib).
     ++ lib.optionals stdenv.isDarwin [ openssl ];
 
   unpackPhase =
@@ -108,7 +91,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "KeyDB (Redis fork) server, prebuilt, for the native demo CDN discovery store";
+    description = "KeyDB server, prebuilt, for the native demo CDN discovery store";
     homepage = "https://keydb.dev";
     platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     mainProgram = "keydb-server";

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
-# When adding/removing native processes (non-docker commands), update the NATIVE_PROCESSES
-# array in scripts/cleanup-process-compose to ensure proper cleanup on test failures.
+# When adding/removing processes, update the NATIVE_PROCESSES array in
+# scripts/cleanup-process-compose to ensure proper cleanup on test failures.
 
 x-availability:
   # terminate process compose if process exits
@@ -21,13 +21,12 @@ environment:
   - ESPRESSO_L1_PROVIDER=http://localhost:${ESPRESSO_L1_PORT}
   - ESPRESSO_NODE_GENESIS_FILE=${ESPRESSO_NODE_GENESIS_FILE:-data/genesis/demo.toml}
   - ESPRESSO_STATE_RELAY_SERVER_URL=http://localhost:${ESPRESSO_STATE_RELAY_SERVER_PORT}
-  - QUERY_SERVICE_URI=http://localhost:${ESPRESSO_NODE_1_API_PORT}/v0/
-  - NODE_VALIDATOR_URI=ws://localhost:${ESPRESSO_NODE_VALIDATOR_PORT}/v0/
 processes:
-  # Cheating a bit here but since we don't usually have to debug go-ethereum
-  # it's using the docker compose service which is a bit easier.
   demo-l1-network:
-    command: docker compose up demo-l1-network --force-recreate --renew-anon-volumes
+    command: >-
+      anvil --host 0.0.0.0 --port ${ESPRESSO_L1_PORT} --chain-id 31337
+      --accounts 20 --balance 1000000000 --block-time 1
+      --slots-in-an-epoch 32
     readiness_probe:
       exec:
         command: >-
@@ -203,16 +202,6 @@ processes:
         path: /healthcheck
     availability: *run-forever
 
-  telemetry-collector:
-    command: docker compose up vector --force-recreate --renew-anon-volumes
-    log_location: logs/vector.log
-    # Telemetry is not load-bearing: a failure (e.g. Docker Hub pull timeout in CI)
-    # must not tear down the whole demo like *run-forever would.
-    availability:
-      restart: on_failure
-      backoff_seconds: 5
-      max_restarts: 5
-
   prover-one-shot:
     # "nice" this compute heavy process to reduce load
     command: nice state-prover
@@ -304,7 +293,7 @@ processes:
     command: espresso-node -- storage-sql -- http -- config -- query -- submit -- explorer -- catchup
     environment:
       - ESPRESSO_NODE_TELEMETRY_METRICS_ENABLE=true
-      - ESPRESSO_NODE_TELEMETRY_ENDPOINT=http://localhost:${ESPRESSO_DEMO_TELEMETRY_PRW_PORT}
+      - ESPRESSO_NODE_TELEMETRY_ENDPOINT=http://intentionally-unreachable-telemetry-endpoint
       - ESPRESSO_NODE_API_PORT=${ESPRESSO_NODE_1_API_PORT}
       - ESPRESSO_NODE_AXUM_PORT=${ESPRESSO_NODE_1_AXUM_PORT}
       - ESPRESSO_NODE_TONIC_PORT=${ESPRESSO_NODE_1_TONIC_PORT}
@@ -334,7 +323,8 @@ processes:
       - ESPRESSO_NODE_IDENTITY_LATITUDE=39.0742
       - ESPRESSO_NODE_IDENTITY_LONGITUDE=21.8243
       - ESPRESSO_NODE_PUBLIC_API_URL=http://localhost:${ESPRESSO_NODE_1_API_PORT}/
-      - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_WS_PORT}
+      # Anvil serves WS on the same port as HTTP (no separate ESPRESSO_L1_WS_PORT).
+      - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_PORT}
     depends_on:
       orchestrator:
         condition: process_healthy
@@ -423,7 +413,7 @@ processes:
     command: espresso-node -- http -- config -- query -- storage-fs
     environment:
       - ESPRESSO_NODE_TELEMETRY_LOGS_ENABLE=true
-      - ESPRESSO_NODE_TELEMETRY_ENDPOINT=http://localhost:${ESPRESSO_DEMO_TELEMETRY_OTLP_PORT}
+      - ESPRESSO_NODE_TELEMETRY_ENDPOINT=http://intentionally-unreachable-telemetry-endpoint
       - ESPRESSO_NODE_TELEMETRY_LOG=info
       - ESPRESSO_NODE_API_PORT=${ESPRESSO_NODE_3_API_PORT}
       - ESPRESSO_NODE_AXUM_PORT=${ESPRESSO_NODE_3_AXUM_PORT}
@@ -449,7 +439,8 @@ processes:
       - ESPRESSO_NODE_IDENTITY_LATITUDE=35.8617
       - ESPRESSO_NODE_IDENTITY_LONGITUDE=104.1954
       - ESPRESSO_NODE_PUBLIC_API_URL=http://localhost:${ESPRESSO_NODE_3_API_PORT}/
-      - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_WS_PORT}
+      # Anvil serves WS on the same port as HTTP (no separate ESPRESSO_L1_WS_PORT).
+      - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_PORT}
     depends_on:
       orchestrator:
         condition: process_healthy
@@ -564,13 +555,9 @@ processes:
       failure_threshold: 100
     availability: *run-forever
 
-  # We use KeyDB (a Redis variant) to maintain consistency between
-  # different parts of the CDN
-  # Cheating a bit here too, but KeyDB is not available as a Nix package.
-  # Could do local (SQLite) discovery, but removes some of the spirit
-  # from the local demo.
+  # Redis backs CDN discovery (shared state between marshal and brokers).
   keydb:
-    command: docker run --rm -p 0.0.0.0:6379:6379 eqalpha/keydb --requirepass changeme!
+    command: redis-server --port 6379 --requirepass 'changeme!'
     readiness_probe:
       exec:
         command: nc -zv localhost 6379
@@ -719,48 +706,27 @@ processes:
     availability: *run-forever
 
   espresso-node-db-0:
-    command:
-      docker run -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p ${ESPRESSO_NODE_0_DB_PORT}:5432 postgres
-    environment:
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_USER=root
-      - POSTGRES_DB=espresso
+    command: scripts/run-postgres ${ESPRESSO_NODE_0_DB_PORT} ${ESPRESSO_BASE_STORAGE_PATH}/pg0
     readiness_probe:
       exec:
-        command: pg_isready -h localhost -p ${ESPRESSO_NODE_0_DB_PORT}
+        # Gate on the espresso DB: the server accepts connections before run-postgres runs
+        # createdb, so a plain pg_isready would report ready too early.
+        command: psql -h localhost -p ${ESPRESSO_NODE_0_DB_PORT} -U root -d espresso -c 'SELECT 1'
       initial_delay_seconds: 5
       period_seconds: 5
       timeout_seconds: 4
-      # Postgres can be falsely "ready" once before running init scripts.
-      # See https://github.com/docker-library/postgres/issues/146 for discussion.
-      success_threshold: 2
       failure_threshold: 20
     availability: *run-forever
 
   espresso-node-db-1:
-    command:
-      docker run -e POSTGRES_PASSWORD -e POSTGRES_USER -e POSTGRES_DB -p ${ESPRESSO_NODE_1_DB_PORT}:5432 postgres
-    environment:
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_USER=root
-      - POSTGRES_DB=espresso
+    command: scripts/run-postgres ${ESPRESSO_NODE_1_DB_PORT} ${ESPRESSO_BASE_STORAGE_PATH}/pg1
     readiness_probe:
       exec:
-        command: pg_isready -h localhost -p ${ESPRESSO_NODE_1_DB_PORT}
+        # Gate on the espresso DB: the server accepts connections before run-postgres runs
+        # createdb, so a plain pg_isready would report ready too early.
+        command: psql -h localhost -p ${ESPRESSO_NODE_1_DB_PORT} -U root -d espresso -c 'SELECT 1'
       initial_delay_seconds: 5
       period_seconds: 5
       timeout_seconds: 4
-      # Postgres can be falsely "ready" once before running init scripts.
-      # See https://github.com/docker-library/postgres/issues/146 for discussion.
-      success_threshold: 2
       failure_threshold: 20
-    availability: *run-forever
-
-  block-explorer:
-    command:
-      docker run --rm -p ${ESPRESSO_BLOCK_EXPLORER_PORT}:3000 -e QUERY_SERVICE_URI -e NODE_VALIDATOR_URI
-      ghcr.io/espressosystems/espresso-block-explorer:main
-    depends_on:
-      espresso-node-1:
-        condition: process_healthy
     availability: *run-forever

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -555,9 +555,10 @@ processes:
       failure_threshold: 100
     availability: *run-forever
 
-  # Redis backs CDN discovery (shared state between marshal and brokers).
+  # KeyDB backs CDN discovery (shared state between marshal and brokers). The CDN
+  # requires KeyDB's EXPIREMEMBER command for broker heartbeats; plain redis lacks it.
   keydb:
-    command: redis-server --bind 127.0.0.1 --port 6379 --requirepass 'changeme!'
+    command: keydb-server --bind 127.0.0.1 --port 6379 --requirepass 'changeme!'
     readiness_probe:
       exec:
         command: nc -zv localhost 6379

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -24,7 +24,7 @@ environment:
 processes:
   demo-l1-network:
     command: >-
-      anvil --host 0.0.0.0 --port ${ESPRESSO_L1_PORT} --chain-id 31337
+      anvil --host 127.0.0.1 --port ${ESPRESSO_L1_PORT} --chain-id 31337
       --accounts 20 --balance 1000000000 --block-time 1
       --slots-in-an-epoch 32
     readiness_probe:
@@ -557,7 +557,7 @@ processes:
 
   # Redis backs CDN discovery (shared state between marshal and brokers).
   keydb:
-    command: redis-server --port 6379 --requirepass 'changeme!'
+    command: redis-server --bind 127.0.0.1 --port 6379 --requirepass 'changeme!'
     readiness_probe:
       exec:
         command: nc -zv localhost 6379

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -323,7 +323,6 @@ processes:
       - ESPRESSO_NODE_IDENTITY_LATITUDE=39.0742
       - ESPRESSO_NODE_IDENTITY_LONGITUDE=21.8243
       - ESPRESSO_NODE_PUBLIC_API_URL=http://localhost:${ESPRESSO_NODE_1_API_PORT}/
-      # Anvil serves WS on the same port as HTTP (no separate ESPRESSO_L1_WS_PORT).
       - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_PORT}
     depends_on:
       orchestrator:
@@ -439,7 +438,6 @@ processes:
       - ESPRESSO_NODE_IDENTITY_LATITUDE=35.8617
       - ESPRESSO_NODE_IDENTITY_LONGITUDE=104.1954
       - ESPRESSO_NODE_PUBLIC_API_URL=http://localhost:${ESPRESSO_NODE_3_API_PORT}/
-      # Anvil serves WS on the same port as HTTP (no separate ESPRESSO_L1_WS_PORT).
       - ESPRESSO_L1_WS_PROVIDER=ws://localhost:${ESPRESSO_L1_PORT}
     depends_on:
       orchestrator:
@@ -555,8 +553,6 @@ processes:
       failure_threshold: 100
     availability: *run-forever
 
-  # KeyDB backs CDN discovery (shared state between marshal and brokers). The CDN
-  # requires KeyDB's EXPIREMEMBER command for broker heartbeats; plain redis lacks it.
   keydb:
     command: keydb-server --bind 127.0.0.1 --port 6379 --requirepass 'changeme!'
     readiness_probe:
@@ -710,8 +706,7 @@ processes:
     command: scripts/run-postgres ${ESPRESSO_NODE_0_DB_PORT} ${ESPRESSO_BASE_STORAGE_PATH}/pg0
     readiness_probe:
       exec:
-        # Gate on the espresso DB: the server accepts connections before run-postgres runs
-        # createdb, so a plain pg_isready would report ready too early.
+        # gate on the espresso db, not just the server accepting connections
         command: psql -h localhost -p ${ESPRESSO_NODE_0_DB_PORT} -U root -d espresso -c 'SELECT 1'
       initial_delay_seconds: 5
       period_seconds: 5
@@ -723,8 +718,7 @@ processes:
     command: scripts/run-postgres ${ESPRESSO_NODE_1_DB_PORT} ${ESPRESSO_BASE_STORAGE_PATH}/pg1
     readiness_probe:
       exec:
-        # Gate on the espresso DB: the server accepts connections before run-postgres runs
-        # createdb, so a plain pg_isready would report ready too early.
+        # gate on the espresso db, not just the server accepting connections
         command: psql -h localhost -p ${ESPRESSO_NODE_1_DB_PORT} -U root -d espresso -c 'SELECT 1'
       initial_delay_seconds: 5
       period_seconds: 5

--- a/scripts/cleanup-process-compose
+++ b/scripts/cleanup-process-compose
@@ -57,7 +57,7 @@ NATIVE_PROCESSES=(
 	staking-cli
 	anvil
 	postgres
-	redis-server
+	keydb-server
 )
 
 # Helper function to safely kill processes only if they're running from this project

--- a/scripts/cleanup-process-compose
+++ b/scripts/cleanup-process-compose
@@ -2,12 +2,11 @@
 #
 # Cleanup script for espresso-network demo
 #
-# This script safely terminates all processes and containers started by the native demo.
+# This script safely terminates all processes started by the native demo.
 # It's called automatically by scripts/demo-native when the demo exits (via trap).
 #
 # Key features:
 # - Only kills processes running from this project directory (checks /proc/$pid/cwd)
-# - Cleans up Docker containers and networks
 # - Safe to run multiple times
 #
 set -e
@@ -56,6 +55,9 @@ NATIVE_PROCESSES=(
 	state-prover
 	espresso-bridge
 	staking-cli
+	anvil
+	postgres
+	redis-server
 )
 
 # Helper function to safely kill processes only if they're running from this project
@@ -86,11 +88,7 @@ kill_project_processes "process-compose" TERM
 sleep 2
 kill_project_processes "process-compose" KILL
 
-# 2. Stop all docker containers via docker compose
-echo "Stopping docker services..."
-docker compose down --remove-orphans --volumes 2>/dev/null || echo "docker-compose not running or already stopped"
-
-# 3. Kill lingering native processes (only if running from this project directory)
+# 2. Kill lingering native processes (only if running from this project directory)
 echo "Killing native processes from $PROJECT_DIR..."
 for proc in "${NATIVE_PROCESSES[@]}"; do
 	kill_project_processes "$proc" TERM

--- a/scripts/run-postgres
+++ b/scripts/run-postgres
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-#
-# Start a single native PostgreSQL instance for the process-compose demo.
-#
-# The caller provides a port and a data directory; this script initializes
-# the cluster, starts postgres bound to 127.0.0.1, creates the "espresso"
-# database, and then blocks in the foreground so process-compose can manage
-# it as one long-lived service. SIGTERM/SIGINT are forwarded to postgres so
-# process-compose can stop it cleanly. initdb creates the data directory
-# itself (the parent must exist); nothing is removed here.
-#
+# Native postgres for the demo: initdb, create the espresso db, run in foreground.
 set -euo pipefail
 
 readonly SCRIPT_NAME="${0##*/}"
@@ -55,11 +46,8 @@ main() {
   postgres -D "${datadir}" -p "${port}" -k "${datadir}" -h 127.0.0.1 &
   pg_pid=$!
 
-  # SIGINT triggers postgres "fast shutdown" (rolls back and disconnects clients
-  # immediately). SIGTERM would be a "smart shutdown" that blocks until every client
-  # disconnects, hanging until process-compose force-kills on teardown. The flag lets
-  # the readiness loop bail out if a signal lands before postgres is ready (otherwise
-  # pg_isready never succeeds against a shutting-down server and the loop spins).
+  # SIGINT = fast shutdown (SIGTERM waits for clients). Flag lets the readiness
+  # loop exit if signalled before postgres is ready.
   local shutting_down=0
   trap 'shutting_down=1; kill -INT "${pg_pid}" 2>/dev/null' TERM INT
 
@@ -72,8 +60,7 @@ main() {
     createdb -h 127.0.0.1 -p "${port}" -U root espresso
   fi
 
-  # Double wait: the first returns as soon as the trap fires; the second blocks until
-  # postgres has actually exited so it is never left orphaned (see scripts/demo-native).
+  # first wait returns on trap; second blocks until postgres actually exits.
   wait "${pg_pid}" || true
   wait "${pg_pid}" 2>/dev/null || true
 }

--- a/scripts/run-postgres
+++ b/scripts/run-postgres
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Start a single native PostgreSQL instance for the process-compose demo.
+#
+# The caller provides a port and a data directory; this script initializes
+# the cluster, starts postgres bound to 127.0.0.1, creates the "espresso"
+# database, and then blocks in the foreground so process-compose can manage
+# it as one long-lived service. SIGTERM/SIGINT are forwarded to postgres so
+# process-compose can stop it cleanly. The data directory is expected to
+# live under a caller-managed temp path; it is not created or removed here.
+#
+set -euo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} PORT DATADIR
+
+Start a native postgres instance bound to 127.0.0.1:PORT, storing data
+and the unix socket under DATADIR, with a "root" superuser (trust auth)
+and an "espresso" database.
+
+ARGUMENTS:
+  PORT      TCP port for postgres to listen on
+  DATADIR   Existing empty data directory to initialize and use
+
+OPTIONS:
+  -h, --help   Show this help
+EOF
+}
+
+err() {
+  echo "[${SCRIPT_NAME}] $*" >&2
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  if [[ $# -ne 2 ]]; then
+    err "Expected 2 arguments, got $#"
+    usage >&2
+    exit 1
+  fi
+
+  local port="$1"
+  local datadir="$2"
+  local pg_pid
+
+  initdb -D "${datadir}" -U root --auth=trust >/dev/null
+
+  postgres -D "${datadir}" -p "${port}" -k "${datadir}" -h 127.0.0.1 &
+  pg_pid=$!
+
+  # SIGINT triggers postgres "fast shutdown" (rolls back and disconnects clients
+  # immediately). SIGTERM would be a "smart shutdown" that blocks until every client
+  # disconnects, hanging until process-compose force-kills on teardown.
+  trap 'kill -INT "${pg_pid}" 2>/dev/null' TERM INT
+
+  until pg_isready -h 127.0.0.1 -p "${port}" >/dev/null 2>&1; do
+    sleep 0.5
+  done
+
+  createdb -h 127.0.0.1 -p "${port}" -U root espresso
+
+  # Double wait: the first returns as soon as the trap fires; the second blocks until
+  # postgres has actually exited so it is never left orphaned (see scripts/demo-native).
+  wait "${pg_pid}" || true
+  wait "${pg_pid}" 2>/dev/null || true
+}
+
+main "$@"

--- a/scripts/run-postgres
+++ b/scripts/run-postgres
@@ -6,8 +6,8 @@
 # the cluster, starts postgres bound to 127.0.0.1, creates the "espresso"
 # database, and then blocks in the foreground so process-compose can manage
 # it as one long-lived service. SIGTERM/SIGINT are forwarded to postgres so
-# process-compose can stop it cleanly. The data directory is expected to
-# live under a caller-managed temp path; it is not created or removed here.
+# process-compose can stop it cleanly. initdb creates the data directory
+# itself (the parent must exist); nothing is removed here.
 #
 set -euo pipefail
 
@@ -23,7 +23,7 @@ and an "espresso" database.
 
 ARGUMENTS:
   PORT      TCP port for postgres to listen on
-  DATADIR   Existing empty data directory to initialize and use
+  DATADIR   Data directory to initialize (created if missing; must be empty if it exists)
 
 OPTIONS:
   -h, --help   Show this help
@@ -57,14 +57,20 @@ main() {
 
   # SIGINT triggers postgres "fast shutdown" (rolls back and disconnects clients
   # immediately). SIGTERM would be a "smart shutdown" that blocks until every client
-  # disconnects, hanging until process-compose force-kills on teardown.
-  trap 'kill -INT "${pg_pid}" 2>/dev/null' TERM INT
+  # disconnects, hanging until process-compose force-kills on teardown. The flag lets
+  # the readiness loop bail out if a signal lands before postgres is ready (otherwise
+  # pg_isready never succeeds against a shutting-down server and the loop spins).
+  local shutting_down=0
+  trap 'shutting_down=1; kill -INT "${pg_pid}" 2>/dev/null' TERM INT
 
   until pg_isready -h 127.0.0.1 -p "${port}" >/dev/null 2>&1; do
+    [[ "${shutting_down}" -eq 1 ]] && break
     sleep 0.5
   done
 
-  createdb -h 127.0.0.1 -p "${port}" -U root espresso
+  if [[ "${shutting_down}" -eq 0 ]]; then
+    createdb -h 127.0.0.1 -p "${port}" -U root espresso
+  fi
 
   # Double wait: the first returns as soon as the trap fires; the second blocks until
   # postgres has actually exited so it is never left orphaned (see scripts/demo-native).


### PR DESCRIPTION
Replace the five Docker-backed process-compose services with native processes so `just demo-native` needs no Docker daemon:

- demo-l1-network: custom geth-l1 image -> native anvil (from foundry)
- espresso-node-db-0/1: docker postgres -> scripts/run-postgres
- keydb: docker keydb -> native redis-server
- telemetry-collector (vector) and block-explorer: dropped

flake.nix adds redis and bumps postgresql_16 -> postgresql_18. cleanup-process-compose drops the docker compose teardown and reaps anvil/postgres/redis-server.

