### PR TITLE
fix(light-client): verify boundary 2-chain QCs against their own epoch

### DIFF
--- a/light-client/src/consensus/leaf.rs
+++ b/light-client/src/consensus/leaf.rs
@@ -31,7 +31,9 @@ pub enum FinalityProof {
     /// * `committing_qc.leaf_commit() == leaf.commit()`
     /// * `committing_qc.view_number() == leaf.view_number()`
     /// * `deciding_qc.view_number() == committing_qc.view_number() + 1`
-    /// * Both QCs have a valid threshold signature given a stake table
+    /// * Both QCs have a valid threshold signature given a stake table. When the leaf is the last
+    ///   leaf of an epoch, the deciding QC is produced in the subsequent epoch and is checked
+    ///   against the next epoch's stake table.
     HotStuff2 {
         committing_qc: Arc<Certificate>,
         deciding_qc: Arc<Certificate>,

--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -81,9 +81,6 @@ pub trait Quorum: Sync {
     ) -> impl Send + Future<Output = Result<()>>;
 
     /// Check a threshold signature on a certificate signed by the epoch after this quorum's.
-    ///
-    /// A QC chain proving the last leaf of an epoch necessarily contains certificates produced
-    /// in the subsequent epoch, signed by that epoch's quorum.
     fn verify_next_epoch(
         &self,
         cert: &Certificate,
@@ -199,13 +196,20 @@ pub trait Quorum: Sync {
                 // the subsequent epoch, signed by the next epoch's quorum. Each certificate commits
                 // to its epoch in the signed payload, so dispatching on it is sound: a certificate
                 // claiming the wrong epoch will fail signature verification.
-                let leaf_epoch = first.unwrap_or(cert).epoch();
-                let next_epoch = match (leaf_epoch, cert.epoch()) {
+                let committing = first.unwrap_or(cert);
+                let next_epoch = match (committing.epoch(), cert.epoch()) {
                     // Certificates from before the epochs upgrade are always checked against the
                     // quorum supplied for this proof.
                     (None, _) | (_, None) => false,
                     (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch => false,
-                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch + 1 => true,
+                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch + 1 => {
+                        // Only the last leaf of an epoch is justified by the next epoch's quorum,
+                        // and its committing QC is dual-signed: it carries a next-epoch QC that
+                        // `verify` has already checked against the next epoch's quorum. Requiring
+                        // that here stops the next epoch's quorum from finalizing an interior leaf
+                        // of the previous epoch, which it never co-signed.
+                        committing.next_epoch_qc().is_some()
+                    },
                     (Some(leaf_epoch), Some(cert_epoch)) => {
                         bail!(
                             "certificate from epoch {cert_epoch} cannot justify a leaf in epoch \
@@ -368,13 +372,22 @@ where
 
         if version(V::MAJOR, V::MINOR) >= EPOCH_VERSION {
             // If this certificate is part of an epoch change, also check that the next epoch's
-            // quorum has signed.
-            if let Some(next_epoch_qc) = cert.verify_next_epoch_qc(self.epoch_height)? {
-                let stake_table = self.membership.next_epoch_stake_table().await?;
-                stake_table
-                    .verify_cert::<V, _>(next_epoch_qc)
-                    .await
-                    .context("verifying next epoch QC")?;
+            // quorum has signed. Reject a next-epoch QC attached to any other certificate: it would
+            // otherwise go unverified, yet the epoch dispatch in `verify_qc_chain_and_get_version`
+            // treats a next-epoch QC on the committing certificate as proof that the next epoch
+            // co-signed the leaf.
+            match cert.verify_next_epoch_qc(self.epoch_height)? {
+                Some(next_epoch_qc) => {
+                    let stake_table = self.membership.next_epoch_stake_table().await?;
+                    stake_table
+                        .verify_cert::<V, _>(next_epoch_qc)
+                        .await
+                        .context("verifying next epoch QC")?;
+                },
+                None => ensure!(
+                    cert.next_epoch_qc().is_none(),
+                    "certificate carries a next-epoch QC but is not an epoch transition"
+                ),
             }
         }
 
@@ -404,8 +417,7 @@ where
 
         // A certificate from the epoch after the proof's epoch is never itself part of an epoch
         // transition (transition certificates belong to the epoch that is ending), so there is no
-        // second next-epoch QC to check. We could not check one anyway: that would require the
-        // stake table two epochs ahead of the proof's.
+        // second next-epoch QC to check.
         ensure!(
             cert.next_epoch_qc().is_none(),
             "unexpected next-epoch QC on a certificate from the next epoch"
@@ -600,7 +612,6 @@ mod test {
 
     const BOUNDARY_EPOCH_HEIGHT: u64 = 10;
 
-    /// Generate BLS keys and stake table entries for validators with the given seeds.
     fn boundary_quorum(seeds: impl IntoIterator<Item = u64>) -> QuorumKeys {
         seeds
             .into_iter()
@@ -620,7 +631,6 @@ mod test {
 
     type QuorumKeys = (Vec<PrivKey>, Vec<StakeTableEntry<PubKey>>);
 
-    /// Sign `msg` with every key in `keys`, aggregated over the quorum given by `entries`.
     fn boundary_signature(
         msg: &[u8],
         (keys, entries): &QuorumKeys,
@@ -679,11 +689,9 @@ mod test {
     }
 
     /// Build a 2-chain proving the last leaf of epoch 1 (block 10), where epochs 1 and 2 have
-    /// disjoint quorums. This mirrors the switch from the genesis stake table to the first
-    /// contract-sourced one on a real network.
-    ///
-    /// The deciding QC is produced in epoch 2. If `deciding_signed_by_next` it is correctly signed
-    /// by epoch 2's quorum; otherwise it is (invalidly) signed by epoch 1's quorum.
+    /// disjoint quorums. The deciding QC is produced in epoch 2. If `deciding_signed_by_next` it
+    /// is correctly signed by epoch 2's quorum; otherwise it is (invalidly) signed by epoch 1's
+    /// quorum.
     async fn epoch_boundary_fixture(
         deciding_signed_by_next: bool,
     ) -> (
@@ -695,7 +703,6 @@ mod test {
         let current = boundary_quorum(0..5);
         let next = boundary_quorum(5..10);
 
-        // Leaf 10 is the last leaf of epoch 1; leaf 11 is the first leaf of epoch 2.
         let leaves = leaf_chain(9..=11, EPOCH_VERSION).await;
 
         // Block 10 is an epoch transition block, so its QC is dual-signed by both quorums.
@@ -756,6 +763,78 @@ mod test {
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_epoch_boundary_deciding_qc_wrong_quorum() {
         let (leaves, committing_qc, deciding_qc, quorum) = epoch_boundary_fixture(false).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
+    }
+
+    /// Build a 2-chain over an interior (non-boundary) leaf of epoch 1 whose deciding QC is forged
+    /// by epoch 2's quorum, mimicking a next epoch trying to finalize a leaf the current epoch
+    /// never decided. If `disguise_as_boundary`, the committing QC also carries a next-epoch QC to
+    /// imitate a genuine epoch-transition committing QC.
+    async fn mid_epoch_forgery_fixture(
+        disguise_as_boundary: bool,
+    ) -> (
+        Vec<LeafQueryData<SeqTypes>>,
+        Certificate,
+        Certificate,
+        StakeTableQuorum<(Arc<StakeTable>, Arc<StakeTable>)>,
+    ) {
+        let current = boundary_quorum(0..5);
+        let next = boundary_quorum(5..10);
+
+        // Block 5 is in the interior of epoch 1 (epoch height 10), not an epoch boundary.
+        let leaves = leaf_chain(4..=6, EPOCH_VERSION).await;
+
+        let committing_data = QuorumData2 {
+            leaf_commit: Committable::commit(leaves[1].leaf()),
+            epoch: Some(EpochNumber::new(1)),
+            block_number: Some(5),
+        };
+        let committing_qc = Certificate::new(
+            boundary_signed_qc(committing_data, ViewNumber::new(5), &current),
+            disguise_as_boundary
+                .then(|| boundary_signed_next_epoch_qc(committing_data, ViewNumber::new(5), &next)),
+        );
+
+        let deciding_qc = Certificate::non_epoch_change(boundary_signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(leaves[2].leaf()),
+                epoch: Some(EpochNumber::new(2)),
+                block_number: Some(6),
+            },
+            ViewNumber::new(6),
+            &next,
+        ));
+
+        let quorum = StakeTableQuorum::new(
+            (
+                Arc::new(StakeTable::from(current.1)),
+                Arc::new(StakeTable::from(next.1)),
+            ),
+            BOUNDARY_EPOCH_HEIGHT,
+        );
+        (leaves, committing_qc, deciding_qc, quorum)
+    }
+
+    /// The next epoch's quorum must not be able to finalize an interior leaf of the previous epoch:
+    /// only the last leaf of an epoch is justified by the next epoch, so a deciding QC signed by
+    /// the next epoch over a non-boundary leaf must be rejected.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_mid_epoch_next_epoch_forgery_rejected() {
+        let (leaves, committing_qc, deciding_qc, quorum) = mid_epoch_forgery_fixture(false).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
+    }
+
+    /// The same forgery must be rejected even when the committing QC is dressed up with a
+    /// next-epoch QC to imitate a genuine epoch-transition committing QC.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_mid_epoch_next_epoch_forgery_with_fake_transition_rejected() {
+        let (leaves, committing_qc, deciding_qc, quorum) = mid_epoch_forgery_fixture(true).await;
         quorum
             .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
             .await

--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -80,6 +80,65 @@ pub trait Quorum: Sync {
         cert2: &Certificate2<SeqTypes>,
     ) -> impl Send + Future<Output = Result<()>>;
 
+    /// Check a threshold signature on a certificate signed by the epoch after this quorum's.
+    ///
+    /// A QC chain proving the last leaf of an epoch necessarily contains certificates produced
+    /// in the subsequent epoch, signed by that epoch's quorum.
+    fn verify_next_epoch(
+        &self,
+        cert: &Certificate,
+        version: Version,
+    ) -> impl Send + Future<Output = Result<()>> {
+        async move {
+            match (version.major, version.minor) {
+                (0, 1) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 1>>(cert)
+                        .await
+                },
+                (0, 2) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 2>>(cert)
+                        .await
+                },
+                (0, 3) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 3>>(cert)
+                        .await
+                },
+                (0, 4) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 4>>(cert)
+                        .await
+                },
+                (0, 5) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 5>>(cert)
+                        .await
+                },
+                (0, 6) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 6>>(cert)
+                        .await
+                },
+                _ => {
+                    const {
+                        assert!(MAX_SUPPORTED_VERSION.major == 0);
+                        assert!(MAX_SUPPORTED_VERSION.minor == 6);
+                    }
+                    bail!("unsupported version {version}");
+                },
+            }
+        }
+    }
+
+    /// Same as [`verify_next_epoch`](Self::verify_next_epoch), but with the version as a
+    /// type-level parameter.
+    ///
+    /// The default delegates to [`verify_static`](Self::verify_static), which is only appropriate
+    /// for quorums that do not distinguish epochs (such as test mocks). Implementations backed by
+    /// per-epoch stake tables must override this to verify against the next epoch's quorum.
+    fn verify_next_epoch_static<V: StaticVersionType + 'static>(
+        &self,
+        qc: &Certificate,
+    ) -> impl Send + Future<Output = Result<()>> {
+        self.verify_static::<V>(qc)
+    }
+
     /// Verify that QCs are signed, form a chain starting from `leaf`, with a particular protocol
     /// version.
     ///
@@ -135,8 +194,32 @@ pub trait Quorum: Sync {
                     _ => version,
                 };
 
+                // Which epoch's quorum do we expect to have signed this certificate? A chain
+                // proving the last leaf of an epoch necessarily contains certificates produced in
+                // the subsequent epoch, signed by the next epoch's quorum. Each certificate commits
+                // to its epoch in the signed payload, so dispatching on it is sound: a certificate
+                // claiming the wrong epoch will fail signature verification.
+                let leaf_epoch = first.unwrap_or(cert).epoch();
+                let next_epoch = match (leaf_epoch, cert.epoch()) {
+                    // Certificates from before the epochs upgrade are always checked against the
+                    // quorum supplied for this proof.
+                    (None, _) | (_, None) => false,
+                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch => false,
+                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch + 1 => true,
+                    (Some(leaf_epoch), Some(cert_epoch)) => {
+                        bail!(
+                            "certificate from epoch {cert_epoch} cannot justify a leaf in epoch \
+                             {leaf_epoch}"
+                        );
+                    },
+                };
+
                 // Check the signature.
-                self.verify(cert, version).await?;
+                if next_epoch {
+                    self.verify_next_epoch(cert, version).await?;
+                } else {
+                    self.verify(cert, version).await?;
+                }
 
                 // Check chaining.
                 if let Some(prev) = curr {
@@ -308,10 +391,43 @@ where
             .await
             .context("verifying cert2")
     }
+
+    async fn verify_next_epoch_static<V: StaticVersionType + 'static>(
+        &self,
+        cert: &Certificate,
+    ) -> Result<()> {
+        let stake_table = self.membership.next_epoch_stake_table().await?;
+        stake_table
+            .verify_cert::<V, _>(cert.qc())
+            .await
+            .context("verifying QC against next epoch quorum")?;
+
+        // A certificate from the epoch after the proof's epoch is never itself part of an epoch
+        // transition (transition certificates belong to the epoch that is ending), so there is no
+        // second next-epoch QC to check. We could not check one anyway: that would require the
+        // stake table two epochs ahead of the proof's.
+        ensure!(
+            cert.next_epoch_qc().is_none(),
+            "unexpected next-epoch QC on a certificate from the next epoch"
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use bitvec::vec::BitVec;
+    use committable::Commitment;
+    use espresso_types::PrivKey;
+    use hotshot_query_service_types::availability::LeafQueryData;
+    use hotshot_types::{
+        data::{EpochNumber, ViewNumber},
+        simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2},
+        simple_vote::{NextEpochQuorumData2, QuorumData2, VersionedVoteData},
+        traits::signature_key::SignatureKey,
+        vote::Certificate as _,
+    };
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -480,5 +596,169 @@ mod test {
             .await
             .unwrap();
         assert_eq!(version, leaves[0].header().version());
+    }
+
+    const BOUNDARY_EPOCH_HEIGHT: u64 = 10;
+
+    /// Generate BLS keys and stake table entries for validators with the given seeds.
+    fn boundary_quorum(seeds: impl IntoIterator<Item = u64>) -> QuorumKeys {
+        seeds
+            .into_iter()
+            .map(|i| {
+                let (stake_key, priv_key) =
+                    PubKey::generated_from_seed_indexed(Default::default(), i);
+                (
+                    priv_key,
+                    StakeTableEntry {
+                        stake_key,
+                        stake_amount: U256::from(1),
+                    },
+                )
+            })
+            .unzip()
+    }
+
+    type QuorumKeys = (Vec<PrivKey>, Vec<StakeTableEntry<PubKey>>);
+
+    /// Sign `msg` with every key in `keys`, aggregated over the quorum given by `entries`.
+    fn boundary_signature(
+        msg: &[u8],
+        (keys, entries): &QuorumKeys,
+    ) -> <PubKey as SignatureKey>::QcType {
+        let total = entries
+            .iter()
+            .fold(U256::ZERO, |acc, entry| acc + entry.stake_amount);
+        let pp = PubKey::public_parameter(entries, supermajority_threshold(total));
+        let sigs = keys
+            .iter()
+            .map(|key| PubKey::sign(key, msg).unwrap())
+            .collect::<Vec<_>>();
+        PubKey::assemble(
+            &pp,
+            &std::iter::repeat_n(true, keys.len()).collect::<BitVec>(),
+            &sigs,
+        )
+    }
+
+    fn boundary_signed_qc(
+        data: QuorumData2<SeqTypes>,
+        view: ViewNumber,
+        quorum: &QuorumKeys,
+    ) -> QuorumCertificate2<SeqTypes> {
+        let commit = VersionedVoteData::new_infallible(
+            data,
+            view,
+            &UpgradeLock::<SeqTypes>::new(Upgrade::trivial(EPOCH_VERSION)),
+        )
+        .commit();
+        let sig = boundary_signature(commit.as_ref(), quorum);
+        QuorumCertificate2::create_signed_certificate(commit, data, sig, view)
+    }
+
+    fn boundary_signed_next_epoch_qc(
+        data: QuorumData2<SeqTypes>,
+        view: ViewNumber,
+        quorum: &QuorumKeys,
+    ) -> NextEpochQuorumCertificate2<SeqTypes> {
+        let data: NextEpochQuorumData2<SeqTypes> = data.into();
+        let commit = VersionedVoteData::new_infallible(
+            data.clone(),
+            view,
+            &UpgradeLock::<SeqTypes>::new(Upgrade::trivial(EPOCH_VERSION)),
+        )
+        .commit();
+        let commit_bytes: [u8; 32] = commit.into();
+        let sig = boundary_signature(commit.as_ref(), quorum);
+        NextEpochQuorumCertificate2::new(
+            data,
+            Commitment::from_raw(commit_bytes),
+            view,
+            Some(sig),
+            Default::default(),
+        )
+    }
+
+    /// Build a 2-chain proving the last leaf of epoch 1 (block 10), where epochs 1 and 2 have
+    /// disjoint quorums. This mirrors the switch from the genesis stake table to the first
+    /// contract-sourced one on a real network.
+    ///
+    /// The deciding QC is produced in epoch 2. If `deciding_signed_by_next` it is correctly signed
+    /// by epoch 2's quorum; otherwise it is (invalidly) signed by epoch 1's quorum.
+    async fn epoch_boundary_fixture(
+        deciding_signed_by_next: bool,
+    ) -> (
+        Vec<LeafQueryData<SeqTypes>>,
+        Certificate,
+        Certificate,
+        StakeTableQuorum<(Arc<StakeTable>, Arc<StakeTable>)>,
+    ) {
+        let current = boundary_quorum(0..5);
+        let next = boundary_quorum(5..10);
+
+        // Leaf 10 is the last leaf of epoch 1; leaf 11 is the first leaf of epoch 2.
+        let leaves = leaf_chain(9..=11, EPOCH_VERSION).await;
+
+        // Block 10 is an epoch transition block, so its QC is dual-signed by both quorums.
+        let committing_data = QuorumData2 {
+            leaf_commit: Committable::commit(leaves[1].leaf()),
+            epoch: Some(EpochNumber::new(1)),
+            block_number: Some(10),
+        };
+        let committing_qc = Certificate::new(
+            boundary_signed_qc(committing_data, ViewNumber::new(10), &current),
+            Some(boundary_signed_next_epoch_qc(
+                committing_data,
+                ViewNumber::new(10),
+                &next,
+            )),
+        );
+
+        let deciding_quorum = if deciding_signed_by_next {
+            &next
+        } else {
+            &current
+        };
+        let deciding_qc = Certificate::non_epoch_change(boundary_signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(leaves[2].leaf()),
+                epoch: Some(EpochNumber::new(2)),
+                block_number: Some(11),
+            },
+            ViewNumber::new(11),
+            deciding_quorum,
+        ));
+
+        let quorum = StakeTableQuorum::new(
+            (
+                Arc::new(StakeTable::from(current.1)),
+                Arc::new(StakeTable::from(next.1)),
+            ),
+            BOUNDARY_EPOCH_HEIGHT,
+        );
+        (leaves, committing_qc, deciding_qc, quorum)
+    }
+
+    /// A 2-chain proving the last leaf of an epoch includes a deciding QC signed by the next
+    /// epoch's quorum; it must be verified against that quorum, not the quorum of the epoch of the
+    /// leaf under proof.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_epoch_boundary_quorum_change() {
+        let (leaves, committing_qc, deciding_qc, quorum) = epoch_boundary_fixture(true).await;
+        let version = quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap();
+        assert_eq!(version, leaves[1].header().version());
+    }
+
+    /// A deciding QC claiming to be from the next epoch but signed by the current epoch's quorum
+    /// must fail verification.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_epoch_boundary_deciding_qc_wrong_quorum() {
+        let (leaves, committing_qc, deciding_qc, quorum) = epoch_boundary_fixture(false).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
     }
 }

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -513,19 +513,32 @@ impl InnerTestClient {
             {
                 assert!(block_header.set_next_stake_table_hash(self.stake_table_hash(*epoch + 1)));
             }
-            let next_epoch_justify_qc = if i > 0 && is_epoch_transition(i as u64, epoch_height) {
+            // As in production, a leaf carries a next-epoch justify QC exactly when the block
+            // justified by its QC (the parent) is part of an epoch transition, and that QC is
+            // signed by the epoch after the parent's. New-protocol leaves never carry one:
+            // epoch changes there are justified by `Certificate2`, and the `Leaf2`
+            // representation always has `next_epoch_justify_qc: None`.
+            let next_epoch_justify_qc = if i > 0
+                && self.version_at(i as u64) < NEW_PROTOCOL_VERSION
+                && is_epoch_transition(i as u64 - 1, epoch_height)
+            {
                 let parent_qc = self.leaves[i - 1].qc().clone();
+                let parent_epoch = epoch_from_block_number(i as u64 - 1, epoch_height);
+                let parent_upgrade = Upgrade::trivial(self.version_at(i as u64 - 1));
                 let data: NextEpochQuorumData2<SeqTypes> = parent_qc.data.into();
                 let versioned_commit = VersionedVoteData::new_infallible(
                     data.clone(),
                     parent_qc.view_number,
-                    &UpgradeLock::<SeqTypes>::new(upgrade),
+                    &UpgradeLock::<SeqTypes>::new(parent_upgrade),
                 )
                 .commit();
                 let commit_bytes: [u8; 32] = versioned_commit.into();
 
-                let (next_keys, next_validators): (Vec<_>, Vec<_>) =
-                    self.quorum_for_epoch(*epoch + 1).iter().cloned().unzip();
+                let (next_keys, next_validators): (Vec<_>, Vec<_>) = self
+                    .quorum_for_epoch(parent_epoch + 1)
+                    .iter()
+                    .cloned()
+                    .unzip();
                 let mut next_entries = vec![];
                 let mut next_total = U256::ZERO;
                 for validator in &next_validators {


### PR DESCRIPTION
## Problem

A 2-chain proving the last leaf of epoch E always includes a deciding QC produced in epoch E+1, signed by that epoch's quorum. `verify_qc_chain_and_get_version` verified every certificate against the single quorum of the leaf's epoch, so fetching the last leaf of an epoch failed with `invalid threshold signature: Pairing check failed` whenever adjacent epochs have different stake tables.

First observed on milk at height 6000 (`epoch_height = 3000`): the boundary between the genesis stake table (epochs 1–2, from `known_nodes_with_stake`, all stakes `0x1`) and the first contract-sourced stake table (epoch 3, real stakes, different ordering). Same members, same size, different order — so the signer bitvec aggregated the wrong keys and the pairing check failed. A freshly-syncing node can never backfill past this height. The bug is invisible at every other epoch boundary because adjacent contract-sourced tables are usually identical.

Same bug family as #4594 (wrong quorum for pre-PoS QCs) and #4669 (cert2 verified against wrong epoch).

## Fix

Dispatch each certificate on the epoch committed in its signed payload: certs from the leaf's epoch verify against the proof's quorum as before; certs from the following epoch verify against the next epoch's stake table (which `StakeTableQuorum` already carries for dual-signed transition certs); any other epoch is rejected. The epoch number is part of the signed vote data, so a certificate claiming the wrong epoch fails signature verification — the dispatch is binding.

Pre-epoch certificates (epoch `None`) keep the existing behavior, leaving the #4594 HotStuff1 path untouched.

**Review focus:** the epoch-dispatch match in `verify_qc_chain_and_get_version`, and the `next_epoch_qc().is_none()` restriction in `StakeTableQuorum::verify_next_epoch_static`.

## Tests

Regression tests build the exact boundary shape with real BLS signatures over disjoint per-epoch quorums (leaf 10 = last leaf of epoch 1, dual-signed transition cert, deciding QC from epoch 2). Both fail without the fix:

- `test_epoch_boundary_quorum_change`: a valid boundary proof must verify (the old code rejected it — the milk symptom)
- `test_epoch_boundary_deciding_qc_wrong_quorum`: a deciding QC claiming the next epoch but signed by the current epoch's quorum must fail (the old code accepted it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)