### PR TITLE
fix(consensus): seed proposal participation from stake table

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -912,7 +912,8 @@ where
                 self.timer.reset_with_epoch(view, epoch);
                 self.gc(epoch, GcScope::Local(view))?;
                 let txns = self.block_builder.on_view_changed(view);
-                self.participation.on_view_changed(epoch);
+                self.participation
+                    .on_view_changed(epoch, &self.membership_coordinator);
                 self.on_view_changed_metrics(view, epoch);
                 if !txns.is_empty() {
                     let next_view = view + 1;

--- a/crates/hotshot/task-impls/src/consensus/mod.rs
+++ b/crates/hotshot/task-impls/src/consensus/mod.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use handlers::handle_epoch_root_quorum_vote_recv;
 use hotshot_task::task::TaskState;
 use hotshot_types::{
-    consensus::OuterConsensus,
+    consensus::{OuterConsensus, resolve_participation_stake_table},
     data::{EpochNumber, ViewNumber},
     epoch_membership::EpochMembershipCoordinator,
     event::{Event, EventType},
@@ -226,7 +226,11 @@ impl<TYPES: NodeType, I: NodeImplementation<TYPES>> ConsensusTaskState<TYPES, I>
                     .update_next_epoch_high_qc(next_epoch_high_qc.clone())
                     .is_ok();
                 if let Some(next_epoch) = next_epoch {
-                    consensus_writer.update_validator_participation_epoch(next_epoch);
+                    let (stake_table, _) = resolve_participation_stake_table(
+                        &self.membership_coordinator,
+                        Some(next_epoch),
+                    );
+                    consensus_writer.update_validator_participation_epoch(stake_table, next_epoch);
                 }
                 drop(consensus_writer);
 

--- a/crates/hotshot/testing/tests/tests_1/vote_participation.rs
+++ b/crates/hotshot/testing/tests/tests_1/vote_participation.rs
@@ -369,4 +369,62 @@ mod tests {
             "previous participation should be empty before any epoch change"
         );
     }
+
+    #[test]
+    fn test_proposal_initial_full_participation() {
+        let (stake_table, threshold) = make_stake_table(5);
+        let consensus = make_test_consensus(stake_table, threshold, Some(EpochNumber::genesis()));
+
+        let participation = consensus.current_proposal_participation();
+        assert_eq!(participation.len(), 5);
+        for ratio in participation.values() {
+            assert_eq!(*ratio, 1.0);
+        }
+    }
+
+    // Regression test for the empty `/participation/proposal/current` response: rolling over to a
+    // new epoch must reseed from the new stake table, never resetting to an empty map.
+    #[test]
+    fn test_proposal_rollover_keeps_full_set() {
+        let (stake_table, threshold) = make_stake_table(5);
+        let mut consensus =
+            make_test_consensus(stake_table, threshold, Some(EpochNumber::genesis()));
+
+        let (next_stake_table, _) = make_stake_table(5);
+        consensus.update_validator_participation_epoch(next_stake_table, EpochNumber::new(1));
+
+        let participation = consensus.current_proposal_participation();
+        assert_eq!(participation.len(), 5);
+        for ratio in participation.values() {
+            assert_eq!(*ratio, 1.0);
+        }
+    }
+
+    #[test]
+    fn test_proposal_count_ratio() {
+        let (stake_table, threshold) = make_stake_table(5);
+        let mut consensus =
+            make_test_consensus(stake_table, threshold, Some(EpochNumber::genesis()));
+
+        let (_, leader_key) = key_pair_for_id::<TestTypes>(0);
+        consensus.update_validator_participation(leader_key.clone(), EpochNumber::genesis(), false);
+
+        let participation = consensus.current_proposal_participation();
+        assert_eq!(participation.len(), 5);
+        assert_eq!(participation[&leader_key], 0.0);
+        for (key, ratio) in &participation {
+            if *key != leader_key {
+                assert_eq!(*ratio, 1.0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_proposal_none_epoch_full() {
+        let (stake_table, threshold) = make_stake_table(5);
+        let consensus = make_test_consensus(stake_table, threshold, None);
+
+        let participation = consensus.current_proposal_participation();
+        assert_eq!(participation.len(), 5);
+    }
 }

--- a/crates/hotshot/types/src/consensus.rs
+++ b/crates/hotshot/types/src/consensus.rs
@@ -302,7 +302,7 @@ impl<TYPES: NodeType> Default for ParticipationTracker<TYPES> {
     fn default() -> Self {
         let (stake_table, success_threshold) = VoteParticipation::unresolved_stake_table();
         Self {
-            validator: ValidatorParticipation::new(),
+            validator: ValidatorParticipation::new(stake_table.clone()),
             vote: VoteParticipation::new(stake_table, success_threshold, None),
         }
     }
@@ -313,7 +313,7 @@ impl<TYPES: NodeType> ParticipationTracker<TYPES> {
         let (stake_table, success_threshold) =
             resolve_participation_stake_table(membership, Some(epoch));
         Self {
-            validator: ValidatorParticipation::new_in_epoch(epoch),
+            validator: ValidatorParticipation::new_in_epoch(stake_table.clone(), epoch),
             vote: VoteParticipation::new(stake_table, success_threshold, Some(epoch)),
         }
     }
@@ -326,8 +326,14 @@ impl<TYPES: NodeType> ParticipationTracker<TYPES> {
         self.validator.update_participation(leader, epoch, false);
     }
 
-    pub fn on_view_changed(&mut self, epoch: EpochNumber) {
-        self.validator.update_participation_epoch(epoch);
+    pub fn on_view_changed(
+        &mut self,
+        epoch: EpochNumber,
+        membership: &EpochMembershipCoordinator<TYPES>,
+    ) {
+        let (stake_table, _) = resolve_participation_stake_table(membership, Some(epoch));
+        self.validator
+            .update_participation_epoch(stake_table, epoch);
     }
 
     pub fn on_leaf_decided(
@@ -370,6 +376,7 @@ impl<TYPES: NodeType> ParticipationTracker<TYPES> {
 #[derive(Debug, Clone)]
 struct ValidatorParticipation<TYPES: NodeType> {
     epoch: EpochNumber,
+    stake_table: HSStakeTable<TYPES>,
     /// Current epoch participation by key maps key -> (num leader, num times proposed)
     current_epoch_participation: ValidatorParticipationMap<TYPES>,
 
@@ -378,16 +385,26 @@ struct ValidatorParticipation<TYPES: NodeType> {
 }
 
 impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
-    fn new() -> Self {
-        Self::new_in_epoch(EpochNumber::genesis())
+    fn new(stake_table: HSStakeTable<TYPES>) -> Self {
+        Self::new_in_epoch(stake_table, EpochNumber::genesis())
     }
 
-    fn new_in_epoch(epoch: EpochNumber) -> Self {
+    fn new_in_epoch(stake_table: HSStakeTable<TYPES>, epoch: EpochNumber) -> Self {
         Self {
             epoch,
-            current_epoch_participation: HashMap::new(),
+            current_epoch_participation: Self::seed_from_stake_table(&stake_table),
+            stake_table,
             previous_epoch_participation: BTreeMap::new(),
         }
+    }
+
+    fn seed_from_stake_table(
+        stake_table: &HSStakeTable<TYPES>,
+    ) -> ValidatorParticipationMap<TYPES> {
+        stake_table
+            .iter()
+            .map(|peer_config| (peer_config.stake_table_entry.public_key(), (0, 0)))
+            .collect()
     }
 
     fn update_participation(
@@ -398,7 +415,7 @@ impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
     ) {
         let participation = match epoch.cmp(&self.epoch) {
             std::cmp::Ordering::Greater => {
-                self.update_participation_epoch(epoch);
+                self.update_participation_epoch(self.stake_table.clone(), epoch);
                 &mut self.current_epoch_participation
             },
             std::cmp::Ordering::Equal => &mut self.current_epoch_participation,
@@ -416,7 +433,7 @@ impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
         entry.0 += 1;
     }
 
-    fn update_participation_epoch(&mut self, epoch: EpochNumber) {
+    fn update_participation_epoch(&mut self, stake_table: HSStakeTable<TYPES>, epoch: EpochNumber) {
         if epoch <= self.epoch {
             return;
         }
@@ -430,7 +447,8 @@ impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
                 ));
 
         self.epoch = epoch;
-        self.current_epoch_participation = HashMap::new();
+        self.current_epoch_participation = Self::seed_from_stake_table(&stake_table);
+        self.stake_table = stake_table;
     }
 
     fn current_proposal_participation(&self) -> HashMap<TYPES::SignatureKey, f64> {
@@ -440,7 +458,7 @@ impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
                 (
                     key.clone(),
                     if *leader == 0 {
-                        0.0
+                        1.0
                     } else {
                         *proposed as f64 / *leader as f64
                     },
@@ -464,7 +482,7 @@ impl<TYPES: NodeType> ValidatorParticipation<TYPES> {
                 (
                     key.clone(),
                     if *leader == 0 {
-                        0.0
+                        1.0
                     } else {
                         *proposed as f64 / *leader as f64
                     },
@@ -723,7 +741,7 @@ impl<TYPES: NodeType> VoteParticipation<TYPES> {
     }
 }
 
-fn resolve_participation_stake_table<TYPES: NodeType>(
+pub fn resolve_participation_stake_table<TYPES: NodeType>(
     membership: &EpochMembershipCoordinator<TYPES>,
     epoch: Option<EpochNumber>,
 ) -> (HSStakeTable<TYPES>, U256) {
@@ -749,7 +767,8 @@ fn track_decided_qc_participation<TYPES: NodeType>(
     if let Some(epoch) = qc_epoch
         && epoch > validator.current_epoch()
     {
-        validator.update_participation_epoch(epoch);
+        let (stake_table, _) = resolve_participation_stake_table(membership, Some(epoch));
+        validator.update_participation_epoch(stake_table, epoch);
     }
     if qc_epoch > vote.current_epoch() {
         let (stake_table, success_threshold) =
@@ -1025,7 +1044,10 @@ impl<TYPES: NodeType> Consensus<TYPES> {
             highest_block: 0,
             state_cert,
             drb_difficulty,
-            validator_participation: ValidatorParticipation::new(),
+            validator_participation: ValidatorParticipation::new_in_epoch(
+                stake_table.clone(),
+                cur_epoch.unwrap_or(EpochNumber::genesis()),
+            ),
             vote_participation: VoteParticipation::new(stake_table, success_threshold, cur_epoch),
             drb_upgrade_difficulty,
         }
@@ -1171,9 +1193,13 @@ impl<TYPES: NodeType> Consensus<TYPES> {
     }
 
     /// Update the validator participation epoch
-    pub fn update_validator_participation_epoch(&mut self, epoch: EpochNumber) {
+    pub fn update_validator_participation_epoch(
+        &mut self,
+        stake_table: HSStakeTable<TYPES>,
+        epoch: EpochNumber,
+    ) {
         self.validator_participation
-            .update_participation_epoch(epoch);
+            .update_participation_epoch(stake_table, epoch);
     }
 
     /// Get the current proposal participation


### PR DESCRIPTION
`/node/participation/proposal/current` periodically returned `{}` at epoch boundaries, tripping monitoring that reads an empty response as "node not in the active set". `ValidatorParticipation` started each epoch with an empty map and filled it lazily as leaders were seen, unlike `VoteParticipation`, which seeds from the epoch stake table.

Seed `ValidatorParticipation.current_epoch_participation` from the epoch stake table on construction and rollover, so the endpoint always lists the full active set. Validators not yet seen as leader report a default ratio of 1.0 (healthy) rather than an ambiguous 0.0, keeping the `f64` wire format unchanged for consumers.
