### PR TITLE
Keep only a limited number of `EpochSnapshot`s.

### DIFF
--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) fn default_telemetry_endpoint(chain_id: ChainId) -> Option<&'static s
     }
 }
 
+pub use espresso_types::RECENT_STAKE_TABLES_LIMIT;
 use genesis::L1Finalized;
 pub use genesis::{Genesis, GenesisSource};
 use hotshot::{
@@ -97,8 +98,6 @@ use url::Url;
 use vbs::version::StaticVersion;
 
 use crate::request_response::data_source::Storage as RequestResponseStorage;
-
-pub const RECENT_STAKE_TABLES_LIMIT: u64 = 20;
 
 /// The Sequencer node is generic over the hotshot CommChannel.
 #[derive(Derivative, Serialize, Deserialize)]

--- a/crates/espresso/node/src/persistence.rs
+++ b/crates/espresso/node/src/persistence.rs
@@ -2396,6 +2396,64 @@ mod tests {
         Ok(())
     }
 
+    // Epoch data is stored piecemeal: `store_drb_result`, `store_epoch_root`
+    // and `store_stake` each write only their part (one row in SQL, separate
+    // files in FS). A loader must report data another writer created the
+    // epoch entry for as absent — regression test for `load_stake` panicking
+    // on a DRB-only row's NULL stake column.
+    #[rstest_reuse::apply(persistence_types)]
+    pub async fn test_load_partially_stored_epoch_data<P: TestablePersistence>(
+        _p: PhantomData<P>,
+    ) -> anyhow::Result<()> {
+        let tmp = P::tmp_storage().await;
+        let storage = P::connect(&tmp).await;
+
+        let instance_state = NodeState::mock();
+        let validated_state = hotshot_types::traits::ValidatedState::genesis(&instance_state).0;
+        let leaf: Leaf2 = Leaf::genesis(&validated_state, &instance_state, MOCK_UPGRADE.base)
+            .await
+            .into();
+        let header = leaf.block_header().clone();
+
+        let validator = AuthenticatedValidator::mock();
+        let mut stake = IndexMap::new();
+        stake.insert(validator.account, validator);
+
+        // Nothing stored yet.
+        let epoch = EpochNumber::new(1);
+        assert!(storage.load_stake(epoch).await?.is_none());
+        assert!(storage.load_drb_result(epoch).await?.is_none());
+        assert!(storage.load_epoch_root(epoch).await?.is_none());
+
+        // A DRB result alone; the other loaders report their data as absent.
+        storage.store_drb_result(epoch, [1; 32]).await?;
+        assert!(storage.load_stake(epoch).await?.is_none());
+        assert_eq!(storage.load_drb_result(epoch).await?, Some([1; 32]));
+        assert!(storage.load_epoch_root(epoch).await?.is_none());
+
+        // A stake table alone, likewise.
+        let epoch2 = EpochNumber::new(2);
+        storage
+            .store_stake(epoch2, stake.clone(), None, None)
+            .await?;
+        assert!(storage.load_stake(epoch2).await?.is_some());
+        assert!(storage.load_drb_result(epoch2).await?.is_none());
+        assert!(storage.load_epoch_root(epoch2).await?.is_none());
+
+        // With everything stored for one epoch, each loader returns its
+        // value and none has clobbered the others.
+        storage.store_epoch_root(epoch, header.clone()).await?;
+        storage
+            .store_stake(epoch, stake.clone(), None, None)
+            .await?;
+        let (table, ..) = storage.load_stake(epoch).await?.unwrap();
+        assert_eq!(stake, table);
+        assert_eq!(storage.load_drb_result(epoch).await?, Some([1; 32]));
+        assert_eq!(storage.load_epoch_root(epoch).await?, Some(header));
+
+        Ok(())
+    }
+
     #[rstest_reuse::apply(persistence_types)]
     pub async fn test_delete_stake_tables<P: TestablePersistence>(
         _p: PhantomData<P>,

--- a/crates/espresso/node/src/persistence/fs.rs
+++ b/crates/espresso/node/src/persistence/fs.rs
@@ -14,8 +14,8 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use clap::Parser;
 use espresso_types::{
-    AuthenticatedValidatorMap, Leaf, Leaf2, NetworkConfig, Payload, PubKey, RegisteredValidatorMap,
-    SeqTypes, StakeTableHash,
+    AuthenticatedValidatorMap, Header, Leaf, Leaf2, NetworkConfig, Payload, PubKey,
+    RegisteredValidatorMap, SeqTypes, StakeTableHash,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
     v0::traits::{EventConsumer, PersistenceOptions, SequencerPersistence},
     v0_3::{
@@ -2050,6 +2050,28 @@ impl MembershipPersistence for Persistence {
         let drb_result = bincode::deserialize::<DrbResult>(&bytes)
             .context(format!("parsing epoch drb result {}", file_path.display()))?;
         Ok(Some(drb_result))
+    }
+
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+        let inner = self.inner.read().await;
+        let file_path = inner
+            .epoch_root_block_header_dir_path()
+            .join(epoch.to_string())
+            .with_extension("txt");
+
+        if !file_path.is_file() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&file_path).context(format!(
+            "reading epoch root block header {}",
+            file_path.display()
+        ))?;
+        let header = bincode::deserialize::<Header>(&bytes).context(format!(
+            "parsing epoch root block header {}",
+            file_path.display()
+        ))?;
+        Ok(Some(header))
     }
 
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {

--- a/crates/espresso/node/src/persistence/fs.rs
+++ b/crates/espresso/node/src/persistence/fs.rs
@@ -2034,6 +2034,24 @@ impl MembershipPersistence for Persistence {
         Ok(Some(stake))
     }
 
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        let inner = self.inner.read().await;
+        let file_path = inner
+            .epoch_drb_result_dir_path()
+            .join(epoch.to_string())
+            .with_extension("txt");
+
+        if !file_path.is_file() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(&file_path)
+            .context(format!("reading epoch drb result {}", file_path.display()))?;
+        let drb_result = bincode::deserialize::<DrbResult>(&bytes)
+            .context(format!("parsing epoch drb result {}", file_path.display()))?;
+        Ok(Some(drb_result))
+    }
+
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {
         let limit = limit as usize;
         let inner = self.inner.read().await;

--- a/crates/espresso/node/src/persistence/no_storage.rs
+++ b/crates/espresso/node/src/persistence/no_storage.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use anyhow::bail;
 use async_trait::async_trait;
 use espresso_types::{
-    AuthenticatedValidatorMap, Leaf2, NetworkConfig, PubKey, RegisteredValidatorMap,
+    AuthenticatedValidatorMap, Header, Leaf2, NetworkConfig, PubKey, RegisteredValidatorMap,
     StakeTableHash,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
     v0::traits::{EventConsumer, PersistenceOptions, SequencerPersistence},
@@ -315,6 +315,10 @@ impl MembershipPersistence for NoStorage {
     }
 
     async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        Ok(None)
+    }
+
+    async fn load_epoch_root(&self, _epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
         Ok(None)
     }
 

--- a/crates/espresso/node/src/persistence/no_storage.rs
+++ b/crates/espresso/node/src/persistence/no_storage.rs
@@ -314,6 +314,10 @@ impl MembershipPersistence for NoStorage {
         Ok(None)
     }
 
+    async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        Ok(None)
+    }
+
     async fn store_stake(
         &self,
         _epoch: EpochNumber,

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -3153,7 +3153,7 @@ impl MembershipPersistence for Persistence {
             .fetch_optional(
                 query(
                     "SELECT stake, block_reward, stake_table_hash FROM epoch_drb_and_root WHERE \
-                     epoch = $1",
+                     epoch = $1 AND stake IS NOT NULL",
                 )
                 .bind(epoch.u64() as i64),
             )

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -3177,6 +3177,28 @@ impl MembershipPersistence for Persistence {
             .transpose()
     }
 
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        let result = self
+            .db
+            .read()
+            .await?
+            .fetch_optional(
+                query(
+                    "SELECT drb_result FROM epoch_drb_and_root WHERE epoch = $1 AND drb_result IS \
+                     NOT NULL",
+                )
+                .bind(epoch.u64() as i64),
+            )
+            .await?;
+
+        result
+            .map(|row| {
+                let bytes: Vec<u8> = row.get("drb_result");
+                bytes.try_into().or_else(|_| bail!("invalid drb result"))
+            })
+            .transpose()
+    }
+
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {
         let mut tx = self.db.read().await?;
 

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -15,7 +15,7 @@ use committable::Committable;
 use derivative::Derivative;
 use derive_more::derive::{From, Into};
 use espresso_types::{
-    AuthenticatedValidatorMap, BackoffParams, BlockMerkleTree, FeeMerkleTree, Leaf, Leaf2,
+    AuthenticatedValidatorMap, BackoffParams, BlockMerkleTree, FeeMerkleTree, Header, Leaf, Leaf2,
     NetworkConfig, Payload, PubKey, Ratio, RegisteredValidatorMap, StakeTableHash, parse_duration,
     parse_size,
     traits::{EventsPersistenceRead, MembershipPersistence, StakeTuple},
@@ -3195,6 +3195,28 @@ impl MembershipPersistence for Persistence {
             .map(|row| {
                 let bytes: Vec<u8> = row.get("drb_result");
                 bytes.try_into().or_else(|_| bail!("invalid drb result"))
+            })
+            .transpose()
+    }
+
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+        let result = self
+            .db
+            .read()
+            .await?
+            .fetch_optional(
+                query(
+                    "SELECT block_header FROM epoch_drb_and_root WHERE epoch = $1 AND \
+                     block_header IS NOT NULL",
+                )
+                .bind(epoch.u64() as i64),
+            )
+            .await?;
+
+        result
+            .map(|row| {
+                let bytes: Vec<u8> = row.get("block_header");
+                bincode::deserialize(&bytes).context("deserializing block header")
             })
             .transpose()
     }

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -695,7 +695,7 @@ impl Membership<SeqTypes> for EpochCommittees {
     ///
     /// Everything persisted for the epoch is restored: the stake table, the
     /// epoch root header, and the randomized committee (rebuilt from the DRB
-    /// result), so lookups on the restored snapshot need no network catchup.
+    /// result).
     async fn load_stake_table(&self, epoch: EpochNumber) -> bool {
         if self.inner.read().snapshots.contains_key(&epoch) {
             return true;

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -693,9 +693,9 @@ impl Membership<SeqTypes> for EpochCommittees {
 
     /// Load the committee for `epoch` from storage.
     ///
-    /// The randomized committee is rebuilt from the persisted DRB result if
-    /// there is one, so leader lookups need no network catchup. The restored
-    /// snapshot carries no header; `add_epoch_root` fills that in when needed.
+    /// Everything persisted for the epoch is restored: the stake table, the
+    /// epoch root header, and the randomized committee (rebuilt from the DRB
+    /// result), so lookups on the restored snapshot need no network catchup.
     async fn load_stake_table(&self, epoch: EpochNumber) -> bool {
         if self.inner.read().snapshots.contains_key(&epoch) {
             return true;
@@ -723,13 +723,25 @@ impl Membership<SeqTypes> for EpochCommittees {
                 None
             },
         };
+        let header = match persistence.load_epoch_root(epoch).await {
+            Ok(header) => header,
+            Err(err) => {
+                warn!(%err, "failed to load epoch root for epoch {epoch} from persistence");
+                None
+            },
+        };
         drop(persistence);
-        info!(%epoch, has_drb = drb.is_some(), "stake table loaded from persistence");
+        info!(
+            %epoch,
+            has_drb = drb.is_some(),
+            has_header = header.is_some(),
+            "stake table loaded from persistence"
+        );
         let committee = Arc::new(EpochCommittee::new(
             validators,
             block_reward,
             stake_table_hash,
-            None,
+            header,
         ));
         let randomized = drb.map(|drb| {
             let leaders = committee
@@ -1555,9 +1567,12 @@ mod tests {
         EpochCommittees::new_stake(peers.clone(), peers, None, fetcher, 100u64)
     }
 
-    /// Persistence stub holding a stake table for epoch 7 only.
+    /// Persistence stub holding stake tables for epochs 7 and 8, plus a DRB
+    /// result and an epoch root header for epoch 7 only.
     #[derive(Debug)]
-    struct MockStakeStore;
+    struct MockStakeStore {
+        header: Header,
+    }
 
     #[async_trait::async_trait]
     impl crate::traits::MembershipPersistence for MockStakeStore {
@@ -1577,6 +1592,10 @@ mod tests {
 
         async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
             Ok((*epoch == 7).then_some([7; 32]))
+        }
+
+        async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
+            Ok((*epoch == 7).then(|| self.header.clone()))
         }
 
         async fn store_stake(
@@ -1632,29 +1651,37 @@ mod tests {
 
     // `load_stake_table` materializes a snapshot from the persisted stake
     // table (e.g. after eviction by `prune_epochs`) without network catchup,
-    // including the randomized committee when a DRB result is persisted.
+    // including the randomized committee and the epoch root header when
+    // they are persisted.
     #[tokio::test]
     async fn restore_stake_table_from_persistence() {
+        let store = MockStakeStore {
+            header: build_epoch_root_header().await,
+        };
         let fetcher = Fetcher::new(
             Arc::new(crate::mock::MockStateCatchup::default()),
-            Arc::new(AsyncMutex::new(MockStakeStore)),
+            Arc::new(AsyncMutex::new(store)),
             crate::L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
                 .expect("Failed to create L1 client"),
             crate::ChainConfig::default(),
         );
         let committees = build_committees_with_fetcher(4, fetcher);
 
-        // Epoch 7 has a stake table and a DRB result in storage.
+        // Epoch 7 has a stake table, a DRB result and a root header in storage.
         let seven = EpochNumber::new(7);
         assert!(committees.snapshot(seven).is_none());
         assert!(committees.load_stake_table(seven).await);
-        assert!(committees.snapshot(seven).unwrap().has_drb());
+        let snapshot = committees.snapshot(seven).unwrap();
+        assert!(snapshot.has_drb());
+        assert!(snapshot.inner.committee.header.is_some());
         // A second call is satisfied by the in-memory snapshot.
         assert!(committees.load_stake_table(seven).await);
-        // Epoch 8 has a stake table but no DRB result.
+        // Epoch 8 has a stake table but no DRB result and no root header.
         let eight = EpochNumber::new(8);
         assert!(committees.load_stake_table(eight).await);
-        assert!(!committees.snapshot(eight).unwrap().has_drb());
+        let snapshot = committees.snapshot(eight).unwrap();
+        assert!(!snapshot.has_drb());
+        assert!(snapshot.inner.committee.header.is_none());
         // Nothing persisted for epoch 9.
         assert!(!committees.load_stake_table(EpochNumber::new(9)).await);
     }

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -521,7 +521,7 @@ impl EpochCommittees {
             },
         }
 
-        // Load the 50 latest stored stake tables
+        // Load the `limit` latest stored stake tables
         let loaded_stake = match self
             .fetcher
             .persistence
@@ -1186,29 +1186,27 @@ impl Inner {
         );
     }
 
-    /// Evict per-epoch state more than [`RECENT_STAKE_TABLES_LIMIT`] epochs
-    /// below `added`.
+    /// Evict snapshots more than [`RECENT_STAKE_TABLES_LIMIT`] epochs below
+    /// `added`.
     ///
     /// The cutoff only ever moves forward: `add_epoch_root` also runs for old
     /// epochs during catchup, and a lagging insert must neither evict newer
     /// state nor evict itself before its readers had a chance to observe it.
+    ///
+    /// `da_committees` is exempt: it holds one entry per configured DA
+    /// committee (seeded from config at startup and on upgrade certificates),
+    /// so it is bounded, and `resolve_da_committee`'s greatest-key-below
+    /// lookup needs the full history for re-inserted old epochs.
+    ///
+    /// This makes the genesis snapshots seeded by the constructor evictable;
+    /// `set_first_epoch` relies on them and must run before the tip advances
+    /// past the retention window (it runs at startup/cutover, so it does).
     #[cfg_attr(not(feature = "node"), allow(dead_code))]
     fn prune_epochs(&mut self, added: EpochNumber) {
         let cutoff = EpochNumber::new(added.saturating_sub(RECENT_STAKE_TABLES_LIMIT));
-        if cutoff <= self.prune_cutoff {
-            return;
-        }
-        self.prune_cutoff = cutoff;
-        self.snapshots = self.snapshots.split_off(&cutoff);
-        // `resolve_da_committee` picks the _greatest_ key <= epoch, so we need
-        // to find that key and can only drop entries below it.
-        if let Some(active) = self
-            .da_committees
-            .range(..=cutoff)
-            .next_back()
-            .map(|(k, _)| *k)
-        {
-            self.da_committees = self.da_committees.split_off(&active);
+        if cutoff > self.prune_cutoff {
+            self.prune_cutoff = cutoff;
+            self.snapshots = self.snapshots.split_off(&cutoff);
         }
     }
 }
@@ -1504,10 +1502,6 @@ mod tests {
             .epoch_committee(EpochNumber::genesis())
             .expect("genesis committee exists")
             .clone();
-        let da = inner.resolve_da_committee(None);
-        inner.da_committees.insert(EpochNumber::new(1), da.clone());
-        inner.da_committees.insert(EpochNumber::new(10), da.clone());
-        inner.da_committees.insert(EpochNumber::new(40), da);
 
         for e in 2..=50 {
             inner.put_epoch_committee(EpochNumber::new(e), template.clone());
@@ -1520,12 +1514,6 @@ mod tests {
             Some(cutoff)
         );
         assert!(inner.snapshots.contains_key(&EpochNumber::new(50)));
-        // The DA committee active at the cutoff (in effect since epoch 10)
-        // must survive; only the entry it shadows (epoch 1) is evicted.
-        assert_eq!(
-            inner.da_committees.keys().copied().collect::<Vec<_>>(),
-            vec![EpochNumber::new(10), EpochNumber::new(40)]
-        );
 
         // A catchup insert below the cutoff is not evicted by its own
         // insertion; it goes once the tip advances past it.

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -1197,17 +1197,17 @@ impl Inner {
     /// committee (seeded from config at startup and on upgrade certificates),
     /// so it is bounded, and `resolve_da_committee`'s greatest-key-below
     /// lookup needs the full history for re-inserted old epochs.
-    ///
-    /// This makes the genesis snapshots seeded by the constructor evictable;
-    /// `set_first_epoch` relies on them and must run before the tip advances
-    /// past the retention window (it runs at startup/cutover, so it does).
     #[cfg_attr(not(feature = "node"), allow(dead_code))]
     fn prune_epochs(&mut self, added: EpochNumber) {
         let cutoff = EpochNumber::new(added.saturating_sub(RECENT_STAKE_TABLES_LIMIT));
-        if cutoff > self.prune_cutoff {
-            self.prune_cutoff = cutoff;
-            self.snapshots = self.snapshots.split_off(&cutoff);
+        if cutoff <= self.prune_cutoff {
+            return;
         }
+        self.prune_cutoff = cutoff;
+        // The snapshots for `first_epoch` and `first_epoch + 1` (seeded by
+        // `set_first_epoch`) are never evicted:
+        let keep = self.first_epoch.unwrap_or_else(EpochNumber::genesis) + 1u64;
+        self.snapshots.retain(|e, _| *e <= keep || *e >= cutoff);
     }
 }
 
@@ -1492,12 +1492,13 @@ mod tests {
     }
 
     // `prune_epochs` keeps a bounded window behind the newest decided epoch
-    // and its cutoff never regresses when an older epoch is (re-)inserted
-    // during catchup.
+    // plus the first-epoch seeds (catchup anchors), and its cutoff never
+    // regresses when an older epoch is (re-)inserted during catchup.
     #[test]
     fn prune_epochs_keeps_recent_window() {
         let committees = build_committees(4);
         let mut inner = committees.inner.write();
+        inner.first_epoch = Some(EpochNumber::new(1));
         let template = inner
             .epoch_committee(EpochNumber::genesis())
             .expect("genesis committee exists")
@@ -1508,12 +1509,18 @@ mod tests {
             inner.prune_epochs(EpochNumber::new(e));
         }
 
+        // The seeds for `first_epoch` and `first_epoch + 1` survive, then
+        // nothing until the cutoff.
         let cutoff = EpochNumber::new(50 - RECENT_STAKE_TABLES_LIMIT);
+        let expected: Vec<EpochNumber> = [1, 2]
+            .into_iter()
+            .chain(*cutoff..=50)
+            .map(EpochNumber::new)
+            .collect();
         assert_eq!(
-            inner.snapshots.first_key_value().map(|(k, _)| *k),
-            Some(cutoff)
+            inner.snapshots.keys().copied().collect::<Vec<_>>(),
+            expected
         );
-        assert!(inner.snapshots.contains_key(&EpochNumber::new(50)));
 
         // A catchup insert below the cutoff is not evicted by its own
         // insertion; it goes once the tip advances past it.

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -60,6 +60,7 @@ pub struct EpochCommittees {
     fetcher: Arc<Fetcher>,
     #[cfg_attr(not(feature = "node"), allow(dead_code))]
     update_fixed_block_reward_lock: Arc<AsyncMutex<()>>,
+    load_from_storage_lock: Arc<AsyncMutex<()>>,
     epoch_height: BlockNumber,
 }
 
@@ -505,6 +506,7 @@ impl EpochCommittees {
             })),
             fetcher: Arc::new(fetcher),
             update_fixed_block_reward_lock: Arc::new(AsyncMutex::new(())),
+            load_from_storage_lock: Arc::new(AsyncMutex::new(())),
             epoch_height: epoch_height.into(),
         }
     }
@@ -689,6 +691,48 @@ impl Membership<SeqTypes> for EpochCommittees {
         self.inner.read().snapshots.get(&epoch).cloned()
     }
 
+    /// Load the committee for `epoch` from storage.
+    ///
+    /// The restored snapshot carries no header and no randomized committee;
+    /// `add_epoch_root` and `add_drb_result` fill those in when needed.
+    async fn load_stake_table(&self, epoch: EpochNumber) -> bool {
+        if self.inner.read().snapshots.contains_key(&epoch) {
+            return true;
+        }
+        // Ensure there is only one `load_stake_table` at a time:
+        let _guard = self.load_from_storage_lock.lock().await;
+        // Check if someone else won the race:
+        if self.inner.read().snapshots.contains_key(&epoch) {
+            return true;
+        }
+        let loaded = self
+            .fetcher
+            .persistence
+            .lock()
+            .await
+            .load_stake(epoch)
+            .await;
+        let (validators, block_reward, stake_table_hash) = match loaded {
+            Ok(Some(stake)) => stake,
+            Ok(None) => return false,
+            Err(err) => {
+                warn!(%err, "failed to load stake table for epoch {epoch} from persistence");
+                return false;
+            },
+        };
+        info!(%epoch, "stake table loaded from persistence");
+        self.inner.write().put_epoch_committee(
+            epoch,
+            Arc::new(EpochCommittee::new(
+                validators,
+                block_reward,
+                stake_table_hash,
+                None,
+            )),
+        );
+        true
+    }
+
     fn non_epoch_snapshot(&self) -> Self::NonEpochSnapshot {
         self.inner.read().non_epoch_snapshot.clone()
     }
@@ -748,6 +792,8 @@ impl Membership<SeqTypes> for EpochCommittees {
                 .map_err(Self::Error::Fetcher)?;
             block_reward = Some(reward);
         }
+
+        self.load_stake_table(epoch).await;
 
         let epoch_committee = self.inner.read().epoch_committee(epoch).cloned();
 
@@ -1477,6 +1523,10 @@ mod tests {
     const TEST_DURATION: Duration = Duration::from_secs(5);
 
     fn build_committees(num_peers: u64) -> EpochCommittees {
+        build_committees_with_fetcher(num_peers, Fetcher::mock())
+    }
+
+    fn build_committees_with_fetcher(num_peers: u64, fetcher: Fetcher) -> EpochCommittees {
         let peers: Vec<PeerConfig<SeqTypes>> = (0..num_peers)
             .map(|i| {
                 ValidatorConfig::<SeqTypes>::generated_from_seed_indexed(
@@ -1488,7 +1538,101 @@ mod tests {
                 .public_config()
             })
             .collect();
-        EpochCommittees::new_stake(peers.clone(), peers, None, Fetcher::mock(), 100u64)
+        EpochCommittees::new_stake(peers.clone(), peers, None, fetcher, 100u64)
+    }
+
+    /// Persistence stub holding a stake table for epoch 7 only.
+    #[derive(Debug)]
+    struct MockStakeStore;
+
+    #[async_trait::async_trait]
+    impl crate::traits::MembershipPersistence for MockStakeStore {
+        async fn load_stake(
+            &self,
+            epoch: EpochNumber,
+        ) -> anyhow::Result<Option<crate::traits::StakeTuple>> {
+            Ok((*epoch == 7).then(|| (Default::default(), None, None)))
+        }
+
+        async fn load_latest_stake(
+            &self,
+            _limit: u64,
+        ) -> anyhow::Result<Option<Vec<crate::v0_3::IndexedStake>>> {
+            Ok(None)
+        }
+
+        async fn store_stake(
+            &self,
+            _epoch: EpochNumber,
+            _stake: AuthenticatedValidatorMap,
+            _block_reward: Option<RewardAmount>,
+            _stake_table_hash: Option<StakeTableHash>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn store_events(
+            &self,
+            _l1_finalized: u64,
+            _events: Vec<(crate::v0_3::EventKey, crate::v0_3::StakeTableEvent)>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load_events(
+            &self,
+            _from_l1_block: u64,
+            _l1_finalized: u64,
+        ) -> anyhow::Result<(
+            Option<crate::traits::EventsPersistenceRead>,
+            Vec<(crate::v0_3::EventKey, crate::v0_3::StakeTableEvent)>,
+        )> {
+            Ok((None, vec![]))
+        }
+
+        async fn delete_stake_tables(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn store_all_validators(
+            &self,
+            _epoch: EpochNumber,
+            _all_validators: IndexMap<Address, crate::v0_3::RegisteredValidator<PubKey>>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load_all_validators(
+            &self,
+            _epoch: EpochNumber,
+            _offset: u64,
+            _limit: u64,
+        ) -> anyhow::Result<Vec<crate::v0_3::RegisteredValidator<PubKey>>> {
+            Ok(vec![])
+        }
+    }
+
+    // `load_stake_table` materializes a snapshot from the persisted stake
+    // table (e.g. after eviction by `prune_epochs`) without network catchup.
+    #[tokio::test]
+    async fn restore_stake_table_from_persistence() {
+        let fetcher = Fetcher::new(
+            Arc::new(crate::mock::MockStateCatchup::default()),
+            Arc::new(AsyncMutex::new(MockStakeStore)),
+            crate::L1Client::new(vec!["http://localhost:3331".parse().unwrap()])
+                .expect("Failed to create L1 client"),
+            crate::ChainConfig::default(),
+        );
+        let committees = build_committees_with_fetcher(4, fetcher);
+
+        let seven = EpochNumber::new(7);
+        assert!(committees.snapshot(seven).is_none());
+        assert!(committees.load_stake_table(seven).await);
+        assert!(committees.snapshot(seven).is_some());
+        // A second call is satisfied by the in-memory snapshot.
+        assert!(committees.load_stake_table(seven).await);
+        // Nothing persisted for epoch 9.
+        assert!(!committees.load_stake_table(EpochNumber::new(9)).await);
     }
 
     // `prune_epochs` keeps a bounded window behind the newest decided epoch

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -44,6 +44,15 @@ use crate::{
     v0_3::{ASSUMED_BLOCK_TIME_SECONDS, AuthenticatedValidator, Fetcher, RewardAmount},
 };
 
+/// Number of recent per-epoch stake tables kept in memory.
+///
+/// `reload_stake` loads this many epochs from persistence on startup and
+/// `prune_epochs` evicts anything older as the tip advances, so a
+/// long-running node holds the same window as a freshly restarted one.
+/// Evicted epochs are recovered on demand via the membership coordinator's
+/// catchup.
+pub const RECENT_STAKE_TABLES_LIMIT: u64 = 20;
+
 /// Type to describe DA and Stake memberships.
 #[derive(Clone, Debug)]
 pub struct EpochCommittees {
@@ -75,6 +84,11 @@ struct Inner {
     ///
     /// Kept separate from `snapshots` because the lookup is a range query.
     da_committees: BTreeMap<EpochNumber, Arc<DaCommittee>>,
+
+    /// Epochs below this have been evicted by `prune_epochs`.
+    ///
+    /// Only ever moves forward.
+    prune_cutoff: EpochNumber,
 
     first_epoch: Option<EpochNumber>,
 
@@ -485,6 +499,7 @@ impl EpochCommittees {
                 da_committees: BTreeMap::new(),
                 snapshots,
                 all_validators: BTreeMap::new(),
+                prune_cutoff: EpochNumber::genesis(),
                 first_epoch: None,
                 fixed_block_reward,
             })),
@@ -840,6 +855,7 @@ impl Membership<SeqTypes> for EpochCommittees {
             // extract `all_validators` for the previous epoch
             previous_validators = inner.all_validators.remove(&previous_epoch);
             inner.all_validators.insert(epoch, all_validators.clone());
+            inner.prune_epochs(epoch);
         }
 
         let persistence_lock = self.fetcher.persistence.lock().await;
@@ -1169,6 +1185,32 @@ impl Inner {
             ),
         );
     }
+
+    /// Evict per-epoch state more than [`RECENT_STAKE_TABLES_LIMIT`] epochs
+    /// below `added`.
+    ///
+    /// The cutoff only ever moves forward: `add_epoch_root` also runs for old
+    /// epochs during catchup, and a lagging insert must neither evict newer
+    /// state nor evict itself before its readers had a chance to observe it.
+    #[cfg_attr(not(feature = "node"), allow(dead_code))]
+    fn prune_epochs(&mut self, added: EpochNumber) {
+        let cutoff = EpochNumber::new(added.saturating_sub(RECENT_STAKE_TABLES_LIMIT));
+        if cutoff <= self.prune_cutoff {
+            return;
+        }
+        self.prune_cutoff = cutoff;
+        self.snapshots = self.snapshots.split_off(&cutoff);
+        // `resolve_da_committee` picks the _greatest_ key <= epoch, so we need
+        // to find that key and can only drop entries below it.
+        if let Some(active) = self
+            .da_committees
+            .range(..=cutoff)
+            .next_back()
+            .map(|(k, _)| *k)
+        {
+            self.da_committees = self.da_committees.split_off(&active);
+        }
+    }
 }
 
 /// A consistent per-epoch view of `EpochCommittees`.
@@ -1449,6 +1491,49 @@ mod tests {
             })
             .collect();
         EpochCommittees::new_stake(peers.clone(), peers, None, Fetcher::mock(), 100u64)
+    }
+
+    // `prune_epochs` keeps a bounded window behind the newest decided epoch
+    // and its cutoff never regresses when an older epoch is (re-)inserted
+    // during catchup.
+    #[test]
+    fn prune_epochs_keeps_recent_window() {
+        let committees = build_committees(4);
+        let mut inner = committees.inner.write();
+        let template = inner
+            .epoch_committee(EpochNumber::genesis())
+            .expect("genesis committee exists")
+            .clone();
+        let da = inner.resolve_da_committee(None);
+        inner.da_committees.insert(EpochNumber::new(1), da.clone());
+        inner.da_committees.insert(EpochNumber::new(10), da.clone());
+        inner.da_committees.insert(EpochNumber::new(40), da);
+
+        for e in 2..=50 {
+            inner.put_epoch_committee(EpochNumber::new(e), template.clone());
+            inner.prune_epochs(EpochNumber::new(e));
+        }
+
+        let cutoff = EpochNumber::new(50 - RECENT_STAKE_TABLES_LIMIT);
+        assert_eq!(
+            inner.snapshots.first_key_value().map(|(k, _)| *k),
+            Some(cutoff)
+        );
+        assert!(inner.snapshots.contains_key(&EpochNumber::new(50)));
+        // The DA committee active at the cutoff (in effect since epoch 10)
+        // must survive; only the entry it shadows (epoch 1) is evicted.
+        assert_eq!(
+            inner.da_committees.keys().copied().collect::<Vec<_>>(),
+            vec![EpochNumber::new(10), EpochNumber::new(40)]
+        );
+
+        // A catchup insert below the cutoff is not evicted by its own
+        // insertion; it goes once the tip advances past it.
+        inner.put_epoch_committee(EpochNumber::new(5), template);
+        inner.prune_epochs(EpochNumber::new(5));
+        assert!(inner.snapshots.contains_key(&EpochNumber::new(5)));
+        inner.prune_epochs(EpochNumber::new(51));
+        assert!(!inner.snapshots.contains_key(&EpochNumber::new(5)));
     }
 
     // Concurrent reads must not panic or deadlock while a writer drives

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -693,8 +693,9 @@ impl Membership<SeqTypes> for EpochCommittees {
 
     /// Load the committee for `epoch` from storage.
     ///
-    /// The restored snapshot carries no header and no randomized committee;
-    /// `add_epoch_root` and `add_drb_result` fill those in when needed.
+    /// The randomized committee is rebuilt from the persisted DRB result if
+    /// there is one, so leader lookups need no network catchup. The restored
+    /// snapshot carries no header; `add_epoch_root` fills that in when needed.
     async fn load_stake_table(&self, epoch: EpochNumber) -> bool {
         if self.inner.read().snapshots.contains_key(&epoch) {
             return true;
@@ -705,14 +706,9 @@ impl Membership<SeqTypes> for EpochCommittees {
         if self.inner.read().snapshots.contains_key(&epoch) {
             return true;
         }
-        let loaded = self
-            .fetcher
-            .persistence
-            .lock()
-            .await
-            .load_stake(epoch)
-            .await;
-        let (validators, block_reward, stake_table_hash) = match loaded {
+        let persistence = self.fetcher.persistence.lock().await;
+        let stake_table = persistence.load_stake(epoch).await;
+        let (validators, block_reward, stake_table_hash) = match stake_table {
             Ok(Some(stake)) => stake,
             Ok(None) => return false,
             Err(err) => {
@@ -720,16 +716,34 @@ impl Membership<SeqTypes> for EpochCommittees {
                 return false;
             },
         };
-        info!(%epoch, "stake table loaded from persistence");
-        self.inner.write().put_epoch_committee(
-            epoch,
-            Arc::new(EpochCommittee::new(
-                validators,
-                block_reward,
-                stake_table_hash,
-                None,
-            )),
-        );
+        let drb = match persistence.load_drb_result(epoch).await {
+            Ok(drb) => drb,
+            Err(err) => {
+                warn!(%err, "failed to load drb result for epoch {epoch} from persistence");
+                None
+            },
+        };
+        drop(persistence);
+        info!(%epoch, has_drb = drb.is_some(), "stake table loaded from persistence");
+        let committee = Arc::new(EpochCommittee::new(
+            validators,
+            block_reward,
+            stake_table_hash,
+            None,
+        ));
+        let randomized = drb.map(|drb| {
+            let leaders = committee
+                .eligible_leaders
+                .iter()
+                .map(|peer_config| peer_config.stake_table_entry.clone())
+                .collect();
+            Arc::new(generate_stake_cdf(leaders, drb))
+        });
+        let mut inner = self.inner.write();
+        inner.put_epoch_committee(epoch, committee);
+        if let Some(randomized) = randomized {
+            inner.put_randomized_committee(epoch, randomized);
+        }
         true
     }
 
@@ -1551,7 +1565,7 @@ mod tests {
             &self,
             epoch: EpochNumber,
         ) -> anyhow::Result<Option<crate::traits::StakeTuple>> {
-            Ok((*epoch == 7).then(|| (Default::default(), None, None)))
+            Ok((*epoch == 7 || *epoch == 8).then(|| (Default::default(), None, None)))
         }
 
         async fn load_latest_stake(
@@ -1559,6 +1573,10 @@ mod tests {
             _limit: u64,
         ) -> anyhow::Result<Option<Vec<crate::v0_3::IndexedStake>>> {
             Ok(None)
+        }
+
+        async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+            Ok((*epoch == 7).then_some([7; 32]))
         }
 
         async fn store_stake(
@@ -1613,7 +1631,8 @@ mod tests {
     }
 
     // `load_stake_table` materializes a snapshot from the persisted stake
-    // table (e.g. after eviction by `prune_epochs`) without network catchup.
+    // table (e.g. after eviction by `prune_epochs`) without network catchup,
+    // including the randomized committee when a DRB result is persisted.
     #[tokio::test]
     async fn restore_stake_table_from_persistence() {
         let fetcher = Fetcher::new(
@@ -1625,12 +1644,17 @@ mod tests {
         );
         let committees = build_committees_with_fetcher(4, fetcher);
 
+        // Epoch 7 has a stake table and a DRB result in storage.
         let seven = EpochNumber::new(7);
         assert!(committees.snapshot(seven).is_none());
         assert!(committees.load_stake_table(seven).await);
-        assert!(committees.snapshot(seven).is_some());
+        assert!(committees.snapshot(seven).unwrap().has_drb());
         // A second call is satisfied by the in-memory snapshot.
         assert!(committees.load_stake_table(seven).await);
+        // Epoch 8 has a stake table but no DRB result.
+        let eight = EpochNumber::new(8);
+        assert!(committees.load_stake_table(eight).await);
+        assert!(!committees.snapshot(eight).unwrap().has_drb());
         // Nothing persisted for epoch 9.
         assert!(!committees.load_stake_table(EpochNumber::new(9)).await);
     }

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -25,7 +25,7 @@ use super::{
 #[cfg(feature = "node")]
 use crate::v0::L1Client;
 use crate::{
-    AuthenticatedValidatorMap, PubKey, RegisteredValidatorMap,
+    AuthenticatedValidatorMap, Header, PubKey, RegisteredValidatorMap,
     v0::{
         GenesisHeader, L1BlockInfo, Timestamp, Upgrade, UpgradeMode,
         impls::{StakeTableHash, fetch_and_calculate_block_reward, reward::EpochRewardsCalculator},
@@ -179,6 +179,10 @@ impl MembershipPersistence for NoStorage {
     }
 
     async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
+        Ok(None)
+    }
+
+    async fn load_epoch_root(&self, _epoch: EpochNumber) -> anyhow::Result<Option<Header>> {
         Ok(None)
     }
 

--- a/crates/espresso/types/src/v0/impls/instance_state.rs
+++ b/crates/espresso/types/src/v0/impls/instance_state.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 #[cfg(feature = "node")]
 use hotshot_contract_adapter::sol_types::{LightClientV3, StakeTableV3};
 use hotshot_types::{
-    HotShotConfig, data::EpochNumber, epoch_membership::EpochMembershipCoordinator,
+    HotShotConfig, data::EpochNumber, drb::DrbResult, epoch_membership::EpochMembershipCoordinator,
     traits::states::InstanceState,
 };
 use moka::future::Cache;
@@ -175,6 +175,10 @@ impl MembershipPersistence for NoStorage {
     }
 
     async fn load_latest_stake(&self, _limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>> {
+        Ok(None)
+    }
+
+    async fn load_drb_result(&self, _epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>> {
         Ok(None)
     }
 

--- a/crates/espresso/types/src/v0/impls/mod.rs
+++ b/crates/espresso/types/src/v0/impls/mod.rs
@@ -13,7 +13,8 @@ mod state;
 mod transaction;
 
 pub use committee::{
-    EpochCommittees, EpochCommitteesError, EpochSnapshot, fetch_and_calculate_block_reward,
+    EpochCommittees, EpochCommitteesError, EpochSnapshot, RECENT_STAKE_TABLES_LIMIT,
+    fetch_and_calculate_block_reward,
 };
 pub use fee_info::{FeeError, retain_accounts};
 #[cfg(any(test, feature = "testing"))]

--- a/crates/espresso/types/src/v0/mod.rs
+++ b/crates/espresso/types/src/v0/mod.rs
@@ -27,8 +27,8 @@ pub use impls::reward::{
 pub use impls::testing;
 pub use impls::{
     BuilderValidationError, EpochCommittees, EpochCommitteesError, EpochSnapshot, FeeError,
-    ProposalValidationError, StateValidationError, ValidatorSet, get_l1_deposits, retain_accounts,
-    validators_from_l1_events,
+    ProposalValidationError, RECENT_STAKE_TABLES_LIMIT, StateValidationError, ValidatorSet,
+    get_l1_deposits, retain_accounts, validators_from_l1_events,
 };
 pub use nsproof::*;
 pub use txproof::*;

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -57,7 +57,7 @@ use super::{
 };
 use crate::{
     AuthenticatedValidatorMap, BlockMerkleTree, FeeAccount, FeeAccountProof, FeeMerkleCommitment,
-    Leaf2, PubKey, SeqTypes,
+    Header, Leaf2, PubKey, SeqTypes,
     v0::impls::StakeTableHash,
     v0_3::{
         ChainConfig, RegisteredValidator, RewardAccountProofV1, RewardAccountV1, RewardAmount,
@@ -524,6 +524,9 @@ pub trait MembershipPersistence: Send + Sync + 'static {
 
     /// Load the DRB result for `epoch`.
     async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>>;
+
+    /// Load the epoch root block header for `epoch`.
+    async fn load_epoch_root(&self, epoch: EpochNumber) -> anyhow::Result<Option<Header>>;
 
     /// Store stake table at `epoch` in the persistence layer
     async fn store_stake(

--- a/crates/espresso/types/src/v0/traits.rs
+++ b/crates/espresso/types/src/v0/traits.rs
@@ -24,7 +24,7 @@ use hotshot_types::{
         DaProposal, DaProposal2, QuorumProposal, QuorumProposal2, QuorumProposalWrapper,
         VidCommitment, VidDisperseShare,
     },
-    drb::{DrbInput, DrbResult},
+    drb::DrbInput,
     event::{HotShotAction, LeafInfo},
     message::{Proposal, convert_proposal},
     simple_certificate::{
@@ -40,6 +40,7 @@ use hotshot_types::{
 };
 use hotshot_types::{
     data::{EpochNumber, ViewNumber},
+    drb::DrbResult,
     epoch_membership::EpochMembershipCoordinator,
     new_protocol::CoordinatorEvent,
     simple_certificate::LightClientStateUpdateCertificateV2,
@@ -520,6 +521,9 @@ pub trait MembershipPersistence: Send + Sync + 'static {
 
     /// Load stake tables for storage for latest `n` known epochs
     async fn load_latest_stake(&self, limit: u64) -> anyhow::Result<Option<Vec<IndexedStake>>>;
+
+    /// Load the DRB result for `epoch`.
+    async fn load_drb_result(&self, epoch: EpochNumber) -> anyhow::Result<Option<DrbResult>>;
 
     /// Store stake table at `epoch` in the persistence layer
     async fn store_stake(

--- a/crates/hotshot/example-types/src/membership/strict_membership.rs
+++ b/crates/hotshot/example-types/src/membership/strict_membership.rs
@@ -294,6 +294,10 @@ where
             committee.into_iter().map(Into::into).collect(),
         );
     }
+
+    async fn load_stake_table(&self, _: EpochNumber) -> bool {
+        false
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/hotshot/types/src/epoch_membership.rs
+++ b/crates/hotshot/types/src/epoch_membership.rs
@@ -337,7 +337,8 @@ impl<TYPES: NodeType> EpochMembershipCoordinator<TYPES> {
 
         // First figure out which epochs we need to fetch
         loop {
-            let has_stake_table = self.membership.snapshot(try_epoch).is_some();
+            let has_stake_table = self.membership.snapshot(try_epoch).is_some()
+                || self.membership.load_stake_table(try_epoch).await;
             if has_stake_table {
                 // We have this stake table but we need to make sure we have the
                 // epoch root of the requested epoch

--- a/crates/hotshot/types/src/traits/election.rs
+++ b/crates/hotshot/types/src/traits/election.rs
@@ -314,6 +314,11 @@ pub trait Membership<T: NodeType>: Debug + Send + Sync {
     /// Called to notify the Membership when a new DRB result has been calculated.
     fn add_drb_result(&self, e: EpochNumber, d: DrbResult);
 
+    /// Load the committee for `epoch` from local storage.
+    ///
+    /// Returns `true` if a snapshot for `epoch` is available afterwards.
+    fn load_stake_table(&self, epoch: EpochNumber) -> impl Future<Output = bool> + Send;
+
     /// Called to notify the Membership that Epochs are enabled.
     /// Implementations should copy the pre-epoch stake table into epoch and epoch+1
     /// when this is called. The value of initial_drb_result should be used for DRB


### PR DESCRIPTION
Currently, snapshots are only added but never removed, constituting a slow memory leak. Here we limit the number of snapshots ~~and DA committees~~ to the most recent `RECENT_STAKE_TABLES_LIMIT`. Evicted epochs are recovered on demand via the membership coordinator's catch-up.