### PR TITLE
[Backport release-ff] Light client fixes and V5→V6 upgrade tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,11 @@ filter = 'test(test_light_client_completeness)'
 slow-timeout = { period = "2m", terminate-after = 15 }
 
 [[profile.default.overrides]]
+filter = 'test(test_light_client_new_protocol_upgrade)'
+slow-timeout = { period = "2m", terminate-after = 15 }
+threads-required = 'num-cpus'
+
+[[profile.default.overrides]]
 filter = 'test(slow_test_restart_new_protocol)'
 slow-timeout = { period = "2m", terminate-after = 5 }
 threads-required = 'num-cpus'

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3180,7 +3180,7 @@ mod test {
     use ::light_client::{
         consensus::{
             header::HeaderProof,
-            leaf::{LeafProof, LeafProofHint},
+            leaf::{FinalityProof, LeafProof, LeafProofHint},
             payload::PayloadProof,
         },
         testing::{EpochChangeQuorum, LEGACY_VERSION},
@@ -3189,7 +3189,7 @@ mod test {
         eips::BlockId,
         network::EthereumWallet,
         primitives::{Address, U256},
-        providers::ProviderBuilder,
+        providers::{ProviderBuilder, ext::AnvilApi},
     };
     use async_lock::Mutex;
     use committable::{Commitment, Committable};
@@ -3204,7 +3204,7 @@ mod test {
         RegisteredValidatorMap, RewardDistributor, StakeTableState, StateCertQueryDataV1,
         StateCertQueryDataV2, ValidatedState, ValidatorLeaderCounts,
         config::PublicHotShotConfig,
-        traits::{MembershipPersistence, NullEventConsumer, PersistenceOptions},
+        traits::{NullEventConsumer, PersistenceOptions},
         v0_3::{COMMISSION_BASIS_POINTS, Fetcher, RewardAmount, RewardMerkleProofV1},
         v0_4::{RewardAccountV2, RewardMerkleProofV2},
         validators_from_l1_events,
@@ -9816,6 +9816,135 @@ mod test {
         network.server.shut_down().await;
     }
 
+    /// Verify the light client leaf, header, and payload proofs at each height
+    /// against the ground truth captured from the availability streams.
+    ///
+    /// Only checks that proofs verify, not which `FinalityProof` variant they
+    /// use
+    async fn check_light_client_proofs(
+        client: &Client<ServerError, StaticVersion<0, 1>>,
+        actual_leaves: &[LeafQueryData<SeqTypes>],
+        actual_blocks: &[BlockQueryData<SeqTypes>],
+        heights: impl IntoIterator<Item = u64>,
+        epoch_height: u64,
+    ) {
+        let quorum = EpochChangeQuorum::new(epoch_height);
+        for i in heights {
+            let leaf = &actual_leaves[i as usize];
+            let block = &actual_blocks[i as usize];
+            let version = leaf.header().version();
+            tracing::info!(i, %version, "check light client proofs");
+
+            // Get the same leaf proof by various IDs.
+            let proofs = try_join_all(
+                [
+                    format!("light-client/leaf/{i}"),
+                    format!("light-client/leaf/hash/{}", leaf.hash()),
+                    format!("light-client/leaf/block-hash/{}", leaf.block_hash()),
+                ]
+                .into_iter()
+                .map(|path| async move {
+                    tracing::info!(i, path, "fetch leaf proof");
+                    let proof = client.get::<LeafProof>(&path).send().await?;
+                    Ok::<_, anyhow::Error>((path, proof))
+                }),
+            )
+            .await
+            .unwrap();
+
+            // Check proofs against the expected leaf.
+            for (path, proof) in proofs {
+                tracing::info!(i, path, "check leaf proof");
+                assert_eq!(
+                    proof
+                        .verify(LeafProofHint::Quorum(&quorum))
+                        .await
+                        .unwrap_or_else(|err| panic!("{path}: proof failed to verify: {err:#}")),
+                    *leaf
+                );
+            }
+
+            // Get the corresponding header.
+            let root_height = i + 1;
+            let root = actual_leaves[root_height as usize].header();
+            let proofs = try_join_all(
+                [
+                    format!("light-client/header/{root_height}/{i}"),
+                    format!(
+                        "light-client/header/{root_height}/hash/{}",
+                        leaf.block_hash()
+                    ),
+                ]
+                .into_iter()
+                .map(|path| async move {
+                    tracing::info!(i, path, "fetch header proof");
+                    let proof = client.get::<HeaderProof>(&path).send().await?;
+                    Ok::<_, anyhow::Error>((path, proof))
+                }),
+            )
+            .await
+            .unwrap();
+            for (path, proof) in proofs {
+                tracing::info!(i, path, "check header proof");
+                assert_eq!(
+                    proof.verify_ref(root.block_merkle_tree_root()).unwrap(),
+                    leaf.header()
+                );
+            }
+
+            // Get the corresponding payload.
+            let proof = client
+                .get::<PayloadProof>(&format!("light-client/payload/{i}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(proof.verify(leaf.header()).unwrap(), *block.payload());
+        }
+    }
+
+    /// Check the light client stake table endpoint: replaying `first_epoch + 2`
+    /// reproduces the validator set loaded from storage, and an earlier epoch
+    /// is a `BAD_REQUEST`.
+    async fn check_light_client_stake_table<N, P>(
+        client: &Client<ServerError, StaticVersion<0, 1>>,
+        server: &SequencerContext<N, P>,
+        first_epoch: EpochNumber,
+    ) where
+        N: ConnectedNetwork<PubKey>,
+        P: SequencerPersistence,
+    {
+        let events: Vec<StakeTableEvent> = client
+            .get(&format!("light-client/stake-table/{}", first_epoch + 2))
+            .send()
+            .await
+            .unwrap();
+        let mut state_from_events = StakeTableState::default();
+        for event in events {
+            state_from_events.apply_event(event).unwrap().unwrap();
+        }
+        assert_eq!(
+            state_from_events.into_validators(),
+            server
+                .consensus_handle()
+                .storage()
+                .await
+                .load_all_validators(first_epoch + 2, 0, 1_000_000)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|v| (v.account, v))
+                .collect::<RegisteredValidatorMap>()
+        );
+
+        // Querying for a stake table before the first real epoch is an error.
+        let err = client
+            .get::<Vec<StakeTableEvent>>(&format!("light-client/stake-table/{}", first_epoch + 1))
+            .send()
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_light_client_completeness() {
         // Run the through a protocol upgrade and epoch change, then check that we are able to get a
@@ -9951,109 +10080,217 @@ mod test {
         // * A few blocks just before and after the stake table comes into effect
             .chain(epoch_heights[1]-1..=max_block);
 
-        let quorum = EpochChangeQuorum::new(EPOCH_HEIGHT);
-        for i in heights {
-            let leaf = &actual_leaves[i as usize];
-            let block = &actual_blocks[i as usize];
-            tracing::info!(i, ?leaf, ?block, "check leaf");
+        check_light_client_proofs(
+            &client,
+            &actual_leaves,
+            &actual_blocks,
+            heights,
+            EPOCH_HEIGHT,
+        )
+        .await;
+        check_light_client_stake_table(&client, &network.server, first_epoch).await;
+    }
 
-            // Get the same leaf proof by various IDs.
-            let client = &client;
-            let proofs = try_join_all(
-                [
-                    format!("light-client/leaf/{i}"),
-                    format!("light-client/leaf/hash/{}", leaf.hash()),
-                    format!("light-client/leaf/block-hash/{}", leaf.block_hash()),
-                ]
-                .into_iter()
-                .map(|path| async move {
-                    tracing::info!(i, path, "fetch leaf proof");
-                    let proof = client.get::<LeafProof>(&path).send().await?;
-                    Ok::<_, anyhow::Error>((path, proof))
-                }),
-            )
+    /// run through the new protocol upgrade and a following epoch change, then check the
+    /// light client serves correct leaf, header, payload, and stake table
+    /// proofs around both boundaries.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_light_client_new_protocol_upgrade() {
+        const NUM_NODES: usize = 5;
+        const EPOCH_HEIGHT: u64 = 70;
+        const UPGRADE_START_PROPOSING_VIEW: u64 = 3 * EPOCH_HEIGHT + 5;
+        const UPGRADE: Upgrade = Upgrade::new(EPOCH_REWARD_VERSION, NEW_PROTOCOL_VERSION);
+
+        let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+        let url: Url = format!("http://localhost:{port}").parse().unwrap();
+
+        let test_config = TestConfigBuilder::<NUM_NODES>::default()
+            .epoch_height(EPOCH_HEIGHT)
+            .epoch_start_block(0)
+            .builder_timeout(Duration::from_millis(500))
+            .set_upgrades(NEW_PROTOCOL_VERSION)
             .await
+            .upgrade_proposing_views(UPGRADE_START_PROPOSING_VIEW, 1000)
+            .build();
+
+        test_config
+            .anvil()
+            .expect("TestConfigBuilder starts an anvil")
+            .anvil_set_interval_mining(1)
+            .await
+            .expect("interval mining");
+
+        // Base version V5 already has epochs, so genesis must carry the stake
+        // table contract deployed above.
+        let genesis_state = ValidatedState {
+            chain_config: test_config
+                .get_upgrade_map()
+                .chain_config(NEW_PROTOCOL_VERSION)
+                .into(),
+            ..Default::default()
+        };
+
+        let storage = join_all((0..NUM_NODES).map(|_| SqlDataSource::create_storage())).await;
+        let persistence: [_; NUM_NODES] = storage
+            .iter()
+            .map(<SqlDataSource as TestableSequencerDataSource>::persistence_options)
+            .collect::<Vec<_>>()
+            .try_into()
             .unwrap();
 
-            // Check proofs against expected leaf.
-            for (path, proof) in proofs {
-                tracing::info!(i, path, ?proof, "check leaf proof");
-                assert_eq!(
-                    proof.verify(LeafProofHint::Quorum(&quorum)).await.unwrap(),
-                    *leaf
-                );
-            }
-
-            // Get the corresponding header.
-            let root_height = i + 1;
-            let root = actual_leaves[root_height as usize].header();
-            let proofs = try_join_all(
-                [
-                    format!("light-client/header/{root_height}/{i}"),
-                    format!(
-                        "light-client/header/{root_height}/hash/{}",
-                        leaf.block_hash()
-                    ),
-                ]
-                .into_iter()
-                .map(|path| async move {
-                    tracing::info!(i, path, "get header proof");
-                    let proof = client.get::<HeaderProof>(&path).send().await?;
-                    Ok::<_, anyhow::Error>((path, proof))
-                }),
+        let config = TestNetworkConfigBuilder::<NUM_NODES, _, _>::with_num_nodes()
+            .api_config(
+                SqlDataSource::options(&storage[0], Options::with_port(port))
+                    .light_client(Default::default()),
             )
+            .persistences(persistence)
+            .states(std::array::from_fn(|_| genesis_state.clone()))
+            .catchups(std::array::from_fn(|_| {
+                StatePeers::<SequencerApiVersion>::from_urls(
+                    vec![url.clone()],
+                    Default::default(),
+                    Duration::from_secs(2),
+                    &NoMetrics,
+                )
+            }))
+            .network_config(test_config)
+            .build();
+
+        let mut network = TestNetwork::new(config, UPGRADE).await;
+        let client: Client<ServerError, StaticVersion<0, 1>> = Client::new(url);
+        client.connect(None).await;
+
+        // Track each leaf and block served by the query service; they are the
+        // ground truth the light client proofs are checked against.
+        let mut actual_leaves = vec![];
+        let mut actual_blocks = vec![];
+        let mut leaves = client
+            .socket("availability/stream/leaves/0")
+            .subscribe::<LeafQueryData<SeqTypes>>()
             .await
-            .unwrap();
-            for (path, proof) in proofs {
-                tracing::info!(i, path, ?proof, "check header proof");
-                assert_eq!(
-                    proof.verify_ref(root.block_merkle_tree_root()).unwrap(),
-                    leaf.header()
+            .unwrap()
+            .zip(
+                client
+                    .socket("availability/stream/blocks/0")
+                    .subscribe::<BlockQueryData<SeqTypes>>()
+                    .await
+                    .unwrap(),
+            )
+            .map(|(leaf, block)| {
+                let leaf = leaf.unwrap();
+                actual_leaves.push(leaf.clone());
+                actual_blocks.push(block.unwrap());
+                leaf
+            });
+
+        // Wait for the upgrade to take effect.
+        let upgrade_height = timeout(Duration::from_secs(600), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                if leaf.header().version() >= NEW_PROTOCOL_VERSION {
+                    break leaf.height();
+                }
+                tracing::info!(
+                    version = %leaf.header().version(),
+                    height = leaf.header().height(),
+                    view = ?leaf.leaf().view_number(),
+                    "waiting for new protocol upgrade"
                 );
             }
+        })
+        .await
+        .expect("the network did not upgrade to the new protocol");
+        let upgrade_epoch = epoch_from_block_number(upgrade_height, EPOCH_HEIGHT);
+        tracing::info!(upgrade_height, upgrade_epoch, "new protocol enabled");
 
-            // Get the corresponding payload.
-            let proof = client
-                .get::<PayloadProof>(&format!("light-client/payload/{i}"))
+        // Wait for the first post upgrade epoch change, to also cover proofs
+        // across a V6 epoch boundary
+        let epoch_change_height = timeout(Duration::from_secs(300), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                let epoch = epoch_from_block_number(leaf.height(), EPOCH_HEIGHT);
+                if epoch > upgrade_epoch {
+                    break leaf.height();
+                }
+                tracing::info!(
+                    height = leaf.height(),
+                    ?epoch,
+                    "waiting for a post-upgrade epoch change"
+                );
+            }
+        })
+        .await
+        .expect("no epoch change happened after the upgrade");
+        tracing::info!(epoch_change_height, "post upgrade epoch change");
+
+        // Run a few more blocks so every queried height has the descendants its
+        // proof needs (QC chains, header roots, and a finalizing `Certificate2`).
+        let max_block = epoch_change_height + 3;
+        timeout(Duration::from_secs(120), async {
+            loop {
+                let leaf = leaves.next().await.unwrap();
+                if leaf.height() > max_block {
+                    break;
+                }
+                tracing::info!(max_block, height = leaf.height(), "waiting for block");
+            }
+        })
+        .await
+        .expect("the chain stopped making progress after the upgrade");
+
+        // Stop consensus: every block we query has already been produced.
+        network.stop_consensus().await;
+
+        // Sample blocks around the two boundaries where proof logic changes
+        // the V5 -> V6 upgrade and the following V6 epoch change.
+        let heights =
+            (upgrade_height - 3..=upgrade_height + 1).chain(epoch_change_height - 1..=max_block);
+
+        check_light_client_proofs(
+            &client,
+            &actual_leaves,
+            &actual_blocks,
+            heights,
+            EPOCH_HEIGHT,
+        )
+        .await;
+
+        let client = &client;
+        let finality_proof = |height: u64| async move {
+            client
+                .get::<LeafProof>(&format!("light-client/leaf/{height}"))
                 .send()
                 .await
-                .unwrap();
-            assert_eq!(proof.verify(leaf.header()).unwrap(), *block.payload());
-        }
-
-        // Check light client stake table.
-        let events: Vec<StakeTableEvent> = client
-            .get(&format!("light-client/stake-table/{}", first_epoch + 2))
-            .send()
-            .await
-            .unwrap();
-        let mut state_from_events = StakeTableState::default();
-        for event in events {
-            state_from_events.apply_event(event).unwrap().unwrap();
-        }
-
-        assert_eq!(
-            state_from_events.into_validators(),
-            network
-                .server
-                .consensus_handle()
-                .storage()
-                .await
-                .load_all_validators(first_epoch + 2, 0, 1_000_000)
-                .await
                 .unwrap()
-                .into_iter()
-                .map(|v| (v.account, v))
-                .collect::<RegisteredValidatorMap>()
-        );
+        };
+        // Everything up to the last two pre cutover leaves is old protocol
+        for height in upgrade_height - 10..=upgrade_height - 3 {
+            let proof = finality_proof(height).await;
+            assert!(
+                matches!(proof.proof(), FinalityProof::HotStuff2 { .. }),
+                "leaf {height} should be proven by a HotStuff2 QC chain, got {:?}",
+                proof.proof(),
+            );
+        }
 
-        // Querying for a stake table before the first real epoch is an error.
-        let err = client
-            .get::<Vec<StakeTableEvent>>(&format!("light-client/stake-table/{}", first_epoch + 1))
-            .send()
-            .await
-            .unwrap_err();
-        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        // A post cutover leaf is proven by a new protocol certificate. The last
+        // two pre cutover leaves will be finalized by new protocol
+        // e.g cutover at 347 the old protocol decides up to 344 (HotStuff2), and the
+        // new protocol's first Cert2 directly commits 347 and finalizes
+        // 345 and 346 with it via the indirect commit rule.
+        for height in [upgrade_height - 1, epoch_change_height] {
+            let proof = finality_proof(height).await;
+            assert!(
+                matches!(proof.proof(), FinalityProof::NewProtocol { .. }),
+                "leaf {height} should be proven by a new protocol certificate, got {:?}",
+                proof.proof(),
+            );
+        }
+
+        // Epochs run from genesis, so `first_epoch` is 1 and the endpoint is
+        // queryable from epoch 3, which the chain has long passed.
+        let first_epoch = EpochNumber::new(epoch_from_block_number(0, EPOCH_HEIGHT));
+        check_light_client_stake_table(client, &network.server, first_epoch).await;
     }
 
     /// Test that `fetch_leaf` returns a leaf with exactly the requested block height.

--- a/crates/espresso/node/src/api/light_client.rs
+++ b/crates/espresso/node/src/api/light_client.rs
@@ -1550,6 +1550,110 @@ mod test {
         );
     }
 
+    /// With a gapless cutover, the leaf two before the cutover (`upgrade_height
+    /// - 2`) is finalized by the old protocol: its HotStuff2 2-chain completes
+    /// within pre-cutover leaves (deciding QC belongs to `upgrade_height - 1`,
+    /// still V5), so no cert2 is needed.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_leaf_before_cutover_uses_hotstuff2() {
+        let storage = <DataSource as TestableSequencerDataSource>::create_storage().await;
+        let ds = DataSource::create(
+            DataSource::persistence_options(&storage),
+            Default::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        // Cutover at height 4, so `upgrade_height - 2` is height 2 (leaves[1]).
+        let leaves = leaf_chain_with_upgrade(
+            1..=5,
+            4,
+            Upgrade::new(DRB_AND_HEADER_UPGRADE_VERSION, NEW_PROTOCOL_VERSION),
+        )
+        .await;
+        assert!(leaves[1].header().version() < NEW_PROTOCOL_VERSION);
+        assert!(leaves[3].header().version() >= NEW_PROTOCOL_VERSION);
+
+        {
+            let mut tx = ds.write().await.unwrap();
+            for leaf in &leaves {
+                tx.insert_leaf(leaf).await.unwrap();
+            }
+            tx.commit().await.unwrap();
+        }
+
+        let proof =
+            get_leaf_proof_with_qc_chain(&ds, leaves[1].clone(), Duration::MAX, CHAIN_LIMIT)
+                .await
+                .unwrap();
+        assert!(matches!(proof.proof(), FinalityProof::HotStuff2 { .. }));
+        assert_eq!(
+            proof
+                .verify(LeafProofHint::Quorum(&VersionCheckQuorum::new(
+                    leaves.iter().map(|leaf| leaf.leaf().clone())
+                )))
+                .await
+                .unwrap(),
+            leaves[1]
+        );
+    }
+
+    /// When a view gap at the cutover prevents a HotStuff2 2-chain from
+    /// completing within pre-cutover leaves, the leaf two before the cutover
+    /// (`upgrade_height - 2`) instead falls through to cert2 finality. Skewing
+    /// the view numbers breaks the consecutive-view requirement, so no 2-chain
+    /// forms and the proof terminates at the first cert2.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_leaf_before_cutover_uses_cert2() {
+        let storage = <DataSource as TestableSequencerDataSource>::create_storage().await;
+        let ds = DataSource::create(
+            DataSource::persistence_options(&storage),
+            Default::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        // Cutover at height 4, so `upgrade_height - 2` is height 2 (leaves[1]).
+        // Skewed views mean no HotStuff2 2-chain ever forms.
+        let leaves = custom_leaf_chain_with_upgrade(
+            1..=5,
+            4,
+            Upgrade::new(DRB_AND_HEADER_UPGRADE_VERSION, NEW_PROTOCOL_VERSION),
+            |proposal| {
+                proposal.view_number = ViewNumber::new(proposal.block_header.height() * 2);
+            },
+        )
+        .await;
+        assert!(leaves[1].header().version() < NEW_PROTOCOL_VERSION);
+        assert!(leaves[3].header().version() >= NEW_PROTOCOL_VERSION);
+        let cert2_leaf = &leaves[3];
+        let cert2 = cert2_for_leaf(cert2_leaf);
+
+        {
+            let mut tx = ds.write().await.unwrap();
+            for leaf in &leaves {
+                tx.insert_leaf(leaf).await.unwrap();
+            }
+            tx.insert_cert2(cert2_leaf.height(), cert2).await.unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        let proof =
+            get_leaf_proof_with_qc_chain(&ds, leaves[1].clone(), Duration::MAX, CHAIN_LIMIT)
+                .await
+                .unwrap();
+        assert!(matches!(proof.proof(), FinalityProof::NewProtocol { .. }));
+        assert_eq!(
+            proof
+                .verify(LeafProofHint::Quorum(&AlwaysTrueQuorum))
+                .await
+                .unwrap(),
+            leaves[1]
+        );
+    }
+
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_bad_finalized() {
         let storage = <DataSource as TestableSequencerDataSource>::create_storage().await;

--- a/light-client/src/client.rs
+++ b/light-client/src/client.rs
@@ -2,9 +2,9 @@ use std::{collections::HashMap, future::Future};
 #[cfg(feature = "client")]
 use std::{fmt::Debug, pin::pin, time::Duration};
 
-#[cfg(feature = "client")]
-use anyhow::Context;
 use anyhow::Result;
+#[cfg(feature = "client")]
+use anyhow::{Context, anyhow};
 #[cfg(feature = "client")]
 use derive_builder::Builder;
 use espresso_types::{Certificate2, NamespaceId, SeqTypes, v0_3::StakeTableEvent};
@@ -17,6 +17,8 @@ use futures::{
 use hotshot_query_service_types::availability::LeafId;
 use hotshot_query_service_types::{availability::LeafQueryData, node::BlockId};
 use hotshot_types::data::EpochNumber;
+#[cfg(feature = "client")]
+use serde::de::DeserializeOwned;
 #[cfg(feature = "client")]
 use surf_disco::Url;
 #[cfg(feature = "client")]
@@ -150,12 +152,21 @@ impl QueryServiceClient {
                 .build(),
         }
     }
+
+    /// GET `path`, deserializing the response
+    async fn fetch<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.client
+            .get(path)
+            .send()
+            .await
+            .with_context(|| format!("fetching {path}"))
+    }
 }
 
 #[cfg(feature = "client")]
 impl Client for QueryServiceClient {
     async fn block_height(&self) -> Result<u64> {
-        Ok(self.client.get("/node/block-height").send().await?)
+        self.fetch("/node/block-height").await
     }
 
     async fn leaf_proof(
@@ -176,8 +187,7 @@ impl Client for QueryServiceClient {
             Some(finalized) => format!("{path}/{finalized}"),
             None => path,
         };
-        let proof = self.client.get(&path).send().await?;
-        Ok(proof)
+        self.fetch(&path).await
     }
 
     /// Get all leaves in the given range `[start, end)`.
@@ -186,33 +196,27 @@ impl Client for QueryServiceClient {
         start: usize,
         end: usize,
     ) -> Result<Vec<LeafQueryData<SeqTypes>>> {
-        let path = format!("/availability/leaf/{start}/{end}");
-        let leaves = self.client.get(&path).send().await?;
-        Ok(leaves)
+        self.fetch(&format!("/availability/leaf/{start}/{end}"))
+            .await
     }
 
     async fn header_proof(&self, root: u64, id: BlockId<SeqTypes>) -> Result<HeaderProof> {
-        let path = format!("/light-client/header/{root}/{}", fmt_block_id(id));
-        let proof = self.client.get(&path).send().await?;
-        Ok(proof)
+        self.fetch(&format!("/light-client/header/{root}/{}", fmt_block_id(id)))
+            .await
     }
 
     async fn payload_proof(&self, height: u64) -> Result<PayloadProof> {
-        let path = format!("/light-client/payload/{height}");
-        Ok(self.client.get(&path).send().await?)
+        self.fetch(&format!("/light-client/payload/{height}")).await
     }
 
     async fn payload_proofs_in_range(&self, start: u64, end: u64) -> Result<Vec<PayloadProof>> {
-        let path = format!("/light-client/payload/{start}/{end}");
-        Ok(self.client.get(&path).send().await?)
+        self.fetch(&format!("/light-client/payload/{start}/{end}"))
+            .await
     }
 
     async fn namespace_proof(&self, height: u64, namespace: NamespaceId) -> Result<NamespaceProof> {
-        Ok(self
-            .client
-            .get(&format!("/light-client/namespace/{height}/{namespace}"))
-            .send()
-            .await?)
+        self.fetch(&format!("/light-client/namespace/{height}/{namespace}"))
+            .await
     }
 
     async fn namespace_proofs_in_range(
@@ -221,13 +225,10 @@ impl Client for QueryServiceClient {
         end: u64,
         namespace: NamespaceId,
     ) -> Result<Vec<NamespaceProof>> {
-        Ok(self
-            .client
-            .get(&format!(
-                "/light-client/namespace/{start}/{end}/{namespace}"
-            ))
-            .send()
-            .await?)
+        self.fetch(&format!(
+            "/light-client/namespace/{start}/{end}/{namespace}"
+        ))
+        .await
     }
 
     async fn namespaces_proofs_in_range(
@@ -237,27 +238,17 @@ impl Client for QueryServiceClient {
         namespaces: &[NamespaceId],
     ) -> Result<Vec<HashMap<NamespaceId, NamespaceProof>>> {
         let encoded = TaggedBase64::new(NAMESPACES_PARAM_TAG, &serde_json::to_vec(namespaces)?)?;
-        Ok(self
-            .client
-            .get(&format!("/light-client/namespaces/{start}/{end}/{encoded}"))
-            .send()
-            .await?)
+        self.fetch(&format!("/light-client/namespaces/{start}/{end}/{encoded}"))
+            .await
     }
 
     async fn stake_table_events(&self, epoch: EpochNumber) -> Result<Vec<StakeTableEvent>> {
-        Ok(self
-            .client
-            .get(&format!("/light-client/stake-table/{epoch}"))
-            .send()
-            .await?)
+        self.fetch(&format!("/light-client/stake-table/{epoch}"))
+            .await
     }
 
     async fn cert2(&self, height: u64) -> Result<Option<Certificate2<SeqTypes>>> {
-        Ok(self
-            .client
-            .get(&format!("/availability/cert2/{height}"))
-            .send()
-            .await?)
+        self.fetch(&format!("/availability/cert2/{height}")).await
     }
 }
 
@@ -402,7 +393,12 @@ impl<T> FallbackClient<T> {
         C: Send + Sync,
         F: TryFuture<Ok: Send, Error = anyhow::Error> + Send,
     {
-        Self::get_any_recursive(0, self.fallback_delay, clients.into_iter(), get).await
+        Self::get_any_recursive(0, self.fallback_delay, clients.into_iter(), get, None)
+            .await
+            .map_err(|err| {
+                tracing::warn!(%err, "failed to fetch on all clients");
+                err.context("failed to fetch on all clients")
+            })
     }
 
     fn get_any_recursive<'a, C, F>(
@@ -410,13 +406,16 @@ impl<T> FallbackClient<T> {
         timeout: Duration,
         mut clients: impl Iterator<Item = C> + Send + 'a,
         get: impl Fn(C) -> F + Send + 'a,
+        prev_err: Option<anyhow::Error>,
     ) -> BoxFuture<'a, Result<F::Ok>>
     where
         C: Send + Sync + 'a,
         F: TryFuture<Ok: Send, Error = anyhow::Error> + Send + 'a,
     {
         async move {
-            let client = clients.next().context("failed to fetch on all clients")?;
+            let Some(client) = clients.next() else {
+                return Err(prev_err.unwrap_or_else(|| anyhow!("no clients available")));
+            };
             match select(
                 pin!(TryFutureExt::into_future(get(client))),
                 pin!(sleep(timeout)),
@@ -430,8 +429,8 @@ impl<T> FallbackClient<T> {
                 Either::Left((Err(err), _)) => {
                     // If the pending future fails, abandon it and immediately start the fallback
                     // even if we haven't hit the timeout.
-                    tracing::warn!("failed to fetch on client {i}: {err:#}");
-                    Self::get_any_recursive(i + 1, timeout, clients, get).await
+                    tracing::info!(i, %err, "failed to fetch on client");
+                    Self::get_any_recursive(i + 1, timeout, clients, get, Some(err)).await
                 },
                 Either::Right((_, fut)) => {
                     // The timeout has elapsed. Start the request on the next client, but also keep
@@ -443,7 +442,7 @@ impl<T> FallbackClient<T> {
                     );
                     Ok(select_ok([
                         fut.boxed(),
-                        Self::get_any_recursive(i + 1, timeout, clients, get),
+                        Self::get_any_recursive(i + 1, timeout, clients, get, prev_err),
                     ])
                     .await?
                     .0)

--- a/light-client/src/consensus/leaf.rs
+++ b/light-client/src/consensus/leaf.rs
@@ -31,7 +31,9 @@ pub enum FinalityProof {
     /// * `committing_qc.leaf_commit() == leaf.commit()`
     /// * `committing_qc.view_number() == leaf.view_number()`
     /// * `deciding_qc.view_number() == committing_qc.view_number() + 1`
-    /// * Both QCs have a valid threshold signature given a stake table
+    /// * Both QCs have a valid threshold signature given a stake table. When the leaf is the last
+    ///   leaf of an epoch, the deciding QC is produced in the subsequent epoch and is checked
+    ///   against the next epoch's stake table.
     HotStuff2 {
         committing_qc: Arc<Certificate>,
         deciding_qc: Arc<Certificate>,

--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -80,6 +80,62 @@ pub trait Quorum: Sync {
         cert2: &Certificate2<SeqTypes>,
     ) -> impl Send + Future<Output = Result<()>>;
 
+    /// Check a threshold signature on a certificate signed by the epoch after this quorum's.
+    fn verify_next_epoch(
+        &self,
+        cert: &Certificate,
+        version: Version,
+    ) -> impl Send + Future<Output = Result<()>> {
+        async move {
+            match (version.major, version.minor) {
+                (0, 1) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 1>>(cert)
+                        .await
+                },
+                (0, 2) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 2>>(cert)
+                        .await
+                },
+                (0, 3) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 3>>(cert)
+                        .await
+                },
+                (0, 4) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 4>>(cert)
+                        .await
+                },
+                (0, 5) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 5>>(cert)
+                        .await
+                },
+                (0, 6) => {
+                    self.verify_next_epoch_static::<StaticVersion<0, 6>>(cert)
+                        .await
+                },
+                _ => {
+                    const {
+                        assert!(MAX_SUPPORTED_VERSION.major == 0);
+                        assert!(MAX_SUPPORTED_VERSION.minor == 6);
+                    }
+                    bail!("unsupported version {version}");
+                },
+            }
+        }
+    }
+
+    /// Same as [`verify_next_epoch`](Self::verify_next_epoch), but with the version as a
+    /// type-level parameter.
+    ///
+    /// The default delegates to [`verify_static`](Self::verify_static), which is only appropriate
+    /// for quorums that do not distinguish epochs (such as test mocks). Implementations backed by
+    /// per-epoch stake tables must override this to verify against the next epoch's quorum.
+    fn verify_next_epoch_static<V: StaticVersionType + 'static>(
+        &self,
+        qc: &Certificate,
+    ) -> impl Send + Future<Output = Result<()>> {
+        self.verify_static::<V>(qc)
+    }
+
     /// Verify that QCs are signed, form a chain starting from `leaf`, with a particular protocol
     /// version.
     ///
@@ -139,8 +195,39 @@ pub trait Quorum: Sync {
                     max_cert_version = cert_version;
                 }
 
+                // Which epoch's quorum do we expect to have signed this certificate? A chain
+                // proving the last leaf of an epoch necessarily contains certificates produced in
+                // the subsequent epoch, signed by the next epoch's quorum. Each certificate commits
+                // to its epoch in the signed payload, so dispatching on it is sound: a certificate
+                // claiming the wrong epoch will fail signature verification.
+                let committing = first.unwrap_or(cert);
+                let next_epoch = match (committing.epoch(), cert.epoch()) {
+                    // Certificates from before the epochs upgrade are always checked against the
+                    // quorum supplied for this proof.
+                    (None, _) | (_, None) => false,
+                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch => false,
+                    (Some(leaf_epoch), Some(cert_epoch)) if cert_epoch == leaf_epoch + 1 => {
+                        // Only the last leaf of an epoch is justified by the next epoch's quorum,
+                        // and its committing QC is dual-signed: it carries a next-epoch QC that
+                        // `verify` has already checked against the next epoch's quorum. Requiring
+                        // that here stops the next epoch's quorum from finalizing an interior leaf
+                        // of the previous epoch, which it never co-signed.
+                        committing.next_epoch_qc().is_some()
+                    },
+                    (Some(leaf_epoch), Some(cert_epoch)) => {
+                        bail!(
+                            "certificate from epoch {cert_epoch} cannot justify a leaf in epoch \
+                             {leaf_epoch}"
+                        );
+                    },
+                };
+
                 // Check the signature.
-                self.verify(cert, cert_version).await?;
+                if next_epoch {
+                    self.verify_next_epoch(cert, cert_version).await?;
+                } else {
+                    self.verify(cert, cert_version).await?;
+                }
 
                 // Check chaining.
                 if let Some(prev) = curr {
@@ -304,13 +391,22 @@ where
 
         if version(V::MAJOR, V::MINOR) >= EPOCH_VERSION {
             // If this certificate is part of an epoch change, also check that the next epoch's
-            // quorum has signed.
-            if let Some(next_epoch_qc) = cert.verify_next_epoch_qc(self.epoch_height)? {
-                let stake_table = self.membership.next_epoch_stake_table().await?;
-                stake_table
-                    .verify_cert::<V, _>(next_epoch_qc)
-                    .await
-                    .context("verifying next epoch QC")?;
+            // quorum has signed. Reject a next-epoch QC attached to any other certificate: it would
+            // otherwise go unverified, yet the epoch dispatch in `verify_qc_chain_and_get_version`
+            // treats a next-epoch QC on the committing certificate as proof that the next epoch
+            // co-signed the leaf.
+            match cert.verify_next_epoch_qc(self.epoch_height)? {
+                Some(next_epoch_qc) => {
+                    let stake_table = self.membership.next_epoch_stake_table().await?;
+                    stake_table
+                        .verify_cert::<V, _>(next_epoch_qc)
+                        .await
+                        .context("verifying next epoch QC")?;
+                },
+                None => ensure!(
+                    cert.next_epoch_qc().is_none(),
+                    "certificate carries a next-epoch QC but is not an epoch transition"
+                ),
             }
         }
 
@@ -327,10 +423,42 @@ where
             .await
             .context("verifying cert2")
     }
+
+    async fn verify_next_epoch_static<V: StaticVersionType + 'static>(
+        &self,
+        cert: &Certificate,
+    ) -> Result<()> {
+        let stake_table = self.membership.next_epoch_stake_table().await?;
+        stake_table
+            .verify_cert::<V, _>(cert.qc())
+            .await
+            .context("verifying QC against next epoch quorum")?;
+
+        // A certificate from the epoch after the proof's epoch is never itself part of an epoch
+        // transition (transition certificates belong to the epoch that is ending), so there is no
+        // second next-epoch QC to check.
+        ensure!(
+            cert.next_epoch_qc().is_none(),
+            "unexpected next-epoch QC on a certificate from the next epoch"
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use bitvec::vec::BitVec;
+    use committable::Commitment;
+    use espresso_types::PrivKey;
+    use hotshot_query_service_types::availability::LeafQueryData;
+    use hotshot_types::{
+        data::{EpochNumber, ViewNumber},
+        simple_certificate::{NextEpochQuorumCertificate2, QuorumCertificate2},
+        simple_vote::{NextEpochQuorumData2, QuorumData2, VersionedVoteData},
+        traits::signature_key::SignatureKey,
+        vote::Certificate as _,
+    };
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -500,5 +628,236 @@ mod test {
             .await
             .unwrap();
         assert_eq!(version, leaves[0].header().version());
+    }
+
+    const BOUNDARY_EPOCH_HEIGHT: u64 = 10;
+
+    fn boundary_quorum(seeds: impl IntoIterator<Item = u64>) -> QuorumKeys {
+        seeds
+            .into_iter()
+            .map(|i| {
+                let (stake_key, priv_key) =
+                    PubKey::generated_from_seed_indexed(Default::default(), i);
+                (
+                    priv_key,
+                    StakeTableEntry {
+                        stake_key,
+                        stake_amount: U256::from(1),
+                    },
+                )
+            })
+            .unzip()
+    }
+
+    type QuorumKeys = (Vec<PrivKey>, Vec<StakeTableEntry<PubKey>>);
+
+    fn boundary_signature(
+        msg: &[u8],
+        (keys, entries): &QuorumKeys,
+    ) -> <PubKey as SignatureKey>::QcType {
+        let total = entries
+            .iter()
+            .fold(U256::ZERO, |acc, entry| acc + entry.stake_amount);
+        let pp = PubKey::public_parameter(entries, supermajority_threshold(total));
+        let sigs = keys
+            .iter()
+            .map(|key| PubKey::sign(key, msg).unwrap())
+            .collect::<Vec<_>>();
+        PubKey::assemble(
+            &pp,
+            &std::iter::repeat_n(true, keys.len()).collect::<BitVec>(),
+            &sigs,
+        )
+    }
+
+    fn boundary_signed_qc(
+        data: QuorumData2<SeqTypes>,
+        view: ViewNumber,
+        quorum: &QuorumKeys,
+    ) -> QuorumCertificate2<SeqTypes> {
+        let commit = VersionedVoteData::new_infallible(
+            data,
+            view,
+            &UpgradeLock::<SeqTypes>::new(Upgrade::trivial(EPOCH_VERSION)),
+        )
+        .commit();
+        let sig = boundary_signature(commit.as_ref(), quorum);
+        QuorumCertificate2::create_signed_certificate(commit, data, sig, view)
+    }
+
+    fn boundary_signed_next_epoch_qc(
+        data: QuorumData2<SeqTypes>,
+        view: ViewNumber,
+        quorum: &QuorumKeys,
+    ) -> NextEpochQuorumCertificate2<SeqTypes> {
+        let data: NextEpochQuorumData2<SeqTypes> = data.into();
+        let commit = VersionedVoteData::new_infallible(
+            data.clone(),
+            view,
+            &UpgradeLock::<SeqTypes>::new(Upgrade::trivial(EPOCH_VERSION)),
+        )
+        .commit();
+        let commit_bytes: [u8; 32] = commit.into();
+        let sig = boundary_signature(commit.as_ref(), quorum);
+        NextEpochQuorumCertificate2::new(
+            data,
+            Commitment::from_raw(commit_bytes),
+            view,
+            Some(sig),
+            Default::default(),
+        )
+    }
+
+    /// Build a 2-chain proving the last leaf of epoch 1 (block 10), where epochs 1 and 2 have
+    /// disjoint quorums. The deciding QC is produced in epoch 2. If `deciding_signed_by_next` it
+    /// is correctly signed by epoch 2's quorum; otherwise it is (invalidly) signed by epoch 1's
+    /// quorum.
+    async fn epoch_boundary_fixture(
+        deciding_signed_by_next: bool,
+    ) -> (
+        Vec<LeafQueryData<SeqTypes>>,
+        Certificate,
+        Certificate,
+        StakeTableQuorum<(Arc<StakeTable>, Arc<StakeTable>)>,
+    ) {
+        let current = boundary_quorum(0..5);
+        let next = boundary_quorum(5..10);
+
+        let leaves = leaf_chain(9..=11, EPOCH_VERSION).await;
+
+        // Block 10 is an epoch transition block, so its QC is dual-signed by both quorums.
+        let committing_data = QuorumData2 {
+            leaf_commit: Committable::commit(leaves[1].leaf()),
+            epoch: Some(EpochNumber::new(1)),
+            block_number: Some(10),
+        };
+        let committing_qc = Certificate::new(
+            boundary_signed_qc(committing_data, ViewNumber::new(10), &current),
+            Some(boundary_signed_next_epoch_qc(
+                committing_data,
+                ViewNumber::new(10),
+                &next,
+            )),
+        );
+
+        let deciding_quorum = if deciding_signed_by_next {
+            &next
+        } else {
+            &current
+        };
+        let deciding_qc = Certificate::non_epoch_change(boundary_signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(leaves[2].leaf()),
+                epoch: Some(EpochNumber::new(2)),
+                block_number: Some(11),
+            },
+            ViewNumber::new(11),
+            deciding_quorum,
+        ));
+
+        let quorum = StakeTableQuorum::new(
+            (
+                Arc::new(StakeTable::from(current.1)),
+                Arc::new(StakeTable::from(next.1)),
+            ),
+            BOUNDARY_EPOCH_HEIGHT,
+        );
+        (leaves, committing_qc, deciding_qc, quorum)
+    }
+
+    /// A 2-chain proving the last leaf of an epoch includes a deciding QC signed by the next
+    /// epoch's quorum; it must be verified against that quorum, not the quorum of the epoch of the
+    /// leaf under proof.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_epoch_boundary_quorum_change() {
+        let (leaves, committing_qc, deciding_qc, quorum) = epoch_boundary_fixture(true).await;
+        let ChainVersions { leaf: version, .. } = quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap();
+        assert_eq!(version, leaves[1].header().version());
+    }
+
+    /// A deciding QC claiming to be from the next epoch but signed by the current epoch's quorum
+    /// must fail verification.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_epoch_boundary_deciding_qc_wrong_quorum() {
+        let (leaves, committing_qc, deciding_qc, quorum) = epoch_boundary_fixture(false).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
+    }
+
+    /// Build a 2-chain over an interior (non-boundary) leaf of epoch 1 whose deciding QC is forged
+    /// by epoch 2's quorum, mimicking a next epoch trying to finalize a leaf the current epoch
+    /// never decided. If `disguise_as_boundary`, the committing QC also carries a next-epoch QC to
+    /// imitate a genuine epoch-transition committing QC.
+    async fn mid_epoch_forgery_fixture(
+        disguise_as_boundary: bool,
+    ) -> (
+        Vec<LeafQueryData<SeqTypes>>,
+        Certificate,
+        Certificate,
+        StakeTableQuorum<(Arc<StakeTable>, Arc<StakeTable>)>,
+    ) {
+        let current = boundary_quorum(0..5);
+        let next = boundary_quorum(5..10);
+
+        // Block 5 is in the interior of epoch 1 (epoch height 10), not an epoch boundary.
+        let leaves = leaf_chain(4..=6, EPOCH_VERSION).await;
+
+        let committing_data = QuorumData2 {
+            leaf_commit: Committable::commit(leaves[1].leaf()),
+            epoch: Some(EpochNumber::new(1)),
+            block_number: Some(5),
+        };
+        let committing_qc = Certificate::new(
+            boundary_signed_qc(committing_data, ViewNumber::new(5), &current),
+            disguise_as_boundary
+                .then(|| boundary_signed_next_epoch_qc(committing_data, ViewNumber::new(5), &next)),
+        );
+
+        let deciding_qc = Certificate::non_epoch_change(boundary_signed_qc(
+            QuorumData2 {
+                leaf_commit: Committable::commit(leaves[2].leaf()),
+                epoch: Some(EpochNumber::new(2)),
+                block_number: Some(6),
+            },
+            ViewNumber::new(6),
+            &next,
+        ));
+
+        let quorum = StakeTableQuorum::new(
+            (
+                Arc::new(StakeTable::from(current.1)),
+                Arc::new(StakeTable::from(next.1)),
+            ),
+            BOUNDARY_EPOCH_HEIGHT,
+        );
+        (leaves, committing_qc, deciding_qc, quorum)
+    }
+
+    /// The next epoch's quorum must not be able to finalize an interior leaf of the previous epoch:
+    /// only the last leaf of an epoch is justified by the next epoch, so a deciding QC signed by
+    /// the next epoch over a non-boundary leaf must be rejected.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_mid_epoch_next_epoch_forgery_rejected() {
+        let (leaves, committing_qc, deciding_qc, quorum) = mid_epoch_forgery_fixture(false).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
+    }
+
+    /// The same forgery must be rejected even when the committing QC is dressed up with a
+    /// next-epoch QC to imitate a genuine epoch-transition committing QC.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_mid_epoch_next_epoch_forgery_with_fake_transition_rejected() {
+        let (leaves, committing_qc, deciding_qc, quorum) = mid_epoch_forgery_fixture(true).await;
+        quorum
+            .verify_qc_chain_and_get_version(leaves[1].leaf(), [&committing_qc, &deciding_qc])
+            .await
+            .unwrap_err();
     }
 }

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -515,19 +515,32 @@ impl InnerTestClient {
             {
                 assert!(block_header.set_next_stake_table_hash(self.stake_table_hash(*epoch + 1)));
             }
-            let next_epoch_justify_qc = if i > 0 && is_epoch_transition(i as u64, epoch_height) {
+            // As in production, a leaf carries a next-epoch justify QC exactly when the block
+            // justified by its QC (the parent) is part of an epoch transition, and that QC is
+            // signed by the epoch after the parent's. New-protocol leaves never carry one:
+            // epoch changes there are justified by `Certificate2`, and the `Leaf2`
+            // representation always has `next_epoch_justify_qc: None`.
+            let next_epoch_justify_qc = if i > 0
+                && self.version_at(i as u64) < NEW_PROTOCOL_VERSION
+                && is_epoch_transition(i as u64 - 1, epoch_height)
+            {
                 let parent_qc = self.leaves[i - 1].qc().clone();
+                let parent_epoch = epoch_from_block_number(i as u64 - 1, epoch_height);
+                let parent_upgrade = Upgrade::trivial(self.version_at(i as u64 - 1));
                 let data: NextEpochQuorumData2<SeqTypes> = parent_qc.data.into();
                 let versioned_commit = VersionedVoteData::new_infallible(
                     data.clone(),
                     parent_qc.view_number,
-                    &UpgradeLock::<SeqTypes>::new(upgrade),
+                    &UpgradeLock::<SeqTypes>::new(parent_upgrade),
                 )
                 .commit();
                 let commit_bytes: [u8; 32] = versioned_commit.into();
 
-                let (next_keys, next_validators): (Vec<_>, Vec<_>) =
-                    self.quorum_for_epoch(*epoch + 1).iter().cloned().unzip();
+                let (next_keys, next_validators): (Vec<_>, Vec<_>) = self
+                    .quorum_for_epoch(parent_epoch + 1)
+                    .iter()
+                    .cloned()
+                    .unzip();
                 let mut next_entries = vec![];
                 let mut next_total = U256::ZERO;
                 for validator in &next_validators {


### PR DESCRIPTION
Backports the three light-client PRs that landed on `main` after the last release-ff sync (#4712):

* #4713 — fix(light-client): verify boundary 2-chain QCs against their own epoch
* #4726 — Improve light client fetch logging
* #4724 — test(light-client): verify proofs across the V5→V6 upgrade (adds `test_light_client_new_protocol_upgrade`)

### This PR:
* Cherry-picks the three commits above onto `release-ff` (with `-x` back-references).
* Resolves the one conflict in `light-client/src/consensus/quorum.rs`: the earlier backport #4728 had been adapted around the then-missing #4713 (`ChainVersions`/`verify_next_epoch`). The resolution restores main's original #4722 code, so #4713 and #4722 now compose exactly as on main.
* After this PR, `light-client/`, `crates/espresso/node/src/api{,/light_client}.rs`, and `.config/nextest.toml` are byte-identical to `main` (verified with `git diff origin/main`).

### This PR does not:
* Backport the other post-sync main PRs (#4695, #4698, #4693, #4708, #4715, #4717).

### Key places to review:
* `light-client/src/consensus/quorum.rs` in the first commit — the conflict resolution that reconciles the adapted #4728 with #4713. Everything else applied cleanly.

### Things tested
* `cargo nextest run -p light-client`: 96/96 pass.
* `cargo check -p light-client -p espresso-node --tests` clean.
* The new `test_light_client_new_protocol_upgrade` integration test is left to CI (30-min budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)