### PR TITLE
Check epoch change structure before signatures

### DIFF
--- a/crates/hotshot/new-protocol/src/cert_verifier.rs
+++ b/crates/hotshot/new-protocol/src/cert_verifier.rs
@@ -20,7 +20,7 @@ use hotshot_types::{
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
     vote::{Certificate, HasViewNumber},
 };
-use hotshot_utils::anytrace::Result;
+use hotshot_utils::anytrace::{Result, Wrap};
 use tokio_util::task::JoinMap;
 use tracing::{error, warn};
 
@@ -76,6 +76,7 @@ pub trait Verifiable<T: NodeType>: HasViewNumber + HasEpoch + Sized {
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self::Output>;
 }
@@ -98,6 +99,7 @@ where
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        _epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self> {
         self.is_valid_cert(stake_table, threshold, upgrade_lock)?;
@@ -117,8 +119,10 @@ impl<T: NodeType> Verifiable<T> for EpochChangeMessage<T, Unchecked> {
         self,
         stake_table: &[<T::SignatureKey as SignatureKey>::StakeTableEntry],
         threshold: U256,
+        epoch_height: u64,
         upgrade_lock: &UpgradeLock<T>,
     ) -> Result<Self::Output> {
+        self.well_formed(epoch_height).wrap()?;
         self.cert1
             .is_valid_cert(stake_table, threshold, upgrade_lock)?;
         self.cert2
@@ -212,11 +216,12 @@ impl<T: NodeType, C: Verifiable<T> + Send + 'static> CertVerifier<T, C> {
         };
 
         let lock = self.upgrade_lock.clone();
+        let epoch_height = *self.membership.epoch_height();
 
         self.tasks.spawn_blocking(key, move || {
             let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
             let threshold = membership.success_threshold();
-            match cert.check(&entries, threshold, &lock) {
+            match cert.check(&entries, threshold, epoch_height, &lock) {
                 Ok(valid) => Some(ValidCert::new(valid, epoch)),
                 Err(err) => {
                     warn!(%key, %epoch, %err, cert = type_name::<C>(), "invalid certificate");
@@ -371,11 +376,12 @@ where
         };
 
         let lock = self.upgrade_lock.clone();
+        let epoch_height = *self.membership.epoch_height();
 
         self.tasks.spawn_blocking(sender, move || {
             let entries = StakeTableEntries::from_iter(membership.stake_table()).0;
             let threshold = membership.success_threshold();
-            match cert.check(&entries, threshold, &lock) {
+            match cert.check(&entries, threshold, epoch_height, &lock) {
                 Ok(valid) => Some(ValidCert::new(valid, epoch)),
                 Err(err) => {
                     warn!(%view, %epoch, %err, cert = type_name::<C>(), "invalid certificate");

--- a/crates/hotshot/new-protocol/src/consensus.rs
+++ b/crates/hotshot/new-protocol/src/consensus.rs
@@ -1518,28 +1518,6 @@ impl<T: NodeType> Consensus<T> {
             warn!("locked certificate is newer than epoch change certificate1");
             return Protocol::Abort;
         }
-        // Check if the certificates match
-        if cert1.view_number() != cert2.view_number()
-            || cert1.epoch() != cert2.epoch()
-            || cert1.data.leaf_commit != cert2.data.leaf_commit
-        {
-            warn!("epoch change certificates do not match");
-            return Protocol::Abort;
-        }
-        // check if it's the last block for the correct epoch
-        if !is_last_block(cert2.data.block_number, *self.epoch_height) {
-            warn!("epoch change certificate2 is not the last block of the epoch");
-            return Protocol::Abort;
-        }
-        if cert2.data.block_number / *self.epoch_height != *cert2.data.epoch {
-            warn!("epoch change certificate2 is not for the correct epoch");
-            return Protocol::Abort;
-        }
-        // Check if the proposal matches the certificate1
-        if proposal_commitment(&proposal) != cert1.data.leaf_commit {
-            warn!("epoch change proposal commitment does not match certificate1 leaf commitment");
-            return Protocol::Abort;
-        }
         let next_view = cert2.view_number() + 1;
         let next_epoch = cert2.data.epoch + 1;
         // Change view to the first view of the next epoch

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -637,7 +637,7 @@ where
                         // the pending guard; consensus's `maybe_propose`
                         // will re-request the DRB when it next tries to
                         // build a transition proposal and finds it missing.
-                        warn!(%failure.error, epoch = %failure.epoch, "DRB request failed");
+                        warn!(err = %failure.error, epoch = %failure.epoch, "DRB request failed");
                         continue;
                     }
                 },

--- a/crates/hotshot/new-protocol/src/message.rs
+++ b/crates/hotshot/new-protocol/src/message.rs
@@ -15,6 +15,7 @@ use hotshot_types::{
         Vote2Data,
     },
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    utils::is_last_block,
     vote::HasViewNumber,
 };
 pub use hotshot_types::{
@@ -22,6 +23,8 @@ pub use hotshot_types::{
     simple_certificate::{Certificate1, Certificate2},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::helpers::proposal_commitment;
 
 pub type Vote2<T> = SimpleVote<T, Vote2Data<T>>;
 pub type TimeoutCertificate<T> = SimpleCertificate<T, TimeoutData2, SuccessThreshold>;
@@ -181,6 +184,26 @@ impl<T: NodeType> EpochChangeMessage<T, Unchecked> {
 }
 
 impl<T: NodeType, S> EpochChangeMessage<T, S> {
+    /// Structural validity of the message, independent of signatures.
+    pub fn well_formed(&self, epoch_height: u64) -> Result<(), EpochChangeError> {
+        if self.cert1.view_number() != self.cert2.view_number()
+            || self.cert1.epoch() != self.cert2.epoch()
+            || self.cert1.data.leaf_commit != self.cert2.data.leaf_commit
+        {
+            return Err(EpochChangeError::CertificateMismatch);
+        }
+        if !is_last_block(self.cert2.data.block_number, epoch_height) {
+            return Err(EpochChangeError::NotLastBlock);
+        }
+        if self.cert2.data.block_number / epoch_height != *self.cert2.data.epoch {
+            return Err(EpochChangeError::WrongEpoch);
+        }
+        if proposal_commitment(&self.proposal) != self.cert1.data.leaf_commit {
+            return Err(EpochChangeError::ProposalMismatch);
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     pub fn into_unchecked(self) -> EpochChangeMessage<T, Unchecked> {
         EpochChangeMessage {
@@ -190,6 +213,19 @@ impl<T: NodeType, S> EpochChangeMessage<T, S> {
             _marker: PhantomData,
         }
     }
+}
+
+/// Reason an [`EpochChangeMessage`] is not [well-formed](EpochChangeMessage::well_formed).
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum EpochChangeError {
+    #[error("certificates differ in view, epoch or leaf commitment")]
+    CertificateMismatch,
+    #[error("certificate2 is not for the last block of an epoch")]
+    NotLastBlock,
+    #[error("certificate2's block number does not match its epoch")]
+    WrongEpoch,
+    #[error("proposal commitment does not match certificate1's leaf commitment")]
+    ProposalMismatch,
 }
 
 impl<T: NodeType, S> HasViewNumber for EpochChangeMessage<T, S> {

--- a/crates/hotshot/new-protocol/src/tests/epoch_change.rs
+++ b/crates/hotshot/new-protocol/src/tests/epoch_change.rs
@@ -15,7 +15,7 @@ use super::common::{
 use crate::{
     consensus::{ConsensusInput, ConsensusOutput},
     helpers::proposal_commitment,
-    message::{EpochChangeMessage, Proposal, ProposalMessage},
+    message::{EpochChangeError, EpochChangeMessage, Proposal, ProposalMessage},
     tests::common::assertions::{
         any, count_matching, has_request_drb_for_epoch, is_proposal, is_request_block_and_header,
         is_vote1,
@@ -117,14 +117,11 @@ async fn test_handle_epoch_change_valid() {
     );
 }
 
-/// An EpochChangeMessage with mismatched cert1 and cert2 view numbers should be rejected.
+/// An EpochChangeMessage with mismatched cert1 and cert2 view numbers is not
+/// well-formed.
 #[tokio::test]
-async fn test_handle_epoch_change_mismatched_views() {
-    let mut harness = ConsensusHarness::new(0).await;
+async fn test_epoch_change_mismatched_views_not_well_formed() {
     let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
-
-    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
 
     // Mix cert1 from view 9 with cert2 from view 10 — mismatched views
     let proposal: Proposal<TestTypes> = test_data.views[9].proposal.data.clone();
@@ -134,28 +131,39 @@ async fn test_handle_epoch_change_mismatched_views() {
         proposal,
     );
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "Mismatched EpochChange should be rejected — no new ViewChanged"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::CertificateMismatch)
+    ));
 }
 
-/// An EpochChangeMessage where the block is not the last block of the epoch
-/// should be rejected (block_number % epoch_height != 0).
+/// Certificates from different epochs are not well-formed. Each certificate
+/// can be individually crypto-valid (adjacent epochs often share a stake
+/// table), so this must be caught structurally before verification.
 #[tokio::test]
-async fn test_handle_epoch_change_wrong_block_number() {
-    let mut harness = ConsensusHarness::new(0).await;
-    let test_data = TestData::new(11).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
+async fn test_epoch_change_cross_epoch_certificates_not_well_formed() {
+    let test_data = TestData::new_with_epoch_height(21, EPOCH_HEIGHT).await;
 
-    run_views_full(&mut harness, &test_data, &node_key, 0..6).await;
+    // cert1 from the epoch-1 boundary (view 10), cert2 from the epoch-2
+    // boundary (view 20); both are genuine boundary certificates.
+    let proposal: Proposal<TestTypes> = test_data.views[9].proposal.data.clone();
+    let epoch_change = EpochChangeMessage::validated(
+        test_data.views[9].cert1.clone(),
+        test_data.views[19].cert2.clone(),
+        proposal,
+    );
+
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::CertificateMismatch)
+    ));
+}
+
+/// An EpochChangeMessage whose block is not the last block of the epoch
+/// (block_number % epoch_height != 0) is not well-formed.
+#[tokio::test]
+async fn test_epoch_change_wrong_block_number_not_well_formed() {
+    let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
 
     // Use view 6 (block 6) which is NOT the last block of the epoch
     let mid_view = &test_data.views[5];
@@ -163,28 +171,17 @@ async fn test_handle_epoch_change_wrong_block_number() {
     let epoch_change =
         EpochChangeMessage::validated(mid_view.cert1.clone(), mid_view.cert2.clone(), proposal);
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "EpochChange with wrong block number should be rejected"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::NotLastBlock)
+    ));
 }
 
 /// An EpochChangeMessage whose proposal commitment doesn't match cert1's
-/// leaf_commit should be rejected.
+/// leaf_commit is not well-formed.
 #[tokio::test]
-async fn test_handle_epoch_change_proposal_mismatch() {
-    let mut harness = ConsensusHarness::new(0).await;
+async fn test_epoch_change_proposal_mismatch_not_well_formed() {
     let test_data = TestData::new_with_epoch_height(11, EPOCH_HEIGHT).await;
-    let node_key = BLSPubKey::generated_from_seed_indexed([0; 32], 0).0;
-
-    run_views_full(&mut harness, &test_data, &node_key, 0..9).await;
 
     // Use cert1/cert2 from view 10 but proposal from view 9 — commitment mismatch
     let epoch_view = &test_data.views[9];
@@ -195,17 +192,10 @@ async fn test_handle_epoch_change_proposal_mismatch() {
         wrong_proposal,
     );
 
-    let view_changed_before = count_matching(harness.outputs(), is_view_changed);
-
-    harness
-        .apply(ConsensusInput::EpochChange(epoch_change))
-        .await;
-
-    assert_eq!(
-        view_changed_before,
-        count_matching(harness.outputs(), is_view_changed),
-        "EpochChange with mismatched proposal should be rejected"
-    );
+    assert!(matches!(
+        epoch_change.well_formed(EPOCH_HEIGHT),
+        Err(EpochChangeError::ProposalMismatch)
+    ));
 }
 
 /// A stale EpochChangeMessage (cert1 view < locked_cert view) should be rejected.


### PR DESCRIPTION
The cert verifier checked both certificates of an `EpochChangeMessage` against the stake table of cert1's claimed epoch and marked the epoch completed as soon as the signatures verified. The structural checks (matching view/epoch/leaf commitment, last block of the epoch, proposal commitment) only ran later, in `Consensus::handle_epoch_change`. Two individually valid certificates from different different epochs sharing a stake table could therefore pass verification, be rejected by consensus, and still permanently occupy the epoch's completed slot in the verifier, suppressing the genuine epoch change for that epoch from every sender.

Here we move the structural checks into `EpochChangeMessage::well_formed` and enforce them in `Verifiable::check` ahead of the signature checks, so a message can only become `Validated` if it is well-formed, and a mismatched one takes the verifier's ordinary failure path. `Verifiable::check` gains an epoch_height parameter to make this possible.

`Consensus` drops its now-duplicate structural checks and trusts `Validated` entirely, as it already does for signature verification. Only the state-dependent stale-epoch and locked-certificate checks remain. The structural rejection tests become well_formed unit tests, with a new cross-epoch case.