### PR TITLE
Bound resources held for unauthenticated cliquenet peers

### DIFF
--- a/crates/cliquenet/src/lib.rs
+++ b/crates/cliquenet/src/lib.rs
@@ -118,6 +118,10 @@ pub struct Config {
     #[builder(default = 6)]
     keep_alive_retries: u8,
 
+    /// Max. number of concurrent accept tasks.
+    #[builder(default = (3 * parties.len()).max(100))]
+    max_accept_tasks: usize,
+
     /// Optional metrics implementation.
     metrics: Option<Arc<dyn Metrics>>,
 }
@@ -156,6 +160,7 @@ impl fmt::Debug for Config {
             .field("keepalive_after", &self.keep_alive_after)
             .field("keepalive_interval", &self.keep_alive_interval)
             .field("keepalive_retries", &self.keep_alive_retries)
+            .field("max_accept_tasks", &self.max_accept_tasks)
             .finish()
     }
 }

--- a/crates/cliquenet/src/msg/hello.rs
+++ b/crates/cliquenet/src/msg/hello.rs
@@ -33,7 +33,7 @@ impl Hello {
         }
     }
 
-    pub fn to_bytes(&self) -> HelloBytes {
+    pub fn to_bytes(self) -> HelloBytes {
         match self {
             Self::Ok => HelloBytes::Ok([0]),
             Self::BackOff(d) => {

--- a/crates/cliquenet/src/msg/hello.rs
+++ b/crates/cliquenet/src/msg/hello.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Hello {
     Ok,
     BackOff(Duration),

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -138,25 +138,27 @@ impl Server {
 
         loop {
             select! {
-                x = listener.accept() => match x {
-                    Ok((stream, addr)) => {
-                        debug!(
-                            name = %self.conf.name,
-                            node = %self.key,
-                            %addr,
-                            "accepted new tcp connection"
-                        );
-                        self.spawn_accept(stream)
+                x = listener.accept(), if self.accept_tasks.len() < self.conf.max_accept_tasks => {
+                    match x {
+                        Ok((stream, addr)) => {
+                            debug!(
+                                name = %self.conf.name,
+                                node = %self.key,
+                                %addr,
+                                "accepted new tcp connection"
+                            );
+                            self.spawn_accept(stream)
+                        }
+                        Err(err) => {
+                            warn!(
+                                name = %self.conf.name,
+                                node = %self.key,
+                                %err,
+                                "error accepting tcp connection"
+                            )
+                        }
                     }
-                    Err(err) => {
-                        warn!(
-                            name = %self.conf.name,
-                            node = %self.key,
-                            %err,
-                            "error accepting tcp connection"
-                        )
-                    }
-                },
+                }
 
                 Some(h) = self.accept_tasks.join_next() => match h {
                     Ok(Ok(conn)) => {

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -35,7 +35,7 @@ pub struct Server {
     obound: UnboundedReceiver<Command>,
     next_slot: watch::Receiver<Slot>,
     accept_tasks: JoinSet<Result<Connection, NetworkError>>,
-    hello_tasks: JoinMap<PublicKey, Result<(Hello, Connection, Hello), NetworkError>>,
+    hello_tasks: JoinMap<PublicKey, Result<(Hello, Connection, Option<Hello>), NetworkError>>,
     connect_tasks: JoinMap<PublicKey, Connection>,
     peer_tasks: JoinMap<PublicKey, Peer>,
     metrics: Arc<dyn Metrics>,
@@ -233,7 +233,7 @@ impl Server {
                             );
                             continue
                         };
-                        if !(our_hello.is_ok() && their_hello.is_ok()) {
+                        if !(our_hello.is_ok() && their_hello.is_some_and(|h| h.is_ok())) {
                             warn!(
                                 name   = %self.conf.name,
                                 node   = %self.key,
@@ -683,12 +683,27 @@ impl Server {
 
         self.metrics.add(&conn.key, HELLOS, 1);
 
+        // Under normal circumstances we should never witness more hellos than parties.
+        // An adversary may nevertheless pass the accept stage and since we do not
+        // know the party we inform it to back off. If the remote does not send us
+        // their hello in due time this will occupy the hello task (and a file
+        // descriptor). To put a cap on that we make the reading of hellos contingent
+        // on how many ongoing hellos we already process. Under attack we do not
+        // bother with reading the remote's (unless it is a peer we want), but only
+        // send our hello and drop the connection. NB that this may cause the remote
+        // to see a connection reset.
+        let under_pressure = self.hello_tasks.len() > 2 * self.parties.len();
+
         self.hello_tasks.abort(&conn.key);
         self.hello_tasks.spawn(
             conn.key,
             until(self.conf.handshake_timeout, async move {
-                let theirs = conn.recv_hello().await?;
-                conn.send_hello(ours.clone()).await?;
+                let theirs = if ours.is_ok() || !under_pressure {
+                    Some(conn.recv_hello().await?)
+                } else {
+                    None
+                };
+                conn.send_hello(ours).await?;
                 Ok::<_, NetworkError>((ours, conn, theirs))
             }),
         );

--- a/crates/cliquenet/src/net/server.rs
+++ b/crates/cliquenet/src/net/server.rs
@@ -35,6 +35,7 @@ pub struct Server {
     obound: UnboundedReceiver<Command>,
     next_slot: watch::Receiver<Slot>,
     accept_tasks: JoinSet<Result<Connection, NetworkError>>,
+    #[allow(clippy::type_complexity)]
     hello_tasks: JoinMap<PublicKey, Result<(Hello, Connection, Option<Hello>), NetworkError>>,
     connect_tasks: JoinMap<PublicKey, Connection>,
     peer_tasks: JoinMap<PublicKey, Peer>,


### PR DESCRIPTION
Two changes:

1. Limit concurrent accept tasks. Adds a new `Config::max_accept_tasks` field. The honest concurrent inbound is on the order of the network size. Implemented as a precondition on the accept arm of the server loop: when saturated, the server stops accepting but resumes when tasks finish. Honest peers retry via their existing connect retries.
2. Under pressure, do not wait for a rejected remote's hello. If ongoing hello tasks exceed twice the live party count, reject-path hellos skip receiving and just send our `BackOff` and drop the connection. Since the gate is checked before each spawn, stalled hello tasks are bounded at 2 * parties + 1. Under normal load, rejects still receive the remote's hello first, but under pressure the remote may see a connection reset instead of the `BackOff`, which is now deliberately best-effort only. A peer that misses the hint falls back to its own escalating reconnect delays.

The existing `accept_tasks` and `hello_tasks` gauges make both bounds observable.
