### PR TITLE
feat(staking-cli): register per-validator metadata URIs in demo

### DIFF
--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1177,7 +1177,7 @@ pub mod testing {
                     .get(i)
                     .cloned()
                     .unwrap_or_else(|| "127.0.0.1:8080".parse().unwrap()),
-                metadata_uri: "https://example.com/metadata".parse().unwrap(),
+                metadata_uri: None,
             })
             .collect()
     }

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -1177,6 +1177,7 @@ pub mod testing {
                     .get(i)
                     .cloned()
                     .unwrap_or_else(|| "127.0.0.1:8080".parse().unwrap()),
+                metadata_uri: "https://example.com/metadata".parse().unwrap(),
             })
             .collect()
     }

--- a/staking-cli/src/cli.rs
+++ b/staking-cli/src/cli.rs
@@ -516,6 +516,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
         num_validators,
         num_delegators_per_validator,
         delegation_config,
+        ref metadata_network,
+        ref metadata_hosts,
         concurrency,
     } = config.commands
     {
@@ -527,6 +529,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
             num_validators,
             num_delegators_per_validator,
             delegation_config,
+            metadata_network.clone(),
+            metadata_hosts.clone(),
             concurrency,
         )
         .await
@@ -541,6 +545,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
                 num_validators,
                 num_delegators_per_validator,
                 delegation_config,
+                metadata_network,
+                metadata_hosts,
                 concurrency,
             } => {
                 tracing::info!(
@@ -552,6 +558,8 @@ pub async fn run(migrated_envs: Vec<(&str, &str)>) -> Result<()> {
                     *num_validators,
                     *num_delegators_per_validator,
                     *delegation_config,
+                    metadata_network.clone(),
+                    metadata_hosts.clone(),
                     *concurrency,
                 )
                 .await

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -60,7 +60,8 @@ pub struct StakingKeySet {
     pub state: StateKeyPair,
     pub x25519: x25519::Keypair,
     pub p2p_addr: NetAddr,
-    pub metadata_uri: Url,
+    /// `None` registers the demo placeholder URI.
+    pub metadata_uri: Option<Url>,
 }
 
 #[derive(Debug, Error)]
@@ -883,8 +884,10 @@ impl StakingTransactions<HttpProviderWithWallet> {
         let mut rng = ChaCha20Rng::from_seed(seed);
 
         let mut validator_info = vec![];
+        let mut configured_metadata_uris = false;
         for (val_index, key_set) in validators.into_iter().enumerate() {
             let commission = Commission::try_from(100u64 + 10u64 * val_index as u64)?;
+            configured_metadata_uris |= key_set.metadata_uri.is_some();
 
             validator_info.push(ValidatorConfig {
                 signer: key_set.signer,
@@ -893,7 +896,11 @@ impl StakingTransactions<HttpProviderWithWallet> {
                 state_key_pair: key_set.state,
                 x25519: key_set.x25519,
                 p2p_addr: key_set.p2p_addr,
-                metadata_uri: MetadataUri::try_from(key_set.metadata_uri)?,
+                metadata_uri: MetadataUri::try_from(
+                    key_set
+                        .metadata_uri
+                        .unwrap_or_else(placeholder_metadata_uri),
+                )?,
                 index: val_index,
             });
         }
@@ -940,6 +947,14 @@ impl StakingTransactions<HttpProviderWithWallet> {
         let st = StakeTableV3::new(stake_table, &token_holder_provider);
         let version: StakeTableContractVersion = st.getVersion().call().await?.try_into()?;
         tracing::info!(?version, "stake table contract version");
+        if configured_metadata_uris && matches!(version, StakeTableContractVersion::V1) {
+            // `registerValidator` has no metadataUri argument before V2, so the demo drops the URI
+            // here the same way it drops x25519 keys and p2p addresses on pre-V3 contracts.
+            tracing::warn!(
+                "stake table V1 does not record metadata URIs: the configured metadata hosts will \
+                 not be registered"
+            );
+        }
         if matches!(
             version,
             StakeTableContractVersion::V2 | StakeTableContractVersion::V3
@@ -1182,27 +1197,61 @@ const METADATA_URI_DOMAIN: &str = "devnet.espresso.network";
 /// Fixed path for demo validator metadata URIs (a node's OpenMetrics endpoint).
 const METADATA_URI_PATH: &str = "v1/status/metrics";
 
+/// URI registered for every validator when no metadata hosts are configured.
+const METADATA_URI_PLACEHOLDER: &str = "https://example.com/metadata";
+
+fn placeholder_metadata_uri() -> Url {
+    METADATA_URI_PLACEHOLDER
+        .parse()
+        .expect("placeholder metadata URI parses")
+}
+
+/// A label interpolated into a metadata URI must be a bare DNS label: `format!` + `Url::parse`
+/// accepts `/`, `@`, `:`, `?` and `#`, but silently yields a URI with a different structure.
+fn check_dns_label(kind: &str, label: &str) -> Result<()> {
+    if label.is_empty() || !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        bail!("invalid metadata {kind} label {label:?}: expected [A-Za-z0-9-]");
+    }
+    Ok(())
+}
+
 /// Build the per-validator metadata URIs registered by the demo.
 fn demo_metadata_uris(
     num_validators: u16,
     network: Option<&str>,
     hosts: &[String],
-) -> Result<Vec<Url>> {
+) -> Result<Option<Vec<Url>>> {
     let num_validators = num_validators as usize;
 
+    // `ESPRESSO_DEMO_METADATA_HOSTS=` and trailing commas arrive as blank entries; treating them
+    // as unset is what lets an env file disable the feature.
+    let hosts: Vec<&str> = hosts
+        .iter()
+        .map(|host| host.trim())
+        .filter(|host| !host.is_empty())
+        .collect();
+
     if hosts.is_empty() {
-        let placeholder: Url = "https://example.com/metadata".parse()?;
-        return Ok(vec![placeholder; num_validators]);
+        return Ok(None);
     }
 
     let network = network.context(
         "--metadata-network (ESPRESSO_DEMO_METADATA_NETWORK) is required when --metadata-hosts is \
          set",
     )?;
+    check_dns_label("network", network)?;
+
     if hosts.len() < num_validators {
         bail!(
             "not enough metadata hosts: {} provided for {num_validators} validators",
             hosts.len()
+        );
+    }
+    if hosts.len() > num_validators {
+        tracing::warn!(
+            hosts = hosts.len(),
+            num_validators,
+            "more metadata hosts than validators, ignoring the surplus"
         );
     }
 
@@ -1210,11 +1259,13 @@ fn demo_metadata_uris(
         .iter()
         .take(num_validators)
         .map(|host| {
+            check_dns_label("host", host)?;
             let url = format!("https://{host}.{network}.{METADATA_URI_DOMAIN}/{METADATA_URI_PATH}");
             url.parse()
                 .with_context(|| format!("invalid metadata URI {url}"))
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()
+        .map(Some)
 }
 
 /// Register validators, and delegate to themselves for demo purposes.
@@ -1233,6 +1284,10 @@ pub(crate) async fn stake_for_demo(
     concurrency: usize,
 ) -> Result<()> {
     tracing::info!("staking to stake table contract for demo");
+
+    // Validate the metadata options before any RPC work, so a bad `--metadata-hosts` fails fast.
+    let metadata_uris =
+        demo_metadata_uris(num_validators, metadata_network.as_deref(), &metadata_hosts)?;
 
     // let grant_recipient = mk_signer(config.signer.account_index.unwrap())?;
     let grant_recipient = build_provider(
@@ -1267,9 +1322,6 @@ pub(crate) async fn stake_for_demo(
         );
     }
 
-    let metadata_uris =
-        demo_metadata_uris(num_validators, metadata_network.as_deref(), &metadata_hosts)?;
-
     let mut validator_keys = vec![];
     for val_index in 0..num_validators {
         let signer = build_signer(
@@ -1279,7 +1331,9 @@ pub(crate) async fn stake_for_demo(
 
         let (bls, state, x25519) = load_validator_keys(val_index, mnemonic_env.as_deref())?;
         let p2p_addr = load_p2p_addr(val_index)?;
-        let metadata_uri = metadata_uris[val_index as usize].clone();
+        let metadata_uri = metadata_uris
+            .as_ref()
+            .map(|uris| uris[val_index as usize].clone());
         tracing::info!(
             val_index,
             address = %signer.address(),
@@ -1287,7 +1341,7 @@ pub(crate) async fn stake_for_demo(
             state_key = %state.ver_key(),
             x25519_key = %x25519.public_key(),
             %p2p_addr,
-            %metadata_uri,
+            ?metadata_uri,
             "registering validator",
         );
         validator_keys.push(StakingKeySet {
@@ -1983,17 +2037,46 @@ mod test {
 
     #[test]
     fn demo_metadata_uris_placeholder_when_no_hosts() {
-        let uris = demo_metadata_uris(3, Some("milk"), &[]).unwrap();
-        assert_eq!(uris.len(), 3);
-        for uri in &uris {
-            assert_eq!(uri.to_string(), "https://example.com/metadata");
+        assert_eq!(demo_metadata_uris(3, Some("milk"), &[]).unwrap(), None);
+        assert_eq!(
+            placeholder_metadata_uri().to_string(),
+            "https://example.com/metadata"
+        );
+    }
+
+    /// `ESPRESSO_DEMO_METADATA_HOSTS=` and trailing commas reach clap as blank entries, and must
+    /// disable the feature rather than build `https://.milk.devnet.espresso.network/...` or trip
+    /// the missing-network error.
+    #[test]
+    fn demo_metadata_uris_ignores_blank_hosts() {
+        for hosts in [
+            vec!["".to_string()],
+            vec!["  ".to_string()],
+            vec!["".to_string(), "".to_string()],
+        ] {
+            assert_eq!(demo_metadata_uris(2, None, &hosts).unwrap(), None);
         }
+
+        let trailing_comma = ["query-1".to_string(), "".to_string()];
+        let uris = demo_metadata_uris(1, Some("milk"), &trailing_comma)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            uris,
+            vec![
+                "https://query-1.milk.devnet.espresso.network/v1/status/metrics"
+                    .parse::<Url>()
+                    .unwrap()
+            ]
+        );
     }
 
     #[test]
     fn demo_metadata_uris_builds_per_host_urls() {
         let hosts = ["query-1".to_string(), "query-2".to_string()];
-        let uris = demo_metadata_uris(2, Some("milk"), &hosts).unwrap();
+        let uris = demo_metadata_uris(2, Some("milk"), &hosts)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             uris.iter().map(|u| u.to_string()).collect::<Vec<_>>(),
             vec![
@@ -2010,7 +2093,9 @@ mod test {
             "query-2".to_string(),
             "query-3".to_string(),
         ];
-        let uris = demo_metadata_uris(2, Some("milk"), &hosts).unwrap();
+        let uris = demo_metadata_uris(2, Some("milk"), &hosts)
+            .unwrap()
+            .unwrap();
         assert_eq!(uris.len(), 2);
         assert_eq!(
             uris[1].to_string(),
@@ -2030,6 +2115,29 @@ mod test {
         let hosts = ["query-1".to_string()];
         let err = demo_metadata_uris(3, Some("milk"), &hosts).unwrap_err();
         assert!(err.to_string().contains("not enough metadata hosts"));
+    }
+
+    /// A label containing URL syntax still parses, but as a different URI: `query-1/x` would put
+    /// the domain in the path. Reject such labels instead of registering the wrong URI on-chain.
+    #[test]
+    fn demo_metadata_uris_rejects_url_syntax_in_labels() {
+        for bad in ["query-1/x", "query-1:8080", "query@1", "query?x", "query#x"] {
+            let hosts = [bad.to_string()];
+            let err = demo_metadata_uris(1, Some("milk"), &hosts).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid metadata host label"),
+                "unexpected error for host {bad}: {err}"
+            );
+        }
+
+        let hosts = ["query-1".to_string()];
+        for bad_network in ["milk/x", "milk.devnet", ""] {
+            let err = demo_metadata_uris(1, Some(bad_network), &hosts).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid metadata network label"),
+                "unexpected error for network {bad_network:?}: {err}"
+            );
+        }
     }
 
     /// Verify that the per-validator consensus keys in `.env` are exactly what `DEV_MNEMONIC` at

--- a/staking-cli/src/demo.rs
+++ b/staking-cli/src/demo.rs
@@ -42,6 +42,7 @@ use url::Url;
 use crate::{
     Config, DEMO_VALIDATOR_START_INDEX,
     info::fetch_token_address,
+    metadata::MetadataUri,
     parse::{
         Commission, ParseCommissionError, parse_bls_priv_key, parse_state_priv_key,
         parse_x25519_priv_key,
@@ -59,6 +60,7 @@ pub struct StakingKeySet {
     pub state: StateKeyPair,
     pub x25519: x25519::Keypair,
     pub p2p_addr: NetAddr,
+    pub metadata_uri: Url,
 }
 
 #[derive(Debug, Error)]
@@ -113,6 +115,14 @@ pub enum DemoCommands {
 
         #[clap(long, value_enum, env = "DELEGATION_CONFIG", default_value_t = DelegationConfig::default())]
         delegation_config: DelegationConfig,
+
+        /// Network label embedded in per-validator metadata URIs.
+        #[clap(long, env = "ESPRESSO_DEMO_METADATA_NETWORK")]
+        metadata_network: Option<String>,
+
+        /// Per-validator host labels for metadata URIs (e.g. `query-1,query-2`).
+        #[clap(long, value_delimiter = ',', env = "ESPRESSO_DEMO_METADATA_HOSTS")]
+        metadata_hosts: Vec<String>,
 
         /// Number of concurrent transaction submissions
         #[clap(long, default_value_t = crate::tx_log::DEFAULT_CONCURRENCY)]
@@ -277,6 +287,7 @@ enum StakeTableTx {
         payload: Box<NodeSignatures>,
         x25519_key: x25519::PublicKey,
         p2p_addr: NetAddr,
+        metadata_uri: MetadataUri,
     },
     Approve {
         from: Address,
@@ -315,6 +326,7 @@ struct ValidatorConfig {
     state_key_pair: StateKeyPair,
     x25519: x25519::Keypair,
     p2p_addr: NetAddr,
+    metadata_uri: MetadataUri,
     index: usize,
 }
 
@@ -390,8 +402,8 @@ impl<P: Provider + Clone> TransactionProcessor<P> {
                 payload,
                 x25519_key,
                 p2p_addr,
+                metadata_uri,
             } => {
-                let metadata_uri = "https://example.com/metadata".parse()?;
                 let (x25519_key, p2p_addr) = match self.version {
                     StakeTableContractVersion::V3 => (Some(x25519_key), Some(p2p_addr)),
                     _ => (None, None),
@@ -748,6 +760,7 @@ impl<P: Provider + Clone> StakingTransactions<P> {
                     payload,
                     x25519_key,
                     p2p_addr,
+                    metadata_uri: _,
                 } = tx
                 {
                     Some(RegistrationInfo {
@@ -880,6 +893,7 @@ impl StakingTransactions<HttpProviderWithWallet> {
                 state_key_pair: key_set.state,
                 x25519: key_set.x25519,
                 p2p_addr: key_set.p2p_addr,
+                metadata_uri: MetadataUri::try_from(key_set.metadata_uri)?,
                 index: val_index,
             });
         }
@@ -984,6 +998,7 @@ impl StakingTransactions<HttpProviderWithWallet> {
                 payload: Box::new(payload),
                 x25519_key: validator.x25519.public_key(),
                 p2p_addr: validator.p2p_addr.clone(),
+                metadata_uri: validator.metadata_uri.clone(),
             });
         }
 
@@ -1161,6 +1176,47 @@ fn load_p2p_addr(val_index: u16) -> Result<NetAddr> {
         .with_context(|| format!("invalid p2p address {name}={value}"))
 }
 
+/// Fixed domain suffix for demo validator metadata URIs.
+const METADATA_URI_DOMAIN: &str = "devnet.espresso.network";
+
+/// Fixed path for demo validator metadata URIs (a node's OpenMetrics endpoint).
+const METADATA_URI_PATH: &str = "v1/status/metrics";
+
+/// Build the per-validator metadata URIs registered by the demo.
+fn demo_metadata_uris(
+    num_validators: u16,
+    network: Option<&str>,
+    hosts: &[String],
+) -> Result<Vec<Url>> {
+    let num_validators = num_validators as usize;
+
+    if hosts.is_empty() {
+        let placeholder: Url = "https://example.com/metadata".parse()?;
+        return Ok(vec![placeholder; num_validators]);
+    }
+
+    let network = network.context(
+        "--metadata-network (ESPRESSO_DEMO_METADATA_NETWORK) is required when --metadata-hosts is \
+         set",
+    )?;
+    if hosts.len() < num_validators {
+        bail!(
+            "not enough metadata hosts: {} provided for {num_validators} validators",
+            hosts.len()
+        );
+    }
+
+    hosts
+        .iter()
+        .take(num_validators)
+        .map(|host| {
+            let url = format!("https://{host}.{network}.{METADATA_URI_DOMAIN}/{METADATA_URI_PATH}");
+            url.parse()
+                .with_context(|| format!("invalid metadata URI {url}"))
+        })
+        .collect()
+}
+
 /// Register validators, and delegate to themselves for demo purposes.
 ///
 /// The environment variables used only for this function but not for the normal staking CLI are
@@ -1172,6 +1228,8 @@ pub(crate) async fn stake_for_demo(
     num_validators: u16,
     num_delegators_per_validator: Option<u64>,
     delegation_config: DelegationConfig,
+    metadata_network: Option<String>,
+    metadata_hosts: Vec<String>,
     concurrency: usize,
 ) -> Result<()> {
     tracing::info!("staking to stake table contract for demo");
@@ -1209,6 +1267,9 @@ pub(crate) async fn stake_for_demo(
         );
     }
 
+    let metadata_uris =
+        demo_metadata_uris(num_validators, metadata_network.as_deref(), &metadata_hosts)?;
+
     let mut validator_keys = vec![];
     for val_index in 0..num_validators {
         let signer = build_signer(
@@ -1218,6 +1279,7 @@ pub(crate) async fn stake_for_demo(
 
         let (bls, state, x25519) = load_validator_keys(val_index, mnemonic_env.as_deref())?;
         let p2p_addr = load_p2p_addr(val_index)?;
+        let metadata_uri = metadata_uris[val_index as usize].clone();
         tracing::info!(
             val_index,
             address = %signer.address(),
@@ -1225,6 +1287,7 @@ pub(crate) async fn stake_for_demo(
             state_key = %state.ver_key(),
             x25519_key = %x25519.public_key(),
             %p2p_addr,
+            %metadata_uri,
             "registering validator",
         );
         validator_keys.push(StakingKeySet {
@@ -1233,6 +1296,7 @@ pub(crate) async fn stake_for_demo(
             state,
             x25519,
             p2p_addr,
+            metadata_uri,
         });
     }
 
@@ -1916,6 +1980,57 @@ mod test {
 
     use super::*;
     use crate::{deploy::TestSystem, info::stake_table_info};
+
+    #[test]
+    fn demo_metadata_uris_placeholder_when_no_hosts() {
+        let uris = demo_metadata_uris(3, Some("milk"), &[]).unwrap();
+        assert_eq!(uris.len(), 3);
+        for uri in &uris {
+            assert_eq!(uri.to_string(), "https://example.com/metadata");
+        }
+    }
+
+    #[test]
+    fn demo_metadata_uris_builds_per_host_urls() {
+        let hosts = ["query-1".to_string(), "query-2".to_string()];
+        let uris = demo_metadata_uris(2, Some("milk"), &hosts).unwrap();
+        assert_eq!(
+            uris.iter().map(|u| u.to_string()).collect::<Vec<_>>(),
+            vec![
+                "https://query-1.milk.devnet.espresso.network/v1/status/metrics",
+                "https://query-2.milk.devnet.espresso.network/v1/status/metrics",
+            ]
+        );
+    }
+
+    #[test]
+    fn demo_metadata_uris_uses_only_first_n_hosts() {
+        let hosts = [
+            "query-1".to_string(),
+            "query-2".to_string(),
+            "query-3".to_string(),
+        ];
+        let uris = demo_metadata_uris(2, Some("milk"), &hosts).unwrap();
+        assert_eq!(uris.len(), 2);
+        assert_eq!(
+            uris[1].to_string(),
+            "https://query-2.milk.devnet.espresso.network/v1/status/metrics"
+        );
+    }
+
+    #[test]
+    fn demo_metadata_uris_requires_network_with_hosts() {
+        let hosts = ["query-1".to_string()];
+        let err = demo_metadata_uris(1, None, &hosts).unwrap_err();
+        assert!(err.to_string().contains("metadata-network"));
+    }
+
+    #[test]
+    fn demo_metadata_uris_requires_enough_hosts() {
+        let hosts = ["query-1".to_string()];
+        let err = demo_metadata_uris(3, Some("milk"), &hosts).unwrap_err();
+        assert!(err.to_string().contains("not enough metadata hosts"));
+    }
 
     /// Verify that the per-validator consensus keys in `.env` are exactly what `DEV_MNEMONIC` at
     /// mnemonic index `DEMO_VALIDATOR_START_INDEX + val_index` produces. Otherwise the demo would

--- a/staking-cli/src/deploy.rs
+++ b/staking-cli/src/deploy.rs
@@ -228,6 +228,7 @@ impl TestSystem {
             state: StateKeyPair::generate_from_seed(rng.r#gen()),
             x25519: x25519::Keypair::generated_from_seed_indexed(rng.r#gen(), 0).unwrap(),
             p2p_addr: "127.0.0.1:8080".parse().unwrap(),
+            metadata_uri: "https://example.com/metadata".parse().unwrap(),
         }
     }
 

--- a/staking-cli/src/deploy.rs
+++ b/staking-cli/src/deploy.rs
@@ -228,7 +228,7 @@ impl TestSystem {
             state: StateKeyPair::generate_from_seed(rng.r#gen()),
             x25519: x25519::Keypair::generated_from_seed_indexed(rng.r#gen(), 0).unwrap(),
             p2p_addr: "127.0.0.1:8080".parse().unwrap(),
-            metadata_uri: "https://example.com/metadata".parse().unwrap(),
+            metadata_uri: None,
         }
     }
 

--- a/staking-cli/src/lib.rs
+++ b/staking-cli/src/lib.rs
@@ -491,6 +491,14 @@ pub(crate) enum Commands {
         #[clap(long, value_enum, env = "DELEGATION_CONFIG", default_value_t = demo::DelegationConfig::default())]
         delegation_config: demo::DelegationConfig,
 
+        /// Network label embedded in per-validator metadata URIs.
+        #[clap(long, env = "ESPRESSO_DEMO_METADATA_NETWORK")]
+        metadata_network: Option<String>,
+
+        /// Per-validator host labels for metadata URIs (e.g. `query-1,query-2`).
+        #[clap(long, value_delimiter = ',', env = "ESPRESSO_DEMO_METADATA_HOSTS")]
+        metadata_hosts: Vec<String>,
+
         /// Number of concurrent transaction submissions
         #[clap(long, default_value_t = tx_log::DEFAULT_CONCURRENCY)]
         concurrency: usize,

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -841,6 +841,30 @@ async fn test_cli_stake_for_demo_three_validators(
     Ok(())
 }
 
+/// `--metadata-network` + `--metadata-hosts` register a distinct metadata URI per validator,
+/// shaped like `https://{host}.{network}.devnet.espresso.network/v1/status/metrics`. The hosts are
+/// assigned to validators in order and there must be at least `--num-validators` of them.
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
+async fn test_cli_stake_for_demo_with_metadata_uris(
+    #[case] version: StakeTableContractVersion,
+) -> Result<()> {
+    let system = TestSystem::deploy_version(version).await?;
+
+    system
+        .cmd(Signer::Mnemonic)
+        .arg("demo")
+        .arg("stake")
+        .arg("--num-validators")
+        .arg("3")
+        .arg("--metadata-network")
+        .arg("milk")
+        .arg("--metadata-hosts")
+        .arg("query-1,query-2,query-3")
+        .assert()
+        .success();
+    Ok(())
+}
+
 #[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_for_demo_with_mnemonic_env(
     #[case] version: StakeTableContractVersion,
@@ -966,6 +990,28 @@ async fn test_cli_deprecated_stake_for_demo_three_validators(
         .arg("stake-for-demo")
         .arg("--num-validators")
         .arg("3")
+        .assert()
+        .success();
+    Ok(())
+}
+
+/// The deprecated `stake-for-demo` command accepts the same per-validator metadata URI options as
+/// `demo stake`.
+#[test_log::test(rstest_reuse::apply(stake_table_versions))]
+async fn test_cli_deprecated_stake_for_demo_with_metadata_uris(
+    #[case] version: StakeTableContractVersion,
+) -> Result<()> {
+    let system = TestSystem::deploy_version(version).await?;
+
+    system
+        .cmd(Signer::Mnemonic)
+        .arg("stake-for-demo")
+        .arg("--num-validators")
+        .arg("3")
+        .arg("--metadata-network")
+        .arg("milk")
+        .arg("--metadata-hosts")
+        .arg("query-1,query-2,query-3")
         .assert()
         .success();
     Ok(())

--- a/staking-cli/tests/cli.rs
+++ b/staking-cli/tests/cli.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use alloy::{
     primitives::{
@@ -12,7 +12,7 @@ use anyhow::Result;
 use common::{MetadataCommand, Signer, TestSystemExt, base_cmd};
 use espresso_contract_deployer::build_signer;
 use espresso_types::{L1Client, v0_3::Fetcher};
-use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
+use hotshot_contract_adapter::{sol_types::StakeTableV3, stake_table::StakeTableContractVersion};
 use hotshot_types::{addr::NetAddr, signature_key::BLSPubKey, x25519};
 use predicates::{prelude::PredicateBooleanExt, str};
 use rand::{SeedableRng as _, rngs::StdRng};
@@ -841,28 +841,86 @@ async fn test_cli_stake_for_demo_three_validators(
     Ok(())
 }
 
+/// Assert that a `--metadata-network milk --metadata-hosts query-1,query-2,...` demo run registered
+/// `https://query-{i+1}.milk.devnet.espresso.network/v1/status/metrics` for validator `i`.
+///
+/// V1's `registerValidator` takes no metadataUri, so the URI is dropped rather than recorded; there
+/// only the registration count can be asserted.
+async fn assert_demo_metadata_uris(
+    system: &TestSystem,
+    version: StakeTableContractVersion,
+    num_validators: u16,
+) -> Result<()> {
+    let stake_table = StakeTableV3::new(system.stake_table, &system.provider);
+    let registered: HashMap<Address, String> = match version {
+        StakeTableContractVersion::V1 => {
+            let events = stake_table
+                .ValidatorRegistered_filter()
+                .from_block(0)
+                .query()
+                .await?;
+            assert_eq!(events.len(), num_validators as usize);
+            return Ok(());
+        },
+        StakeTableContractVersion::V2 => stake_table
+            .ValidatorRegisteredV2_filter()
+            .from_block(0)
+            .query()
+            .await?
+            .into_iter()
+            .map(|(event, _)| (event.account, event.metadataUri))
+            .collect(),
+        StakeTableContractVersion::V3 => stake_table
+            .ValidatorRegisteredV3_filter()
+            .from_block(0)
+            .query()
+            .await?
+            .into_iter()
+            .map(|(event, _)| (event.account, event.metadataUri))
+            .collect(),
+    };
+
+    assert_eq!(registered.len(), num_validators as usize);
+    for i in 0..num_validators {
+        let address = build_signer(DEV_MNEMONIC, DEMO_VALIDATOR_START_INDEX + i as u32).address();
+        let expected = format!(
+            "https://query-{}.milk.devnet.espresso.network/v1/status/metrics",
+            i + 1
+        );
+        assert_eq!(
+            registered.get(&address),
+            Some(&expected),
+            "metadata URI mismatch for validator {i}"
+        );
+    }
+    Ok(())
+}
+
 /// `--metadata-network` + `--metadata-hosts` register a distinct metadata URI per validator,
-/// shaped like `https://{host}.{network}.devnet.espresso.network/v1/status/metrics`. The hosts are
-/// assigned to validators in order and there must be at least `--num-validators` of them.
+/// shaped like `https://{host}.{network}.devnet.espresso.network/v1/status/metrics` and assigned to
+/// validators in order. Asserted against the registration events, since a `.success()`-only check
+/// also passes when every validator silently gets the placeholder URI.
 #[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_stake_for_demo_with_metadata_uris(
     #[case] version: StakeTableContractVersion,
 ) -> Result<()> {
     let system = TestSystem::deploy_version(version).await?;
+    let num_validators = 3u16;
 
     system
         .cmd(Signer::Mnemonic)
         .arg("demo")
         .arg("stake")
         .arg("--num-validators")
-        .arg("3")
+        .arg(num_validators.to_string())
         .arg("--metadata-network")
         .arg("milk")
         .arg("--metadata-hosts")
         .arg("query-1,query-2,query-3")
         .assert()
         .success();
-    Ok(())
+
+    assert_demo_metadata_uris(&system, version, num_validators).await
 }
 
 #[test_log::test(rstest_reuse::apply(stake_table_versions))]
@@ -996,25 +1054,27 @@ async fn test_cli_deprecated_stake_for_demo_three_validators(
 }
 
 /// The deprecated `stake-for-demo` command accepts the same per-validator metadata URI options as
-/// `demo stake`.
+/// `demo stake`, and registers the same URIs.
 #[test_log::test(rstest_reuse::apply(stake_table_versions))]
 async fn test_cli_deprecated_stake_for_demo_with_metadata_uris(
     #[case] version: StakeTableContractVersion,
 ) -> Result<()> {
     let system = TestSystem::deploy_version(version).await?;
+    let num_validators = 3u16;
 
     system
         .cmd(Signer::Mnemonic)
         .arg("stake-for-demo")
         .arg("--num-validators")
-        .arg("3")
+        .arg(num_validators.to_string())
         .arg("--metadata-network")
         .arg("milk")
         .arg("--metadata-hosts")
         .arg("query-1,query-2,query-3")
         .assert()
         .success();
-    Ok(())
+
+    assert_demo_metadata_uris(&system, version, num_validators).await
 }
 
 #[test_log::test(rstest_reuse::apply(stake_table_versions))]


### PR DESCRIPTION
### This PR:
* Registers a distinct metadata URI per demo validator, built from the new `--metadata-network` / `--metadata-hosts` flags (`ESPRESSO_DEMO_METADATA_NETWORK` / `ESPRESSO_DEMO_METADATA_HOSTS`) as `https://{host}.{network}.devnet.espresso.network/v1/status/metrics`, so a devnet's on-chain metadata points at each node's metrics endpoint.
* Keeps the previous hardcoded `https://example.com/metadata` for every validator when `--metadata-hosts` is unset, so existing demo invocations are unchanged.
* Carries the URI on `StakeTableTx::RegisterValidator` and `ValidatorConfig` instead of parsing a constant inside the transaction processor.
* Adds five `demo_metadata_uris` unit tests (placeholder, per-host URLs, surplus hosts, missing network, too few hosts) plus CLI tests for `demo stake` and the deprecated `stake-for-demo`.

### This PR does not:
* Set the new flags anywhere in the demo configs — `ESPRESSO_DEMO_METADATA_*` appears only in `staking-cli/src/lib.rs` and `staking-cli/src/demo.rs`, so the native and docker demos keep registering the placeholder URI until they opt in.

### Key places to review:
* `staking-cli/src/demo.rs`, `demo_metadata_uris` — positional host→validator mapping (first `--num-validators` hosts win) and its two error paths: `--metadata-network` is required alongside hosts, and there must be at least `--num-validators` of them.
* `staking-cli/src/demo.rs`, `TransactionProcessor::process` `RegisterValidator` arm — `metadata_uri` is now sent for every `StakeTableContractVersion`, unlike `x25519_key`/`p2p_addr` which remain V3-only.
* `staking-cli/src/demo.rs:752`, `StakingTransactions::registrations` — the destructure drops the URI (`metadata_uri: _`); confirm nothing downstream of the registration log wants it.
