### PR TITLE
[new-protocol] Let a fully replaced committee start its epoch

### DIFF
--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -510,7 +510,14 @@ where
                     return Ok(ConsensusInput::AdvanceView(cert1))
                 }
                 Some(epoch_change) = self.cert_verifiers.epoch_change.next() => {
-                    return Ok(ConsensusInput::EpochChange(epoch_change.into_cert()))
+                    let epoch_change = epoch_change.into_cert();
+                    // The boundary leaf is final (Cert1 + Cert2), so seed a
+                    // commitment-only state for it: a validator whose
+                    // membership starts at this boundary can then build and
+                    // validate the new epoch's first proposals via catchup.
+                    self.state_manager
+                        .seed_from_header(epoch_change.proposal.clone());
+                    return Ok(ConsensusInput::EpochChange(epoch_change))
                 }
                 Some((cert1, state_cert)) = self.epoch_root_collector.next() => {
                     self.cert_verifiers.cert1.mark_completed(cert1.view_number());
@@ -899,6 +906,11 @@ where
                     epoch = ?epoch_change.cert1.epoch().map(|e| *e),
                     "send epoch change"
                 );
+                // A node that decided the boundary from broadcast Cert2s needs
+                // the boundary state seeded just like a receiver of an
+                // EpochChangeMessage; for members this is a no-op.
+                self.state_manager
+                    .seed_from_header(epoch_change.proposal.clone());
                 self.broadcast(
                     ConsensusMessage::EpochChange(epoch_change),
                     "broadcast epoch change",

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -211,14 +211,20 @@ impl<T: NodeType> StateManager<T> {
                 epoch = %request.epoch,
                 block = %request.block,
                 parent_commitment = %request.parent_commitment,
-                "parent state unavailable; deferring state validation (from_header stub inserted). \
-                 If this persists, the node cannot vote until the parent state is recovered."
+                "parent state unavailable; queued on parent for retry (from_header stub inserted). \
+                 If this persists, the parent state never arrived and the node cannot vote."
             );
             self.insert_empty_state(request.proposal.clone());
-            self.pending_requests
+            let queued = self
+                .pending_requests
                 .entry(request.parent_commitment)
-                .or_default()
-                .push(Pending::State(request));
+                .or_default();
+            if !queued
+                .iter()
+                .any(|p| matches!(p, Pending::State(r) if r.view == request.view))
+            {
+                queued.push(Pending::State(request));
+            }
             self.start_pending(commitment);
             return;
         };

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -214,7 +214,11 @@ impl<T: NodeType> StateManager<T> {
                 "parent state unavailable; deferring state validation (from_header stub inserted). \
                  If this persists, the node cannot vote until the parent state is recovered."
             );
-            self.insert_empty_state(request.proposal);
+            self.insert_empty_state(request.proposal.clone());
+            self.pending_requests
+                .entry(request.parent_commitment)
+                .or_default()
+                .push(Pending::State(request));
             self.start_pending(commitment);
             return;
         };

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -175,8 +175,15 @@ impl<T: NodeType> StateManager<T> {
 
     /// Seed a commitment-only (`from_header`) state so a child proposal can be
     /// validated against this leaf via catchup instead of being dropped.
+    ///
+    /// A real (validated) state for the leaf is never displaced, and any
+    /// header/state requests already queued on this leaf are restarted.
     pub(crate) fn seed_from_header(&mut self, proposal: Proposal<T>) {
-        self.insert_empty_state(proposal);
+        let commitment = proposal_commitment(&proposal);
+        if !self.validated_states.contains_key(&commitment) {
+            self.insert_empty_state(proposal);
+        }
+        self.start_pending(commitment);
     }
 
     pub fn request_state(&mut self, request: StateRequest<T>) {

--- a/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
+++ b/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
@@ -58,6 +58,13 @@ async fn validator_joins_at_epoch_boundary() {
 /// Cert2): the coordinator seeds a commitment-only state for it, so the
 /// first epoch-4 leader and voters need neither the epoch-3 tail's payloads
 /// nor its replayed state.
+///
+/// Reaching block 55 proves nodes 5-9 drove epoch 4: nodes 0-4 hold no
+/// epoch-4 stake, so no quorum forms without the incoming cohort. The
+/// 55-decision target also binds the outgoing nodes 0-4, which can only
+/// meet it as retained followers — peers keep a leaving validator for one
+/// extra epoch, so 0-4 follow epoch 4 by broadcast until the cliff at
+/// block 60. Shortening that retention window breaks this test.
 #[tokio::test(flavor = "multi_thread")]
 async fn validator_set_replaced_at_epoch_boundary() {
     TestRunner::builder()

--- a/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
+++ b/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
@@ -49,6 +49,32 @@ async fn validator_joins_at_epoch_boundary() {
         .unwrap();
 }
 
+/// 10 nodes, epoch_height=15; the committee narrows to nodes 0-4 at epoch 3
+/// (blocks 31-45) and is replaced wholesale by the disjoint set 5-9 at
+/// epoch 4 (blocks 46-60) — a 100% turnover of the active committee.
+///
+/// The incoming cohort followed epoch 3 via broadcast cert2s without VID
+/// shares. The handoff works because the boundary leaf is final (Cert1 +
+/// Cert2): the coordinator seeds a commitment-only state for it, so the
+/// first epoch-4 leader and voters need neither the epoch-3 tail's payloads
+/// nor its replayed state.
+#[tokio::test(flavor = "multi_thread")]
+async fn validator_set_replaced_at_epoch_boundary() {
+    TestRunner::builder()
+        .num_nodes(10)
+        .target_decisions(55)
+        .max_runtime(Duration::from_secs(500))
+        .epoch_height(15)
+        .stake_table_schedule(StakeTableSchedule {
+            initial: (0..10).collect(),
+            changes: vec![(3, vec![0, 1, 2, 3, 4]), (4, vec![5, 6, 7, 8, 9])],
+        })
+        .build()
+        .run()
+        .await
+        .unwrap();
+}
+
 /// 6 nodes, epoch_height=10; all form epochs 1-2, node 5 is removed from
 /// the committee at epoch 3 (blocks 21-30).
 ///

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -149,6 +149,45 @@ async fn test_state_request_missing_parent_inserts_empty() {
     );
 }
 
+/// A state request whose parent is entirely unknown is retried once the
+/// parent is seeded from its header — the ordering where a first-of-epoch
+/// proposal arrives before the boundary leaf's `EpochChangeMessage`.
+#[tokio::test]
+async fn test_state_request_missing_parent_retried_after_seed() {
+    let mut manager =
+        StateManager::new(Arc::new(TestInstanceState::default()), test_upgrade_lock());
+    let test_data = TestData::new(3).await;
+
+    // View 2 arrives while view 1 (its parent) is entirely unknown.
+    manager.request_state(make_state_request(&test_data.views[1]));
+
+    let view_1_commit = proposal_commitment(&test_data.views[0].proposal.data.clone());
+    assert!(
+        manager.pending_contains_commitment(&view_1_commit),
+        "View 2 should be queued on its missing parent's commitment"
+    );
+    assert!(
+        manager.validated_contains_view(test_data.views[1].view_number),
+        "A from_header stub should be inserted for view 2"
+    );
+
+    // The parent becomes final (e.g. via a verified EpochChangeMessage):
+    // seeding it must restart the queued request.
+    manager.seed_from_header(test_data.views[0].proposal.data.clone());
+
+    let output = manager.next().await.expect("view 2 should complete");
+    assert!(
+        matches!(
+            output,
+            StateManagerOutput::State {
+                validated: true,
+                ..
+            }
+        ),
+        "View 2 should validate against the seeded parent state"
+    );
+}
+
 /// State request with seeded genesis parent spawns validation and produces output.
 #[tokio::test]
 async fn test_state_request_with_genesis_parent() {

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -175,6 +175,11 @@ async fn test_state_request_missing_parent_retried_after_seed() {
     // seeding it must restart the queued request.
     manager.seed_from_header(test_data.views[0].proposal.data.clone());
 
+    assert!(
+        !manager.pending_contains_commitment(&view_1_commit),
+        "the queued request should be consumed, not re-queued"
+    );
+
     let output = manager.next().await.expect("view 2 should complete");
     assert!(
         matches!(


### PR DESCRIPTION
## Problem

A wholesale committee replacement at an epoch boundary deadlocked the network. The incoming cohort followed the old epoch via broadcast Cert2s without VID shares, so the `StateManager` never held the boundary leaf's validated state: first-of-epoch header requests queued forever (`missing=block_header,block_payload`) and voters could not validate (`missing=state_validation`), while the outgoing members held no stake in the new committee — no quorum was reachable.

## Fix

Seed a commitment-only (`from_header`) state for the boundary leaf:

- when a validated `EpochChangeMessage` arrives, and
- when the node itself decides a last-block-of-epoch (a node that decided the boundary from broadcast Cert2s needs it too; for members it is a no-op).

The boundary leaf is final (Cert1 + Cert2) and `well_formed` binds the embedded proposal to `cert1.data.leaf_commit`, so the header is trustworthy without replaying the previous epoch's chain. The restart path already seeds `from_header` stubs the same way.

The second commit closes the ordering gap: `request_state` used to *drop* a request whose parent was entirely unknown (only stubbing the child), so the seeding only helped if the `EpochChangeMessage` was processed before the first-of-epoch proposal. The request is now also queued on the parent commitment — mirroring `request_header` — and `seed_from_header`'s `start_pending` retries it. A duplicate request for a view already queued on the same parent is skipped at insertion. Stale entries are pruned by the view-based `gc` once decides resume — `gc` only runs on decide, so a stalled node prunes nothing until the seed itself unsticks it.

## Testing

- New `validator_set_replaced_at_epoch_boundary`: 10 nodes, the committee narrows to nodes 0-4 and is then replaced wholesale by the disjoint set 5-9 — 100% turnover. Reaching the 55-decision target proves 5-9 drove epoch 4 (0-4 hold no epoch-4 stake); the target also binds the outgoing nodes, which rely on the one-epoch peer-retention window to follow epoch 4.
- New `test_state_request_missing_parent_retried_after_seed`: deterministically encodes the proposal-before-`EpochChangeMessage` ordering at the `StateManager` level, and asserts the queued request is consumed by the seed rather than re-queued.

## Reviewer focus

- `seed_from_header` (`state.rs`): never displaces an existing state, restarts queued requests.
- The two seeding sites in `coordinator.rs` (verified epoch change intake, `SendEpochChange`).
- The `request_state` missing-parent branch now queues instead of dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
