### PR TITLE
test(node): test-network support for mid-run stake table changes

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -1867,25 +1867,26 @@ where
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
-    use std::{cmp::max, time::Duration};
+    use std::{cmp::max, collections::HashSet, time::Duration};
 
     use alloy::{
         network::EthereumWallet,
-        primitives::{Address, U256},
-        providers::{ProviderBuilder, ext::AnvilApi},
+        primitives::{Address, U256, utils::parse_ether},
+        providers::{Provider, ProviderBuilder, ext::AnvilApi},
+        signers::local::PrivateKeySigner,
     };
-    use committable::Committable;
+    use committable::{Commitment, Committable};
     use espresso_contract_deployer::{
         Contract, Contracts, DEFAULT_EXIT_ESCROW_PERIOD_SECONDS, builder::DeployerArgsBuilder,
         network_config::light_client_genesis_from_stake_table,
     };
     use espresso_types::{
         MOCK_SEQUENCER_VERSIONS, NamespaceId, ValidatedState,
-        v0::traits::{NullEventConsumer, PersistenceOptions, StateCatchup},
+        v0::traits::{NullEventConsumer, PersistenceOptions, SequencerPersistence, StateCatchup},
     };
     use futures::{
         future::{FutureExt, join_all},
-        stream::StreamExt,
+        stream::{Stream, StreamExt},
     };
     use hotshot::types::{Event, EventType};
     use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
@@ -1895,7 +1896,10 @@ pub mod test_helpers {
     };
     use itertools::izip;
     use jf_merkle_tree_compat::{MerkleCommitment, MerkleTreeScheme};
-    use staking_cli::demo::{DelegationConfig, StakingTransactions};
+    use staking_cli::{
+        Transaction as StakingTransaction,
+        demo::{DelegationConfig, StakingTransactions},
+    };
     use surf_disco::Client;
     use tempfile::TempDir;
     use test_utils::reserve_tcp_port;
@@ -1910,7 +1914,10 @@ pub mod test_helpers {
         catchup::NullStateCatchup,
         network,
         persistence::no_storage,
-        testing::{TestConfig, TestConfigBuilder, run_legacy_builder, wait_for_decide_on_handle},
+        testing::{
+            TestConfig, TestConfigBuilder, run_legacy_builder, wait_for_decide_on_handle,
+            wait_for_epochs,
+        },
     };
 
     pub const STAKE_TABLE_CAPACITY_FOR_TEST: usize = 10;
@@ -2061,6 +2068,27 @@ pub mod test_helpers {
             stake_table_version: StakeTableContractVersion,
             upgrade: Upgrade,
         ) -> anyhow::Result<Self> {
+            let registered: Vec<usize> = (0..NUM_NODES).collect();
+            self.pos_hook_with_registered(
+                delegation_config,
+                stake_table_version,
+                upgrade,
+                &registered,
+            )
+            .await
+        }
+
+        /// Like [`Self::pos_hook`], but registers only the validators at the
+        /// `registered` node indices on the stake table contract. The other
+        /// nodes still run from genesis (which seeds the first two epochs)
+        /// and can be registered mid-test via [`register_validators`].
+        pub async fn pos_hook_with_registered(
+            self,
+            delegation_config: DelegationConfig,
+            stake_table_version: StakeTableContractVersion,
+            upgrade: Upgrade,
+            registered: &[usize],
+        ) -> anyhow::Result<Self> {
             if upgrade.base < EPOCH_VERSION && upgrade.target < EPOCH_VERSION {
                 panic!("given version does not require pos deployment");
             };
@@ -2133,7 +2161,7 @@ pub mod test_helpers {
                 l1_url.clone(),
                 &deployer,
                 stake_table_address,
-                network_config.staking_priv_keys(),
+                network_config.staking_key_sets(registered),
                 None,
                 delegation_config,
             )
@@ -2314,6 +2342,245 @@ pub mod test_helpers {
 
             for ctx in &mut self.peers {
                 ctx.shutdown_consensus().await;
+            }
+        }
+
+        /// The context of the node at index `i` (node 0 is the API server).
+        pub fn node(&self, i: usize) -> &SequencerContext<network::Memory, P::Persistence> {
+            if i == 0 {
+                &self.server
+            } else {
+                &self.peers[i - 1]
+            }
+        }
+    }
+
+    /// Registers and delegates to a batch of new validators mid-run, funding
+    /// their L1 accounts from the network's deployer signer.
+    pub async fn register_validators<const NUM_NODES: usize>(
+        cfg: &TestConfig<NUM_NODES>,
+        stake_table: Address,
+        indices: &[usize],
+        delegation_config: DelegationConfig,
+    ) -> anyhow::Result<()> {
+        let deployer = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(cfg.signer()))
+            .connect_http(cfg.l1_url());
+        StakingTransactions::create(
+            cfg.l1_url(),
+            &deployer,
+            stake_table,
+            cfg.staking_key_sets(indices),
+            None,
+            delegation_config,
+        )
+        .await?
+        .apply_all()
+        .await?;
+        Ok(())
+    }
+
+    /// Deregisters the validators at the given node indices, each exit sent
+    /// from that validator's own funded provider.
+    pub async fn deregister_validators<const NUM_NODES: usize>(
+        cfg: &TestConfig<NUM_NODES>,
+        stake_table: Address,
+        indices: &[usize],
+    ) -> anyhow::Result<()> {
+        let providers = cfg.validator_providers();
+        for &i in indices {
+            let (address, provider) = &providers[i];
+            let receipt = StakingTransaction::DeregisterValidator { stake_table }
+                .send(provider)
+                .await?
+                .get_receipt()
+                .await?;
+            anyhow::ensure!(
+                receipt.status(),
+                "deregistration of validator {i} ({address}) reverted"
+            );
+        }
+        Ok(())
+    }
+
+    /// Funds a fresh delegator account (ETH via anvil, ESP from the deployer)
+    /// and delegates `amount` to `validator`. Returns the delegator's provider
+    /// so the test can later undelegate.
+    pub async fn delegate_new<const NUM_NODES: usize>(
+        cfg: &TestConfig<NUM_NODES>,
+        token: Address,
+        stake_table: Address,
+        validator: Address,
+        amount: U256,
+    ) -> anyhow::Result<impl Provider + Clone + use<NUM_NODES>> {
+        let deployer = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(cfg.signer()))
+            .connect_http(cfg.l1_url());
+        let signer = PrivateKeySigner::random();
+        let delegator = signer.address();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect_http(cfg.l1_url());
+
+        deployer
+            .anvil_set_balance(delegator, parse_ether("10").unwrap())
+            .await?;
+        let funding = StakingTransaction::Transfer {
+            token,
+            to: delegator,
+            amount,
+        }
+        .send(&deployer)
+        .await?
+        .get_receipt()
+        .await?;
+        anyhow::ensure!(funding.status(), "ESP transfer to delegator reverted");
+
+        for tx in [
+            StakingTransaction::Approve {
+                token,
+                spender: stake_table,
+                amount,
+            },
+            StakingTransaction::Delegate {
+                stake_table,
+                validator,
+                amount,
+            },
+        ] {
+            let receipt = tx.send(&provider).await?.get_receipt().await?;
+            anyhow::ensure!(receipt.status(), "delegator transaction reverted");
+        }
+        Ok(provider)
+    }
+
+    /// Waits epoch by epoch, starting at `start_epoch`, until the committee
+    /// reported by `node/validators/{epoch}` satisfies `pred`. Returns the
+    /// first matching epoch and its committee; panics after `max_epochs`
+    /// epochs without a match.
+    pub async fn wait_for_committee(
+        client: &Client<ServerError, SequencerApiVersion>,
+        events: &mut (impl Stream<Item = CoordinatorEvent<SeqTypes>> + Unpin),
+        epoch_height: u64,
+        start_epoch: u64,
+        max_epochs: u64,
+        pred: impl Fn(&AuthenticatedValidatorMap) -> bool,
+    ) -> (u64, AuthenticatedValidatorMap) {
+        let mut last = None;
+        for epoch in start_epoch..start_epoch + max_epochs {
+            wait_for_epochs(events, epoch_height, epoch).await;
+            let validators = client
+                .get::<AuthenticatedValidatorMap>(&format!("node/validators/{epoch}"))
+                .send()
+                .await
+                .expect("validators for a decided epoch");
+            if pred(&validators) {
+                return (epoch, validators);
+            }
+            last = Some((epoch, validators));
+        }
+        let last =
+            last.map(|(epoch, validators)| (epoch, validators.keys().copied().collect::<Vec<_>>()));
+        panic!(
+            "committee predicate not satisfied within {max_epochs} epochs starting at \
+             {start_epoch}; last committee: {last:?}"
+        );
+    }
+
+    /// The L1 accounts of the validators at the given node indices.
+    pub fn staking_addresses<const NUM_NODES: usize>(
+        cfg: &TestConfig<NUM_NODES>,
+        indices: &[usize],
+    ) -> HashSet<Address> {
+        cfg.staking_key_sets(indices)
+            .iter()
+            .map(|keys| keys.signer.address())
+            .collect()
+    }
+
+    /// Predicate for [`wait_for_committee`]: the committee is exactly the
+    /// expected set of validator accounts.
+    pub fn committee_is(expected: HashSet<Address>) -> impl Fn(&AuthenticatedValidatorMap) -> bool {
+        move |validators| validators.keys().copied().collect::<HashSet<_>>() == expected
+    }
+
+    /// Asserts the node is live: it must advance `epochs_ahead` epochs past
+    /// its current decided epoch, and — when the chain runs the self-building
+    /// new protocol — sequence a newly submitted transaction. Inclusion is
+    /// not asserted on legacy versions because the test-only legacy builder
+    /// stops producing non-empty blocks after roughly a hundred views,
+    /// independent of any stake table activity.
+    pub async fn assert_node_live<P: SequencerPersistence>(
+        node: &SequencerContext<network::Memory, P>,
+        epoch_height: u64,
+        epochs_ahead: u64,
+    ) {
+        let mut events = node.event_stream();
+        let leaf = node.decided_leaf().await;
+        let current = leaf
+            .epoch(epoch_height)
+            .map(|epoch| epoch.u64())
+            .unwrap_or_default();
+        wait_for_epochs(&mut events, epoch_height, current + epochs_ahead).await;
+
+        if node.decided_leaf().await.block_header().version() < versions::NEW_PROTOCOL_VERSION {
+            tracing::info!("legacy version: skipping transaction-inclusion liveness check");
+            return;
+        }
+        // Detect inclusion via the header's namespace table: the namespace is
+        // unique to this check, and decide events at 0.6 do not carry
+        // payloads.
+        let namespace = NamespaceId::from(10_101_u32);
+        let tx = Transaction::new(namespace, vec![7; 8]);
+        node.submit_transaction(tx)
+            .await
+            .expect("live node accepts transactions");
+        tokio::time::timeout(Duration::from_secs(120), async {
+            loop {
+                let leaf = match events.next().await.unwrap() {
+                    CoordinatorEvent::LegacyEvent(Event {
+                        event: EventType::Decide { leaf_chain, .. },
+                        ..
+                    }) => leaf_chain[0].leaf.clone(),
+                    CoordinatorEvent::NewDecide { leaf_infos, .. } => leaf_infos[0].leaf.clone(),
+                    _ => continue,
+                };
+                if leaf
+                    .block_header()
+                    .ns_table()
+                    .find_ns_id(&namespace)
+                    .is_some()
+                {
+                    tracing::info!(height = leaf.height(), "transaction namespace sequenced");
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("submitted transaction was not sequenced in time");
+    }
+
+    /// Asserts every node has decided at least `min_height`, and that nodes
+    /// which have decided the same height agree on the leaf.
+    pub async fn assert_nodes_agree<P: SequencerPersistence>(
+        nodes: &[&SequencerContext<network::Memory, P>],
+        min_height: u64,
+    ) {
+        let leaves = join_all(nodes.iter().map(|node| node.decided_leaf())).await;
+        let mut by_height: std::collections::BTreeMap<u64, Commitment<Leaf2>> = Default::default();
+        for (i, leaf) in leaves.iter().enumerate() {
+            assert!(
+                leaf.height() >= min_height,
+                "node {i} decided height {} is below {min_height}",
+                leaf.height()
+            );
+            if let Some(other) = by_height.insert(leaf.height(), leaf.commit()) {
+                assert_eq!(
+                    other,
+                    leaf.commit(),
+                    "decided-leaf divergence at height {}",
+                    leaf.height()
+                );
             }
         }
     }

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -1867,7 +1867,12 @@ where
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
-    use std::{cmp::max, collections::HashSet, time::Duration};
+    use std::{
+        cmp::max,
+        collections::HashSet,
+        sync::atomic::{AtomicU32, Ordering},
+        time::Duration,
+    };
 
     use alloy::{
         network::EthereumWallet,
@@ -1915,8 +1920,8 @@ pub mod test_helpers {
         network,
         persistence::no_storage,
         testing::{
-            TestConfig, TestConfigBuilder, run_legacy_builder, wait_for_decide_on_handle,
-            wait_for_epochs,
+            TestConfig, TestConfigBuilder, deploy_stake_table, run_legacy_builder,
+            wait_for_decide_on_handle, wait_for_epochs,
         },
     };
 
@@ -2140,18 +2145,9 @@ pub mod test_helpers {
                 .build()
                 .unwrap();
 
-            match stake_table_version {
-                StakeTableContractVersion::V1 => {
-                    args.deploy_to_stake_table_v1(&mut contracts).await
-                },
-                StakeTableContractVersion::V2 => {
-                    args.deploy_to_stake_table_v2(&mut contracts).await
-                },
-                StakeTableContractVersion::V3 => {
-                    args.deploy_to_stake_table_v3(&mut contracts).await
-                },
-            }
-            .context("failed to deploy contracts")?;
+            deploy_stake_table(&args, stake_table_version, &mut contracts)
+                .await
+                .context("failed to deploy contracts")?;
 
             let stake_table_address = contracts
                 .address(Contract::StakeTableProxy)
@@ -2504,33 +2500,37 @@ pub mod test_helpers {
         move |validators| validators.keys().copied().collect::<HashSet<_>>() == expected
     }
 
-    /// Asserts the node is live: it must advance `epochs_ahead` epochs past
-    /// its current decided epoch, and — when the chain runs the self-building
-    /// new protocol — sequence a newly submitted transaction. Inclusion is
-    /// not asserted on legacy versions because the test-only legacy builder
-    /// stops producing non-empty blocks after roughly a hundred views,
-    /// independent of any stake table activity.
+    /// Asserts the node is live: it must advance `epochs_ahead` epochs (at
+    /// least 1) past its current decided epoch, and — when the chain runs the
+    /// self-building new protocol — sequence a newly submitted transaction.
+    /// Inclusion is not asserted on legacy versions because the test-only
+    /// legacy builder stops producing non-empty blocks after roughly a
+    /// hundred views, independent of any stake table activity.
     pub async fn assert_node_live<P: SequencerPersistence>(
         node: &SequencerContext<network::Memory, P>,
         epoch_height: u64,
         epochs_ahead: u64,
     ) {
+        assert!(epochs_ahead > 0, "epochs_ahead must be at least 1");
         let mut events = node.event_stream();
         let leaf = node.decided_leaf().await;
         let current = leaf
             .epoch(epoch_height)
             .map(|epoch| epoch.u64())
             .unwrap_or_default();
-        wait_for_epochs(&mut events, epoch_height, current + epochs_ahead).await;
+        // `wait_for_epochs` returns on the first epoch strictly greater than
+        // its target.
+        wait_for_epochs(&mut events, epoch_height, current + epochs_ahead - 1).await;
 
         if node.decided_leaf().await.block_header().version() < versions::NEW_PROTOCOL_VERSION {
             tracing::info!("legacy version: skipping transaction-inclusion liveness check");
             return;
         }
         // Detect inclusion via the header's namespace table: the namespace is
-        // unique to this check, and decide events at 0.6 do not carry
+        // unique to this call, and decide events at 0.6 do not always carry
         // payloads.
-        let namespace = NamespaceId::from(10_101_u32);
+        static NAMESPACE_COUNTER: AtomicU32 = AtomicU32::new(10_101);
+        let namespace = NamespaceId::from(NAMESPACE_COUNTER.fetch_add(1, Ordering::Relaxed));
         let tx = Transaction::new(namespace, vec![7; 8]);
         node.submit_transaction(tx)
             .await

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -999,6 +999,7 @@ pub mod testing {
     use hotshot_builder_refactored::service::{
         BuilderConfig as LegacyBuilderConfig, GlobalState as LegacyGlobalState,
     };
+    use hotshot_contract_adapter::stake_table::StakeTableContractVersion;
     use hotshot_testing::block_builder::{
         BuilderTask, SimpleBuilderImplementation, TestBuilderImplementation,
     };
@@ -1150,6 +1151,24 @@ pub mod testing {
         builder_port: Option<u16>,
         upgrades: BTreeMap<Version, Upgrade>,
         coordinator_addrs: Vec<NetAddr>,
+        contracts: Option<Contracts>,
+    }
+
+    /// Picks the key sets at `indices` out of the full deterministic sequence,
+    /// preserving the order of `indices`. Panics on duplicate or out-of-range
+    /// indices.
+    fn select_staking_key_sets(all: Vec<StakingKeySet>, indices: &[usize]) -> Vec<StakingKeySet> {
+        let mut by_index: Vec<Option<StakingKeySet>> = all.into_iter().map(Some).collect();
+        indices
+            .iter()
+            .map(|&i| {
+                by_index
+                    .get_mut(i)
+                    .unwrap_or_else(|| panic!("validator index {i} out of range"))
+                    .take()
+                    .unwrap_or_else(|| panic!("duplicate validator index {i}"))
+            })
+            .collect()
     }
 
     pub fn staking_priv_keys(
@@ -1231,7 +1250,22 @@ pub mod testing {
 
         /// Version specific upgrade setup. Extend to future upgrades
         /// by adding a branch to the `match` statement.
-        pub async fn set_upgrades(mut self, version: Version) -> Self {
+        pub async fn set_upgrades(self, version: Version) -> Self {
+            let registered: Vec<usize> = (0..NUM_NODES).collect();
+            self.set_upgrades_with(version, StakeTableContractVersion::V3, &registered)
+                .await
+        }
+
+        /// Like [`Self::set_upgrades`], but deploys the requested stake table
+        /// contract version and registers only the validators at the
+        /// `registered` node indices. The deployed [`Contracts`] registry is
+        /// retained and available via [`TestConfig::contracts`].
+        pub async fn set_upgrades_with(
+            mut self,
+            version: Version,
+            stake_table_version: StakeTableContractVersion,
+            registered: &[usize],
+        ) -> Self {
             let upgrade = match version {
                 version if version >= EPOCH_VERSION => {
                     tracing::debug!(?version, "upgrade version");
@@ -1244,11 +1278,14 @@ pub mod testing {
                     )
                     .unwrap();
 
-                    let validators = staking_priv_keys(
-                        &self.priv_keys,
-                        &self.state_key_pairs,
-                        &self.coordinator_addrs,
-                        NUM_NODES,
+                    let validators = select_staking_key_sets(
+                        staking_priv_keys(
+                            &self.priv_keys,
+                            &self.state_key_pairs,
+                            &self.coordinator_addrs,
+                            NUM_NODES,
+                        ),
+                        registered,
                     );
 
                     let deployer = ProviderBuilder::new()
@@ -1282,9 +1319,18 @@ pub mod testing {
                         .safe_exit_timelock_executors(vec![self.signer.address()])
                         .build()
                         .unwrap();
-                    args.deploy_to_stake_table_v3(&mut contracts)
-                        .await
-                        .expect("failed to deploy all contracts");
+                    match stake_table_version {
+                        StakeTableContractVersion::V1 => {
+                            args.deploy_to_stake_table_v1(&mut contracts).await
+                        },
+                        StakeTableContractVersion::V2 => {
+                            args.deploy_to_stake_table_v2(&mut contracts).await
+                        },
+                        StakeTableContractVersion::V3 => {
+                            args.deploy_to_stake_table_v3(&mut contracts).await
+                        },
+                    }
+                    .expect("failed to deploy all contracts");
 
                     let st_addr = contracts
                         .address(Contract::StakeTableProxy)
@@ -1302,6 +1348,8 @@ pub mod testing {
                     .apply_all()
                     .await
                     .expect("send all txns failed");
+
+                    self.contracts = Some(contracts);
 
                     Upgrade::pos_view_based(st_addr)
                 },
@@ -1365,6 +1413,7 @@ pub mod testing {
                 upgrades: self.upgrades,
                 anvil_provider: self.anvil_provider,
                 coordinator_addrs: self.coordinator_addrs,
+                contracts: self.contracts,
             }
         }
 
@@ -1482,6 +1531,7 @@ pub mod testing {
                 builder_port: None,
                 upgrades: Default::default(),
                 coordinator_addrs,
+                contracts: None,
             }
         }
     }
@@ -1501,6 +1551,8 @@ pub mod testing {
         upgrades: BTreeMap<Version, Upgrade>,
         /// Per-node cliquenet coordinator bind addresses, indexed by node.
         coordinator_addrs: Vec<NetAddr>,
+        /// Contracts deployed by [`TestConfigBuilder::set_upgrades_with`], if any.
+        contracts: Option<Contracts>,
     }
 
     impl<const NUM_NODES: usize> TestConfig<NUM_NODES> {
@@ -1547,6 +1599,20 @@ pub mod testing {
                 &self.coordinator_addrs,
                 self.num_nodes(),
             )
+        }
+
+        /// Key sets for the given node indices, aligned with
+        /// [`Self::staking_priv_keys`]: the full deterministic sequence is
+        /// generated first and then filtered, so a subset keeps the same keys
+        /// per node index.
+        pub fn staking_key_sets(&self, indices: &[usize]) -> Vec<StakingKeySet> {
+            select_staking_key_sets(self.staking_priv_keys(), indices)
+        }
+
+        /// Contracts deployed by [`TestConfigBuilder::set_upgrades_with`], if
+        /// that was used to set up this config.
+        pub fn contracts(&self) -> Option<Contracts> {
+            self.contracts.clone()
         }
 
         pub fn validator_providers(
@@ -1792,31 +1858,31 @@ pub mod testing {
             let event = events.next().await.unwrap();
             tracing::info!("Received event from handle: {event:?}");
 
-            if let CoordinatorEvent::LegacyEvent(Event {
-                event: EventType::Decide { leaf_chain, .. },
-                ..
-            }) = event
-            {
-                if let Some((height, size)) =
-                    leaf_chain.iter().find_map(|LeafInfo { leaf, .. }| {
-                        if leaf
-                            .block_payload()
-                            .as_ref()?
-                            .transaction_commitments(leaf.block_header().metadata())
-                            .contains(&commitment)
-                        {
-                            let size = leaf.block_payload().unwrap().encode().len();
-                            Some((leaf.block_header().block_number(), size))
-                        } else {
-                            None
-                        }
-                    })
+            // Decides arrive as `LegacyEvent` before the new protocol and as
+            // `NewDecide` after.
+            let leaf_chain: &[LeafInfo<SeqTypes>] = match &event {
+                CoordinatorEvent::LegacyEvent(Event {
+                    event: EventType::Decide { leaf_chain, .. },
+                    ..
+                }) => leaf_chain,
+                CoordinatorEvent::NewDecide { leaf_infos, .. } => leaf_infos,
+                _ => continue,
+            };
+            if let Some((height, size)) = leaf_chain.iter().find_map(|LeafInfo { leaf, .. }| {
+                if leaf
+                    .block_payload()
+                    .as_ref()?
+                    .transaction_commitments(leaf.block_header().metadata())
+                    .contains(&commitment)
                 {
-                    tracing::info!(height, "transaction {commitment} sequenced");
-                    return (height, size);
+                    let size = leaf.block_payload().unwrap().encode().len();
+                    Some((leaf.block_header().block_number(), size))
+                } else {
+                    None
                 }
-            } else {
-                // Keep waiting
+            }) {
+                tracing::info!(height, "transaction {commitment} sequenced");
+                return (height, size);
             }
         }
     }

--- a/crates/espresso/node/src/lib.rs
+++ b/crates/espresso/node/src/lib.rs
@@ -955,7 +955,7 @@ async fn check_cliquenet_info_registered(
 pub mod testing {
     use std::{
         cmp::max,
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, HashMap, HashSet},
         net::Ipv4Addr,
         time::Duration,
     };
@@ -965,7 +965,7 @@ pub mod testing {
         node_bindings::{Anvil, AnvilInstance},
         primitives::{Address, U256},
         providers::{
-            Provider, ProviderBuilder, RootProvider,
+            Provider, ProviderBuilder, RootProvider, WalletProvider,
             fillers::{
                 BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
             },
@@ -976,7 +976,8 @@ pub mod testing {
     use catchup::NullStateCatchup;
     use committable::Committable;
     use espresso_contract_deployer::{
-        Contract, Contracts, DEFAULT_EXIT_ESCROW_PERIOD_SECONDS, builder::DeployerArgsBuilder,
+        Contract, Contracts, DEFAULT_EXIT_ESCROW_PERIOD_SECONDS,
+        builder::{DeployerArgs, DeployerArgsBuilder},
         network_config::light_client_genesis_from_stake_table,
     };
     use espresso_types::{
@@ -1018,7 +1019,7 @@ pub mod testing {
     use rand_chacha::ChaCha20Rng;
     use staking_cli::demo::{DelegationConfig, StakingKeySet, StakingTransactions};
     use test_utils::reserve_tcp_port;
-    use tokio::spawn;
+    use tokio::{spawn, time::timeout};
     use vbs::version::{StaticVersionType, Version};
     use versions::EPOCH_VERSION;
 
@@ -1171,6 +1172,20 @@ pub mod testing {
             .collect()
     }
 
+    /// Deploys the contract suite up to and including the requested stake
+    /// table version, recording addresses in `contracts`.
+    pub async fn deploy_stake_table(
+        args: &DeployerArgs<impl Provider + WalletProvider>,
+        version: StakeTableContractVersion,
+        contracts: &mut Contracts,
+    ) -> anyhow::Result<()> {
+        match version {
+            StakeTableContractVersion::V1 => args.deploy_to_stake_table_v1(contracts).await,
+            StakeTableContractVersion::V2 => args.deploy_to_stake_table_v2(contracts).await,
+            StakeTableContractVersion::V3 => args.deploy_to_stake_table_v3(contracts).await,
+        }
+    }
+
     pub fn staking_priv_keys(
         priv_keys: &[BLSPrivKey],
         state_key_pairs: &[StateKeyPair],
@@ -1319,18 +1334,9 @@ pub mod testing {
                         .safe_exit_timelock_executors(vec![self.signer.address()])
                         .build()
                         .unwrap();
-                    match stake_table_version {
-                        StakeTableContractVersion::V1 => {
-                            args.deploy_to_stake_table_v1(&mut contracts).await
-                        },
-                        StakeTableContractVersion::V2 => {
-                            args.deploy_to_stake_table_v2(&mut contracts).await
-                        },
-                        StakeTableContractVersion::V3 => {
-                            args.deploy_to_stake_table_v3(&mut contracts).await
-                        },
-                    }
-                    .expect("failed to deploy all contracts");
+                    deploy_stake_table(&args, stake_table_version, &mut contracts)
+                        .await
+                        .expect("failed to deploy all contracts");
 
                     let st_addr = contracts
                         .address(Contract::StakeTableProxy)
@@ -1845,46 +1851,80 @@ pub mod testing {
         }
     }
 
-    // Wait for decide event, make sure it matches submitted transaction. Return the block number
-    // containing the transaction and the block payload size
+    // Wait for the submitted transaction to be sequenced in a decided block. Return the block
+    // number containing the transaction and the block payload size.
     pub async fn wait_for_decide_on_handle(
         events: &mut (impl Stream<Item = CoordinatorEvent<SeqTypes>> + Unpin),
         submitted_txn: &Transaction,
     ) -> (u64, usize) {
         let commitment = submitted_txn.commit();
 
-        // Keep getting events until we see a Decide event
-        loop {
-            let event = events.next().await.unwrap();
-            tracing::info!("Received event from handle: {event:?}");
+        // At 0.6 a decide carries the block payload only on the node that
+        // built the block; every other node receives the payload through a
+        // separate `BlockPayloadReconstructed` event, which can arrive before
+        // or after the decide. Pair the two by view so the transaction is
+        // only reported once its block is decided.
+        let mut reconstructed = HashMap::new();
+        let mut decided_without_payload = HashSet::new();
 
-            // Decides arrive as `LegacyEvent` before the new protocol and as
-            // `NewDecide` after.
-            let leaf_chain: &[LeafInfo<SeqTypes>] = match &event {
-                CoordinatorEvent::LegacyEvent(Event {
-                    event: EventType::Decide { leaf_chain, .. },
-                    ..
-                }) => leaf_chain,
-                CoordinatorEvent::NewDecide { leaf_infos, .. } => leaf_infos,
-                _ => continue,
-            };
-            if let Some((height, size)) = leaf_chain.iter().find_map(|LeafInfo { leaf, .. }| {
-                if leaf
-                    .block_payload()
-                    .as_ref()?
-                    .transaction_commitments(leaf.block_header().metadata())
-                    .contains(&commitment)
+        let (height, size) = timeout(Duration::from_secs(120), async {
+            loop {
+                let event = events.next().await.unwrap();
+                tracing::info!("Received event from handle: {event:?}");
+
+                if let CoordinatorEvent::BlockPayloadReconstructed {
+                    view,
+                    header,
+                    payload,
+                } = &event
                 {
-                    let size = leaf.block_payload().unwrap().encode().len();
-                    Some((leaf.block_header().block_number(), size))
-                } else {
-                    None
+                    if payload
+                        .transaction_commitments(header.metadata())
+                        .contains(&commitment)
+                    {
+                        let found = (header.block_number(), payload.encode().len());
+                        if decided_without_payload.contains(view) {
+                            return found;
+                        }
+                        reconstructed.insert(*view, found);
+                    }
+                    continue;
                 }
-            }) {
-                tracing::info!(height, "transaction {commitment} sequenced");
-                return (height, size);
+
+                // Decides arrive as `LegacyEvent` before the new protocol and
+                // as `NewDecide` after.
+                let leaf_chain: &[LeafInfo<SeqTypes>] = match &event {
+                    CoordinatorEvent::LegacyEvent(Event {
+                        event: EventType::Decide { leaf_chain, .. },
+                        ..
+                    }) => leaf_chain,
+                    CoordinatorEvent::NewDecide { leaf_infos, .. } => leaf_infos,
+                    _ => continue,
+                };
+                for LeafInfo { leaf, .. } in leaf_chain {
+                    let Some(payload) = leaf.block_payload() else {
+                        let view = leaf.view_number();
+                        if let Some(found) = reconstructed.remove(&view) {
+                            return found;
+                        }
+                        decided_without_payload.insert(view);
+                        continue;
+                    };
+                    if payload
+                        .transaction_commitments(leaf.block_header().metadata())
+                        .contains(&commitment)
+                    {
+                        return (leaf.block_header().block_number(), payload.encode().len());
+                    }
+                }
             }
-        }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("transaction {commitment} was not sequenced within the timeout")
+        });
+        tracing::info!(height, "transaction {commitment} sequenced");
+        (height, size)
     }
 
     /// Waits until a node has reached the given target epoch (exclusive).

--- a/crates/hotshot/new-protocol/src/coordinator.rs
+++ b/crates/hotshot/new-protocol/src/coordinator.rs
@@ -510,7 +510,14 @@ where
                     return Ok(ConsensusInput::AdvanceView(cert1))
                 }
                 Some(epoch_change) = self.cert_verifiers.epoch_change.next() => {
-                    return Ok(ConsensusInput::EpochChange(epoch_change.into_cert()))
+                    let epoch_change = epoch_change.into_cert();
+                    // The boundary leaf is final (Cert1 + Cert2), so seed a
+                    // commitment-only state for it: a validator whose
+                    // membership starts at this boundary can then build and
+                    // validate the new epoch's first proposals via catchup.
+                    self.state_manager
+                        .seed_from_header(epoch_change.proposal.clone());
+                    return Ok(ConsensusInput::EpochChange(epoch_change))
                 }
                 Some((cert1, state_cert)) = self.epoch_root_collector.next() => {
                     self.cert_verifiers.cert1.mark_completed(cert1.view_number());
@@ -899,6 +906,11 @@ where
                     epoch = ?epoch_change.cert1.epoch().map(|e| *e),
                     "send epoch change"
                 );
+                // A node that decided the boundary from broadcast Cert2s needs
+                // the boundary state seeded just like a receiver of an
+                // EpochChangeMessage; for members this is a no-op.
+                self.state_manager
+                    .seed_from_header(epoch_change.proposal.clone());
                 self.broadcast(
                     ConsensusMessage::EpochChange(epoch_change),
                     "broadcast epoch change",

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -211,14 +211,20 @@ impl<T: NodeType> StateManager<T> {
                 epoch = %request.epoch,
                 block = %request.block,
                 parent_commitment = %request.parent_commitment,
-                "parent state unavailable; deferring state validation (from_header stub inserted). \
-                 If this persists, the node cannot vote until the parent state is recovered."
+                "parent state unavailable; queued on parent for retry (from_header stub inserted). \
+                 If this persists, the parent state never arrived and the node cannot vote."
             );
             self.insert_empty_state(request.proposal.clone());
-            self.pending_requests
+            let queued = self
+                .pending_requests
                 .entry(request.parent_commitment)
-                .or_default()
-                .push(Pending::State(request));
+                .or_default();
+            if !queued
+                .iter()
+                .any(|p| matches!(p, Pending::State(r) if r.view == request.view))
+            {
+                queued.push(Pending::State(request));
+            }
             self.start_pending(commitment);
             return;
         };

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -214,7 +214,11 @@ impl<T: NodeType> StateManager<T> {
                 "parent state unavailable; deferring state validation (from_header stub inserted). \
                  If this persists, the node cannot vote until the parent state is recovered."
             );
-            self.insert_empty_state(request.proposal);
+            self.insert_empty_state(request.proposal.clone());
+            self.pending_requests
+                .entry(request.parent_commitment)
+                .or_default()
+                .push(Pending::State(request));
             self.start_pending(commitment);
             return;
         };

--- a/crates/hotshot/new-protocol/src/state.rs
+++ b/crates/hotshot/new-protocol/src/state.rs
@@ -175,8 +175,15 @@ impl<T: NodeType> StateManager<T> {
 
     /// Seed a commitment-only (`from_header`) state so a child proposal can be
     /// validated against this leaf via catchup instead of being dropped.
+    ///
+    /// A real (validated) state for the leaf is never displaced, and any
+    /// header/state requests already queued on this leaf are restarted.
     pub(crate) fn seed_from_header(&mut self, proposal: Proposal<T>) {
-        self.insert_empty_state(proposal);
+        let commitment = proposal_commitment(&proposal);
+        if !self.validated_states.contains_key(&commitment) {
+            self.insert_empty_state(proposal);
+        }
+        self.start_pending(commitment);
     }
 
     pub fn request_state(&mut self, request: StateRequest<T>) {

--- a/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
+++ b/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
@@ -58,6 +58,13 @@ async fn validator_joins_at_epoch_boundary() {
 /// Cert2): the coordinator seeds a commitment-only state for it, so the
 /// first epoch-4 leader and voters need neither the epoch-3 tail's payloads
 /// nor its replayed state.
+///
+/// Reaching block 55 proves nodes 5-9 drove epoch 4: nodes 0-4 hold no
+/// epoch-4 stake, so no quorum forms without the incoming cohort. The
+/// 55-decision target also binds the outgoing nodes 0-4, which can only
+/// meet it as retained followers — peers keep a leaving validator for one
+/// extra epoch, so 0-4 follow epoch 4 by broadcast until the cliff at
+/// block 60. Shortening that retention window breaks this test.
 #[tokio::test(flavor = "multi_thread")]
 async fn validator_set_replaced_at_epoch_boundary() {
     TestRunner::builder()

--- a/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
+++ b/crates/hotshot/new-protocol/src/tests/stake_table_changes.rs
@@ -49,6 +49,32 @@ async fn validator_joins_at_epoch_boundary() {
         .unwrap();
 }
 
+/// 10 nodes, epoch_height=15; the committee narrows to nodes 0-4 at epoch 3
+/// (blocks 31-45) and is replaced wholesale by the disjoint set 5-9 at
+/// epoch 4 (blocks 46-60) — a 100% turnover of the active committee.
+///
+/// The incoming cohort followed epoch 3 via broadcast cert2s without VID
+/// shares. The handoff works because the boundary leaf is final (Cert1 +
+/// Cert2): the coordinator seeds a commitment-only state for it, so the
+/// first epoch-4 leader and voters need neither the epoch-3 tail's payloads
+/// nor its replayed state.
+#[tokio::test(flavor = "multi_thread")]
+async fn validator_set_replaced_at_epoch_boundary() {
+    TestRunner::builder()
+        .num_nodes(10)
+        .target_decisions(55)
+        .max_runtime(Duration::from_secs(500))
+        .epoch_height(15)
+        .stake_table_schedule(StakeTableSchedule {
+            initial: (0..10).collect(),
+            changes: vec![(3, vec![0, 1, 2, 3, 4]), (4, vec![5, 6, 7, 8, 9])],
+        })
+        .build()
+        .run()
+        .await
+        .unwrap();
+}
+
 /// 6 nodes, epoch_height=10; all form epochs 1-2, node 5 is removed from
 /// the committee at epoch 3 (blocks 21-30).
 ///

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -149,6 +149,45 @@ async fn test_state_request_missing_parent_inserts_empty() {
     );
 }
 
+/// A state request whose parent is entirely unknown is retried once the
+/// parent is seeded from its header — the ordering where a first-of-epoch
+/// proposal arrives before the boundary leaf's `EpochChangeMessage`.
+#[tokio::test]
+async fn test_state_request_missing_parent_retried_after_seed() {
+    let mut manager =
+        StateManager::new(Arc::new(TestInstanceState::default()), test_upgrade_lock());
+    let test_data = TestData::new(3).await;
+
+    // View 2 arrives while view 1 (its parent) is entirely unknown.
+    manager.request_state(make_state_request(&test_data.views[1]));
+
+    let view_1_commit = proposal_commitment(&test_data.views[0].proposal.data.clone());
+    assert!(
+        manager.pending_contains_commitment(&view_1_commit),
+        "View 2 should be queued on its missing parent's commitment"
+    );
+    assert!(
+        manager.validated_contains_view(test_data.views[1].view_number),
+        "A from_header stub should be inserted for view 2"
+    );
+
+    // The parent becomes final (e.g. via a verified EpochChangeMessage):
+    // seeding it must restart the queued request.
+    manager.seed_from_header(test_data.views[0].proposal.data.clone());
+
+    let output = manager.next().await.expect("view 2 should complete");
+    assert!(
+        matches!(
+            output,
+            StateManagerOutput::State {
+                validated: true,
+                ..
+            }
+        ),
+        "View 2 should validate against the seeded parent state"
+    );
+}
+
 /// State request with seeded genesis parent spawns validation and produces output.
 #[tokio::test]
 async fn test_state_request_with_genesis_parent() {

--- a/crates/hotshot/new-protocol/src/tests/state.rs
+++ b/crates/hotshot/new-protocol/src/tests/state.rs
@@ -175,6 +175,11 @@ async fn test_state_request_missing_parent_retried_after_seed() {
     // seeding it must restart the queued request.
     manager.seed_from_header(test_data.views[0].proposal.data.clone());
 
+    assert!(
+        !manager.pending_contains_commitment(&view_1_commit),
+        "the queued request should be consumed, not re-queued"
+    );
+
     let output = manager.next().await.expect("view 2 should complete");
     assert!(
         matches!(


### PR DESCRIPTION
Stacked on #4751.

Adds the infrastructure for integration tests that change the validator set while a network runs:

- `set_upgrades_with` / `pos_hook_with_registered`: deploy a chosen stake table contract version and register only a subset of nodes; the deployed `Contracts` registry is retained for mid-test upgrades.
- `register_validators` / `deregister_validators` / `delegate_new`: drive registration, exit, and delegation transactions against the running network's L1.
- `wait_for_committee` / `committee_is` / `staking_addresses`: scan epochs until the reported committee matches a predicate.
- `assert_node_live` / `assert_nodes_agree`: liveness (epoch advancement + transaction sequencing at 0.6) and decided-leaf agreement checks.
- `wait_for_decide_on_handle` now also understands `NewDecide` events so it works across the 0.6 cutover.

No behavior change for existing tests: `set_upgrades` and `pos_hook` delegate to the new variants with all nodes registered and StakeTable V3.

## Reviewer focus

- `select_staking_key_sets` keeps key sets aligned by node index (the full deterministic sequence is generated first, then filtered), so validators registered mid-test get the same keys their nodes run with.
- `assert_node_live` skips the transaction-inclusion check on legacy versions because the test-only legacy builder stops producing non-empty blocks after roughly a hundred views.

Used by the integration tests in the next PR of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)