### PR TITLE
feat(api): add status endpoint for node public keys

### DIFF
--- a/crates/espresso/api/examples/test_api.rs
+++ b/crates/espresso/api/examples/test_api.rs
@@ -398,6 +398,8 @@ impl v1::FeeStateApi for TestApi {
 
 #[async_trait]
 impl v1::StatusApi for TestApi {
+    type Keys = serde_json::Value;
+
     async fn block_height(&self) -> Result<u64> {
         Ok(0)
     }
@@ -409,6 +411,9 @@ impl v1::StatusApi for TestApi {
     }
     async fn metrics(&self) -> Result<String> {
         Ok(String::new())
+    }
+    async fn keys(&self) -> Result<Self::Keys> {
+        Ok(serde_json::Value::Null)
     }
 }
 

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -1746,10 +1746,10 @@ where
             routes::v1::STATUS_KEYS_ROUTE,
             get_with(status_keys, |op| {
                 op.summary("Get node public keys").description(
-                    "Get this node's public keys (Ethereum account, BLS, Schnorr, x25519), \
-                     formatted as in stake-table responses. The Ethereum account is taken from \
-                     the node's stake-table registration and is null if the node is not \
-                     registered.",
+                    "Get this node's public keys (Ethereum account, BLS, Schnorr, x25519). The \
+                     BLS and Schnorr keys are formatted as in stake-table responses; the x25519 \
+                     key is tagged base64. The Ethereum account is taken from the node's \
+                     stake-table registration and is null if the node is not registered.",
                 )
             }),
         )

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -1706,6 +1706,13 @@ where
         }
     };
 
+    let status_keys = |State(state): State<S>| async move {
+        <S as v1::StatusApi>::keys(&state)
+            .await
+            .map(ApiJson)
+            .map_err(ApiError::Internal)
+    };
+
     ApiRouter::new()
         .api_route(
             routes::v1::STATUS_BLOCK_HEIGHT_ROUTE,
@@ -1733,6 +1740,17 @@ where
             get_with(status_metrics, |op| {
                 op.summary("Get Prometheus metrics")
                     .description("Prometheus endpoint exposing consensus-related metrics.")
+            }),
+        )
+        .api_route(
+            routes::v1::STATUS_KEYS_ROUTE,
+            get_with(status_keys, |op| {
+                op.summary("Get node public keys").description(
+                    "Get this node's public keys (Ethereum account, BLS, Schnorr, x25519), \
+                     formatted as in stake-table responses. The Ethereum account is taken from \
+                     the node's stake-table registration and is null if the node is not \
+                     registered.",
+                )
             }),
         )
         .with_state(state)
@@ -4356,6 +4374,8 @@ mod tests {
 
     #[async_trait::async_trait]
     impl v1::StatusApi for MockState {
+        type Keys = ();
+
         async fn block_height(&self) -> anyhow::Result<u64> {
             unimplemented!()
         }
@@ -4366,6 +4386,9 @@ mod tests {
             unimplemented!()
         }
         async fn metrics(&self) -> anyhow::Result<String> {
+            unimplemented!()
+        }
+        async fn keys(&self) -> anyhow::Result<Self::Keys> {
             unimplemented!()
         }
     }

--- a/crates/espresso/api/src/axum/routes.rs
+++ b/crates/espresso/api/src/axum/routes.rs
@@ -156,6 +156,7 @@ pub mod v1 {
     pub const STATUS_SUCCESS_RATE_ROUTE: &str = "/v1/status/success-rate";
     pub const STATUS_TIME_SINCE_LAST_DECIDE_ROUTE: &str = "/v1/status/time-since-last-decide";
     pub const STATUS_METRICS_ROUTE: &str = "/v1/status/metrics";
+    pub const STATUS_KEYS_ROUTE: &str = "/v1/status/keys";
 
     pub const CONFIG_HOTSHOT_ROUTE: &str = "/v1/config/hotshot";
     pub const CONFIG_ENV_ROUTE: &str = "/v1/config/env";
@@ -603,6 +604,7 @@ pub mod v1 {
         STATUS_TIME_SINCE_LAST_DECIDE_ROUTE
     );
     path_fn!(status_metrics, STATUS_METRICS_ROUTE);
+    path_fn!(status_keys, STATUS_KEYS_ROUTE);
 
     // Config
     path_fn!(config_hotshot, CONFIG_HOTSHOT_ROUTE);

--- a/crates/espresso/api/src/v1/status.rs
+++ b/crates/espresso/api/src/v1/status.rs
@@ -1,14 +1,21 @@
 //! V1 status API.
 //!
-//! Mirrors the tide-disco endpoints defined in `hotshot-query-service/api/status.toml`.
+//! Mirrors the tide-disco endpoints defined in `hotshot-query-service/api/status.toml`,
+//! plus the Espresso-specific `keys` endpoint.
 
 use async_trait::async_trait;
+use serde::Serialize;
 
 #[async_trait]
 pub trait StatusApi {
+    /// The node's public keys, formatted as in stake-table responses.
+    type Keys: Serialize + Send + Sync + 'static;
+
     async fn block_height(&self) -> anyhow::Result<u64>;
     async fn success_rate(&self) -> anyhow::Result<f64>;
     async fn time_since_last_decide(&self) -> anyhow::Result<u64>;
 
     async fn metrics(&self) -> anyhow::Result<String>;
+
+    async fn keys(&self) -> anyhow::Result<Self::Keys>;
 }

--- a/crates/espresso/api/src/v1/status.rs
+++ b/crates/espresso/api/src/v1/status.rs
@@ -1,14 +1,12 @@
 //! V1 status API.
 //!
-//! Mirrors the tide-disco endpoints defined in `hotshot-query-service/api/status.toml`,
-//! plus the Espresso-specific `keys` endpoint.
+//! Mirrors the tide-disco endpoints defined in `hotshot-query-service/api/status.toml`.
 
 use async_trait::async_trait;
 use serde::Serialize;
 
 #[async_trait]
 pub trait StatusApi {
-    /// The node's public keys, formatted as in stake-table responses.
     type Keys: Serialize + Send + Sync + 'static;
 
     async fn block_height(&self) -> anyhow::Result<u64>;

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -2675,7 +2675,8 @@ pub mod test_helpers {
         assert!(bls.starts_with("BLS_VER_KEY~"), "{bls}");
         let schnorr = json["state_ver_key"].as_str().unwrap();
         assert!(schnorr.starts_with("SCHNORR_VER_KEY~"), "{schnorr}");
-        assert!(json["x25519_key"].is_string(), "{json}");
+        let x25519 = json["x25519_key"].as_str().unwrap();
+        assert!(x25519.starts_with("X25519_PK~"), "{x25519}");
     }
 
     /// Test the submit API with custom options.

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -2660,7 +2660,6 @@ pub mod test_helpers {
         // We know at least some views have been successful, since we finalized a block.
         assert!(success_rate > 0.0, "{success_rate}");
 
-        // The keys endpoint reports the server's public keys.
         let keys: NodePublicKeys = client.get("status/keys").send().await.unwrap();
         let expected = network.server.validator_config();
         assert_eq!(keys.consensus_key, expected.public_key);
@@ -2669,11 +2668,8 @@ pub mod test_helpers {
             keys.x25519_key,
             expected.x25519_keypair.as_ref().map(|kp| kp.public_key())
         );
-        // This network runs without a stake table contract, so the node has no registered
-        // Ethereum account.
         assert_eq!(keys.eth_account, None);
 
-        // Keys are serialized in the same format as stake-table responses.
         let json: serde_json::Value = client.get("status/keys").send().await.unwrap();
         let bls = json["consensus_key"].as_str().unwrap();
         assert!(bls.starts_with("BLS_VER_KEY~"), "{bls}");

--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -71,7 +71,10 @@ use tokio::time::timeout;
 use url::Url;
 use vbs::version::Version;
 
-use self::data_source::{HotShotConfigDataSource, NodeStateDataSource, StateSignatureDataSource};
+use self::data_source::{
+    HotShotConfigDataSource, NodeKeysDataSource, NodePublicKeys, NodeStateDataSource,
+    StateSignatureDataSource,
+};
 use crate::{
     SeqTypes, SequencerApiVersion, SequencerContext,
     api::data_source::TokenDataSource,
@@ -1265,6 +1268,34 @@ impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> HotShotConfigDataSour
 {
     async fn get_config(&self) -> PublicNetworkConfig {
         self.network_config().await.into()
+    }
+}
+
+impl<N: ConnectedNetwork<PubKey>, D: Sync, P: SequencerPersistence> NodeKeysDataSource
+    for StorageState<N, P, D>
+{
+    async fn node_public_keys(&self) -> NodePublicKeys {
+        self.as_ref().node_public_keys().await
+    }
+}
+
+impl<N: ConnectedNetwork<PubKey>, P: SequencerPersistence> NodeKeysDataSource for ApiState<N, P> {
+    async fn node_public_keys(&self) -> NodePublicKeys {
+        let ctx = self.sequencer_context.as_ref().get().await.get_ref();
+        let config = ctx.validator_config();
+        let consensus_key = config.public_key;
+        let eth_account = ctx
+            .consensus_handle()
+            .membership_coordinator()
+            .await
+            .membership()
+            .latest_account(&consensus_key);
+        NodePublicKeys {
+            eth_account,
+            consensus_key,
+            state_ver_key: config.state_public_key.clone(),
+            x25519_key: config.x25519_keypair.as_ref().map(|kp| kp.public_key()),
+        }
     }
 }
 
@@ -2603,7 +2634,7 @@ pub mod test_helpers {
             .api_config(options)
             .network_config(network_config)
             .build();
-        let _network = TestNetwork::new(config, MOCK_SEQUENCER_VERSIONS).await;
+        let network = TestNetwork::new(config, MOCK_SEQUENCER_VERSIONS).await;
         client.connect(None).await;
 
         // The status API is well tested in the query service repo. Here we are just smoke testing
@@ -2628,6 +2659,27 @@ pub mod test_helpers {
         assert!(success_rate.is_finite(), "{success_rate}");
         // We know at least some views have been successful, since we finalized a block.
         assert!(success_rate > 0.0, "{success_rate}");
+
+        // The keys endpoint reports the server's public keys.
+        let keys: NodePublicKeys = client.get("status/keys").send().await.unwrap();
+        let expected = network.server.validator_config();
+        assert_eq!(keys.consensus_key, expected.public_key);
+        assert_eq!(keys.state_ver_key, expected.state_public_key);
+        assert_eq!(
+            keys.x25519_key,
+            expected.x25519_keypair.as_ref().map(|kp| kp.public_key())
+        );
+        // This network runs without a stake table contract, so the node has no registered
+        // Ethereum account.
+        assert_eq!(keys.eth_account, None);
+
+        // Keys are serialized in the same format as stake-table responses.
+        let json: serde_json::Value = client.get("status/keys").send().await.unwrap();
+        let bls = json["consensus_key"].as_str().unwrap();
+        assert!(bls.starts_with("BLS_VER_KEY~"), "{bls}");
+        let schnorr = json["state_ver_key"].as_str().unwrap();
+        assert!(schnorr.starts_with("SCHNORR_VER_KEY~"), "{schnorr}");
+        assert!(json["x25519_key"].is_string(), "{json}");
     }
 
     /// Test the submit API with custom options.

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -131,7 +131,29 @@ pub struct NodePublicKeys {
     pub eth_account: Option<Address>,
     pub consensus_key: BLSPubKey,
     pub state_ver_key: StateVerKey,
+    #[serde(with = "x25519_tagged")]
     pub x25519_key: Option<x25519::PublicKey>,
+}
+
+mod x25519_tagged {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+    use super::x25519;
+
+    pub fn serialize<S: Serializer>(
+        key: &Option<x25519::PublicKey>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        key.as_ref().map(ToString::to_string).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<x25519::PublicKey>, D::Error> {
+        Option::<String>::deserialize(d)?
+            .map(|s| s.parse().map_err(D::Error::custom))
+            .transpose()
+    }
 }
 
 pub(crate) trait NodeKeysDataSource {
@@ -641,7 +663,7 @@ mod test {
         assert_eq!(keys["eth_account"], validator["account"]);
         assert_eq!(keys["consensus_key"], validator["stake_table_key"]);
         assert_eq!(keys["state_ver_key"], validator["state_ver_key"]);
-        assert_eq!(keys["x25519_key"], validator["x25519_key"]);
+        assert_eq!(keys["x25519_key"], x25519_key.to_string());
     }
 }
 

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -126,16 +126,11 @@ pub(crate) trait NodeStateDataSource {
     fn node_state(&self) -> impl Send + Future<Output = NodeState>;
 }
 
-/// This node's public keys, serialized in the same format as stake-table responses.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodePublicKeys {
-    /// Ethereum account of the node's stake-table registration, if registered.
     pub eth_account: Option<Address>,
-    /// The node's BLS (staking) key.
     pub consensus_key: BLSPubKey,
-    /// The node's Schnorr (state) key.
     pub state_ver_key: StateVerKey,
-    /// The node's x25519 (cliquenet) key, if configured.
     pub x25519_key: Option<x25519::PublicKey>,
 }
 
@@ -613,8 +608,6 @@ mod test {
 
     use super::*;
 
-    /// `NodePublicKeys` must serialize each key exactly as `RegisteredValidator` does, so the
-    /// keys endpoint displays keys in the same format as stake-table responses.
     #[test]
     fn test_node_public_keys_serialize_like_stake_table() {
         let account = Address::random();

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -28,9 +28,10 @@ use hotshot_query_service::{
 use hotshot_types::{
     PeerConfig,
     data::{EpochNumber, VidShare, ViewNumber},
-    light_client::LCV3StateSignatureRequestBody,
+    light_client::{LCV3StateSignatureRequestBody, StateVerKey},
     simple_certificate::LightClientStateUpdateCertificateV2,
     traits::{network::ConnectedNetwork, node_implementation::NodeType},
+    x25519,
 };
 use indexmap::IndexMap;
 use light_client::{state::LightClientOptions, storage::LightClientSqliteOptions};
@@ -123,6 +124,23 @@ pub(crate) trait StateSignatureDataSource<N: ConnectedNetwork<PubKey>> {
 
 pub(crate) trait NodeStateDataSource {
     fn node_state(&self) -> impl Send + Future<Output = NodeState>;
+}
+
+/// This node's public keys, serialized in the same format as stake-table responses.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodePublicKeys {
+    /// Ethereum account of the node's stake-table registration, if registered.
+    pub eth_account: Option<Address>,
+    /// The node's BLS (staking) key.
+    pub consensus_key: BLSPubKey,
+    /// The node's Schnorr (state) key.
+    pub state_ver_key: StateVerKey,
+    /// The node's x25519 (cliquenet) key, if configured.
+    pub x25519_key: Option<x25519::PublicKey>,
+}
+
+pub(crate) trait NodeKeysDataSource {
+    fn node_public_keys(&self) -> impl Send + Future<Output = NodePublicKeys>;
 }
 
 pub(crate) trait TokenDataSource<T: NodeType> {
@@ -587,6 +605,51 @@ pub(crate) trait PruningDataSource {
     fn get_oldest_leaf(
         &self,
     ) -> impl Send + Future<Output = anyhow::Result<Option<LeafQueryData<SeqTypes>>>>;
+}
+
+#[cfg(test)]
+mod test {
+    use hotshot_types::{light_client::StateKeyPair, traits::signature_key::SignatureKey as _};
+
+    use super::*;
+
+    /// `NodePublicKeys` must serialize each key exactly as `RegisteredValidator` does, so the
+    /// keys endpoint displays keys in the same format as stake-table responses.
+    #[test]
+    fn test_node_public_keys_serialize_like_stake_table() {
+        let account = Address::random();
+        let consensus_key = BLSPubKey::generated_from_seed_indexed([1; 32], 0).0;
+        let state_ver_key = StateKeyPair::generate_from_seed_indexed([2; 32], 0).ver_key();
+        let x25519_key = x25519::Keypair::generated_from_seed_indexed([3; 32], 0)
+            .unwrap()
+            .public_key();
+
+        let validator = serde_json::to_value(RegisteredValidator::<BLSPubKey> {
+            account,
+            stake_table_key: Some(consensus_key),
+            state_ver_key: Some(state_ver_key.clone()),
+            stake: U256::from(1u64),
+            commission: 0,
+            delegators: HashMap::new(),
+            authenticated: true,
+            x25519_key: Some(x25519_key),
+            p2p_addr: None,
+        })
+        .unwrap();
+
+        let keys = serde_json::to_value(NodePublicKeys {
+            eth_account: Some(account),
+            consensus_key,
+            state_ver_key,
+            x25519_key: Some(x25519_key),
+        })
+        .unwrap();
+
+        assert_eq!(keys["eth_account"], validator["account"]);
+        assert_eq!(keys["consensus_key"], validator["stake_table_key"]);
+        assert_eq!(keys["state_ver_key"], validator["state_ver_key"]);
+        assert_eq!(keys["x25519_key"], validator["x25519_key"]);
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/espresso/node/src/api/state.rs
+++ b/crates/espresso/node/src/api/state.rs
@@ -66,9 +66,9 @@ use super::{
     RewardMerkleTreeDataSource, RewardMerkleTreeV2Data as InternalRewardTreeData,
     data_source::{
         CatchupDataSource as _, DatabaseMetadataSource as _, HotShotConfigDataSource as _,
-        NodeStateDataSource as _, PruningDataSource as _, RequestResponseDataSource as _,
-        StakeTableDataSource, StateCertDataSource, StateCertFetchingDataSource,
-        StateSignatureDataSource, TokenDataSource as _,
+        NodeKeysDataSource, NodePublicKeys, NodeStateDataSource as _, PruningDataSource as _,
+        RequestResponseDataSource as _, StakeTableDataSource, StateCertDataSource,
+        StateCertFetchingDataSource, StateSignatureDataSource, TokenDataSource as _,
     },
 };
 
@@ -2284,8 +2284,10 @@ where
 impl<D> espresso_api::v1::StatusApi for NodeApiStateImpl<D>
 where
     D: std::ops::Deref + Clone + Send + Sync + 'static,
-    D::Target: hotshot_query_service::status::StatusDataSource + Send + Sync,
+    D::Target: hotshot_query_service::status::StatusDataSource + NodeKeysDataSource + Send + Sync,
 {
+    type Keys = NodePublicKeys;
+
     async fn block_height(&self) -> anyhow::Result<u64> {
         let ds = &*self.data_source;
         let h = hotshot_query_service::status::StatusDataSource::block_height(ds)
@@ -2311,6 +2313,10 @@ where
     async fn metrics(&self) -> anyhow::Result<String> {
         let ds = &*self.data_source;
         ds.metrics().export().map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    async fn keys(&self) -> anyhow::Result<NodePublicKeys> {
+        Ok(self.data_source.node_public_keys().await)
     }
 }
 

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -454,6 +454,11 @@ where
         self.consensus_handle.clone()
     }
 
+    /// Return a reference to this node's validator config, including its key material.
+    pub fn validator_config(&self) -> &ValidatorConfig<SeqTypes> {
+        &self.validator_config
+    }
+
     pub async fn upgrade_lock(&self) -> UpgradeLock<SeqTypes> {
         self.consensus_handle.upgrade_lock().await
     }

--- a/crates/espresso/node/src/context.rs
+++ b/crates/espresso/node/src/context.rs
@@ -454,7 +454,6 @@ where
         self.consensus_handle.clone()
     }
 
-    /// Return a reference to this node's validator config, including its key material.
     pub fn validator_config(&self) -> &ValidatorConfig<SeqTypes> {
         &self.validator_config
     }

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -220,11 +220,6 @@ impl EpochCommittees {
             .cloned()
     }
 
-    /// Find the Ethereum account under which `key` is registered.
-    ///
-    /// Scans loaded epochs from highest to lowest. Returns `None` if the key
-    /// does not appear in any loaded epoch stake table (the pre-epoch
-    /// committee has no Ethereum accounts).
     pub fn latest_account(&self, key: &PubKey) -> Option<Address> {
         let inner = self.inner.read();
         inner

--- a/crates/espresso/types/src/v0/impls/committee.rs
+++ b/crates/espresso/types/src/v0/impls/committee.rs
@@ -220,6 +220,20 @@ impl EpochCommittees {
             .cloned()
     }
 
+    /// Find the Ethereum account under which `key` is registered.
+    ///
+    /// Scans loaded epochs from highest to lowest. Returns `None` if the key
+    /// does not appear in any loaded epoch stake table (the pre-epoch
+    /// committee has no Ethereum accounts).
+    pub fn latest_account(&self, key: &PubKey) -> Option<Address> {
+        let inner = self.inner.read();
+        inner
+            .snapshots
+            .values()
+            .rev()
+            .find_map(|snap| snap.inner.committee.address_mapping.get(key).copied())
+    }
+
     /// Fetch the fixed block reward and update it if its None.
     /// We used a fixed block reward for version v3
     /// Version v4 uses the dynamic block reward


### PR DESCRIPTION
Adds a `/v1/status/keys` endpoint that returns the node's public keys (Ethereum account, BLS, Schnorr, x25519). The BLS and Schnorr keys are serialized as in stake-table responses; the x25519 key is tagged base64. The Ethereum account comes from the node's stake-table registration and is null if the node is not registered.

Example output:

```json
{
  "consensus_key": "BLS_VER_KEY~YUMp62sfuHY4h7Uc3NuiD-iKa5aaJ7XfaoeXFWi4rgUsly6Si9UTSa3GRQfUkEPL0yRu7M3mjMwL9gWKss6VLZBif-5I6gmhfAWiFBkBSn2k4YK8yRYLILBPG0yVZWcgeI-54-yVvFKjR1doeOCIatgPf_ietXK1HzuuKbYvla-U",
  "eth_account": "0x0d82dee032515c2dff1594c5a988830ea090ecc4",
  "state_ver_key": "SCHNORR_VER_KEY~28GxE4Aw4K9BmgUyVMFRHWE5HOOl_UDYi_YQsoyfYyt4bXDH1RohWWv91d0cKlt9j5XYhH2Gmlv5Iqev40rwA5w",
  "x25519_key": "X25519_PK~agZ857qxGHtBlOeHj0CXTBMzHt-jgGXm5Land0TmxQ9B"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)