### PR TITLE
Add a function to recover genesis from light client

### DIFF
--- a/light-client/src/consensus/quorum.rs
+++ b/light-client/src/consensus/quorum.rs
@@ -291,6 +291,12 @@ impl From<StakeTableEntries<SeqTypes>> for StakeTable {
     }
 }
 
+impl From<StakeTable> for Vec<StakeTableEntry<PubKey>> {
+    fn from(stake_table: StakeTable) -> Self {
+        stake_table.entries
+    }
+}
+
 impl FromIterator<StakeTableEntry<PubKey>> for StakeTable {
     fn from_iter<T: IntoIterator<Item = StakeTableEntry<PubKey>>>(entries: T) -> Self {
         let mut total_stake = U256::ZERO;

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -147,6 +147,15 @@ where
         }
     }
 
+    pub fn genesis(&self) -> Genesis {
+        Genesis {
+            epoch_height: self.epoch_height,
+            first_epoch_with_dynamic_stake_table: self.first_epoch_with_dynamic_stake_table,
+            stake_table: (*self.genesis_stake_table).clone().into(),
+            chain_id: self.chain_id,
+        }
+    }
+
     /// Get the number of known blocks in the chain.
     ///
     /// This is equivalent to one more than the block number of the latest known block. The latest

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -1816,6 +1816,19 @@ mod test {
             "{err:#}"
         );
     }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_genesis_round_trip() {
+        let client = TestClient::default();
+        let genesis = client.genesis().await;
+        let lc = LightClient::from_genesis(
+            SqliteStorage::default().await.unwrap(),
+            client.clone(),
+            genesis.clone(),
+        );
+        assert_eq!(lc.genesis(), genesis);
+    }
 }
 
 #[cfg(all(test, feature = "rlp"))]


### PR DESCRIPTION
This is helpful for the ZK Espresso stack reader, which needs to recover the minimal Espresso state (which includes the genesis) before and after executing, to prove that it is stepping correctly.

Also just generally good for observability/verifiability to be able to look at the genesis which forms the root of trust for a light client.