### PR TITLE
feat(node): add storage profile to skip derivable data

### DIFF
--- a/crates/espresso/node/src/api.rs
+++ b/crates/espresso/node/src/api.rs
@@ -3735,6 +3735,89 @@ mod test {
         assert!(migration_status.iter().all(|m| !m.name.is_empty()));
     }
 
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_compact_data_source() {
+        let port = reserve_tcp_port().expect("OS should have ephemeral ports available");
+
+        let storage = SqlDataSource::create_storage().await;
+        let options =
+            SqlDataSource::compact_ds_options(&storage, Options::with_port(port)).unwrap();
+
+        let network_config = TestConfigBuilder::default().build();
+        let config = TestNetworkConfigBuilder::default()
+            .api_config(options)
+            .network_config(network_config)
+            .build();
+        let _network = TestNetwork::new(config, MOCK_SEQUENCER_VERSIONS).await;
+        let url = format!("http://localhost:{port}").parse().unwrap();
+        let client: Client<ServerError, SequencerApiVersion> = Client::new(url);
+
+        tracing::info!("waiting for blocks");
+        client.connect(Some(Duration::from_secs(15))).await;
+
+        let account = TestConfig::<5>::builder_key().fee_account();
+
+        let _headers = client
+            .socket("availability/stream/headers/0")
+            .subscribe::<Header>()
+            .await
+            .unwrap()
+            .take(10)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        for i in 1..5 {
+            let leaf = client
+                .get::<LeafQueryData<SeqTypes>>(&format!("availability/leaf/{i}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(leaf.height(), i);
+
+            let header = client
+                .get::<Header>(&format!("availability/header/{i}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(header.height(), i);
+
+            let vid = client
+                .get::<VidCommonQueryData<SeqTypes>>(&format!("availability/vid/common/{i}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(vid.height(), i);
+
+            // Compact keeps payloads, so block queries succeed.
+            client
+                .get::<BlockQueryData<SeqTypes>>(&format!("availability/block/{i}"))
+                .send()
+                .await
+                .unwrap();
+
+            // Merklized-state APIs are not registered under Compact.
+            client
+                .get::<MerkleProof<Commitment<Header>, u64, Sha3Node, 3>>(&format!(
+                    "block-state/{i}/{}",
+                    i - 1
+                ))
+                .send()
+                .await
+                .unwrap_err();
+
+            client
+                .get::<MerkleProof<FeeAmount, FeeAccount, Sha3Node, 256>>(&format!(
+                    "fee-state/{}/{}",
+                    i + 1,
+                    account
+                ))
+                .send()
+                .await
+                .unwrap_err();
+        }
+    }
+
     async fn run_catchup_test(url_suffix: &str) {
         // Start a sequencer network, using the query service for catchup.
         let port = reserve_tcp_port().expect("OS should have ephemeral ports available");

--- a/crates/espresso/node/src/api/data_source.rs
+++ b/crates/espresso/node/src/api/data_source.rs
@@ -605,6 +605,9 @@ pub mod testing {
         ) -> anyhow::Result<Options> {
             anyhow::bail!("not supported")
         }
+        fn compact_ds_options(_storage: &Self::Storage, _opt: Options) -> anyhow::Result<Options> {
+            anyhow::bail!("not supported")
+        }
         fn options(storage: &Self::Storage, opt: Options) -> Options;
     }
 }

--- a/crates/espresso/node/src/api/options.rs
+++ b/crates/espresso/node/src/api/options.rs
@@ -532,48 +532,51 @@ impl Options {
                 .context("failed to define database api")
         })?;
 
-        // Initialize merklized state module for block merkle tree
+        let contents = mod_opt.storage_profile.contents();
 
-        register_api("block-state", &mut app, move |ver| {
-            endpoints::merklized_state::<N, P, _, BlockMerkleTree, 3>(ver)
-                .context("failed to define block-state api")
-        })?;
+        if contents.merklized_state {
+            // Initialize merklized state module for block merkle tree
+            register_api("block-state", &mut app, move |ver| {
+                endpoints::merklized_state::<N, P, _, BlockMerkleTree, 3>(ver)
+                    .context("failed to define block-state api")
+            })?;
 
-        // Initialize merklized state module for fee merkle tree
+            // Initialize merklized state module for fee merkle tree
+            register_api("fee-state", &mut app, move |ver| {
+                endpoints::fee::<_, SequencerApiVersion>(ver)
+                    .context("failed to define fee-state api")
+            })?;
 
-        register_api("fee-state", &mut app, move |ver| {
-            endpoints::fee::<_, SequencerApiVersion>(ver).context("failed to define fee-state api")
-        })?;
+            register_api("reward-state", &mut app, move |ver| {
+                endpoints::reward::<
+                    _,
+                    SequencerApiVersion,
+                    RewardMerkleTreeV1,
+                    { RewardMerkleTreeV1::ARITY },
+                >(ver, RewardMerkleTreeVersion::V1)
+                .context("failed to define reward-state api")
+            })?;
 
-        register_api("reward-state", &mut app, move |ver| {
-            endpoints::reward::<
-                _,
-                SequencerApiVersion,
-                RewardMerkleTreeV1,
-                { RewardMerkleTreeV1::ARITY },
-            >(ver, RewardMerkleTreeVersion::V1)
-            .context("failed to define reward-state api")
-        })?;
+            // register new api for new reward merkle tree
+            register_api("reward-state-v2", &mut app, move |ver| {
+                endpoints::reward::<
+                    _,
+                    SequencerApiVersion,
+                    RewardMerkleTreeV2,
+                    { RewardMerkleTreeV2::ARITY },
+                >(ver, RewardMerkleTreeVersion::V2)
+                .context("failed to define reward-state api")
+            })?;
 
-        // register new api for new reward merkle tree
-        register_api("reward-state-v2", &mut app, move |ver| {
-            endpoints::reward::<
-                _,
-                SequencerApiVersion,
-                RewardMerkleTreeV2,
-                { RewardMerkleTreeV2::ARITY },
-            >(ver, RewardMerkleTreeVersion::V2)
-            .context("failed to define reward-state api")
-        })?;
-
-        let get_node_state = {
-            let state = state.clone();
-            async move { state.node_state().await.clone() }
-        };
-        tasks.spawn(
-            "merklized state storage update loop",
-            update_state_storage_loop(ds.clone(), get_node_state),
-        );
+            let get_node_state = {
+                let state = state.clone();
+                async move { state.node_state().await.clone() }
+            };
+            tasks.spawn(
+                "merklized state storage update loop",
+                update_state_storage_loop(ds.clone(), get_node_state),
+            );
+        }
 
         // Initialize hotshot events API if enabled
         if self.hotshot_events.is_some() {

--- a/crates/espresso/node/src/api/sql.rs
+++ b/crates/espresso/node/src/api/sql.rs
@@ -87,6 +87,10 @@ impl SequencerDataSource for DataSource {
             builder = builder.leaf_only();
         }
 
+        if !opt.storage_profile.contents().aggregates {
+            builder = builder.disable_aggregator();
+        }
+
         if let Some(delay) = active_fetch_delay {
             builder = builder.with_active_fetch_delay(delay);
         }
@@ -1811,6 +1815,15 @@ pub(crate) mod impl_testable_data_source {
         ) -> anyhow::Result<api::Options> {
             let mut ds_opts = tmp_options(storage);
             ds_opts.lightweight = true;
+            Ok(opt.query_sql(Default::default(), ds_opts))
+        }
+
+        fn compact_ds_options(
+            storage: &Self::Storage,
+            opt: api::Options,
+        ) -> anyhow::Result<api::Options> {
+            let mut ds_opts = tmp_options(storage);
+            ds_opts.storage_profile = crate::persistence::sql::StorageProfile::Compact;
             Ok(opt.query_sql(Default::default(), ds_opts))
         }
 

--- a/crates/espresso/node/src/persistence/sql.rs
+++ b/crates/espresso/node/src/persistence/sql.rs
@@ -10,7 +10,7 @@ use std::{
 use alloy::primitives::Address;
 use anyhow::{Context, bail};
 use async_trait::async_trait;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use committable::Committable;
 use derivative::Derivative;
 use derive_more::derive::{From, Into};
@@ -78,6 +78,42 @@ use crate::{
     catchup::SqlStateCatchup,
     persistence::{migrate_network_config, persistence_metrics::PersistenceMetricsValue},
 };
+
+/// Selects how much derivable data a node persists.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum StorageProfile {
+    /// Store all data, including everything derivable. Required for validators and any node that
+    /// serves the historical state-query APIs or reward-claim-input.
+    #[default]
+    Full,
+    /// Drop merklized state and aggregate statistics (both derivable). Keeps leaves, payloads,
+    /// headers, the transaction index, and VID. Disables the historical state-query APIs
+    /// (block-state/fee-state/reward-state[-v2]) and reward-claim-input.
+    Compact,
+}
+
+/// Resolved set of optional datasets a node persists. Leaves, payloads, and consensus tables are
+/// always stored; this set covers data that a profile may omit. Extended in later profiles.
+#[derive(Clone, Copy, Debug)]
+pub struct StorageContents {
+    pub merklized_state: bool,
+    pub aggregates: bool,
+}
+
+impl StorageProfile {
+    pub fn contents(self) -> StorageContents {
+        match self {
+            Self::Full => StorageContents {
+                merklized_state: true,
+                aggregates: true,
+            },
+            Self::Compact => StorageContents {
+                merklized_state: false,
+                aggregates: false,
+            },
+        }
+    }
+}
 
 /// Options for Postgres-backed persistence.
 #[derive(Parser, Clone, Derivative)]
@@ -255,6 +291,11 @@ pub struct Options {
     )]
     pub(crate) lightweight: bool,
 
+    /// How much derivable data to persist. See `StorageProfile`. Independent of `--lightweight`,
+    /// which is a separate leaf-only mode that also drops payloads.
+    #[clap(long, value_enum, env = "ESPRESSO_NODE_STORAGE_PROFILE", default_value_t = StorageProfile::Full)]
+    pub(crate) storage_profile: StorageProfile,
+
     /// The maximum idle time of a database connection.
     ///
     /// Any connection which has been open and unused longer than this duration will be
@@ -431,6 +472,7 @@ impl From<SqliteOptions> for Options {
             disable_proactive_fetching: false,
             archive: false,
             lightweight: false,
+            storage_profile: StorageProfile::Full,
             min_connections: 0,
             pool: None,
             serializable_retry: SerializableRetryOptions::default(),
@@ -4974,5 +5016,24 @@ mod postgres_tests {
 
         let latest = storage.load_latest_acted_view().await.unwrap();
         assert_eq!(latest, Some(ViewNumber::new(19)));
+    }
+}
+
+#[cfg(test)]
+mod storage_profile_tests {
+    use super::StorageProfile;
+
+    #[test]
+    fn full_profile_enables_all() {
+        let c = StorageProfile::Full.contents();
+        assert!(c.merklized_state);
+        assert!(c.aggregates);
+    }
+
+    #[test]
+    fn compact_profile_disables_merklized_state_and_aggregates() {
+        let c = StorageProfile::Compact.contents();
+        assert!(!c.merklized_state);
+        assert!(!c.aggregates);
     }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -633,9 +633,11 @@ services:
     image: ghcr.io/espressosystems/espresso-network/espresso-node:${DOCKER_TAG:-main}
     ports:
       - "$ESPRESSO_NODE_4_API_PORT:$ESPRESSO_NODE_4_API_PORT"
-    command: espresso-node -- http -- config -- query -- storage-fs
+    command: espresso-node -- http -- config -- query
     environment:
       - ESPRESSO_NODE_EMBEDDED_DB=true
+      - ESPRESSO_NODE_STORAGE_PROFILE=compact
+      - ESPRESSO_NODE_STORAGE_PATH=/store/seq4
       - LIGHT_CLIENT_DB_PATH=/store/lc
       - ESPRESSO_NODE_GENESIS_FILE=${ESPRESSO_NODE_GENESIS_FILE:-genesis/demo.toml}
       - ESPRESSO_NODE_ORCHESTRATOR_URL=http://orchestrator:${ESPRESSO_ORCHESTRATOR_PORT}

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -465,7 +465,7 @@ processes:
   espresso-node-4:
     command: espresso-node-sqlite -- storage-sql -- http -- config -- query
     environment:
-      - ESPRESSO_NODE_LIGHTWEIGHT=true
+      - ESPRESSO_NODE_STORAGE_PROFILE=compact
       - ESPRESSO_NODE_API_PORT=${ESPRESSO_NODE_4_API_PORT}
       - ESPRESSO_NODE_TONIC_PORT=${ESPRESSO_NODE_4_TONIC_PORT}
       - ESPRESSO_NODE_STATE_PEERS=http://localhost:${ESPRESSO_NODE_0_API_PORT},http://localhost:${ESPRESSO_NODE_1_API_PORT}


### PR DESCRIPTION
- `StorageProfile { Full, Compact }` in `persistence/sql.rs`, selected via `--storage-profile` / `ESPRESSO_NODE_STORAGE_PROFILE`, default `Full`
- profile resolves to `StorageContents { merklized_state, aggregates }`; all gating reads the resolved set with positive logic
- `Compact` skips the merklized-state API registrations (block-state/fee-state/reward-state[-v2], which also serves reward-claim-input) and the state storage update loop, so those endpoints 404 instead of querying empty tables
- `Compact` calls `disable_aggregator()` on the data-source builder
- independent of `--lightweight`, which is a leaf-only mode that also drops payloads
- on mainnet at height 16.8M this drops merkle trees + aggregates: 1151 GB -> ~208 GB
- demo node 4 runs `compact` in process-compose and docker-compose (docker-compose node 4 switches from storage-fs to the embedded DB so the profile applies)
