### PR TITLE
Fix cargo audit CI check

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,4 +21,7 @@ ignore = [
     # hickory-proto O(n^2) name compression on encode. libp2p does lookups one name at a time, not
     # vulnerable, no patch release in libp2p available yet
     "RUSTSEC-2026-0119",
+    # rkyv OOB read, only fixed in 0.8 while Push-CDN pins 0.7. Needs unsized `Rc`/`Arc` pointees,
+    # which the CDN archived types don't have.
+    "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
The rkyv out-of-bounds read is only fixed in rkyv 0.8 while Push-CDN pins rkyv 0.7, and it needs several shared pointers to one address with differing metadata, which the CDN archived types cannot produce.