### PR TITLE
fix(api): serve /version on every axum-migrated service

### DIFF
--- a/crates/builder/src/api.rs
+++ b/crates/builder/src/api.rs
@@ -18,7 +18,7 @@ use axum::{
 };
 use committable::Committable;
 use espresso_api::{
-    cors_layer, healthcheck_response,
+    cors_layer, healthcheck_response, version,
     wire::{self, DecodeFailure, WireFormat},
 };
 use espresso_types::SeqTypes;
@@ -338,6 +338,7 @@ pub fn router(state: ProxyGlobalState<SeqTypes>) -> Router {
         .nest("/txn_submit", txn_submit_router(state));
     Router::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .merge(api.clone())
         .nest("/v0", api)
         .layer(cors_layer())

--- a/crates/espresso/api/src/axum.rs
+++ b/crates/espresso/api/src/axum.rs
@@ -493,9 +493,9 @@ async fn module_healthcheck(headers: HeaderMap) -> Response {
     module_healthcheck_response(&headers)
 }
 
-/// Tide-disco-compatible version response. Tide emits the binary's clap version; we emit the
-/// crate version so `surf_disco::Client::connect` and similar polling helpers succeed.
-async fn version() -> Json<serde_json::Value> {
+/// App-level `/version`, served by every migrated service. All workspace crates carry one version,
+/// so this reports the same value each binary would report itself.
+pub async fn version() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
     }))

--- a/crates/espresso/api/src/lib.rs
+++ b/crates/espresso/api/src/lib.rs
@@ -20,7 +20,7 @@ pub mod proto {
 pub use self::{
     axum::{
         WsFormat, cors_layer, create_combined_router, create_router_v1, create_router_v2,
-        drive_ws_stream, healthcheck_response, routes, ws_format,
+        drive_ws_stream, healthcheck_response, routes, version, ws_format,
     },
     tonic::create_reward_service,
 };

--- a/crates/espresso/dev-node/src/main.rs
+++ b/crates/espresso/dev-node/src/main.rs
@@ -27,7 +27,7 @@ use axum::{
     routing::{get, post},
 };
 use clap::{Parser, ValueEnum};
-use espresso_api::{cors_layer, healthcheck_response};
+use espresso_api::{cors_layer, healthcheck_response, version};
 use espresso_contract_deployer::{
     self as deployer, Contract, Contracts, DEFAULT_EXIT_ESCROW_PERIOD_SECONDS, DeployedContracts,
     HttpProviderWithWallet, network_config::light_client_genesis_from_stake_table,
@@ -954,6 +954,7 @@ fn dev_node_router(state: DevNodeState) -> Router {
         .merge(api.clone())
         .nest("/v0", api)
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .layer(cors_layer())
 }
 

--- a/crates/espresso/node/src/bin/nasty-client.rs
+++ b/crates/espresso/node/src/bin/nasty-client.rs
@@ -31,7 +31,7 @@ use axum::{
 use clap::Parser;
 use committable::Committable;
 use derivative::Derivative;
-use espresso_api::{cors_layer, healthcheck_response};
+use espresso_api::{cors_layer, healthcheck_response, version};
 use espresso_node::SequencerApiVersion;
 use espresso_types::{
     ADVZNamespaceProofQueryData, BlockMerkleTree, FeeMerkleTree, Header, SeqTypes, parse_duration,
@@ -1384,6 +1384,7 @@ async fn serve(port: u16, metrics: PrometheusMetrics) {
     let metrics = Arc::new(metrics);
     let app = axum::Router::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .route("/status/metrics", get(status_metrics))
         .route("/v0/status/metrics", get(status_metrics))
         .with_state(metrics)

--- a/crates/espresso/node/src/bin/submit-transactions.rs
+++ b/crates/espresso/node/src/bin/submit-transactions.rs
@@ -14,7 +14,7 @@ use clap::Parser;
 use committable::{Commitment, Committable};
 #[cfg(feature = "benchmarking")]
 use csv::Writer;
-use espresso_api::{cors_layer, healthcheck_response};
+use espresso_api::{cors_layer, healthcheck_response, version};
 use espresso_node::SequencerApiVersion;
 use espresso_types::{SeqTypes, Transaction, parse_duration, parse_size};
 use espresso_utils::logging;
@@ -513,6 +513,7 @@ async fn submit_transactions<ApiVer: StaticVersionType>(
 async fn server(port: u16) {
     let app = axum::Router::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .layer(cors_layer());
     let addr = format!("0.0.0.0:{port}");
     let listener = match TcpListener::bind(&addr).await {

--- a/crates/espresso/node/src/state_signature/relay_server.rs
+++ b/crates/espresso/node/src/state_signature/relay_server.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{get, post},
 };
 use espresso_api::{
-    cors_layer, healthcheck_response,
+    cors_layer, healthcheck_response, version,
     wire::{self, DecodeFailure, WireFormat},
 };
 use hotshot_types::{
@@ -342,6 +342,7 @@ const LATEST_STATE_PATH: &str = "/api/lateststate";
 fn router(state: SharedState) -> Router {
     let mut router = Router::<SharedState>::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .route(STATE_PATH, post(post_state).get(get_state))
         .route(
             LEGACY_STATE_PATH,

--- a/crates/hotshot/orchestrator/src/lib.rs
+++ b/crates/hotshot/orchestrator/src/lib.rs
@@ -31,7 +31,7 @@ use axum::{
 use client::{BenchResults, BenchResultsDownloadConfig};
 use csv::Writer;
 use espresso_api::{
-    cors_layer, healthcheck_response,
+    cors_layer, healthcheck_response, version,
     wire::{self, WireFormat},
 };
 use futures::{StreamExt, stream::FuturesUnordered};
@@ -910,6 +910,7 @@ fn app<TYPES: NodeType>(state: SharedOrchestratorState<TYPES>) -> Router {
     let api = Router::new().nest("/api", api_router::<TYPES>());
     Router::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .merge(api.clone())
         .nest("/v0", api)
         .with_state(state)

--- a/hotshot-state-prover/src/http.rs
+++ b/hotshot-state-prover/src/http.rs
@@ -3,7 +3,7 @@
 
 use alloy::primitives::Address;
 use axum::{Json, Router, http::HeaderMap, response::Response, routing::get};
-use espresso_api::{cors_layer, healthcheck_response};
+use espresso_api::{cors_layer, healthcheck_response, version};
 
 /// Serves the light client contract address at the paths tide-disco used to expose it:
 /// `/v0/api/lightclient_contract` directly, and `/api/lightclient_contract` (which tide-disco
@@ -20,6 +20,7 @@ fn router(light_client_address: Address) -> Router {
             get(move || async move { Json(light_client_address) }),
         )
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .layer(cors_layer())
 }
 
@@ -102,5 +103,14 @@ mod tests {
                 "{uri}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn probe_version_status() {
+        println!("PROVER /version -> {}", get("/version").await.status());
+        println!(
+            "PROVER /healthcheck -> {}",
+            get("/healthcheck").await.status()
+        );
     }
 }

--- a/light-client-query-service/src/api.rs
+++ b/light-client-query-service/src/api.rs
@@ -15,7 +15,7 @@ use axum::{
     routing::get,
 };
 use espresso_api::{
-    cors_layer, drive_ws_stream, healthcheck_response,
+    cors_layer, drive_ws_stream, healthcheck_response, version,
     wire::{self, WireFormat},
     ws_format,
 };
@@ -1174,6 +1174,7 @@ pub fn router(ds: DataSource) -> Router {
         .nest("/node", node_router(ds));
     Router::new()
         .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .merge(api.clone())
         .nest("/v1", api)
         .layer(cors_layer())

--- a/node-metrics/src/lib.rs
+++ b/node-metrics/src/lib.rs
@@ -100,9 +100,9 @@ pub mod api;
 pub mod service;
 
 use api::node_validator::v0::SurfDiscoAvailabilityAPIStream;
-use axum::Router;
+use axum::{Router, http::HeaderMap, response::Response, routing::get};
 use clap::Parser;
-use espresso_api::cors_layer;
+use espresso_api::{cors_layer, healthcheck_response, version};
 use futures::{
     StreamExt,
     channel::mpsc::{self, Sender},
@@ -215,10 +215,16 @@ fn app(state: MainState) -> Router {
         api::node_validator::v0::router::<MainState>(),
     );
     Router::new()
+        .route("/healthcheck", get(healthcheck))
+        .route("/version", get(version))
         .merge(api.clone())
         .nest("/v0", api)
         .with_state(state)
         .layer(cors_layer())
+}
+
+async fn healthcheck(headers: HeaderMap) -> Response {
+    healthcheck_response(&headers)
 }
 
 /// Run the service by itself.
@@ -359,6 +365,18 @@ mod tests {
                 .unwrap();
             let resp = tower::ServiceExt::oneshot(test_app(), req).await.unwrap();
             assert_ne!(resp.status(), StatusCode::NOT_FOUND, "{uri} did not route");
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_app_level_routes() {
+        for uri in ["/healthcheck", "/version", "/node-validator/details"] {
+            let req = Request::builder()
+                .uri(uri)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let resp = tower::ServiceExt::oneshot(test_app(), req).await.unwrap();
+            println!("NODE-METRICS {uri} -> {}", resp.status());
         }
     }
 }


### PR DESCRIPTION
tide-disco auto-registered an app-level `/version` next to `/healthcheck` on every service, so all of them answered it; the axum migration reproduced `/healthcheck` on each router but `/version` only on the espresso-node API, so the route now 404s on the builder, orchestrator, state relay server, dev-node, light-client-query-service, node-metrics, hotshot-state-prover, submit-transactions and nasty-client, and node-metrics lost `/healthcheck` as well. Anything polling `/version` breaks silently at cutover, since an unregistered route is not an error the server logs. The existing handler in espresso-api is now `pub` and every service routes `/version` to it directly; all workspace crates carry one version, so it reports the same value each binary would report itself. node-metrics gets both routes back.