### PR TITLE
fix(http-client): review fixes for the surf-disco port

### DIFF
--- a/crates/http-client/src/client.rs
+++ b/crates/http-client/src/client.rs
@@ -195,9 +195,11 @@ impl<E: ClientError, VER: StaticVersionType> Client<E, VER> {
         &self,
         prefix: &str,
     ) -> Result<Client<E2, VER>, url::ParseError> {
+        let mut base_url = self.base_url.join(prefix)?;
+        ensure_trailing_slash(&mut base_url);
         Ok(Client {
             inner: self.inner.clone(),
-            base_url: self.base_url.join(prefix)?,
+            base_url,
             accept: self.accept,
             _marker: PhantomData,
         })
@@ -219,11 +221,7 @@ pub struct ClientBuilder<E: ClientError, VER: StaticVersionType> {
 
 impl<E: ClientError, VER: StaticVersionType> ClientBuilder<E, VER> {
     fn new(mut base_url: Url) -> Self {
-        // If the path part of `base_url` does not end in `/`, `join` will treat it as a filename
-        // and remove it, which is never what we want: `base_url` is always a directory-like path.
-        if !base_url.path().ends_with('/') {
-            base_url.set_path(&format!("{}/", base_url.path()));
-        }
+        ensure_trailing_slash(&mut base_url);
         Self {
             inner: reqwest::Client::builder(),
             accept: ContentType::Binary,
@@ -270,6 +268,16 @@ impl<E: ClientError, VER: StaticVersionType> From<ClientBuilder<E, VER>> for Cli
     }
 }
 
+/// Ensure a base URL's path ends in `/`, so that `join` treats it as a directory.
+///
+/// If the path does not end in `/`, `join` will treat the last segment as a filename and remove
+/// it, which is never what we want: a base URL is always a directory-like path.
+fn ensure_trailing_slash(url: &mut Url) {
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+}
+
 #[cfg(test)]
 mod test {
     use vbs::version::StaticVersion;
@@ -304,5 +312,15 @@ mod test {
         let client =
             Client::<ClientErr, Ver01>::builder("http://example.com".parse().unwrap()).build();
         assert_eq!(client.base_url(), "http://example.com/".parse().unwrap());
+    }
+
+    #[test]
+    fn module_adds_trailing_slash_to_prefix() {
+        let client = Client::<ClientErr, Ver01>::new("http://example.com/api".parse().unwrap());
+        let module = client.module::<ClientErr>("sub").unwrap();
+        assert_eq!(
+            module.base_url(),
+            "http://example.com/api/sub/".parse().unwrap()
+        );
     }
 }

--- a/crates/http-client/src/client.rs
+++ b/crates/http-client/src/client.rs
@@ -38,6 +38,7 @@ pub struct Client<E, VER: StaticVersionType> {
     inner: reqwest::Client,
     base_url: Url,
     accept: ContentType,
+    retry_interval: Duration,
     _marker: PhantomData<fn(E, VER)>,
 }
 
@@ -47,6 +48,7 @@ impl<E, VER: StaticVersionType> Clone for Client<E, VER> {
             inner: self.inner.clone(),
             base_url: self.base_url.clone(),
             accept: self.accept,
+            retry_interval: self.retry_interval,
             _marker: PhantomData,
         }
     }
@@ -78,7 +80,8 @@ impl<E: ClientError, VER: StaticVersionType> Client<E, VER> {
     /// This is useful to wait for the server to come up if it may be offline when the client is
     /// created.
     ///
-    /// Polls the server's `/healthcheck` endpoint every 10 seconds until it returns
+    /// Polls the server's `/healthcheck` endpoint at the configured
+    /// [retry interval](ClientBuilder::set_retry_interval) until it returns
     /// [`StatusCode::OK`](reqwest::StatusCode::OK), or until `timeout` elapses (or forever, if
     /// `timeout` is `None`).
     pub async fn connect(&self, timeout: Option<Duration>) -> bool {
@@ -108,7 +111,7 @@ impl<E: ClientError, VER: StaticVersionType> Client<E, VER> {
                     );
                 },
             }
-            sleep(Duration::from_secs(10)).await;
+            sleep(self.retry_interval).await;
         }
         false
     }
@@ -128,7 +131,7 @@ impl<E: ClientError, VER: StaticVersionType> Client<E, VER> {
         while deadline.map(|t| Instant::now() < t).unwrap_or(true) {
             match self.healthcheck::<H>().await {
                 Ok(health) if healthy(&health) => return Some(health),
-                _ => sleep(Duration::from_secs(10)).await,
+                _ => sleep(self.retry_interval).await,
             }
         }
         None
@@ -201,6 +204,7 @@ impl<E: ClientError, VER: StaticVersionType> Client<E, VER> {
             inner: self.inner.clone(),
             base_url,
             accept: self.accept,
+            retry_interval: self.retry_interval,
             _marker: PhantomData,
         })
     }
@@ -216,6 +220,7 @@ pub struct ClientBuilder<E: ClientError, VER: StaticVersionType> {
     accept: ContentType,
     base_url: Url,
     timeout: Option<Duration>,
+    retry_interval: Duration,
     _marker: PhantomData<fn(E, VER)>,
 }
 
@@ -227,6 +232,7 @@ impl<E: ClientError, VER: StaticVersionType> ClientBuilder<E, VER> {
             accept: ContentType::Binary,
             base_url,
             timeout: Some(Duration::from_secs(60)),
+            retry_interval: Duration::from_secs(10),
             _marker: PhantomData,
         }
     }
@@ -238,6 +244,15 @@ impl<E: ClientError, VER: StaticVersionType> ClientBuilder<E, VER> {
     /// Default: `Some(Duration::from_secs(60))`.
     pub fn set_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Set the interval between healthcheck probes in [`connect`](Client::connect) and
+    /// [`wait_for_health`](Client::wait_for_health).
+    ///
+    /// Default: 10 seconds.
+    pub fn set_retry_interval(mut self, interval: Duration) -> Self {
+        self.retry_interval = interval;
         self
     }
 
@@ -257,6 +272,7 @@ impl<E: ClientError, VER: StaticVersionType> ClientBuilder<E, VER> {
             inner: builder.build().unwrap(),
             base_url: self.base_url,
             accept: self.accept,
+            retry_interval: self.retry_interval,
             _marker: PhantomData,
         }
     }

--- a/crates/http-client/tests/loopback.rs
+++ b/crates/http-client/tests/loopback.rs
@@ -160,6 +160,17 @@ async fn module_prefixes_routes() {
 }
 
 #[tokio::test]
+async fn module_without_trailing_slash_prefixes_routes() {
+    let app = Router::new().route("/mod/get_json", get(get_json));
+    let base_url = spawn_server(app).await;
+
+    let client = Client::<ClientErr, Ver01>::new(base_url);
+    let module = client.module::<ClientErr>("mod").unwrap();
+    let res: String = module.get("get_json").send().await.unwrap();
+    assert_eq!(res, "response");
+}
+
+#[tokio::test]
 async fn socket_subscribe_decodes_binary_frames() {
     let app = Router::new().route("/ws_naturals", get(ws_naturals));
     let base_url = spawn_server(app).await;

--- a/crates/http-client/tests/loopback.rs
+++ b/crates/http-client/tests/loopback.rs
@@ -276,6 +276,10 @@ async fn connect_returns_false_when_server_is_down() {
     let addr = listener.local_addr().unwrap();
     drop(listener);
 
-    let client = Client::<ClientErr, Ver01>::new(format!("http://{addr}/").parse().unwrap());
-    assert!(!client.connect(Some(Duration::ZERO)).await);
+    // A non-zero timeout guarantees at least one probe reaches the refused connection before the
+    // deadline check stops the retry loop.
+    let client = Client::<ClientErr, Ver01>::builder(format!("http://{addr}/").parse().unwrap())
+        .set_retry_interval(Duration::from_millis(10))
+        .build();
+    assert!(!client.connect(Some(Duration::from_millis(100))).await);
 }

--- a/crates/http-client/tests/loopback.rs
+++ b/crates/http-client/tests/loopback.rs
@@ -1,6 +1,6 @@
 //! Loopback tests against a small axum server, covering the response-decode paths of
-//! `Request::send`, `Request::bytes`, healthcheck polling, and the frame-decode and
-//! redirect-following paths of `SocketRequest`.
+//! `Request::send`, `Request::bytes`, healthcheck polling, and the frame-encode, frame-decode,
+//! and redirect-following paths of `SocketRequest`.
 
 use std::{
     sync::{Arc, RwLock},
@@ -17,7 +17,7 @@ use axum::{
     routing::{get, post},
 };
 use futures::{SinkExt, StreamExt};
-use http_client::{Client, ClientError, error::ClientErr, healthcheck::HealthStatus};
+use http_client::{Client, ClientError, ContentType, error::ClientErr, healthcheck::HealthStatus};
 use tokio::net::TcpListener;
 use vbs::{BinarySerializer, Serializer, version::StaticVersion};
 
@@ -64,6 +64,18 @@ async fn ws_redirect() -> impl IntoResponse {
         axum::http::StatusCode::TEMPORARY_REDIRECT,
         [(axum::http::header::LOCATION, "/ws_naturals")],
     )
+}
+
+async fn ws_echo(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(|mut socket| async move {
+        while let Some(Ok(msg)) = socket.next().await {
+            if matches!(msg, WsMessage::Binary(_) | WsMessage::Text(_))
+                && socket.send(msg).await.is_err()
+            {
+                return;
+            }
+        }
+    })
 }
 
 async fn ws_naturals(ws: WebSocketUpgrade) -> impl IntoResponse {
@@ -184,6 +196,38 @@ async fn socket_subscribe_decodes_binary_frames() {
         .collect()
         .await;
     assert_eq!(naturals, (0u64..3).map(Ok).collect::<Vec<_>>());
+}
+
+#[tokio::test]
+async fn socket_send_encodes_binary_frames() {
+    let app = Router::new().route("/ws_echo", get(ws_echo));
+    let base_url = spawn_server(app).await;
+
+    let client = Client::<ClientErr, Ver01>::new(base_url);
+    let mut conn = client
+        .socket("ws_echo")
+        .connect::<u64, u64>()
+        .await
+        .unwrap();
+    conn.send(&42).await.unwrap();
+    assert_eq!(conn.next().await.unwrap().unwrap(), 42);
+}
+
+#[tokio::test]
+async fn socket_send_encodes_json_frames() {
+    let app = Router::new().route("/ws_echo", get(ws_echo));
+    let base_url = spawn_server(app).await;
+
+    let client = Client::<ClientErr, Ver01>::builder(base_url)
+        .content_type(ContentType::Json)
+        .build();
+    let mut conn = client
+        .socket("ws_echo")
+        .connect::<u64, u64>()
+        .await
+        .unwrap();
+    conn.send(&42).await.unwrap();
+    assert_eq!(conn.next().await.unwrap().unwrap(), 42);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes for three review findings on #4705, stacked on `ma/http-client`.

## Changes

**1. `Client::module` silently dropped the module prefix without a trailing slash.**
`ClientBuilder::new` normalizes the base URL path to end in `/` because `Url::join` otherwise strips the last segment, but `module()` passed the prefix straight to `join`. `client.module("availability")` followed by `get("leaf/1")` produced `/leaf/1` instead of `/availability/leaf/1`. The joined module URL now gets the same normalization, via a shared `ensure_trailing_slash` helper. Covered by a unit test and a loopback test using a slash-less prefix.

**2. `connect_returns_false_when_server_is_down` never contacted the server.**
The test used `Duration::ZERO`, and `connect` checks the deadline before the first probe, so the retry loop body never ran and the refused-connection path was uncovered. The 10s retry interval was hard-coded, making the real path too expensive to test. The interval is now configurable on `ClientBuilder` (`set_retry_interval`, default unchanged at 10s, also used by `wait_for_health`), and the test now genuinely probes a dropped port with a 10ms interval and 100ms timeout.

**3. The `Sink` half of `Connection` was completely untested.**
No loopback test sent a client-to-server message, even though in-repo consumers (builder event service, node-metrics validator API) hold bidirectional connections. Added a WS echo route and two round-trip tests exercising `start_send`'s framing in both content types (Binary/vbs and Json/serde_json).

## Where to focus

- The `retry_interval` plumbing in `client.rs` is the only production behavior change beyond the `module()` fix; the default matches surf-disco's hard-coded 10s.
- `cargo test -p http-client`: 28 tests pass; `cargo clippy -p http-client --all-targets` is clean.
