### PR TITLE
Miscellaneous light client features to support Espresso stack

### DIFF
--- a/light-client/src/consensus/header.rs
+++ b/light-client/src/consensus/header.rs
@@ -7,7 +7,7 @@ use jf_merkle_tree_compat::MerkleTreeScheme;
 use serde::{Deserialize, Serialize};
 
 /// A proof that a header is finalized, relative to some known-finalized leaf.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct HeaderProof {
     header: Header,
     proof: <BlockMerkleTree as MerkleTreeScheme>::MembershipProof,

--- a/light-client/src/consensus/leaf.rs
+++ b/light-client/src/consensus/leaf.rs
@@ -18,7 +18,7 @@ use crate::consensus::quorum::StakeTableQuorum;
 ///
 /// There are different types of proofs for different scenarios and protocol versions. New proof
 /// types can be added while remaining compatible with old serialized proofs.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub enum FinalityProof {
     /// The client has stated that they already trust the finality of this particular leaf.
     #[default]
@@ -91,7 +91,7 @@ impl<'a> LeafProofHint<'a, StakeTableQuorum<EpochMembership<SeqTypes>>> {
 }
 
 /// A proof that a leaf is finalized.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LeafProof {
     /// A chain of leaves from the requested leaf to a provably finalized leaf.
     ///

--- a/light-client/src/state.rs
+++ b/light-client/src/state.rs
@@ -108,6 +108,12 @@ pub struct LightClient<P, S> {
     stake_tables: RwLock<BTreeMap<EpochNumber, Arc<StakeTable>>>,
 }
 
+impl<P, S> AsRef<S> for LightClient<P, S> {
+    fn as_ref(&self) -> &S {
+        &self.server
+    }
+}
+
 impl<P, S> LightClient<P, S>
 where
     P: Storage,

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -1,13 +1,11 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
+
 #[cfg(feature = "client")]
 use std::{
     collections::HashMap,
     path::PathBuf,
     str::FromStr,
-    sync::{
-        Arc,
-        atomic::{AtomicI64, Ordering},
-    },
+    sync::atomic::{AtomicI64, Ordering},
     time::Duration,
 };
 #[cfg(all(unix, feature = "client"))]
@@ -216,6 +214,59 @@ pub trait Storage: Sized + Send + Sync + 'static {
         epoch_root_protocol_version: Version,
         next_epoch_root_protocol_version: Version,
     ) -> impl Send + Future<Output = Result<()>>;
+}
+
+impl<T: Storage> Storage for Arc<T> {
+    async fn default() -> Result<Self> {
+        Ok(Arc::new(T::default().await?))
+    }
+
+    async fn block_height(&self) -> Result<u64> {
+        (**self).block_height().await
+    }
+
+    async fn leaf_upper_bound(
+        &self,
+        leaf: impl Into<LeafRequest> + Send,
+    ) -> Result<Option<LeafQueryData<SeqTypes>>> {
+        (**self).leaf_upper_bound(leaf).await
+    }
+
+    async fn get_leaves_in_range(
+        &self,
+        start: u32,
+        end: u32,
+    ) -> Result<Vec<LeafQueryData<SeqTypes>>> {
+        (**self).get_leaves_in_range(start, end).await
+    }
+
+    async fn insert_leaf(&self, leaf: LeafQueryData<SeqTypes>) -> Result<()> {
+        (**self).insert_leaf(leaf).await
+    }
+
+    async fn stake_table_lower_bound(
+        &self,
+        epoch: EpochNumber,
+    ) -> Result<Option<(EpochNumber, StakeTableState, Version, Version)>> {
+        (**self).stake_table_lower_bound(epoch).await
+    }
+
+    async fn insert_stake_table(
+        &self,
+        epoch: EpochNumber,
+        stake_table: &StakeTableState,
+        epoch_root_protocol_version: Version,
+        next_epoch_root_protocol_version: Version,
+    ) -> Result<()> {
+        (**self)
+            .insert_stake_table(
+                epoch,
+                stake_table,
+                epoch_root_protocol_version,
+                next_epoch_root_protocol_version,
+            )
+            .await
+    }
 }
 
 #[cfg(feature = "client")]

--- a/light-client/src/storage.rs
+++ b/light-client/src/storage.rs
@@ -1,5 +1,3 @@
-use std::{future::Future, sync::Arc};
-
 #[cfg(feature = "client")]
 use std::{
     collections::HashMap,
@@ -10,6 +8,7 @@ use std::{
 };
 #[cfg(all(unix, feature = "client"))]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+use std::{future::Future, sync::Arc};
 
 #[cfg(feature = "client")]
 use alloy::primitives::Address;

--- a/light-client/src/testing.rs
+++ b/light-client/src/testing.rs
@@ -457,26 +457,31 @@ impl InnerTestClient {
         state.commit()
     }
 
-    async fn leaf(&mut self, height: usize, epoch_height: u64) -> LeafQueryData<SeqTypes> {
-        let epoch = epoch_from_block_number(height as u64, epoch_height);
-        let (quorum, stake_table): (Vec<_>, Vec<_>) =
-            self.quorum_for_epoch(epoch).iter().cloned().unzip();
-        let mut stake_entries = vec![];
-        let mut total_stake = U256::ZERO;
-        for validator in &stake_table {
-            stake_entries.push(StakeTableEntry {
-                stake_key: *validator.stake_table_key(),
-                stake_amount: validator.stake,
-            });
-            total_stake += validator.stake;
-        }
-
-        let pp = PubKey::public_parameter(&stake_entries, supermajority_threshold(total_stake));
-
+    async fn leaf(
+        &mut self,
+        height: usize,
+        epoch_height: u64,
+        mut payload: Option<Vec<Transaction>>,
+    ) -> LeafQueryData<SeqTypes> {
         for i in self.leaves.len()..=height {
             let epoch = EpochNumber::new(epoch_from_block_number(i as u64, epoch_height));
             let view_offset = self.view_gaps.iter().filter(|&&g| g < i).count() as u64;
             let view_number = ViewNumber::new(i as u64 + view_offset);
+
+            let (quorum, stake_table): (Vec<_>, Vec<_>) =
+                self.quorum_for_epoch(*epoch).iter().cloned().unzip();
+
+            let mut stake_entries = vec![];
+            let mut total_stake = U256::ZERO;
+            for validator in &stake_table {
+                stake_entries.push(StakeTableEntry {
+                    stake_key: *validator.stake_table_key(),
+                    stake_amount: validator.stake,
+                });
+                total_stake += validator.stake;
+            }
+
+            let pp = PubKey::public_parameter(&stake_entries, supermajority_threshold(total_stake));
 
             let upgrade = Upgrade::trivial(self.version_at(i as u64));
             let node_state = NodeState::mock_v3().with_genesis_version(upgrade.base);
@@ -492,7 +497,13 @@ impl InnerTestClient {
                 (parent.qc().clone(), mt)
             };
 
-            let transactions = vec![Transaction::random(&mut rand::thread_rng())];
+            let random_transactions = vec![Transaction::random(&mut rand::thread_rng())];
+            let transactions = if i == height {
+                payload.take().unwrap_or(random_transactions)
+            } else {
+                random_transactions
+            };
+            tracing::debug!(?transactions, "generated block {i}");
             let (payload, ns_table) =
                 Payload::from_transactions_sync(transactions, node_state.chain_config).unwrap();
             let payload_comm = vid_commitment(
@@ -731,14 +742,25 @@ impl TestClient {
         }
     }
 
+    pub async fn add_block(&self, height: usize, transactions: Vec<Transaction>) {
+        let mut inner = self.inner.lock().await;
+        assert!(
+            inner.leaves.len() <= height,
+            "cannot add transactions for a block which has already been generated"
+        );
+        inner
+            .leaf(height, self.epoch_height, Some(transactions))
+            .await;
+    }
+
     pub async fn leaf(&self, height: usize) -> LeafQueryData<SeqTypes> {
         let mut inner = self.inner.lock().await;
-        inner.leaf(height, self.epoch_height).await
+        inner.leaf(height, self.epoch_height, None).await
     }
 
     pub async fn payload(&self, height: usize) -> Payload {
         let mut inner = self.inner.lock().await;
-        inner.leaf(height, self.epoch_height).await;
+        inner.leaf(height, self.epoch_height, None).await;
         inner.payloads[height].clone()
     }
 
@@ -752,13 +774,13 @@ impl TestClient {
         inner.missing_leaves.remove(&height);
         inner.invalid_proofs.remove(&height);
         inner.swapped_leaves.remove(&height);
-        inner.leaf(height, self.epoch_height).await
+        inner.leaf(height, self.epoch_height, None).await
     }
 
     pub async fn forget_leaf(&self, height: usize) -> LeafQueryData<SeqTypes> {
         let mut inner = self.inner.lock().await;
         inner.missing_leaves.insert(height);
-        inner.leaf(height, self.epoch_height).await
+        inner.leaf(height, self.epoch_height, None).await
     }
 
     pub async fn return_invalid_proof(&self, for_height: usize) {
@@ -855,7 +877,7 @@ impl Client for TestClient {
             );
         }
 
-        let leaf = inner.leaf(height, self.epoch_height).await;
+        let leaf = inner.leaf(height, self.epoch_height, None).await;
 
         let mut proof = LeafProof::default();
         proof.push(leaf.clone());
@@ -888,7 +910,7 @@ impl Client for TestClient {
         const MAX_PROOF_LEAVES: usize = 16;
         let mut next = height + 1;
         loop {
-            let leaf = inner.leaf(next, self.epoch_height).await;
+            let leaf = inner.leaf(next, self.epoch_height, None).await;
             next += 1;
             if proof.push(leaf) {
                 break;
@@ -914,7 +936,7 @@ impl Client for TestClient {
         );
         if inner.invalid_proofs.contains(&height) {
             tracing::info!(root, height, "return mock invalid proof");
-            let leaf = inner.leaf(height, self.epoch_height).await;
+            let leaf = inner.leaf(height, self.epoch_height, None).await;
             // Construct a proof using a Merkle tree of the wrong height.
             let mt = BlockMerkleTree::from_elems(
                 Some(BLOCK_MERKLE_TREE_HEIGHT + 1),
@@ -934,7 +956,11 @@ impl Client for TestClient {
         let mt = &inner.merkle_trees[root];
         tracing::info!(height, root = %mt.commitment(), "get proof from Merkle tree");
         let proof = mt.lookup(height as u64).expect_ok().unwrap().1;
-        let header = inner.leaf(height, self.epoch_height).await.header().clone();
+        let header = inner
+            .leaf(height, self.epoch_height, None)
+            .await
+            .header()
+            .clone();
         Ok(HeaderProof::new(header, proof))
     }
 
@@ -947,7 +973,7 @@ impl Client for TestClient {
         let mut inner = self.inner.lock().await;
         for h in start_height..end_height {
             let height = *inner.swapped_leaves.get(&h).unwrap_or(&h);
-            leaves.push(inner.leaf(height, self.epoch_height).await);
+            leaves.push(inner.leaf(height, self.epoch_height, None).await);
         }
         Ok(leaves)
     }


### PR DESCRIPTION
* Make proof types `Eq`, which aids in writing test assertions
* Expose inner client from `LightClient` via `AsRef`. The Espresso stack needs this because it uses the inner Espresso client to record which leaves get fetched, to then populate those inside the zkVM
* Blanket `Client` impl for `Arc<Client>`, which makes wrapping and sharing clients easy
* Add features to `TestClient` for populating blocks with specific transactions instead of randomly generated ones
